### PR TITLE
fix #21: update documentation for BizTalk migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MuleSoft graph parsers** — `MuleXmlFlowParser` (Mule 3.x/4.x XML) and `DataWeaveParser` (`.dwl` files) with dedicated node and edge types; `XmlRouteParser` skips Mule XML automatically
 
+- **BizTalk migration support** — Microsoft BizTalk Server added as the 4th supported migration source platform
+  - `BizTalkParser` — hybrid GraphParser with 4 internal StAX-based parsers for ODX orchestrations (37 shape types), BTM maps (45 functoid type mappings), BTP pipelines, and binding XML files
+  - 10 new `NodeType` and 7 new `EdgeType` values for BizTalk artifacts
+  - XmlRouteParser exclusion for BizTalk XML files (namespace and content sniffing)
+  - `--source-platform biztalk` option for `camel-kit init`
+  - BizTalk project detection in `detectProjectType()` (orchestrations, maps, pipelines)
+  - 6 migration skill guides: `biztalk-phase1.md`, `biztalk-phase2.md`, `biztalk-component-mapping.md` (37 shape-to-EIP mappings, 16+ adapter mappings), `biztalk-map-conversion.md`, `biztalk-expression-mapping.md`, `biztalk-pipeline-mapping.md`
+  - `/camel-migrate` SKILL.md updated with BizTalk vendor detection signals and guide manifest
+  - UTF-16 binding file detection (BizTalk Admin Console exports UTF-16 by default)
+  - Atomic graph mutation via buffering (prevents partial graph corruption on parse failures)
+  - Deferred BTP component emission (handles FriendlyName appearing after Component elements)
+  - Suspend Shape marked as not supported (BizTalk dehydration has no Camel equivalent)
+
 - **3-phase orchestrated pipeline** — replaced the linear `/camel-project` → `/camel-flow` → `/camel-implement` → `/camel-validate` → `/camel-test` workflow with a structured 3-phase pipeline:
   - `/camel-brainstorm` — interactive design session producing a Blueprint Reference Document (BRD) with Technical Design Documents (TDDs)
   - `/camel-plan` — reviews approved design, creates detailed implementation plan with task decomposition

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,8 @@ The `camel-kit-graph` module builds a property graph of the project structure by
 
 **BizTalk parser architecture:** The `BizTalkParser` is a hybrid parser that delegates to 4 internal StAX-based parsers (`BizTalkOdxParser`, `BizTalkBtmParser`, `BizTalkBtpParser`, `BizTalkBindingParser`) based on file extension and content. StAX was chosen over DOM to handle large orchestration files efficiently (streaming parse instead of full in-memory tree). The parser recognizes 37 orchestration shape types (Receive, Send, Decide, Loop, Parallel, Call, Scope, etc.) and 45 functoid type mappings (string ops, math, looping, scripting, database lookup).
 
