### PR TITLE
fix #14: replace even-number LTS heuristic with explicit supported versions set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,7 +255,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`camel-implement` — Route validation with MCP** — replaced Maven YAML DSL Validator with MCP `camel_validate_route` tool; validates all endpoint URIs against Camel catalog in real-time
 
+- **`/camel-ship` — autonomous end-to-end pipeline with configurable oversight** — new skill that chains the entire camel-kit pipeline (brainstorm → plan → execute → verify → stamp) with three oversight levels: `always` (pause at every stage), `smart` (auto-proceed on clear outcomes, pause on ambiguity), `never` (fully autonomous). State persistence via `.camel-kit/ship-state.json` for `--resume` and `--start-from`. Auto-fix loop: classify → fix → re-verify, max 3 rounds then escalate. Stamp gate: build, tests, Iron Laws, constitution, acceptance criteria.
+
+- **Agent traits system — build-time append of agent-specific instructions** — `applyTraits()` method in `DefaultGenerator` scans `templates/traits/{agent}/` and appends `.append.md` files to matching skill files during `camel-kit init`. Two granularity levels: SKILL.md-level (strategy) and guide-level (tactics). 24 trait files across 5 agents: Claude Code (worktrees, cron, parallel Agent), Gemini CLI (read_many_files, TOML auto-approval), IBM Bob (switch_mode, gates), Qwen Code (serial dispatch, todo_write), OpenCode (LSP, step limits). Idempotent via HTML comment sentinels (`<!-- TRAIT:agent -->`).
+
+### Changed
+
+- **BizTalk documentation updated** — added BizTalk migration references to `docs/user-guide.md`, `docs/commands.md`, `docs/architecture.md`, `docs/camel-kit-overview.md`, `README.md`, `CONTRIBUTING.md`. BizTalkMigrationStarter repository URL corrected. Camel validator-starter component reference corrected.
+
 ### Fixed
