### PR TITLE
fix #36: harden version-selection guide against LLM training data drift

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/version-selection.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/version-selection.md
@@ -74,9 +74,15 @@ Default: `{CAMEL_QUARKUS_VERSION}`
 
 ## Step 3: Resolve Platform BOM Version
 
+<HARD-RULE>
+The Quarkus platform BOM version MUST come from the mapping table in Step 2 above. Do NOT use your own knowledge of Quarkus versions. Do NOT look up versions on the internet. Do NOT guess. The table above is the ONLY source of truth for the Camel-to-Quarkus version mapping.
+
+If the selected Camel version does not appear in the mapping table, it is NOT supported on Quarkus. Do NOT invent a platform version.
+</HARD-RULE>
+
 - **If runtime is `main`:** no platform BOM needed — JBang uses the Camel version directly
 - **If runtime is `spring-boot`:** platform BOM version = Camel version (same release train)
-- **If runtime is `quarkus`:** look up the Quarkus platform BOM from the mapping table above
+- **If runtime is `quarkus`:** look up the Quarkus platform BOM from the mapping table in Step 2. Use EXACTLY the version from the table — no other source.
 
 ---
 
@@ -93,7 +99,9 @@ project.platformBomVersion={QUARKUS_PLATFORM_VERSION}
 These values are the single source of truth for all subsequent skills.
 
 <HARD-RULE>
-Do NOT guess or derive versions. Read `project.camelVersion` and `project.platformBomVersion` from `.camel-kit/config.properties` in all skills.
+Do NOT guess or derive versions from your training data. ALL version numbers MUST come from THIS FILE (the tables in Step 2 above) during version selection, and from `.camel-kit/config.properties` in all downstream skills.
+
+Your training data about Quarkus platform versions is WRONG — the mapping table above is the ONLY truth. If you think a different version is "more current," you are wrong. Use the table.
 
 The runtime determines the available versions. Never present Quarkus users with versions that have no Quarkus support.
 </HARD-RULE>


### PR DESCRIPTION
## Summary

- Add HARD-RULE before Step 3 in `version-selection.md` stating Quarkus platform BOM version MUST come from the mapping table in Step 2
- Strengthen the bottom HARD-RULE to cover version selection itself (not just downstream skills reading `config.properties`)
- Add explicit "Your training data about Quarkus platform versions is WRONG" phrasing to override LLM confidence

## Problem

During `camel-ship` testing, the LLM selected Camel 4.18.0 on Quarkus **3.32.0** instead of the correct **3.33.1**. The deployed skill file (after Qute substitution) correctly shows 3.33.1 in the mapping table, but the LLM ignored the table and used its training data.

Verified: the JAR, the Qute substitution, and the deployed file are all correct. The problem is purely LLM hallucination.

## Test plan

- [x] Build passes (`./mvnw clean install -B`)
- [ ] Re-test with `camel-ship` on a Quarkus project — verify LLM uses 3.33.1 from the table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version selection guide with explicit constraints clarifying where Quarkus platform BOM versions and all configuration values must be sourced from during the version selection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->