+**Reference implementation:** The [BizTalkMigrationStarter](https://github.com/luigidemasi/BizTalkMigrationStarter) project (BizTalk → Azure Logic Apps) provided the reference parsing patterns. Its C# `BizTalkOrchestrationParser` (ODX text extraction + XPath), `BtmParser` (functoid/link resolution), `PipelineParser` (XmlSerializer deserialization), and `BindingSnapshot` (LINQ-to-XML) were translated to Java StAX equivalents for camel-kit.
+
 ---
 
 ## 3. The Orchestration Model

--- a/examples/biztalk-order-processing/OrderProcess.odx
+++ b/examples/biztalk-order-processing/OrderProcess.odx
@@ -19,6 +19,19 @@
                 </om:Element>
             </om:Element>
         </om:Element>
+        <om:Element Type="PortType" OID="port-type-002" LowerBound="8.1" HigherBound="13.1">
+            <om:Property Name="Name" Value="SendPortType" />
+            <om:Property Name="Modifier" Value="Internal" />
+            <om:Element Type="OperationDeclaration" OID="op-002" LowerBound="9.1" HigherBound="12.1">
+                <om:Property Name="Name" Value="Operation_1" />
+                <om:Property Name="OperationType" Value="OneWay" />
+                <om:Element Type="MessageRef" OID="msgref-002" LowerBound="10.1" HigherBound="11.1">
+                    <om:Property Name="Name" Value="Request" />
+                    <om:Property Name="Ref" Value="MyApp.Schemas.InvoiceSchema" />
+                    <om:Property Name="Direction" Value="In" />
+                </om:Element>
+            </om:Element>
+        </om:Element>
         <om:Element Type="ServiceDeclaration" OID="svc-001" LowerBound="14.1" HigherBound="32.1">
             <om:Property Name="Name" Value="OrderProcessOrchestration" />
             <om:Property Name="Signal" Value="False" />

--- a/examples/biztalk-order-processing/OrderProcess.odx
+++ b/examples/biztalk-order-processing/OrderProcess.odx
@@ -1,0 +1,84 @@
+#if __DESIGNER_DATA
+#error Do not define __DESIGNER_DATA.
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<om:MetaModel MajorVersion="1" MinorVersion="3" Core="2b131234-7959-458d-834f-2dc0769ce683" ScheduleModel="66366196-361d-448d-976f-cab5e87496d2" xmlns:om="http://schemas.microsoft.com/BizTalk/2003/DesignerData">
+    <om:Element Type="Module" OID="18fa1db3-2e14-4674-981e-1a9e576ef635" LowerBound="1.1" HigherBound="33.1">
+        <om:Property Name="ReportToAnalyst" Value="True" />
+        <om:Property Name="Name" Value="MyApp.Orchestrations" />
+        <om:Property Name="Signal" Value="False" />
+        <om:Element Type="PortType" OID="port-type-001" LowerBound="3.1" HigherBound="8.1">
+            <om:Property Name="Name" Value="ReceivePortType" />
+            <om:Property Name="Modifier" Value="Internal" />
+            <om:Element Type="OperationDeclaration" OID="op-001" LowerBound="4.1" HigherBound="7.1">
+                <om:Property Name="Name" Value="Operation_1" />
+                <om:Property Name="OperationType" Value="OneWay" />
+                <om:Element Type="MessageRef" OID="msgref-001" LowerBound="5.1" HigherBound="6.1">
+                    <om:Property Name="Name" Value="Request" />
+                    <om:Property Name="Ref" Value="MyApp.Schemas.OrderSchema" />
+                    <om:Property Name="Direction" Value="In" />
+                </om:Element>
+            </om:Element>
+        </om:Element>
+        <om:Element Type="ServiceDeclaration" OID="svc-001" LowerBound="14.1" HigherBound="32.1">
+            <om:Property Name="Name" Value="OrderProcessOrchestration" />
+            <om:Property Name="Signal" Value="False" />
+            <om:Element Type="MessageDeclaration" OID="msg-001" LowerBound="15.1" HigherBound="16.1">
+                <om:Property Name="Name" Value="OrderMsg" />
+                <om:Property Name="Type" Value="MyApp.Schemas.OrderSchema" />
+                <om:Property Name="Direction" Value="In" />
+            </om:Element>
+            <om:Element Type="MessageDeclaration" OID="msg-002" LowerBound="16.1" HigherBound="17.1">
+                <om:Property Name="Name" Value="InvoiceMsg" />
+                <om:Property Name="Type" Value="MyApp.Schemas.InvoiceSchema" />
+                <om:Property Name="Direction" Value="Out" />
+            </om:Element>
+            <om:Element Type="PortDeclaration" OID="port-001" LowerBound="17.1" HigherBound="18.1">
+                <om:Property Name="Name" Value="ReceivePort" />
+                <om:Property Name="PortType" Value="ReceivePortType" />
+                <om:Property Name="Direction" Value="Receive" />
+                <om:Property Name="Binding" Value="Physical" />
+                <om:Property Name="Adapter" Value="FILE" />
+                <om:Property Name="Address" Value="C:\Orders\In" />
+            </om:Element>
+            <om:Element Type="PortDeclaration" OID="port-002" LowerBound="18.1" HigherBound="19.1">
+                <om:Property Name="Name" Value="SendPort" />
+                <om:Property Name="PortType" Value="SendPortType" />
+                <om:Property Name="Direction" Value="Send" />
+                <om:Property Name="Binding" Value="Physical" />
+                <om:Property Name="Adapter" Value="SQL" />
+                <om:Property Name="Address" Value="mssql://localhost/InvoiceDB" />
+            </om:Element>
+            <om:Element Type="ServiceBody" OID="body-001" LowerBound="19.1" HigherBound="31.1">
+                <om:Element Type="Receive" OID="shape-001" LowerBound="20.1" HigherBound="21.1">
+                    <om:Property Name="Name" Value="ReceiveOrder" />
+                    <om:Property Name="Activate" Value="True" />
+                    <om:Property Name="PortName" Value="ReceivePort" />
+                    <om:Property Name="MessageName" Value="OrderMsg" />
+                    <om:Property Name="OperationName" Value="Operation_1" />
+                </om:Element>
+                <om:Element Type="Decide" OID="shape-002" LowerBound="21.1" HigherBound="27.1">
+                    <om:Property Name="Name" Value="CheckOrderType" />
+                    <om:Property Name="Expression" Value="OrderMsg(MyApp.Schemas.OrderSchema.OrderType) == &quot;Priority&quot;" />
+                </om:Element>
+                <om:Element Type="Construct" OID="shape-004" LowerBound="22.5" HigherBound="23.5">
+                    <om:Property Name="Name" Value="ConstructInvoice" />
+                    <om:Property Name="MessagesConstructed" Value="InvoiceMsg" />
+                    <om:Element Type="Transform" OID="shape-005" LowerBound="22.8" HigherBound="23.2">
+                        <om:Property Name="Name" Value="MapOrderToInvoice" />
+                        <om:Property Name="ClassName" Value="MyApp.Maps.OrderToInvoice" />
+                        <om:Property Name="InputMessages" Value="OrderMsg" />
+                        <om:Property Name="OutputMessages" Value="InvoiceMsg" />
+                    </om:Element>
+                </om:Element>
+                <om:Element Type="Send" OID="shape-008" LowerBound="27.1" HigherBound="28.1">
+                    <om:Property Name="Name" Value="SendInvoice" />
+                    <om:Property Name="PortName" Value="SendPort" />
+                    <om:Property Name="MessageName" Value="InvoiceMsg" />
+                    <om:Property Name="OperationName" Value="Operation_1" />
+                </om:Element>
+            </om:Element>
+        </om:Element>
+    </om:Element>
+</om:MetaModel>
+#endif
+__DESIGNER_DATA binary content follows...

--- a/examples/biztalk-order-processing/OrderSchema.xsd
+++ b/examples/biztalk-order-processing/OrderSchema.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:b="http://schemas.microsoft.com/BizTalk/2003"
+           targetNamespace="http://MyApp.Schemas.OrderSchema" xmlns:ns0="http://MyApp.Schemas.OrderSchema"
+           elementFormDefault="qualified">
+  <xs:element name="OrderSchema">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="OrderId" type="xs:string" />
+        <xs:element name="OrderType" type="xs:string" />
+        <xs:element name="FirstName" type="xs:string" />
+        <xs:element name="LastName" type="xs:string" />
+        <xs:element name="OrderDate" type="xs:string" />
+        <xs:element name="Quantity" type="xs:int" />
+        <xs:element name="UnitPrice" type="xs:decimal" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/examples/biztalk-order-processing/OrderToInvoice.btm
+++ b/examples/biztalk-order-processing/OrderToInvoice.btm
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mapsource Name="OrderToInvoice" BizTalkServerMapperTool_Version="3.0" Version="2" XRange="100" YRange="420">
+  <SrcTree RootNode_Name="OrderSchema" Schema="MyApp.Schemas.OrderSchema">
+    <SchemaReference Location="OrderSchema.xsd" xmlns:ns0="http://MyApp.Schemas.OrderSchema" />
+  </SrcTree>
+  <TrgTree RootNode_Name="InvoiceSchema" Schema="MyApp.Schemas.InvoiceSchema">
+    <SchemaReference Location="InvoiceSchema.xsd" xmlns:ns0="http://MyApp.Schemas.InvoiceSchema" />
+  </TrgTree>
+  <Functoid FunctoidID="1" Functoid-FID="107" X-Cell="50" Y-Cell="100" FunctoidType="String">
+    <Input-Parameters>
+      <Parameter Type="link" Value="0" LinkIndex="0" />
+      <Parameter Type="constant" Value=" - " />
+      <Parameter Type="link" Value="1" LinkIndex="1" />
+    </Input-Parameters>
+  </Functoid>
+  <Functoid FunctoidID="2" Functoid-FID="260" X-Cell="50" Y-Cell="200" FunctoidType="Scripting">
+    <Input-Parameters>
+      <Parameter Type="link" Value="2" LinkIndex="0" />
+    </Input-Parameters>
+    <ScripterCode Language="CSharp">
+      <![CDATA[
+public string FormatDate(string input) {
+    return DateTime.Parse(input).ToString("yyyy-MM-dd");
+}
+      ]]>
+    </ScripterCode>
+  </Functoid>
+  <Functoid FunctoidID="3" Functoid-FID="111" X-Cell="50" Y-Cell="300" FunctoidType="Math">
+    <Input-Parameters>
+      <Parameter Type="link" Value="3" LinkIndex="0" />
+      <Parameter Type="link" Value="4" LinkIndex="1" />
+    </Input-Parameters>
+  </Functoid>
+  <Link LinkID="0" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='FirstName']" LinkTo="1" />
+  <Link LinkID="1" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='LastName']" LinkTo="1" />
+  <Link LinkID="5" LinkFrom="1" LinkTo="/*[local-name()='InvoiceSchema']/*[local-name()='CustomerName']" IsFromFunctoid="true" />
+  <Link LinkID="6" LinkFrom="2" LinkTo="/*[local-name()='InvoiceSchema']/*[local-name()='InvoiceDate']" IsFromFunctoid="true" />
+  <Link LinkID="7" LinkFrom="3" LinkTo="/*[local-name()='InvoiceSchema']/*[local-name()='TotalAmount']" IsFromFunctoid="true" />
+</mapsource>