+
+- **README: `-d` flag in Camel JBang Plugin install command corrected to `--description`** — the `-d` short option is not recognized by current versions of Camel JBang. Fixed to use the correct `--description` long option.
+
+- **Hardcoded version numbers in skill files replaced with Qute-substituted placeholders** — skill Markdown files contained hardcoded Camel/Quarkus version numbers (e.g., `3.33.0`, `4.18.0`, `3.27.2`) that drifted from `distribution.properties`, causing stale versions in generated projects. Added Qute-based placeholder substitution to `copySkills` using an escape-then-unescape approach (escape all `{` to `\{`, restore only known version keys, then Qute-render). New `{QUARKUS_PLATFORM_TABLE}` placeholder dynamically generates the Camel-to-Quarkus mapping table from `quarkus.platform.*` keys. `DistributionConfig.quarkusPlatformMappings()` added. 16 hardcoded values replaced across 8 skill files.
+
+- **Fallback LTS version in `CatalogDownloader` no longer hardcoded** — `getLatestLtsVersion()` returned a hardcoded `"4.20.0"` when Maven Central was unreachable. Replaced with a `fallbackVersion` constructor parameter so callers provide the value from `DistributionConfig.camelMainVersion()`.
+
+- **LTS version detection no longer relies on even-number heuristic** — `getLatestLtsVersion()` assumed LTS versions have even minor numbers (`minor % 2 == 0`), which is not officially guaranteed by Apache Camel. Replaced with an explicit `Set<String>` of known LTS minor versions passed via constructor, built from `DistributionConfig.camelMainSupported()`.
 
 - **`.kaoto` filename and format hardening against hallucination**
   - Filename must be `.kaoto` (single project-level file) — NOT `kaoto-datamapper-{id}.kaoto` (per-mapping file invented by analogy with XSL naming)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloader.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -32,16 +33,19 @@ public class CatalogDownloader {
 
     private final Path cacheDir;
     private final String fallbackVersion;
+    private final Set<String> ltsMinorVersions;
     private final HttpClient httpClient;
     private final ObjectMapper mapper;
 
-    public CatalogDownloader(Path cacheDir, String fallbackVersion) {
+    public CatalogDownloader(Path cacheDir, String fallbackVersion, Set<String> ltsMinorVersions) {
         Objects.requireNonNull(cacheDir, "cacheDir must not be null");
+        Objects.requireNonNull(ltsMinorVersions, "ltsMinorVersions must not be null");
         if (fallbackVersion == null || fallbackVersion.isBlank()) {
             throw new IllegalArgumentException("fallbackVersion must not be null or blank");
         }
         this.cacheDir = cacheDir;
         this.fallbackVersion = fallbackVersion;
+        this.ltsMinorVersions = Set.copyOf(ltsMinorVersions);
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .followRedirects(HttpClient.Redirect.NORMAL)
@@ -229,16 +233,11 @@ public class CatalogDownloader {
 
             for (JsonNode doc : docs) {
                 String version = doc.path("v").asText();
-                // LTS versions have even minor numbers (4.0, 4.4, 4.8, 4.10, 4.14, 4.18, 4.20, ...)
                 String[] parts = version.split("\\.");
                 if (parts.length >= 2) {
-                    try {
-                        int minor = Integer.parseInt(parts[1]);
-                        if (minor % 2 == 0) {
-                            return version;
-                        }
-                    } catch (NumberFormatException e) {
-                        // ignore
+                    String majorMinor = parts[0] + "." + parts[1];
+                    if (ltsMinorVersions.contains(majorMinor)) {
+                        return version;
                     }
                 }
             }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
@@ -1,6 +1,7 @@
 package io.github.luigidemasi.camelkit.catalog;
 
 import java.nio.file.Path;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -9,33 +10,40 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CatalogDownloaderTest {
 
+    private static final Set<String> LTS_VERSIONS = Set.of("4.14", "4.18", "4.20");
+
     @TempDir
     Path tempDir;
 
     @Test
     void fallbackVersionComesFromConstructor() {
-        CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7");
+        CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7", LTS_VERSIONS);
         assertEquals("4.14.7", downloader.fallbackVersion());
     }
 
     @Test
     void rejectsNullCacheDir() {
-        assertThrows(NullPointerException.class, () -> new CatalogDownloader(null, "4.14.7"));
+        assertThrows(NullPointerException.class, () -> new CatalogDownloader(null, "4.14.7", LTS_VERSIONS));
     }
 
     @Test
     void rejectsNullFallbackVersion() {
-        assertThrows(IllegalArgumentException.class, () -> new CatalogDownloader(tempDir, null));
+        assertThrows(IllegalArgumentException.class, () -> new CatalogDownloader(tempDir, null, LTS_VERSIONS));
     }
 
     @Test
     void rejectsBlankFallbackVersion() {
-        assertThrows(IllegalArgumentException.class, () -> new CatalogDownloader(tempDir, "  "));
+        assertThrows(IllegalArgumentException.class, () -> new CatalogDownloader(tempDir, "  ", LTS_VERSIONS));
     }
 
     @Test
-    void searchComponentsOnEmptyCatalog() throws Exception {
-        CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7");
+    void rejectsNullLtsVersions() {
+        assertThrows(NullPointerException.class, () -> new CatalogDownloader(tempDir, "4.20.0", null));
+    }
+
+    @Test
+    void searchComponentsOnEmptyCatalog() {
+        CatalogDownloader downloader = new CatalogDownloader(tempDir, "4.14.7", LTS_VERSIONS);
         var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
         var catalog = mapper.createObjectNode();
         catalog.putArray("components");


### PR DESCRIPTION
## Summary

- Replaced the unreliable even-minor-number LTS heuristic in `CatalogDownloader.getLatestLtsVersion()` with an explicit `Set<String>` of known LTS minor versions passed via constructor
- Callers build the set from `DistributionConfig.camelMainSupported()` (e.g., `"4.20.0,4.18.2,4.14.7"` → `{"4.20", "4.18", "4.14"}`)
- The set is defensively copied via `Set.copyOf()` and validated non-null in the constructor

## Test plan

- [x] `CatalogDownloaderTest.fallbackVersionComesFromConstructor` — verifies constructor stores value
- [x] `CatalogDownloaderTest.rejectsNullLtsVersions` — validates null check
- [x] `CatalogDownloaderTest.rejectsNullCacheDir` / `rejectsNullFallbackVersion` / `rejectsBlankFallbackVersion` — existing validation tests updated for new constructor signature
- [x] `CatalogDownloaderTest.searchComponentsOnEmptyCatalog` — existing test updated
- [x] Full build passes (255 tests, 0 failures)

Closes #14