### PR TITLE
fix #23: agent traits system — build-time append of agent-specific capability instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,13 @@ camel-kit/
 │           ├── claude/          # Anthropic Claude Code
 │           ├── gemini/          # Google Gemini CLI
 │           ├── qwen/            # Qwen
-│           └── opencode/        # OpenCode
+n│           ├── opencode/        # OpenCode
+│           └── traits/          # Agent-specific trait files (appended to skills at init)
+│               ├── claude/      # Claude Code traits
+│               ├── gemini/      # Gemini CLI traits
+│               ├── bob/         # IBM Bob traits
+│               ├── qwen/        # Qwen traits
+│               └── opencode/    # OpenCode traits
 ├── camel-jbang-plugin-kit/      # Camel JBang plugin
 ├── camel-kit-graph/             # Project graph analysis (9 parsers)
 │   │   # Parsers: JavaClassParser, CamelRouteParser, MavenPomParser,
@@ -371,6 +377,21 @@ Each guide in `guides/` is a self-contained markdown file loaded by the agent wh
 - Update `docs/commands.md` if user-invocable
 
 See [Architecture Guide](docs/architecture.md#9-how-to-add-a-skill) for the full process.
+
+### 5. Add Agent Traits (Optional)
+
+If the skill benefits from agent-specific optimizations (parallel dispatch, tool-specific guidance, state management), add trait files:
+
+```
+templates/traits/{agent}/{skill-name}.append.md          # SKILL.md-level trait
+templates/traits/{agent}/{skill-name}/{guide-name}.append.md  # Guide-level trait
+```
+
+Traits are appended to the corresponding skill files during `camel-kit init` with idempotent sentinels. Each trait should contain instructions specific to that agent's tools and capabilities — not generic content that belongs in the shared skill.
+
+To register a new SKILL.md-level trait, add the skill name to the `skillNames` list in `DefaultGenerator.applyTraits()`. For guide-level traits, add the guide name to the `guideNames` list in `DefaultGenerator.applyGuideTraits()`.
+
+See [Architecture Guide](docs/architecture.md#agent-traits) for details on the trait system.
 
 ## Release Process
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/ClaudeGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/ClaudeGenerator.java
@@ -13,16 +13,8 @@ public class ClaudeGenerator extends DefaultGenerator {
 
     @Override
     public void generate(InitContext ctx) throws Exception {
-        // Run all default generation (commands, skills, MCP config)
         super.generate(ctx);
-
-        // Claude-specific: generate CLAUDE.md at project root
         generateClaudeMd(ctx);
-
-        // Claude-specific: append parallel dispatch to camel-implement skill
-        appendParallelDispatch(ctx);
-
-        // Claude-specific: generate .claude/settings.json with permissions
         generateSettings(ctx);
     }
 
@@ -32,17 +24,6 @@ public class ClaudeGenerator extends DefaultGenerator {
                         "COMMAND_PREFIX", ctx.commandPrefix()));
         String content = templateEngine.render("templates/claude/claude-md.md", data);
         Files.writeString(ctx.projectDir().resolve("CLAUDE.md"), content);
-    }
-
-    private void appendParallelDispatch(InitContext ctx) throws Exception {
-        Path implementSkill = ctx.skillsDir().resolve("camel-implement/SKILL.md");
-        if (Files.exists(implementSkill)) {
-            Map<String, Object> data = Map.of("COMMAND_PREFIX", ctx.commandPrefix());
-            String parallelBlock = templateEngine.render(
-                    "templates/claude/dispatch-parallel.md", data);
-            String existing = Files.readString(implementSkill);
-            Files.writeString(implementSkill, existing + "\n---\n\n" + parallelBlock);
-        }
     }
 
     private void generateSettings(InitContext ctx) throws Exception {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -314,7 +314,7 @@ public class DefaultGenerator implements AgentGenerator {
         }
     }
 
-    private int applyGuideTraits(String traitDirPath, Path guidesDir, String agentName) {
+    private int applyGuideTraits(String traitDirPath, Path guidesDir, String agentName) throws Exception {
         int count = 0;
         List<String> guideNames = List.of(
                 "implementer-context", "spec-reviewer-criteria",
@@ -324,12 +324,8 @@ public class DefaultGenerator implements AgentGenerator {
         for (String guideName : guideNames) {
             String traitResourcePath = traitDirPath + guideName + ".append.md";
             Path targetGuide = guidesDir.resolve(guideName + ".md");
-            try {
-                if (appendTraitIfExists(traitResourcePath, targetGuide, agentName)) {
-                    count++;
-                }
-            } catch (Exception e) {
-                // Guide trait not found or target doesn't exist
+            if (appendTraitIfExists(traitResourcePath, targetGuide, agentName)) {
+                count++;
             }
         }
         return count;

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -27,6 +27,7 @@ public class DefaultGenerator implements AgentGenerator {
         generateAgentsMd(ctx);
         createCommandTemplates(ctx);
         copySkills(ctx);
+        applyTraits(ctx);
         createMcpConfigs(ctx);
     }
 
@@ -283,6 +284,78 @@ public class DefaultGenerator implements AgentGenerator {
         } catch (Exception e) {
             ctx.printer().println(AnsiColors.yellow("  Warning: Could not create MCP config: " + e.getMessage()));
         }
+    }
+
+    private void applyTraits(InitContext ctx) throws Exception {
+        String traitsBasePath = "templates/traits/" + ctx.agentName() + "/";
+        int traitCount = 0;
+
+        List<String> skillNames = List.of(
+                "camel-brainstorm", "camel-execute", "camel-implement", "camel-verify",
+                "camel-validate", "camel-test", "camel-plan", "camel-ship",
+                "camel-migrate", "camel-knowledge", "camel-flow");
+
+        for (String skillName : skillNames) {
+            String traitResourcePath = traitsBasePath + skillName + ".append.md";
+            Path targetSkillMd = ctx.skillsDir().resolve(skillName + "/SKILL.md");
+            if (appendTraitIfExists(traitResourcePath, targetSkillMd, ctx.agentName())) {
+                traitCount++;
+            }
+
+            traitCount += applyGuideTraits(
+                    traitsBasePath + skillName + "/",
+                    ctx.skillsDir().resolve(skillName + "/guides/"),
+                    ctx.agentName());
+        }
+
+        if (traitCount > 0) {
+            ctx.printer().println(AnsiColors.green("✓") + " Applied " + traitCount
+                                  + " agent traits for " + ctx.agentName());
+        }
+    }
+
+    private int applyGuideTraits(String traitDirPath, Path guidesDir, String agentName) {
+        int count = 0;
+        List<String> guideNames = List.of(
+                "implementer-context", "spec-reviewer-criteria",
+                "quality-reviewer-criteria", "verify-loop",
+                "test-generation", "test-runner");
+
+        for (String guideName : guideNames) {
+            String traitResourcePath = traitDirPath + guideName + ".append.md";
+            Path targetGuide = guidesDir.resolve(guideName + ".md");
+            try {
+                if (appendTraitIfExists(traitResourcePath, targetGuide, agentName)) {
+                    count++;
+                }
+            } catch (Exception e) {
+                // Guide trait not found or target doesn't exist
+            }
+        }
+        return count;
+    }
+
+    private boolean appendTraitIfExists(String traitResourcePath, Path targetFile, String agentName) throws Exception {
+        if (!Files.exists(targetFile)) {
+            return false;
+        }
+        String traitContent;
+        try {
+            traitContent = TemplateUtils.readTemplate(traitResourcePath);
+        } catch (IOException e) {
+            return false;
+        }
+
+        String sentinel = "<!-- TRAIT:" + agentName + " -->";
+        String existing = Files.readString(targetFile);
+        if (existing.contains(sentinel)) {
+            return false;
+        }
+
+        String closeSentinel = "<!-- /TRAIT:" + agentName + " -->";
+        Files.writeString(targetFile,
+                existing + "\n---\n\n" + sentinel + "\n" + traitContent + "\n" + closeSentinel + "\n");
+        return true;
     }
 
     protected void copyTemplateResource(String resourcePath, Path target) throws IOException {

--- a/camel-kit-core/src/main/resources/templates/gemini/agents/camel-brainstormer.md
+++ b/camel-kit-core/src/main/resources/templates/gemini/agents/camel-brainstormer.md
@@ -3,7 +3,7 @@ name: camel-brainstormer
 tools:
   - read_file
   - glob
-  - grep
+  - grep_search
   - mcp_camel_*
 max_turns: 20
 timeout_mins: 10

--- a/camel-kit-core/src/main/resources/templates/gemini/agents/camel-planner.md
+++ b/camel-kit-core/src/main/resources/templates/gemini/agents/camel-planner.md
@@ -3,7 +3,7 @@ name: camel-planner
 tools:
   - read_file
   - glob
-  - grep
+  - grep_search
   - mcp_camel_*
 max_turns: 25
 timeout_mins: 10

--- a/camel-kit-core/src/main/resources/templates/gemini/agents/camel-tester.md
+++ b/camel-kit-core/src/main/resources/templates/gemini/agents/camel-tester.md
@@ -3,9 +3,9 @@ name: camel-tester
 tools:
   - read_file
   - write_file
-  - edit
+  - replace
   - glob
-  - grep
+  - grep_search
   - run_shell_command
   - mcp_camel_*
 max_turns: 30

--- a/camel-kit-core/src/main/resources/templates/gemini/agents/camel-validator.md
+++ b/camel-kit-core/src/main/resources/templates/gemini/agents/camel-validator.md
@@ -3,11 +3,11 @@ name: camel-validator
 tools:
   - read_file
   - glob
-  - grep
+  - grep_search
   - run_shell_command
   - mcp_camel_*
 max_turns: 20
-timeout_mins: 10
+timeout_mins: 20
 ---
 
 You are a Camel integration validator. Read .gemini/skills/camel-validate/SKILL.md and follow those instructions exactly.

--- a/camel-kit-core/src/main/resources/templates/traits/bob/camel-brainstorm.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob/camel-brainstorm.append.md
@@ -1,0 +1,25 @@
+## Agent Optimization: IBM Bob
+
+### Mode-Based Interview Phases
+
+Use `switch_mode` to transition between structured interview phases:
+
+- Start in current mode for discovery
+- Switch to "camel-brainstorm" custom mode for the design interview (this loads interview-specific gates and rules)
+- The mode provides automatic gate validation — interview gates prevent advancing past incomplete phases
+
+### Codebase Analysis for Migrations
+
+When the user is migrating from an existing integration platform, use `list_code_definition_names` to scan the source project:
+
+- This identifies classes, methods, and entry points in the existing codebase
+- Use the results to inform component mapping decisions during the design interview
+- Especially valuable for MuleSoft and BizTalk migrations where code structure reveals integration patterns
+
+### Browser-Based UI Validation
+
+If the integration involves web UI components (REST API consumers, webhook endpoints), use the browser tool group to validate:
+
+- Test webhook URLs are accessible
+- Verify REST API endpoint responses match expected schemas
+- Screenshot UI dashboards that the integration needs to interact with

--- a/camel-kit-core/src/main/resources/templates/traits/bob/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob/camel-execute.append.md
@@ -1,0 +1,27 @@
+## Agent Optimization: IBM Bob
+
+### Mode-Based Execution
+
+Use `switch_mode` to transition to "camel-implement" custom mode before dispatching implementation tasks. This mode loads:
+
+- Implementation-specific rules from `rules-camel-implement/implementation.md`
+- Implementation gate from `gates/camel-implement.md`
+- The gate validates that each implementation task meets quality criteria before marking complete
+
+### Gate Validation Before Phase Transitions
+
+Before transitioning from implementation to review, the gate file (`gates/camel-execute.md`) automatically validates:
+
+- All tasks in the plan are addressed
+- Generated files exist at expected paths
+- No YAML syntax errors in generated routes
+
+Let the gate system handle validation rather than implementing manual checks.
+
+### Precise Code Insertion
+
+Use `insert_content` instead of full file writes when adding code to existing files:
+
+- For `application.properties`: insert new properties at the end without rewriting the file
+- For `pom.xml`: insert dependency blocks at the correct position
+- This prevents accidentally overwriting user-added content in existing files

--- a/camel-kit-core/src/main/resources/templates/traits/bob/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob/camel-execute/implementer-context.append.md
@@ -1,0 +1,13 @@
+## Agent Optimization: IBM Bob
+
+### Precise Code Placement
+
+When generating implementation artifacts, instruct the implementer to use `insert_content` for additive changes:
+
+- Properties files: insert at end rather than rewriting
+- POM files: insert dependencies at the correct `<dependencies>` location
+- This preserves any existing user content that the implementer should not modify
+
+### Mode Context
+
+Instruct the implementer to check the current mode rules (`rules-camel-implement/implementation.md`) before generating code. The rules contain project-specific constraints loaded by the mode system.

--- a/camel-kit-core/src/main/resources/templates/traits/bob/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob/camel-ship.append.md
@@ -1,0 +1,20 @@
+## Agent Optimization: IBM Bob
+
+### Mode-Based Pipeline
+
+Chain the pipeline using Bob's mode system:
+
+- Stage 0 (Brainstorm): `switch_mode` to "camel-brainstorm" — interview gates control progress
+- Stage 1 (Plan): `switch_mode` to "camel-plan" — plan structure gates validate completeness
+- Stage 2 (Execute): `switch_mode` to "camel-implement" — implementation gates validate quality
+- Stage 3 (Verify): `switch_mode` to "camel-validate" — validation gates check all criteria
+
+### Gate-Based Oversight
+
+Bob's existing gate system maps directly to the `--ask` oversight levels:
+
+- `always`: gates pause and require explicit approval at every checkpoint
+- `smart`: gates auto-approve when all criteria pass, pause when any criterion is ambiguous
+- `never`: gates log results but don't block — pipeline continues unless a gate reports a blocker
+
+The gate files in `.bob/gates/` already define per-skill validation criteria. The ship command leverages them rather than implementing a separate oversight mechanism.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-brainstorm.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-brainstorm.append.md
@@ -1,0 +1,18 @@
+## Agent Optimization: Claude Code
+
+### Structured Design Interviews
+
+Use `AskUserQuestion` with structured multiple-choice options for design decisions. Structure each question with:
+- `header`: Short label (max 12 chars) for the decision category
+- `options`: 2-4 concrete choices with descriptions
+- `preview`: Use preview fields for side-by-side comparison of architecture options
+
+This produces cleaner interview transcripts than open-ended text prompts.
+
+### Pattern Research
+
+Use `WebSearch` to research integration patterns when the user describes unfamiliar source/target systems. Use `WebFetch` to retrieve API documentation URLs the user provides.
+
+### Interview Progress Tracking
+
+Use `TaskCreate` to create a task for each interview phase (discovery, component selection, design assembly). Mark each as `in_progress` when entering the phase and `completed` when exiting. This gives the user visible progress.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
@@ -1,0 +1,35 @@
+## Agent Optimization: Claude Code
+
+### Parallel Task Dispatch
+
+Use the `Agent` tool with `run_in_background: true` for independent implementation tasks within the same wave. When `{COMMAND_PREFIX} plan analyze` identifies parallel waves, dispatch all tasks in a wave simultaneously:
+
+- Set `description` to a 3-5 word summary of the task
+- Include the full task text, design spec context, and project config in the `prompt`
+- Use `run_in_background: true` for all tasks in a wave except the last one
+- Wait for all background agents to complete before proceeding to the next wave
+
+### Worktree Isolation
+
+Before dispatching implementation tasks, use `EnterWorktree` to create an isolated copy of the project:
+
+- This prevents parallel subagents from conflicting on file writes
+- Use `ExitWorktree` with `action: "keep"` after all tasks complete so the user can review
+- Only use worktrees when dispatching 2+ parallel tasks — single-task waves don't need isolation
+
+### Scheduled Build Verification
+
+For long implementation sessions (3+ tasks), use `CronCreate` to schedule a periodic build check:
+
+- Schedule `{COMMAND_PREFIX} verify --quick` every 15 minutes during execution
+- This catches regressions early, before the full verification phase
+- Delete the cron job (`CronDelete`) when execution completes
+
+### State Tracking
+
+Use Claude Code's task tracking tools for real-time progress visibility:
+
+- `TaskCreate` for each implementation task at the start of execution
+- `TaskUpdate` to mark tasks `in_progress` when the implementer subagent is dispatched
+- `TaskUpdate` to mark tasks `completed` after both review stages pass
+- `TaskList` to report progress after each wave completes

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/implementer-context.append.md
@@ -1,0 +1,14 @@
+## Agent Optimization: Claude Code
+
+When constructing the implementer subagent prompt, leverage Claude Code-specific features:
+
+### Background Dispatch
+
+Set `run_in_background: true` in the Agent tool call when this task is part of a parallel wave. This allows the orchestrator to dispatch the next independent task without waiting.
+
+### NotebookEdit for Data Transforms
+
+If the task involves data transformation (DataMapper, XSLT, Groovy), instruct the subagent to also create a test notebook:
+
+- Add to the prompt: "After generating the transformation code, create a Jupyter notebook at `test/{flow-name}-transform-test.ipynb` with cells that execute the transformation on sample data and verify output."
+- The subagent can use `NotebookEdit` to create and populate the notebook cells.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/spec-reviewer-criteria.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/spec-reviewer-criteria.append.md
@@ -1,0 +1,7 @@
+## Agent Optimization: Claude Code
+
+### Typed Review Dispatch
+
+When dispatching the spec-compliance reviewer subagent, use the `Agent` tool with `subagent_type: "superpowers:code-reviewer"` if available. This gives the reviewer access to code-review-specific tools and prompts.
+
+If `subagent_type` is not recognized (the reviewer is a general agent), fall back to the standard dispatch with a detailed review-focused prompt.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-implement.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-implement.append.md
@@ -1,0 +1,14 @@
+## Parallel Route Implementation
+
+When implementing multiple routes, check route independence before dispatching:
+
+1. Run `{COMMAND_PREFIX} graph route-topology` to get route connections
+2. Identify routes with no shared endpoints or upstream/downstream dependencies
+3. For independent routes: dispatch parallel subagents using the Agent tool — one subagent per route
+4. For dependent routes: dispatch sequentially in dependency order
+
+Example: If route-A produces to kafka topic-X and route-B consumes from kafka topic-X (dependent),
+but route-C uses only timer+http (independent of A and B), dispatch route-C in parallel with
+the sequential A→B chain.
+
+Only parallelize when the graph confirms independence. When in doubt, dispatch sequentially.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-ship.append.md
@@ -1,0 +1,34 @@
+## Agent Optimization: Claude Code
+
+### Worktree Isolation
+
+At the start of the ship pipeline, use `EnterWorktree` to isolate all generated artifacts:
+
+- Create the worktree before Stage 0 (Brainstorm)
+- All stages execute in the worktree
+- On successful completion, use `ExitWorktree` with `action: "keep"` so the user can review
+- On failure, report the worktree path so the user can inspect partial results
+
+### Build Health Monitoring
+
+Use `CronCreate` to schedule periodic build health checks during Stage 2 (Execute):
+
+- Schedule `mvn compile -q` every 10 minutes
+- If the build breaks, pause execution and report immediately (regardless of --ask level)
+- Delete the cron job after Stage 2 completes
+
+### Oversight via AskUserQuestion
+
+When the pipeline needs to pause for user input (based on --ask level), use `AskUserQuestion` with structured options:
+
+- For design spec approval: present summary with "Approve" / "Request changes" / "Abort pipeline" options
+- For plan approval: present task list with "Approve plan" / "Modify tasks" options
+- For execution failures: present the error with "Auto-fix" / "Manual fix" / "Skip task" / "Abort" options
+- Always include an "Abort pipeline" option — the user should be able to stop at any point
+
+### Smart Pacing with ScheduleWakeup
+
+During Stage 2 (Execute), use `ScheduleWakeup` for dynamic loop pacing:
+
+- After dispatching a wave of implementation tasks, use `ScheduleWakeup` with `delaySeconds: 270` (4.5 min, stays in cache)
+- Set `reason` to describe what you're waiting for: "waiting for implementation wave 2 (3 tasks) to complete"

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-test.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-test.append.md
@@ -1,0 +1,18 @@
+## Agent Optimization: Claude Code
+
+### Parallel Test Suite Dispatch
+
+Use the `Agent` tool to dispatch independent test generation tasks in parallel:
+
+- If the design spec has multiple flows, dispatch one test-generation subagent per flow
+- Use `run_in_background: true` for all but the last flow
+- Each subagent should generate tests for one flow only
+
+### Data Transform Testing with Notebooks
+
+When the integration includes data transformations (DataMapper, XSLT, Groovy scripts), use `NotebookEdit` to create a Jupyter notebook for interactive testing:
+
+- Create a notebook in the project's `test/` directory
+- Add cells that execute the transformation with sample input data
+- Add assertion cells that verify the output matches expected results
+- This is especially useful for complex transformations where visual inspection helps

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-verify.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-verify.append.md
@@ -1,0 +1,17 @@
+## Agent Optimization: Claude Code
+
+### Dynamic Retry Pacing
+
+Use `ScheduleWakeup` for intelligent retry pacing in the verification loop:
+
+- After kicking off a build (`mvn verify`), use `ScheduleWakeup` with `delaySeconds: 180` (3 min, stays in cache window) instead of polling
+- Set `reason` to a specific description: "waiting for Maven build to complete"
+- After a fix attempt, use a shorter delay (90s) since fixes are typically faster to verify
+
+### Periodic Health Checks
+
+Use `CronCreate` to schedule background health monitoring during extended verification sessions:
+
+- Schedule `git diff --stat` every 10 minutes to track cumulative changes
+- This helps detect runaway fix loops that modify too many files
+- Delete the cron job when verification completes or after 3 fix rounds

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-verify/verify-loop.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-verify/verify-loop.append.md
@@ -1,0 +1,18 @@
+## Agent Optimization: Claude Code
+
+### Dynamic Build Wait
+
+Instead of polling in a tight loop after running `mvn verify`, use `ScheduleWakeup`:
+
+- After starting `mvn verify` in the background (via `Bash` with `run_in_background: true`), call `ScheduleWakeup` with `delaySeconds: 180` and `reason: "waiting for Maven verify to complete"`
+- On wake, check the background task output. If still running, schedule another wakeup at 90s.
+- This avoids burning cache windows on repeated polling.
+
+### Fix Attempt Tracking
+
+Use `TaskCreate` to track each fix attempt in the verification loop:
+
+- Create a task for each error found: "Fix: {error-taxonomy-category} — {brief description}"
+- Mark `in_progress` when attempting the fix
+- Mark `completed` when the re-verification passes
+- If a fix fails after 3 rounds, leave the task as `in_progress` for the user to see

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-brainstorm.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-brainstorm.append.md
@@ -1,0 +1,23 @@
+## Agent Optimization: Gemini CLI
+
+### Batch Guide Loading
+
+At the start of each interview phase, use `read_many_files` to load all guides for that phase in a single tool call:
+
+- Phase 1 (discovery): `read_many_files` with paths to `guides/greenfield-interview.md` and `guides/migration-discovery.md`
+- Phase 2 (design): `read_many_files` with paths to all `camel-design/guides/*.md` files relevant to the user's answers
+- Phase 3 (assembly): `read_many_files` with `guides/design-assembly.md` and `guides/version-selection.md`
+
+This reduces tool call overhead compared to loading guides one at a time.
+
+### Pattern Research
+
+Use `google_web_search` to research integration patterns when the user describes unfamiliar systems or protocols. Include search results as context for component selection.
+
+### Design Decision Persistence
+
+Use `save_memory` to persist key design decisions after each interview phase:
+
+- Save source/target system types, selected components, chosen EIPs, and version selections
+- This allows resuming an interrupted brainstorming session without re-interviewing
+- Memory key format: `camel-kit:design:{project-name}:{phase}`

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute.append.md
@@ -1,0 +1,24 @@
+## Agent Optimization: Gemini CLI
+
+### Named Agent Delegation
+
+Delegate implementation tasks to pre-registered agents by name:
+
+- Implementation tasks: delegate to `camel-implementer`
+- Spec review: delegate to `camel-validator`
+- Quality review: delegate to `camel-validator` (reuse with different prompt)
+
+Include `max_turns: 50` and `timeout_mins: 15` in each delegation to prevent runaway agents.
+
+### TOML Policy for MCP Auto-Approval
+
+The project's `.gemini/policies/camel-kit.toml` should include auto-approval for MCP catalog tools. If it doesn't, instruct the user to add:
+
+```toml
+[[rules]]
+description = "Auto-approve Camel MCP catalog lookups"
+tools = ["mcp_camel_catalog_*", "mcp_camel_docs_*"]
+action = "allow"
+```
+
+This eliminates permission prompts during implementation, which would break autonomous execution.

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute.append.md
@@ -16,9 +16,10 @@ The project's `.gemini/policies/camel-kit.toml` should include auto-approval for
 
 ```toml
 [[rules]]
-description = "Auto-approve Camel MCP catalog lookups"
-tools = ["mcp_camel_catalog_*", "mcp_camel_docs_*"]
-action = "allow"
+name = "Allow Camel MCP tools"
+toolName = "mcp_camel_*"
+decision = "allow"
+priority = 3
 ```
 
 This eliminates permission prompts during implementation, which would break autonomous execution.

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute/implementer-context.append.md
@@ -1,0 +1,12 @@
+## Agent Optimization: Gemini CLI
+
+### Batch Guide Pre-Loading
+
+Before constructing the implementer prompt, use `read_many_files` to load all implementation guides in a single call:
+
+- Load: `camel-implement/guides/orchestrator.md`, `camel-implement/guides/yaml-structure.md`, `camel-implement/guides/yaml-catalog-rules.md`, `camel-implement/guides/component-loading.md`, `camel-implement/guides/properties-generation.md`
+- Include only the guides relevant to the current task (check the task description for which patterns are needed)
+
+### Named Agent Delegation
+
+Delegate the implementation to the `camel-implementer` pre-registered agent. Include `max_turns: 50` to prevent excessive iteration.

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute/spec-reviewer-criteria.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute/spec-reviewer-criteria.append.md
@@ -1,0 +1,5 @@
+## Agent Optimization: Gemini CLI
+
+### Named Reviewer Delegation
+
+Delegate spec compliance review to the `camel-validator` pre-registered agent with `timeout_mins: 10`. Include the full spec-reviewer-criteria in the delegation prompt.

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-ship.append.md
@@ -1,0 +1,26 @@
+## Agent Optimization: Gemini CLI
+
+### Named Agent Pipeline
+
+Chain the pipeline using named agent delegation:
+
+- Stage 0 (Brainstorm): self (main agent orchestrates interview directly)
+- Stage 1 (Plan): self (plan generation stays in main context)
+- Stage 2 (Execute): delegate wave execution to `camel-implementer` agents
+- Stage 3 (Verify): delegate to `camel-validator` with `timeout_mins: 20`
+
+### State Persistence via Memory
+
+Use `save_memory` to persist pipeline state between stages:
+
+- Key: `camel-kit:ship:state`
+- Value: JSON string matching the `.camel-kit/ship-state.json` format
+- This provides an additional persistence mechanism alongside the file-based state
+
+### Batch Context Loading
+
+At each stage transition, use `read_many_files` to load all artifacts from previous stages in one call:
+
+- Before Plan: load design-spec.md
+- Before Execute: load design-spec.md + implementation-plan.md
+- Before Verify: load design-spec.md + all generated route files

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
@@ -1,0 +1,20 @@
+## Agent Optimization: OpenCode
+
+### Step-Limited Subagents
+
+Set `steps` limits on each subagent to prevent runaway execution:
+
+- Implementation subagents: `steps: 100` (enough for complex route generation)
+- Spec review subagents: `steps: 50` (review is read-heavy, fewer writes)
+- Quality review subagents: `steps: 50`
+
+If a subagent hits its step limit, report a warning and continue to the next task.
+
+### Strategic Agent Type Selection
+
+OpenCode provides built-in agent types. Map task types to optimal agents:
+
+- Implementation tasks: use `Build` agent type (optimized for code generation)
+- Plan analysis: use `Plan` agent type (optimized for structured planning)
+- Review tasks: use `General` agent type (balanced read/write)
+- Quick checks: use `Fast` agent type (minimal context, fast response)

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
@@ -10,11 +10,11 @@ Set `steps` limits on each subagent to prevent runaway execution:
 
 If a subagent hits its step limit, report a warning and continue to the next task.
 
-### Strategic Agent Type Selection
+### Strategic Agent Selection
 
-OpenCode provides built-in agent types. Map task types to optimal agents:
+OpenCode provides two primary agents (`Build` for code generation, `Plan` for analysis) and two subagent types (`General` for multi-step tasks, `Explore` for read-only codebase search). When dispatching subagents:
 
-- Implementation tasks: use `Build` agent type (optimized for code generation)
-- Plan analysis: use `Plan` agent type (optimized for structured planning)
-- Review tasks: use `General` agent type (balanced read/write)
-- Quick checks: use `Fast` agent type (minimal context, fast response)
+- Implementation subagents: use `General` with full `edit` and `bash` permissions
+- Review subagents: use `General` with read-focused permissions
+- Codebase exploration: use `Explore` (read-only, no edit or bash access)
+- Plan analysis: stays in the `Plan` primary agent (no subagent dispatch needed)

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute/implementer-context.append.md
@@ -1,0 +1,9 @@
+## Agent Optimization: OpenCode
+
+### Build Agent Type
+
+When constructing the implementer subagent, specify the `Build` agent type. This agent type is optimized for code generation tasks — it has higher edit and bash permissions than the default.
+
+### Step Limit
+
+Set `steps: 100` for each implementer subagent. This provides enough steps for complex route generation (reading guides, generating YAML, generating properties, running validation) while preventing runaway execution.

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute/implementer-context.append.md
@@ -1,8 +1,8 @@
 ## Agent Optimization: OpenCode
 
-### Build Agent Type
+### Implementer Permissions
 
-When constructing the implementer subagent, specify the `Build` agent type. This agent type is optimized for code generation tasks — it has higher edit and bash permissions than the default.
+Configure the implementer subagent with full `edit` and `bash` permissions (matching the built-in Build primary agent's capabilities). Agent template frontmatter supports: `name`, `mode`, `description`, `steps`, and `permission.*` fields — agent type cannot be set at the template level.
 
 ### Step Limit
 

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-ship.append.md
@@ -1,0 +1,19 @@
+## Agent Optimization: OpenCode
+
+### Step-Limited Pipeline Stages
+
+Apply step limits per pipeline stage to prevent any single stage from consuming the entire session:
+
+- Stage 0 (Brainstorm): `steps: 200` (interview can be lengthy)
+- Stage 1 (Plan): `steps: 100` (structured output)
+- Stage 2 (Execute): `steps: 500` (most complex, multiple subagents)
+- Stage 3 (Verify): `steps: 150` (build + diagnosis loop)
+
+### Agent Type Mapping
+
+Use the appropriate OpenCode agent type for each pipeline stage:
+
+- Stage 0 (Brainstorm): `General` — balanced for conversational design
+- Stage 1 (Plan): `Plan` — optimized for structured planning output
+- Stage 2 (Execute): `Build` — optimized for code generation
+- Stage 3 (Verify): `Build` — needs to read code and run builds

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-validate.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-validate.append.md
@@ -1,0 +1,20 @@
+## Agent Optimization: OpenCode
+
+### LSP-Powered Validation
+
+Use the `lsp` tool to enhance validation with IDE-grade code intelligence:
+
+- **Go-to-definition:** When validating that a bean reference in a route exists, use `lsp` go-to-definition to confirm the bean class is reachable
+- **Find references:** When checking for unused routes or dead code, use `lsp` find-references to verify whether a route or processor is called
+- **Hover:** When verifying method signatures in bean references, use `lsp` hover to inspect return types and parameter lists
+
+Note: `lsp` is experimental and may not be available. If `lsp` calls fail, fall back to grep-based validation.
+
+### Path-Scoped Safety
+
+OpenCode supports glob-based path permissions. During validation, restrict file access to:
+
+- Read: `**/*.yaml`, `**/*.xml`, `**/*.properties`, `**/*.java`, `**/*.groovy`
+- Write: none (validation is read-only)
+
+This prevents the validator from accidentally modifying files.

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-execute.append.md
@@ -1,0 +1,21 @@
+## Agent Optimization: Qwen Code
+
+### Serial Task Dispatch
+
+Qwen Code's `task` tool dispatches one subagent at a time (serial only). Adapt wave-based execution:
+
+- Even if `{COMMAND_PREFIX} plan analyze` identifies parallel waves, execute ALL tasks sequentially
+- Process tasks in dependency order: complete all dependencies before starting a dependent task
+- Within a wave, process tasks in the order they appear in the plan
+
+### Progress Tracking via todo_write
+
+Use `todo_write` to maintain a visible progress list:
+
+- At the start of execution, write all tasks as unchecked items
+- Check off each task as it completes both review stages
+- This provides the user with a real-time progress view since parallel dispatch isn't available
+
+### Explicit Context Passing
+
+Since subagents are serial, each subagent can read the outputs of all previous subagents. Include explicit file paths to prior outputs in each subagent prompt — don't assume the subagent will discover them.

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-ship.append.md
@@ -1,0 +1,21 @@
+## Agent Optimization: Qwen Code
+
+### Serial Pipeline Execution
+
+Execute all pipeline stages sequentially. Since Qwen Code dispatches one subagent at a time:
+
+- Complete each stage fully before starting the next
+- Do not attempt to parallelize any part of the pipeline
+- Use checkpoints between stages to save state
+
+### State Tracking via todo_write
+
+Maintain a pipeline progress list using `todo_write`:
+
+- Write a todo item for each stage: "Stage 0: Brainstorm", "Stage 1: Plan", "Stage 2: Execute", "Stage 3: Verify", "Final: Stamp"
+- Check off each stage as it completes
+- If the pipeline is interrupted, the todo list shows which stages are done
+
+### Checkpoint Between Stages
+
+After each stage completes, write the state to `.camel-kit/ship-state.json` AND update the todo list. This dual-write ensures state is recoverable from either mechanism.

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ClaudeGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ClaudeGeneratorTest.java
@@ -44,7 +44,7 @@ class ClaudeGeneratorTest {
     }
 
     @Test
-    void appendsParallelDispatch() throws Exception {
+    void appendsParallelDispatchViaTrait() throws Exception {
         InitContext ctx = createContext();
         new ClaudeGenerator().generate(ctx);
 
@@ -53,6 +53,7 @@ class ClaudeGeneratorTest {
         String content = Files.readString(implementSkill);
         assertTrue(content.contains("Parallel Route Implementation"));
         assertTrue(content.contains("route-topology"));
+        assertTrue(content.contains("<!-- TRAIT:claude -->"), "Should be applied via trait sentinel");
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -93,6 +93,42 @@ class DefaultGeneratorTest {
     }
 
     @Test
+    void appliesSkillLevelTraits() throws Exception {
+        InitContext ctx = createContext("claude");
+        new ClaudeGenerator().generate(ctx);
+
+        Path brainstormSkill = ctx.skillsDir().resolve("camel-brainstorm/SKILL.md");
+        String content = Files.readString(brainstormSkill);
+        assertTrue(content.contains("<!-- TRAIT:claude -->"), "Sentinel should be present");
+        assertTrue(content.contains("AskUserQuestion"), "Claude trait content should be appended");
+    }
+
+    @Test
+    void traitsAreIdempotent() throws Exception {
+        InitContext ctx = createContext("claude");
+        ClaudeGenerator generator = new ClaudeGenerator();
+        generator.generate(ctx);
+        generator.generate(ctx);
+
+        Path brainstormSkill = ctx.skillsDir().resolve("camel-brainstorm/SKILL.md");
+        String content = Files.readString(brainstormSkill);
+        int count = content.split("<!-- TRAIT:claude -->").length - 1;
+        assertEquals(1, count, "Trait sentinel should appear exactly once after double init");
+    }
+
+    @Test
+    void appliesGuideLevelTraits() throws Exception {
+        InitContext ctx = createContext("claude");
+        new ClaudeGenerator().generate(ctx);
+
+        Path implementerGuide = ctx.skillsDir().resolve("camel-execute/guides/implementer-context.md");
+        if (Files.exists(implementerGuide)) {
+            String content = Files.readString(implementerGuide);
+            assertTrue(content.length() > 0, "Guide should have content");
+        }
+    }
+
+    @Test
     void wrapsTomlForGemini() throws Exception {
         InitContext ctx = createContext("gemini");
         new DefaultGenerator().generate(ctx);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -122,10 +122,9 @@ class DefaultGeneratorTest {
         new ClaudeGenerator().generate(ctx);
 
         Path implementerGuide = ctx.skillsDir().resolve("camel-execute/guides/implementer-context.md");
-        if (Files.exists(implementerGuide)) {
-            String content = Files.readString(implementerGuide);
-            assertTrue(content.length() > 0, "Guide should have content");
-        }
+        assertTrue(Files.exists(implementerGuide), "Guide-level trait should create implementer-context.md");
+        String content = Files.readString(implementerGuide);
+        assertTrue(content.length() > 0, "Guide should have content");
     }
 
     @Test

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -198,11 +198,11 @@ name: camel-validator
 tools:
   - read_file
   - glob
-  - grep
+  - grep_search
   - run_shell_command
   - mcp_camel_*           # all tools from Camel catalog MCP server
 max_turns: 20
-timeout_mins: 10
+timeout_mins: 20
 ```
 
 `mcp_camel_*` automatically includes new tools when the MCP server adds them -- future-proof. Different subagents can have different MCP server access (e.g., validator gets catalog but not knowledge).

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -15,12 +15,14 @@ Each agent uses a different architecture designed to **maximize that agent's nat
 - MCP tool calls (same tools, same parameters)
 - Output formats (same YAML routes, properties, test files)
 
-**What equalization does NOT cover:**
+**What equalization does NOT cover (handled by traits and templates):**
 - Dispatch mechanism (subagents vs. modes vs. inline)
 - Tool restriction model (each agent's permission system is different)
 - File reading patterns (context isolation varies)
 - Parallelization strategy (only Claude supports parallel subagent dispatch)
 - Configuration format (YAML modes, TOML policies, markdown frontmatter)
+
+**Agent traits** bridge the gap: they append agent-specific instructions to shared skill files during `camel-kit init`. For example, all agents share the same `camel-execute/SKILL.md`, but Claude's trait adds `Agent` tool parallel dispatch, Gemini's adds named agent delegation, Bob's adds `switch_mode` orchestration, and OpenCode's adds step-limited subagents. See [Architecture Guide](architecture.md#agent-traits) for details.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -288,6 +288,25 @@ All five agents receive the same skills (markdown instruction files). The templa
 - Parallelization strategy (only Claude supports parallel subagent dispatch)
 - Configuration format (YAML modes, TOML policies, markdown frontmatter)
 
+### Agent Traits
+
+Traits are agent-specific instruction fragments that are appended to shared skill files during `camel-kit init`. They bridge the gap between the equalization layer (identical skills) and the per-agent template layer (different dispatch models).
+
+**Location:** `camel-kit-core/src/main/resources/templates/traits/{agent}/`
+
+**How it works:** During `camel-kit init --ai {agent}`, `DefaultGenerator.applyTraits()` scans the traits directory for the selected agent and appends each `.append.md` file to the corresponding skill file. Idempotent HTML comment sentinels (`<!-- TRAIT:{agent} -->` / `<!-- /TRAIT:{agent} -->`) prevent duplicate application on re-init.
+
+**Two granularity levels:**
+
+| Level | Path Pattern | Appended To |
+|-------|-------------|-------------|
+| SKILL.md-level (strategy) | `traits/{agent}/{skill-name}.append.md` | `{skills-dir}/{skill-name}/SKILL.md` |
+| Guide-level (tactics) | `traits/{agent}/{skill-name}/{guide-name}.append.md` | `{skills-dir}/{skill-name}/guides/{guide-name}.md` |
+
+**Example:** `traits/claude/camel-execute.append.md` appends Claude-specific instructions to `camel-execute/SKILL.md` -- parallel subagent dispatch via the `Agent` tool, worktree isolation via `EnterWorktree`, build health monitoring via `CronCreate`. The same skill on Gemini gets different trait content: named agent delegation, TOML policy guidance, batch context loading via `read_many_files`.
+
+**What traits contain:** Agent-specific tool usage, dispatch strategies, state persistence mechanisms, and execution optimizations. Each trait is written for the specific agent's capabilities -- Claude traits reference `Agent`, `ScheduleWakeup`, `TaskCreate`; Gemini traits reference `save_memory`, `read_many_files`; Bob traits reference `switch_mode`, `insert_content`.
+
 ### Iron Laws
 
 The five Iron Laws from `skills/shared/iron-laws.md` are embedded in each agent's instruction file:


### PR DESCRIPTION
## Summary

- Add `applyTraits()` method to `DefaultGenerator` that scans `templates/traits/{agent}/` and appends `.append.md` files to matching skill files with idempotent HTML comment sentinels
- Migrate `ClaudeGenerator.appendParallelDispatch()` from hardcoded Java to a trait file (`templates/traits/claude/camel-implement.append.md`)
- Create 24 trait files across 5 agents (Claude Code, Gemini CLI, IBM Bob, Qwen Code, OpenCode)
- Two granularity levels: SKILL.md-level (strategy) and guide-level (tactics)

## Review feedback addressed

- Fixed Gemini agent definitions: `grep`→`grep_search`, `edit`→`replace` (matching official Gemini CLI tools reference)
- Bumped `camel-validator.md` `timeout_mins` 10→20 for consistency with ship pipeline
- Fixed TOML policy snippet field names in gemini/camel-execute trait
- Fixed OpenCode traits: removed non-existent `Fast` agent type, clarified `Build` vs subagent distinction
- Removed broad `catch(Exception)` in `applyGuideTraits` that swallowed real IO errors
- Strengthened `appliesGuideLevelTraits` test to assert file existence

## Test plan

- [x] `appliesSkillLevelTraits` — verify sentinel and content appended to SKILL.md
- [x] `traitsAreIdempotent` — verify double-init produces single sentinel
- [x] `appliesGuideLevelTraits` — verify guide-level trait mechanism
- [x] `appendsParallelDispatchViaTrait` — verify migrated parallel dispatch via trait sentinel
- [x] `./mvnw clean install -B` passes (all tests green)

## References

- Closes #23
- ADR-0024: Agent Traits System and `/camel-ship` Autonomous Pipeline
- Inspired by [cc-spex](https://github.com/rhuss/cc-spex) traits system

🤖 Generated with [Claude Code](https://claude.com/claude-code)