--- a/examples/biztalk-order-processing/OrderToInvoice.btm
+++ b/examples/biztalk-order-processing/OrderToInvoice.btm
@@ -33,6 +33,9 @@ public string FormatDate(string input) {
   </Functoid>
   <Link LinkID="0" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='FirstName']" LinkTo="1" />
   <Link LinkID="1" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='LastName']" LinkTo="1" />
+  <Link LinkID="2" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='OrderDate']" LinkTo="2" />
+  <Link LinkID="3" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='Quantity']" LinkTo="3" />
+  <Link LinkID="4" LinkFrom="/*[local-name()='OrderSchema']/*[local-name()='UnitPrice']" LinkTo="3" />
   <Link LinkID="5" LinkFrom="1" LinkTo="/*[local-name()='InvoiceSchema']/*[local-name()='CustomerName']" IsFromFunctoid="true" />
   <Link LinkID="6" LinkFrom="2" LinkTo="/*[local-name()='InvoiceSchema']/*[local-name()='InvoiceDate']" IsFromFunctoid="true" />
   <Link LinkID="7" LinkFrom="3" LinkTo="/*[local-name()='InvoiceSchema']/*[local-name()='TotalAmount']" IsFromFunctoid="true" />

--- a/examples/biztalk-order-processing/PortBindings.xml
+++ b/examples/biztalk-order-processing/PortBindings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BindingInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Assembly="MyApp, Version=1.0.0.0" Version="2.0" BindingStatus="FullyBound" xmlns="http://schemas.microsoft.com/BizTalk/2003">
+  <ReceivePortCollection>
+    <ReceivePort Name="ReceivePort_Orders" IsTwoWay="false">
+      <ReceiveLocations>
+        <ReceiveLocation Name="ReceiveLocation_FileOrders">
+          <Address>C:\Orders\In\*.xml</Address>
+          <ReceivePipeline Name="MyApp.Pipelines.XMLReceive" />
+          <TransportType Name="FILE" />
+          <PollingInterval>60</PollingInterval>
+        </ReceiveLocation>
+      </ReceiveLocations>
+    </ReceivePort>
+  </ReceivePortCollection>
+  <SendPortCollection>
+    <SendPort Name="SendPort_Invoices" IsStatic="true" IsTwoWay="false">
+      <Address>mssql://localhost/InvoiceDB</Address>
+      <SendPipeline Name="Microsoft.BizTalk.DefaultPipelines.PassThruTransmit" />
+      <TransportType Name="SQL" />
+    </SendPort>
+  </SendPortCollection>
+</BindingInfo>

