### PR TITLE
fix #16: guard against null label in GraphRouteContextCommand error flow filter

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/graph/GraphRouteContextCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/graph/GraphRouteContextCommand.java
@@ -60,8 +60,8 @@ public class GraphRouteContextCommand extends GraphQueryCommand {
         ArrayNode ef = root.putArray("errorFlow");
         tracer.trace(routeId).stream()
                 .filter(s -> {
-                    String t = s.type().toLowerCase(Locale.ROOT);
-                    String l = s.label().toLowerCase(Locale.ROOT);
+                    String t = s.type() != null ? s.type().toLowerCase(Locale.ROOT) : "";
+                    String l = s.label() != null ? s.label().toLowerCase(Locale.ROOT) : "";
                     return t.contains("error") || t.contains("exception") || l.contains("dlq")
                             || l.contains("deadletter");
                 })

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/graph/GraphRouteContextCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/graph/GraphRouteContextCommandTest.java
@@ -3,6 +3,13 @@ package io.github.luigidemasi.camelkit.command.graph;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Path;
+import java.util.Map;
+
+import io.github.luigidemasi.camelkit.graph.ProjectGraph;
+import io.github.luigidemasi.camelkit.graph.model.EdgeType;
+import io.github.luigidemasi.camelkit.graph.model.GraphEdge;
+import io.github.luigidemasi.camelkit.graph.model.GraphNode;
+import io.github.luigidemasi.camelkit.graph.model.NodeType;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,12 +69,30 @@ class GraphRouteContextCommandTest {
         assertTrue(MAPPER.readTree(run("route:order-process")).has("errorFlow"));
     }
 
+    @Test
+    void doesNotThrowWhenProcessorLabelIsNull() throws Exception {
+        ProjectGraph graph = TestGraphs.sampleProject();
+        graph.addNode(new GraphNode(
+                "proc:no-type", NodeType.CAMEL_PROCESSOR, Map.of("name", "anonymous")));
+        graph.addEdge(new GraphEdge(
+                "route:order-process", "proc:no-type", EdgeType.PROCESSES, Map.of("order", "0")));
+        Path subDir = tempDir.resolve("null-label");
+        java.nio.file.Files.createDirectories(subDir);
+        Path gf = TestGraphs.writeToTempFile(graph, subDir);
+        String json = runWithGraph(gf, "route:order-process");
+        assertTrue(MAPPER.readTree(json).has("errorFlow"));
+    }
+
     private String run(String routeId) {
+        return runWithGraph(graphFile, routeId);
+    }
+
+    private String runWithGraph(Path gf, String routeId) {
         StringWriter out = new StringWriter(), err = new StringWriter();
         CommandLine cl = new CommandLine(new GraphRouteContextCommand());
         cl.setOut(new PrintWriter(out));
         cl.setErr(new PrintWriter(err));
-        assertEquals(0, cl.execute("--graph-file", graphFile.toString(), routeId));
+        assertEquals(0, cl.execute("--graph-file", gf.toString(), routeId));
         return out.toString().trim();
     }
 }


### PR DESCRIPTION
## Summary

- Added null guards for `type()` and `label()` in the error flow filter of `GraphRouteContextCommand` to prevent NPE when a processor node has no `type` property
- `RouteFlowTracer.FlowStep.label()` can be null when created from `processor.properties().get("type")` for nodes without a `type` entry

## Test plan

- [x] `doesNotThrowWhenProcessorLabelIsNull` — creates a graph with a processor node that has no `type` property, verifies the command completes without NPE
- [x] All existing tests pass (no regressions)
- [x] Full build passes (257 tests, 0 failures)

Closes #16