### PR TITLE
fix #24: /camel-ship — autonomous end-to-end pipeline with configurable oversight

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -43,7 +43,8 @@ public class DefaultGenerator implements AgentGenerator {
 
     private void createCommandTemplates(InitContext ctx) throws Exception {
         List<String> commands
-                = List.of("brainstorm", "flow", "plan", "execute", "verify", "validate", "migrate", "knowledge");
+                = List.of("brainstorm", "flow", "plan", "execute", "verify", "validate", "migrate", "knowledge",
+                        "ship");
 
         // Extract agent base folder (e.g., ".bob" from ".bob/commands")
         String agentBaseFolder = ctx.agent().folder().substring(0, ctx.agent().folder().lastIndexOf("/"));

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: camel-ship
+description: Use this skill when the user wants to run the entire integration workflow autonomously — from brainstorm through verification — in a single command. Trigger for phrases like 'ship it', 'build the whole thing', 'run the full pipeline', 'autonomous mode', 'end to end', or when the user provides requirements and wants everything generated without manual phase transitions. Also use when the user references '--ask', 'oversight level', 'resume pipeline', or 'auto-fix'.
+user_invocable: true
+---
+
+# Camel Ship — Autonomous Pipeline
+
+Chain the full camel-kit pipeline (brainstorm → plan → execute → verify) with configurable human oversight.
+
+**Announce at start:** "I'm using the camel-ship skill to run the full pipeline."
+
+**Violating the letter of these rules is violating the spirit of these rules.**
+
+---
+
+## Arguments
+
+Parse the skill arguments for these flags:
+
+| Argument | Default | Description |
+|---|---|---|
+| `[input-file]` | none | Requirements document, design spec, or brainstorm notes |
+| `--ask` | `smart` | Oversight level: `always`, `smart`, or `never` |
+| `--resume` | false | Continue from `.camel-kit/ship-state.json` |
+| `--start-from <stage>` | none | Skip to stage: `brainstorm`, `plan`, `execute`, `verify` |
+| `--create-pr` | false | Auto-create GitHub PR on success |
+
+---
+
+## Pipeline
+
+```
+Stage 0: BRAINSTORM  →  Stage 1: PLAN  →  Stage 2: EXECUTE  →  Stage 3: VERIFY  →  STAMP
+```
+
+### Before Starting
+
+1. Check for `--resume` flag. If set, read `.camel-kit/ship-state.json` and jump to `currentStage`.
+2. Check for `--start-from` flag. If set, verify prerequisite artifacts exist:
+   - `plan` requires `docs/design-spec.md`
+   - `execute` requires `docs/design-spec.md` AND `docs/implementation-plan.md`
+   - `verify` requires generated route files to exist
+3. If neither flag is set, start from Stage 0.
+4. Parse `--ask` level (default: `smart`).
+5. Initialize state file: write `.camel-kit/ship-state.json` with initial state.
+
+### Stage Execution
+
+For each stage:
+
+1. Load the oversight matrix: read `guides/oversight-matrix.md`
+2. Update state: set `currentStage` in `.camel-kit/ship-state.json`
+3. Invoke the corresponding skill:
+   - Stage 0: invoke `/camel-brainstorm` with `[input-file]` as context
+   - Stage 1: invoke `/camel-plan` (reads design spec from Stage 0)
+   - Stage 2: invoke `/camel-execute` (reads plan from Stage 1)
+   - Stage 3: invoke `/camel-verify` (verifies generated routes)
+4. After the skill completes, apply oversight decision from the matrix
+5. If oversight says "pause": present results and wait for user input
+6. If oversight says "auto-proceed": save state and continue to next stage
+7. If a failure occurs during any stage: load `guides/auto-fix-loop.md` and attempt repair
+
+### Stamp Gate (After Stage 3)
+
+After verification completes, run the final quality gate:
+
+1. Verify build passes: run `{COMMAND_PREFIX} verify` (or `mvn verify` directly)
+2. Check Iron Law compliance: scan generated YAML for Iron Law violations
+3. Constitution compliance: compare generated routes against `docs/constitution.md`
+4. Check for uncommitted artifacts: `git status` should show only expected files
+5. Acceptance criteria: cross-reference design spec acceptance criteria with generated output
+
+If ALL checks pass:
+- If `--create-pr`: run `gh pr create` with a summary
+- Report: "Pipeline complete. All checks passed."
+
+If ANY check fails:
+- Report failures clearly
+- If `--ask never`: attempt auto-fix (load `guides/auto-fix-loop.md`)
+- Otherwise: present failures and ask user for next steps
+
+---
+
+## Guide Manifest
+
+| Guide | When to Load | Purpose |
+|---|---|---|
+| `guides/oversight-matrix.md` | At each stage transition | Determines pause/proceed behavior |
+| `guides/state-management.md` | At pipeline start and after each stage | State persistence format |
+| `guides/auto-fix-loop.md` | When any stage fails or review finds issues | Fix-retry logic |
+
+---
+
+## Shared Guides
+
+Load these shared guides at pipeline start:
+- `shared/iron-laws.md` — all 4 laws apply across all stages
+- `shared/mcp-setup.md` — MCP tool configuration for verification

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -24,13 +24,12 @@ Parse the skill arguments for these flags:
 | `--ask` | `smart` | Oversight level: `always`, `smart`, or `never` |
 | `--resume` | false | Continue from `.camel-kit/ship-state.json` |
 | `--start-from <stage>` | none | Skip to stage: `brainstorm`, `plan`, `execute`, `verify` |
-| `--create-pr` | false | Auto-create GitHub PR on success |
 
 ---
 
 ## Pipeline
 
-```
+```text
 Stage 0: BRAINSTORM  →  Stage 1: PLAN  →  Stage 2: EXECUTE  →  Stage 3: VERIFY  →  STAMP
 ```
 
@@ -59,7 +58,9 @@ For each stage:
 4. After the skill completes, apply oversight decision from the matrix
 5. If oversight says "pause": present results and wait for user input
 6. If oversight says "auto-proceed": save state and continue to next stage
-7. If a failure occurs during any stage: load `guides/auto-fix-loop.md` and attempt repair
+7. If a failure occurs during any stage:
+   - If matrix action is `AUTO-FIX`: load `guides/auto-fix-loop.md` and attempt repair
+   - Otherwise: PAUSE and wait for user decision
 
 ### Stamp Gate (After Stage 3)
 
@@ -68,11 +69,9 @@ After verification completes, run the final quality gate:
 1. Verify build passes: run `{COMMAND_PREFIX} verify` (or `mvn verify` directly)
 2. Check Iron Law compliance: scan generated YAML for Iron Law violations
 3. Constitution compliance: compare generated routes against `docs/constitution.md`
-4. Check for uncommitted artifacts: `git status` should show only expected files
-5. Acceptance criteria: cross-reference design spec acceptance criteria with generated output
+4. Acceptance criteria: cross-reference design spec acceptance criteria with generated output
 
 If ALL checks pass:
-- If `--create-pr`: run `gh pr create` with a summary
 - Report: "Pipeline complete. All checks passed."
 
 If ANY check fails:

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/auto-fix-loop.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/auto-fix-loop.md
@@ -1,0 +1,100 @@
+# Auto-Fix Loop
+
+Automated fix-verify-retry logic for pipeline failures. Used when the oversight level allows autonomous fixing.
+
+---
+
+## When to Enter
+
+The auto-fix loop is entered when:
+- A stage produces a failure AND the oversight matrix says AUTO-FIX
+- This only happens with `--ask never` (and for some outcomes with `--ask smart`)
+
+## Loop Logic
+
+```
+ROUND = 0
+MAX_ROUNDS = 3
+
+while ROUND < MAX_ROUNDS:
+    1. CLASSIFY the finding
+    2. ATTEMPT the fix
+    3. RE-VERIFY
+    4. If verification passes → EXIT loop (success)
+    5. ROUND += 1
+
+If ROUND == MAX_ROUNDS:
+    ESCALATE to user (regardless of --ask level)
+```
+
+---
+
+## Step 1: Classify Finding
+
+Categorize each finding:
+
+| Category | Description | Examples |
+|---|---|---|
+| **Critical** | Prevents build/run | Compilation error, missing dependency, YAML parse error |
+| **Important** | Passes build but violates rules | Iron Law violation, Constitution non-compliance, test failure |
+| **Suggestion** | Improvement opportunity | Code quality, performance optimization, style |
+
+- `--ask smart`: auto-fix Critical and Important. Pause on Suggestion (user decides).
+- `--ask never`: auto-fix all categories.
+
+## Step 2: Attempt Fix
+
+Based on category:
+
+### Critical Fixes
+- Compilation error → read the error message, locate the source file, fix the syntax/type issue
+- Missing dependency → add to pom.xml, re-run `mvn compile`
+- YAML parse error → validate YAML structure, fix indentation/syntax
+
+### Important Fixes
+- Iron Law violation → re-verify the component/EIP via MCP catalog, correct the usage
+- Constitution violation → compare route against constitution rules, adjust
+- Test failure → read the test output, identify the assertion that failed, fix the route or test
+
+### Suggestion Fixes
+- Apply the improvement directly (only in `--ask never` mode)
+
+## Step 3: Re-Verify
+
+After applying a fix:
+
+1. Re-run the specific check that failed:
+   - Build error → `mvn compile`
+   - Test failure → `mvn test`
+   - Iron Law → re-scan the specific YAML file
+   - Constitution → re-check the specific rule
+2. If the check passes → the finding is resolved
+3. If the check fails → increment round counter and loop
+
+## Step 4: Escalate
+
+After 3 failed rounds for the same finding:
+
+1. Present the finding to the user with:
+   - What was tried (3 fix attempts)
+   - What the current state is
+   - The specific error that persists
+2. Ask the user to: "Fix manually" / "Skip this check" / "Abort pipeline"
+3. This pause happens regardless of `--ask` level — 3 failed auto-fixes is always a blocker
+
+---
+
+## Fix Attempt Tracking
+
+Track fix attempts in the state file under `fixAttempts`:
+
+```json
+"fixAttempts": {
+    "2:task-3": 2,
+    "3:iron-law-1": 1
+}
+```
+
+Key format: `{stage}:{finding-id}`
+
+This allows `--resume` to continue with the correct round count after an interruption.

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/auto-fix-loop.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/auto-fix-loop.md
@@ -12,7 +12,7 @@ The auto-fix loop is entered when:
 
 ## Loop Logic
 
-```
+```text
 ROUND = 0
 MAX_ROUNDS = 3
 
@@ -39,7 +39,7 @@ Categorize each finding:
 | **Important** | Passes build but violates rules | Iron Law violation, Constitution non-compliance, test failure |
 | **Suggestion** | Improvement opportunity | Code quality, performance optimization, style |
 
-- `--ask smart`: auto-fix Critical and Important. Pause on Suggestion (user decides).
+- `--ask smart`: follow `guides/oversight-matrix.md` for each stage outcome; only auto-fix when the matrix action is AUTO-FIX.
 - `--ask never`: auto-fix all categories.
 
 ## Step 2: Attempt Fix

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/oversight-matrix.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/oversight-matrix.md
@@ -1,0 +1,76 @@
+# Oversight Matrix
+
+Decision rules for each oversight level at each pipeline stage. The orchestrator consults this matrix after each stage completes to determine whether to pause for user input or auto-proceed.
+
+---
+
+## Matrix
+
+| Stage | Outcome | `always` | `smart` | `never` |
+|---|---|---|---|---|
+| **Brainstorm** | Design spec complete, no open questions | PAUSE | AUTO-PROCEED | AUTO-PROCEED |
+| **Brainstorm** | Design spec has open questions or ambiguities | PAUSE | PAUSE | AUTO-PROCEED (pick reasonable defaults) |
+| **Brainstorm** | Failed to produce design spec | PAUSE | PAUSE | PAUSE (blocker) |
+| **Plan** | Plan complete, all tasks defined | PAUSE | AUTO-PROCEED | AUTO-PROCEED |
+| **Plan** | Plan has gaps or inconsistencies | PAUSE | PAUSE | AUTO-PROCEED (fill gaps) |
+| **Plan** | Failed to produce plan | PAUSE | PAUSE | PAUSE (blocker) |
+| **Execute** | Task implemented, tests pass | PAUSE | AUTO-PROCEED | AUTO-PROCEED |
+| **Execute** | Task implemented, tests fail | PAUSE | PAUSE | AUTO-FIX (up to 3 rounds) |
+| **Execute** | Task implementation failed | PAUSE | PAUSE | AUTO-FIX (up to 3 rounds) |
+| **Execute** | Auto-fix exhausted (3 rounds) | PAUSE | PAUSE | PAUSE (blocker) |
+| **Verify** | All checks pass | PAUSE (present report) | PAUSE (present report) | AUTO-PROCEED to PR |
+| **Verify** | Some checks fail | PAUSE | PAUSE | AUTO-FIX (up to 3 rounds) |
+| **Stamp** | All gates pass | DONE (create PR if --create-pr) | DONE (create PR if --create-pr) | DONE (create PR if --create-pr) |
+| **Stamp** | Gate failure | PAUSE | PAUSE | PAUSE (blocker) |
+
+---
+
+## Decision Logic
+
+For each stage completion, execute this logic:
+
+```
+1. Determine outcome category (success / partial / failure)
+2. Look up action in matrix for (stage, outcome, --ask level)
+3. If action is PAUSE:
+   - Present results to user
+   - Wait for user response
+   - User can: approve, request changes, abort pipeline
+4. If action is AUTO-PROCEED:
+   - Save state
+   - Continue to next stage
+5. If action is AUTO-FIX:
+   - Load guides/auto-fix-loop.md
+   - Attempt fix (max 3 rounds)
+   - If fix succeeds → treat as AUTO-PROCEED
+   - If fix fails → escalate to PAUSE
+6. If action is PAUSE (blocker):
+   - This is a hard stop regardless of --ask level
+   - Present the blocker to the user
+   - Pipeline cannot continue until user resolves it
+```
+
+---
+
+## Ambiguity Detection
+
+"Ambiguous outcomes" (relevant for `smart` vs `never`) are detected by:
+
+### Brainstorm Stage
+- Open questions in the design spec (sections marked TODO or containing "?" in decision fields)
+- Multiple equally viable architecture options presented without a recommendation
+- Missing component selections (source or target system not mapped to a Camel component)
+
+### Plan Stage
+- Tasks with missing acceptance criteria
+- Circular dependencies in the task graph
+- Tasks referencing components not in the design spec
+
+### Execute Stage
+- Test failures (clear signal — not ambiguous, but requires decision)
+- Compilation errors (clear signal)
+- MCP verification failures (component not found in catalog)
+
+### Verify Stage
+- Partial verification (some checks pass, some fail)
+- Constitution violations (may be intentional deviations)

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/oversight-matrix.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/oversight-matrix.md
@@ -18,9 +18,9 @@ Decision rules for each oversight level at each pipeline stage. The orchestrator
 | **Execute** | Task implemented, tests fail | PAUSE | PAUSE | AUTO-FIX (up to 3 rounds) |
 | **Execute** | Task implementation failed | PAUSE | PAUSE | AUTO-FIX (up to 3 rounds) |
 | **Execute** | Auto-fix exhausted (3 rounds) | PAUSE | PAUSE | PAUSE (blocker) |
-| **Verify** | All checks pass | PAUSE (present report) | PAUSE (present report) | AUTO-PROCEED to PR |
+| **Verify** | All checks pass | PAUSE (present report) | PAUSE (present report) | AUTO-PROCEED to Stamp |
 | **Verify** | Some checks fail | PAUSE | PAUSE | AUTO-FIX (up to 3 rounds) |
-| **Stamp** | All gates pass | DONE (create PR if --create-pr) | DONE (create PR if --create-pr) | DONE (create PR if --create-pr) |
+| **Stamp** | All gates pass | DONE | DONE | DONE |
 | **Stamp** | Gate failure | PAUSE | PAUSE | PAUSE (blocker) |
 
 ---
@@ -29,7 +29,7 @@ Decision rules for each oversight level at each pipeline stage. The orchestrator
 
 For each stage completion, execute this logic:
 
-```
+```text
 1. Determine outcome category (success / partial / failure)
 2. Look up action in matrix for (stage, outcome, --ask level)
 3. If action is PAUSE:

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
@@ -23,7 +23,6 @@ Location: `.camel-kit/ship-state.json`
     }
   },
   "inputFile": "path to input file or null",
-  "createPr": false,
   "fixAttempts": {
     "stage:task": 0
   }
@@ -38,6 +37,7 @@ Location: `.camel-kit/ship-state.json`
 | 1 | Plan | `docs/implementation-plan.md` |
 | 2 | Execute | generated routes in `src/` |
 | 3 | Verify | `docs/verification-report.md` |
+| 4 | Stamp | `docs/stamp-report.md` |
 
 ---
 
@@ -54,7 +54,6 @@ At pipeline start (no `--resume`):
   "currentStage": 0,
   "stageResults": {},
   "inputFile": "{parsed input-file or null}",
-  "createPr": false,
   "fixAttempts": {}
 }
 ```
@@ -96,7 +95,7 @@ When `--resume` is specified:
 
 When `--start-from <stage>` is specified:
 
-1. Map stage name to number: brainstorm=0, plan=1, execute=2, verify=3
+1. Map stage name to number: brainstorm=0, plan=1, execute=2, verify=3, stamp=4
 2. Verify prerequisite artifacts exist (see SKILL.md for requirements)
 3. Create fresh state with `currentStage` set to the specified stage
 4. Mark all prior stages as `"completed"` in stageResults (with current artifact paths)

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
@@ -1,0 +1,112 @@
+# State Management
+
+Pipeline state persistence for resume and crash recovery.
+
+---
+
+## State File
+
+Location: `.camel-kit/ship-state.json`
+
+### Schema
+
+```json
+{
+  "started": "ISO-8601 timestamp of pipeline start",
+  "ask": "always | smart | never",
+  "currentStage": 0,
+  "stageResults": {
+    "0": {
+      "status": "pending | in_progress | completed | failed",
+      "artifact": "path to primary output artifact",
+      "completedAt": "ISO-8601 timestamp"
+    }
+  },
+  "inputFile": "path to input file or null",
+  "createPr": false,
+  "fixAttempts": {
+    "stage:task": 0
+  }
+}
+```
+
+### Stage Numbers
+
+| Number | Stage | Primary Artifact |
+|---|---|---|
+| 0 | Brainstorm | `docs/design-spec.md` |
+| 1 | Plan | `docs/implementation-plan.md` |
+| 2 | Execute | generated routes in `src/` |
+| 3 | Verify | `docs/verification-report.md` |
+
+---
+
+## Operations
+
+### Initialize
+
+At pipeline start (no `--resume`):
+
+```json
+{
+  "started": "{current ISO-8601 timestamp}",
+  "ask": "{parsed --ask value or 'smart'}",
+  "currentStage": 0,
+  "stageResults": {},
+  "inputFile": "{parsed input-file or null}",
+  "createPr": false,
+  "fixAttempts": {}
+}
+```
+
+Write to `.camel-kit/ship-state.json`. Create `.camel-kit/` directory if it doesn't exist.
+
+### Update After Stage
+
+After each stage completes:
+
+1. Read current state
+2. Set `stageResults[N].status` to `"completed"` and `stageResults[N].artifact` to the output path
+3. Set `stageResults[N].completedAt` to current timestamp
+4. Increment `currentStage` to N+1
+5. Write updated state
+
+### Update on Failure
+
+If a stage fails:
+
+1. Read current state
+2. Set `stageResults[N].status` to `"failed"`
+3. Do NOT increment `currentStage`
+4. Write updated state
+5. The next `--resume` will retry this stage
+
+### Resume
+
+When `--resume` is specified:
+
+1. Read `.camel-kit/ship-state.json`
+2. If file doesn't exist: error — "No pipeline state found. Start a new pipeline without --resume."
+3. Restore `--ask` level from state
+4. Jump to `currentStage`
+5. Verify prerequisite artifacts from completed stages still exist
+6. If artifacts are missing: error — "State indicates Stage N completed but {artifact} is missing."
+
+### Start-From
+
+When `--start-from <stage>` is specified:
+
+1. Map stage name to number: brainstorm=0, plan=1, execute=2, verify=3
+2. Verify prerequisite artifacts exist (see SKILL.md for requirements)
+3. Create fresh state with `currentStage` set to the specified stage
+4. Mark all prior stages as `"completed"` in stageResults (with current artifact paths)
+
+---
+
+## Cleanup
+
+After successful pipeline completion (all stages complete, stamp gate passes):
+
+- Keep `.camel-kit/ship-state.json` as a record
+- Do NOT delete it — it serves as an audit trail
+- The user can delete it manually or it will be overwritten on the next `/camel-ship` run

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -128,6 +128,28 @@ class DefaultGeneratorTest {
     }
 
     @Test
+    void generatesShipCommand() throws Exception {
+        InitContext ctx = createContext("bob");
+        new DefaultGenerator().generate(ctx);
+
+        assertTrue(Files.exists(ctx.commandsDir().resolve("camel-ship.md")));
+        String content = Files.readString(ctx.commandsDir().resolve("camel-ship.md"));
+        assertTrue(content.contains("SKILL.md"));
+    }
+
+    @Test
+    void copiesShipSkill() throws Exception {
+        InitContext ctx = createContext("bob");
+        new DefaultGenerator().generate(ctx);
+
+        assertTrue(Files.exists(ctx.skillsDir().resolve("camel-ship/SKILL.md")));
+        assertTrue(Files.isDirectory(ctx.skillsDir().resolve("camel-ship/guides")));
+        assertTrue(Files.exists(ctx.skillsDir().resolve("camel-ship/guides/oversight-matrix.md")));
+        assertTrue(Files.exists(ctx.skillsDir().resolve("camel-ship/guides/state-management.md")));
+        assertTrue(Files.exists(ctx.skillsDir().resolve("camel-ship/guides/auto-fix-loop.md")));
+    }
+
+    @Test
     void wrapsTomlForGemini() throws Exception {
         InitContext ctx = createContext("gemini");
         new DefaultGenerator().generate(ctx);


### PR DESCRIPTION
## Summary

- Add `/camel-ship` skill that chains the full pipeline (brainstorm → plan → execute → verify → stamp) in a single command
- Three-level oversight model (`--ask always|smart|never`) with per-stage behavior matrix
- State persistence (`.camel-kit/ship-state.json`) for `--resume` and `--start-from`
- Auto-fix loop: classify → fix → re-verify, max 3 rounds then escalate to user
- Stamp gate: build, tests, Iron Laws, constitution, acceptance criteria

## Review feedback addressed

- Removed `--create-pr` flag — PR creation is not camel-kit's responsibility
- Fixed failure handling to route through oversight matrix (not unconditional auto-fix)
- Fixed `smart` mode in auto-fix loop to defer to matrix
- Fixed Verify success under `never`: AUTO-PROCEED to Stamp (not to PR)
- Added Stamp as stage 4 in state-management
- Added `text` language tags to all code fences (markdownlint MD040)

## Test plan

- [x] `generatesShipCommand` — verify `camel-ship.md` command file is generated
- [x] `copiesShipSkill` — verify skill directory structure (SKILL.md + 3 guides)
- [x] `./mvnw clean install -B` passes (all tests green)

## References

- Closes #24
- Rebased from closed PR #26 (was targeting deleted `ci-issue-23` branch)
- ADR-0024: Agent Traits System and `/camel-ship` Autonomous Pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `camel-ship` command: end-to-end workflow (brainstorm → plan → execute → verify → stamp) with resumable state and configurable oversight (--ask always/smart/never).
  * Built-in “Stamp Gate” that runs build verification and compliance/acceptance checks; reports failures and attempts auto-fix when allowed.
  * Auto-fix loop with up to three retry rounds, then escalation to user.

* **Documentation**
  * Added guides: oversight decision matrix, state management, and auto-fix loop.

* **Tests**
  * Added tests covering generation of the new skill and associated guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->