--- a/examples/biztalk-order-processing/README.md
+++ b/examples/biztalk-order-processing/README.md
@@ -1,0 +1,81 @@
+# BizTalk Order Processing - Migration Example
+
+This directory contains a sample Microsoft BizTalk Server integration project for testing Camel Kit's BizTalk migration capabilities.
+
+## What's Included
+
+This example demonstrates a typical BizTalk order processing flow:
+
+1. **OrderProcess.odx** - BizTalk Orchestration that:
+   - Receives order messages from a FILE adapter
+   - Checks the order type (Priority vs. Standard)
+   - Transforms orders to invoices using a BizTalk map
+   - Sends invoices to a SQL database
+
+2. **OrderToInvoice.btm** - BizTalk Map with functoids:
+   - String Concatenate functoid (FirstName + LastName -> CustomerName)
+   - Scripting functoid (C# date formatting)
+   - Math functoid (quantity * unit price -> total amount)
+
+3. **XMLReceive.btp** - Receive Pipeline with:
+   - XML Disassembler component (with validation enabled)
+   - XML Validator component
+
+4. **PortBindings.xml** - Binding configuration for:
+   - FILE receive location (polling C:\Orders\In)
+   - SQL send port (connecting to InvoiceDB)
+
+5. **OrderSchema.xsd** - XML Schema defining order message structure
+
+## How to Run Migration
+
+From the camel-kit repository root:
+
+```bash
+# Initialize migration project with BizTalk source platform
+camel-kit init biztalk-order-processing --ai claude --source-platform biztalk
+
+# Navigate to the initialized project
+cd biztalk-order-processing
+
+# Copy this example's BizTalk files into the project
+cp ../examples/biztalk-order-processing/*.{odx,btm,btp,xml,xsd} .
+
+# Start the migration skill
+/camel-migrate
+```
+
+The `/camel-migrate` skill will:
+1. Detect the BizTalk project artifacts (orchestrations, maps, pipelines, bindings)
+2. Build a dependency graph using BizTalkParser
+3. Guide you through the migration phases:
+   - Phase 1: Generate Camel route structure from orchestrations
+   - Phase 2: Convert BizTalk maps to XSLT or DataWeave
+   - Phase 3: Map BizTalk adapters to Camel components
+   - Phase 4: Translate expressions and pipeline logic
+
+## Expected Output
+
+See the `expected-output/` directory for examples of what the migration produces. The migration should generate:
+
+- **Camel YAML routes** - One route per orchestration service
+- **application.properties** - Camel component configurations (file polling, SQL connection)
+- **XSLT/DataWeave transformations** - Converted from BTM functoid graphs
+- **Validation logic** - Converted from BTP pipeline components
+- **Migration notes** - Documenting manual review items and unsupported features
+
+## BizTalk Features Demonstrated
+
+This example covers common BizTalk patterns:
+- **Orchestration Shapes**: Receive (activate), Decide, Construct, Transform, Send
+- **Port Types**: One-way operations, physical bindings
+- **Adapters**: FILE (polling), SQL (database insert)
+- **Maps**: Functoids (String Concatenate, Scripting, Math), XPath links
+- **Pipelines**: XML disassembly, validation stages
+- **Bindings**: Receive locations, send ports, adapter configurations
+
+## References
+
+- [Camel Kit BizTalk Migration Guide](../../docs/architecture.md#biztalk-parser-architecture)
+- [BizTalk Component Mapping Reference](../../.claude/skills/camel-migrate/guides/biztalk-component-mapping.md)
+- [Apache Camel Documentation](https://camel.apache.org/)

--- a/examples/biztalk-order-processing/XMLReceive.btp
+++ b/examples/biztalk-order-processing/XMLReceive.btp
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyFilePath="BTSReceivePolicy.xml" MajorVersion="1" MinorVersion="0">
+  <Description>XML Receive Pipeline</Description>
+  <CategoryId>f66b9f5e-43ff-4f5f-ba46-885348ae1b4e</CategoryId>
+  <FriendlyName>XMLReceive</FriendlyName>
+  <Stages>
+    <Stage CategoryId="9d0e4103-4cce-4536-83fa-4a5040674ad6" ExecutionMode="All">
+      <Components>
+        <Component Name="Microsoft.BizTalk.Component.XmlDasmComp" ComponentName="XML disassembler" Version="1.0" Description="Streaming XML disassembler">
+          <Properties>
+            <Property Name="ValidateDocument">
+              <Value xsi:type="xsd:string">True</Value>
+            </Property>
+          </Properties>
+        </Component>
+      </Components>
+    </Stage>
+    <Stage CategoryId="9d0e4107-4cce-4536-83fa-4a5040674ad6" ExecutionMode="All">
+      <Components>
+        <Component Name="Microsoft.BizTalk.Component.XmlValidator" ComponentName="XML validator" Version="1.0" Description="XML validator component">
+          <Properties />
+        </Component>
+      </Components>
+    </Stage>
+  </Stages>
+</Document>

--- a/examples/biztalk-order-processing/expected-output/README.md
+++ b/examples/biztalk-order-processing/expected-output/README.md
@@ -26,8 +26,8 @@ This directory describes the expected output when migrating the BizTalk order pr
               - expression:
                   simple: "${body.orderType} == 'Priority'"
                 steps:
-                  - to: "xslt:OrderToInvoice.xslt"
-                  - to: "sql:insert-invoice"
+                  - to: "xslt-saxon:OrderToInvoice.xslt"
+                  - to: "sql:{{sql.insert-invoice}}"
             otherwise:
               steps:
                 - log: "Standard order - no invoice generated"
@@ -62,6 +62,7 @@ sql.insert-invoice=INSERT INTO Invoices (CustomerName, InvoiceDate, TotalAmount)
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:order="http://MyApp.Schemas.OrderSchema"
                 xmlns:invoice="http://MyApp.Schemas.InvoiceSchema">
   
@@ -111,16 +112,16 @@ sql.insert-invoice=INSERT INTO Invoices (CustomerName, InvoiceDate, TotalAmount)
     <artifactId>camel-sql-starter</artifactId>
   </dependency>
   
-  <!-- XSLT component (from Transform shape) -->
+  <!-- XSLT Saxon component (from Transform shape — XSLT 2.0) -->
   <dependency>
     <groupId>org.apache.camel.springboot</groupId>
-    <artifactId>camel-xslt-starter</artifactId>
+    <artifactId>camel-xslt-saxon-starter</artifactId>
   </dependency>
   
-  <!-- Bean Validation (from XMLReceive.btp) -->
+  <!-- XML Validator (from XMLReceive.btp pipeline) -->
   <dependency>
     <groupId>org.apache.camel.springboot</groupId>
-    <artifactId>camel-bean-validator-starter</artifactId>
+    <artifactId>camel-xml-jaxp-starter</artifactId>
   </dependency>
   
   <!-- SQL Server JDBC driver -->
@@ -191,8 +192,8 @@ The migration requires these Camel components (detected from BizTalk adapter typ
 
 - `camel-file` - FILE adapter replacement
 - `camel-sql` - SQL adapter replacement  
-- `camel-xslt` - BizTalk map transformation
-- `camel-bean-validator` - Pipeline validation stage
+- `camel-xslt-saxon` - BizTalk map transformation (XSLT 2.0)
+- `camel-xml-jaxp` - XML validator for pipeline validation stage
 
 ## Configuration Externalization
 

--- a/examples/biztalk-order-processing/expected-output/README.md
+++ b/examples/biztalk-order-processing/expected-output/README.md
@@ -1,0 +1,199 @@
+# Expected Migration Output
+
+This directory describes the expected output when migrating the BizTalk order processing example to Apache Camel.
+
+## Generated Files
+
+### 1. Camel YAML Routes
+
+**order-process-orchestration.camel.yaml**
+
+```yaml
+- route:
+    id: OrderProcessOrchestration
+    from:
+      uri: "file:{{orders.input.directory}}"
+      parameters:
+        fileName: "*.xml"
+        delay: "{{orders.polling.interval}}"
+      steps:
+        - unmarshal:
+            jaxb:
+              contextPath: "com.myapp.schemas"
+        - to: "validator:OrderSchema.xsd"
+        - choice:
+            when:
+              - expression:
+                  simple: "${body.orderType} == 'Priority'"
+                steps:
+                  - to: "xslt:OrderToInvoice.xslt"
+                  - to: "sql:insert-invoice"
+            otherwise:
+              steps:
+                - log: "Standard order - no invoice generated"
+```
+
+### 2. Application Properties
+
+**application.properties**
+
+```properties
+# File adapter configuration (from PortBindings.xml)
+orders.input.directory=/opt/camel/orders/in
+orders.polling.interval=60000
+
+# SQL adapter configuration (from PortBindings.xml)
+camel.component.sql.data-source=#bean:invoiceDataSource
+
+# DataSource configuration (from binding Address)
+spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=InvoiceDB
+spring.datasource.username=sa
+spring.datasource.password=${SQL_PASSWORD}
+spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
+
+# SQL query (from orchestration Send port)
+sql.insert-invoice=INSERT INTO Invoices (CustomerName, InvoiceDate, TotalAmount) VALUES (:#customerName, :#invoiceDate, :#totalAmount)
+```
+
+### 3. XSLT Transformation (from BTM)
+
+**OrderToInvoice.xslt**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:order="http://MyApp.Schemas.OrderSchema"
+                xmlns:invoice="http://MyApp.Schemas.InvoiceSchema">
+  
+  <xsl:template match="/order:OrderSchema">
+    <invoice:InvoiceSchema>
+      <!-- String Concatenate functoid: FirstName + " - " + LastName -->
+      <invoice:CustomerName>
+        <xsl:value-of select="concat(order:FirstName, ' - ', order:LastName)"/>
+      </invoice:CustomerName>
+      
+      <!-- Scripting functoid: C# DateTime.Parse -> yyyy-MM-dd -->
+      <invoice:InvoiceDate>
+        <xsl:value-of select="format-date(xs:date(order:OrderDate), '[Y0001]-[M01]-[D01]')"/>
+      </invoice:InvoiceDate>
+      
+      <!-- Math functoid: Quantity * UnitPrice -->
+      <invoice:TotalAmount>
+        <xsl:value-of select="order:Quantity * order:UnitPrice"/>
+      </invoice:TotalAmount>
+    </invoice:InvoiceSchema>
+  </xsl:template>
+  
+</xsl:stylesheet>
+```
+
+### 4. Maven/Gradle Dependencies
+
+**pom.xml additions**
+
+```xml
+<dependencies>
+  <!-- Camel Core + Spring Boot -->
+  <dependency>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>camel-spring-boot-starter</artifactId>
+  </dependency>
+  
+  <!-- File component (from FILE adapter) -->
+  <dependency>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>camel-file-starter</artifactId>
+  </dependency>
+  
+  <!-- SQL component (from SQL adapter) -->
+  <dependency>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>camel-sql-starter</artifactId>
+  </dependency>
+  
+  <!-- XSLT component (from Transform shape) -->
+  <dependency>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>camel-xslt-starter</artifactId>
+  </dependency>
+  
+  <!-- Bean Validation (from XMLReceive.btp) -->
+  <dependency>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>camel-bean-validator-starter</artifactId>
+  </dependency>
+  
+  <!-- SQL Server JDBC driver -->
+  <dependency>
+    <groupId>com.microsoft.sqlserver</groupId>
+    <artifactId>mssql-jdbc</artifactId>
+  </dependency>
+</dependencies>
+```
+
+### 5. Migration Notes
+
+**migration-notes.md**
+
+```markdown
+# BizTalk to Camel Migration Notes
+
+## Successfully Migrated
+
+- Orchestration flow structure (Receive -> Decide -> Construct/Transform -> Send)
+- FILE adapter polling configuration
+- SQL adapter endpoint configuration
+- BizTalk Map functoids converted to XSLT 2.0
+- XML validation pipeline stage
+
+## Manual Review Required
+
+1. **SQL INSERT statement** - Verify column mappings match target database schema
+2. **Date format conversion** - BizTalk C# DateTime.Parse vs XSLT format-date() may differ for edge cases
+3. **Error handling** - BizTalk compensation/exception handlers not present in this example
+4. **Transaction management** - BizTalk orchestration transactions need explicit Camel error handler configuration
+
+## BizTalk Features Not Present in Example
+
+- Long-running orchestration (persistence/dehydration)
+- Correlation sets
+- Parallel convoy patterns
+- BAM tracking points
+- Business rules engine integration
+
+## Testing Recommendations
+
+1. Unit test the XSLT transformation with sample order XML files
+2. Integration test with a test SQL database
+3. Compare output invoice XML with BizTalk orchestration output
+4. Validate performance under expected file polling load
+```
+
+## Mapping Summary
+
+| BizTalk Artifact | Camel Equivalent | Notes |
+|-----------------|------------------|-------|
+| Orchestration Service | Camel Route | One route per orchestration |
+| Receive Shape (activate) | `from` endpoint | FILE component with polling |
+| Decide Shape | `choice` / `when` | Simple expression language |
+| Construct + Transform | `to` XSLT endpoint | BTM map -> XSLT conversion |
+| Send Shape | `to` endpoint | SQL component with named query |
+| FILE Adapter | `camel-file` | Polling interval from bindings |
+| SQL Adapter | `camel-sql` | DataSource from binding address |
+| XMLReceive Pipeline | `unmarshal` + `validator` | JAXB + Bean Validator |
+| String Concatenate Functoid | `concat()` XSLT function | Direct translation |
+| Scripting Functoid (C#) | XSLT 2.0 function | Manual conversion required |
+| Math Functoid | XPath arithmetic | Direct translation |
+
+## Component Dependencies
+
+The migration requires these Camel components (detected from BizTalk adapter types):
+
+- `camel-file` - FILE adapter replacement
+- `camel-sql` - SQL adapter replacement  
+- `camel-xslt` - BizTalk map transformation
+- `camel-bean-validator` - Pipeline validation stage
+
+## Configuration Externalization
+
+All environment-specific values (file paths, database URLs, credentials) are externalized to `application.properties` with placeholders for deployment-time configuration.


### PR DESCRIPTION
## Summary

- Add BizTalk migration example in `examples/biztalk-order-processing/` with sample ODX, BTM, BTP, binding, and XSD files plus expected migration output documentation
- Update CHANGELOG.md `[Unreleased]` section with BizTalk migration entries (parser, shape types, functoid mappings, skill guides, UTF-16 detection, atomic mutations)
- Document BizTalkMigrationStarter reference project in `docs/architecture.md`

## Test plan

- [x] Verify example files are valid BizTalk artifacts (parseable by BizTalkParser)
- [x] Verify CHANGELOG entries are under the correct section
- [x] Verify architecture doc reference paragraph is in the right location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added BizTalk Server as a supported migration source platform via the `--source-platform biztalk` CLI option.
  * Introduced a comprehensive BizTalk order-processing example demonstrating orchestration, mapping, and pipeline migration to Apache Camel.

* **Documentation**
  * Added architecture documentation describing BizTalk parsing implementation patterns.
  * Added example README and expected output specification guiding BizTalk migration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->