### PR TITLE
fix: use --description instead of -d in Camel JBang Plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you already use [Camel JBang](https://camel.apache.org/manual/camel-jbang.htm
 ```bash
 camel plugin add kit \
   --gav io.github.luigidemasi:camel-kit-jbang-plugin:LATEST \
-  -d "Design Apache Camel Integrations with AI"
+  --description "Design Apache Camel Integrations with AI"
 
 # Then use via the camel CLI
 camel kit init my-integration --ai bob


### PR DESCRIPTION
The -d flag is not available for `camel plugin add`; the correct option is --description.

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin command example to use the long-form flag option for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->