### PR TITLE
fix #15: read fallback LTS version from constructor instead of hardcoding

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
@@ -30,11 +30,13 @@ public class CatalogDownloader {
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
 
     private final Path cacheDir;
+    private final String fallbackVersion;
     private final HttpClient httpClient;
     private final ObjectMapper mapper;
 
-    public CatalogDownloader(Path cacheDir) {
+    public CatalogDownloader(Path cacheDir, String fallbackVersion) {
         this.cacheDir = cacheDir;
+        this.fallbackVersion = fallbackVersion;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .followRedirects(HttpClient.Redirect.NORMAL)
@@ -238,7 +240,7 @@ public class CatalogDownloader {
             }
         }
 
-        return "4.20.0"; // fallback
+        return fallbackVersion;
     }
 
     /**

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -35,6 +36,10 @@ public class CatalogDownloader {
     private final ObjectMapper mapper;
 
     public CatalogDownloader(Path cacheDir, String fallbackVersion) {
+        Objects.requireNonNull(cacheDir, "cacheDir must not be null");
+        if (fallbackVersion == null || fallbackVersion.isBlank()) {
+            throw new IllegalArgumentException("fallbackVersion must not be null or blank");
+        }
         this.cacheDir = cacheDir;
         this.fallbackVersion = fallbackVersion;
         this.httpClient = HttpClient.newBuilder()

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
@@ -49,6 +49,10 @@ public class CatalogDownloader {
         this.mapper = new ObjectMapper();
     }
 
+    String fallbackVersion() {
+        return fallbackVersion;
+    }
+
     /**
      * Fetch component catalog for a Camel version. Downloads from Maven Central and extracts component JSONs.
      */

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
@@ -22,6 +22,21 @@ class CatalogDownloaderTest {
     }
 
     @Test
+    void rejectsNullCacheDir() {
+        assertThrows(NullPointerException.class, () -> new CatalogDownloader(null, "4.14.7"));
+    }
+
+    @Test
+    void rejectsNullFallbackVersion() {
+        assertThrows(IllegalArgumentException.class, () -> new CatalogDownloader(tempDir, null));
+    }
+
+    @Test
+    void rejectsBlankFallbackVersion() {
+        assertThrows(IllegalArgumentException.class, () -> new CatalogDownloader(tempDir, "  "));
+    }
+
+    @Test
     void searchComponentsOnEmptyCatalog() throws Exception {
         CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7");
         var mapper = new com.fasterxml.jackson.databind.ObjectMapper();

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
@@ -1,0 +1,33 @@
+package io.github.luigidemasi.camelkit.catalog;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CatalogDownloaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void fallbackVersionComesFromConstructor() throws Exception {
+        CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7");
+        // getLatestLtsVersion hits Maven Central; if the network call fails or
+        // returns no LTS match, the fallback from the constructor is used.
+        // We can't control the network, but we verify the object accepts the value.
+        assertNotNull(downloader);
+    }
+
+    @Test
+    void searchComponentsOnEmptyCatalog() throws Exception {
+        CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7");
+        var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        var catalog = mapper.createObjectNode();
+        catalog.putArray("components");
+        var results = downloader.searchComponents("kafka", catalog, 10);
+        assertTrue(results.isEmpty());
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
@@ -13,12 +13,9 @@ class CatalogDownloaderTest {
     Path tempDir;
 
     @Test
-    void fallbackVersionComesFromConstructor() throws Exception {
+    void fallbackVersionComesFromConstructor() {
         CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7");
-        // getLatestLtsVersion hits Maven Central; if the network call fails or
-        // returns no LTS match, the fallback from the constructor is used.
-        // We can't control the network, but we verify the object accepts the value.
-        assertNotNull(downloader);
+        assertEquals("4.14.7", downloader.fallbackVersion());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replaced hardcoded `"4.20.0"` fallback in `CatalogDownloader.getLatestLtsVersion()` with a `fallbackVersion` constructor parameter
- Callers provide the value from `DistributionConfig.camelMainVersion()`, keeping `distribution.properties` as the single source of truth
- No existing callers to update (class is not yet integrated)

## Test plan

- [x] `CatalogDownloaderTest.fallbackVersionComesFromConstructor` — verifies constructor accepts the fallback
- [x] `CatalogDownloaderTest.searchComponentsOnEmptyCatalog` — verifies search on empty catalog
- [x] Full build passes (252 tests, 0 failures)

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fallback version is now configurable during component initialization, allowing users to specify custom fallback versions instead of relying on a fixed default, providing greater deployment flexibility.

* **Tests**
  * Added test coverage for fallback version configuration and catalog component search functionality to ensure proper operation with custom fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->