### PR TITLE
Fix #44: Add prerequisite check and overwrite detection to init command

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -71,6 +71,8 @@ public class InitCommand extends CamelKitCommand {
             description = "Source platform for migration graph analysis: mulesoft, camel, biztalk, auto (default: auto)")
     public String sourcePlatform;
 
+    private Path resolvedTargetDir;
+
     public InitCommand(CamelKitMain main) {
         super(main);
     }
@@ -102,24 +104,23 @@ public class InitCommand extends CamelKitCommand {
             return 1;
         }
 
-        // Resolve target directory early for overwrite check
-        Path targetDir;
+        // Resolve target directory once — reused in doInitWork()
         if (here) {
-            targetDir = Path.of("").toAbsolutePath();
-            projectName = targetDir.getFileName().toString();
+            resolvedTargetDir = Path.of("").toAbsolutePath();
+            projectName = resolvedTargetDir.getFileName().toString();
         } else {
-            targetDir = Path.of(projectName).toAbsolutePath();
+            resolvedTargetDir = Path.of(projectName).toAbsolutePath();
         }
 
         // Overwrite detection (runs before TUI so colors work on error)
-        Path agentsMd = targetDir.resolve("AGENTS.md");
-        Path camelKitDir = targetDir.resolve(".camel-kit");
+        Path agentsMd = resolvedTargetDir.resolve("AGENTS.md");
+        Path camelKitDir = resolvedTargetDir.resolve(".camel-kit");
         if (!force && (Files.exists(agentsMd) || Files.isDirectory(camelKitDir))) {
             if (!silent)
                 main.printBanner();
             printer().println();
             printer().println(yellow("⚠") + bold(" Project already initialized"));
-            printer().println(dim("  Directory: ") + cyan(targetDir.toString()));
+            printer().println(dim("  Directory: ") + cyan(resolvedTargetDir.toString()));
             if (Files.exists(agentsMd)) {
                 printer().println(dim("  Found:     ") + "AGENTS.md");
             }
@@ -167,14 +168,7 @@ public class InitCommand extends CamelKitCommand {
         }
 
         AgentConfig agent = AgentRegistry.get(ai);
-
-        // targetDir already resolved and validated in doCall()
-        Path targetDir;
-        if (here) {
-            targetDir = Path.of("").toAbsolutePath();
-        } else {
-            targetDir = Path.of(projectName).toAbsolutePath();
-        }
+        Path targetDir = resolvedTargetDir;
         Path camelKitDir = targetDir.resolve(".camel-kit");
 
         // Get Citrus version

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -21,6 +21,7 @@ import io.github.luigidemasi.camelkit.graph.RuntimeDetector;
 import io.github.luigidemasi.camelkit.output.Printer;
 import io.github.luigidemasi.camelkit.tui.InitTuiView;
 import io.github.luigidemasi.camelkit.tui.TaskTracker;
+import io.github.luigidemasi.camelkit.util.PrerequisiteChecker;
 import io.github.luigidemasi.camelkit.util.TemplateUtils;
 
 import dev.tamboui.image.capability.TerminalImageCapabilities;
@@ -51,6 +52,9 @@ public class InitCommand extends CamelKitCommand {
 
     @Option(names = {"--no-fetch"}, description = "Skip external catalog fetching")
     public boolean noFetch;
+
+    @Option(names = {"--force"}, description = "Overwrite existing project without prompting")
+    public boolean force;
 
     @Option(names = {"--silent"}, description = "Suppress all output (no banner, no progress, no summary)")
     public boolean silent;
@@ -126,6 +130,11 @@ public class InitCommand extends CamelKitCommand {
     }
 
     private Integer doInitWork() throws Exception {
+        // Prerequisite check (non-blocking, skipped in silent mode)
+        if (!silent) {
+            PrerequisiteChecker.check(printer());
+        }
+
         AgentConfig agent = AgentRegistry.get(ai);
         // Resolve target directory
         Path targetDir;
@@ -134,6 +143,18 @@ public class InitCommand extends CamelKitCommand {
             projectName = targetDir.getFileName().toString();
         } else {
             targetDir = Path.of(projectName).toAbsolutePath();
+        }
+
+        // Overwrite detection
+        Path agentsMd = targetDir.resolve("AGENTS.md");
+        Path camelKitDir = targetDir.resolve(".camel-kit");
+        if (!force && (Files.exists(agentsMd) || Files.isDirectory(camelKitDir))) {
+            printer().println(yellow("⚠") + " Project already initialized in " + targetDir);
+            String found = (Files.exists(agentsMd) ? "AGENTS.md " : "")
+                           + (Files.isDirectory(camelKitDir) ? ".camel-kit/" : "");
+            printer().println("  Found: " + found.trim());
+            printer().println("  Use --force to overwrite, or choose a different directory.");
+            return 1;
         }
 
         // Get Citrus version
@@ -148,7 +169,6 @@ public class InitCommand extends CamelKitCommand {
         Files.createDirectories(targetDir);
         Path commandsDir = targetDir.resolve(agent.folder());
         Files.createDirectories(commandsDir);
-        Path camelKitDir = targetDir.resolve(".camel-kit");
         Files.createDirectories(camelKitDir);
         Path docsDir = targetDir.resolve("docs");
         Files.createDirectories(docsDir.resolve("flows"));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -149,11 +149,19 @@ public class InitCommand extends CamelKitCommand {
         Path agentsMd = targetDir.resolve("AGENTS.md");
         Path camelKitDir = targetDir.resolve(".camel-kit");
         if (!force && (Files.exists(agentsMd) || Files.isDirectory(camelKitDir))) {
-            printer().println(yellow("⚠") + " Project already initialized in " + targetDir);
-            String found = (Files.exists(agentsMd) ? "AGENTS.md " : "")
-                           + (Files.isDirectory(camelKitDir) ? ".camel-kit/" : "");
-            printer().println("  Found: " + found.trim());
-            printer().println("  Use --force to overwrite, or choose a different directory.");
+            printer().println();
+            printer().println(yellow("⚠") + bold(" Project already initialized"));
+            printer().println(dim("  Directory: ") + cyan(targetDir.toString()));
+            if (Files.exists(agentsMd)) {
+                printer().println(dim("  Found:     ") + "AGENTS.md");
+            }
+            if (Files.isDirectory(camelKitDir)) {
+                printer().println(dim("  Found:     ") + ".camel-kit/");
+            }
+            printer().println();
+            printer().println(dim("  To overwrite: ") + bold("--force"));
+            printer().println(dim("  Example:      ") + "camel-kit init " + projectName + " --ai " + ai + " --force");
+            printer().println();
             return 1;
         }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -102,6 +102,37 @@ public class InitCommand extends CamelKitCommand {
             return 1;
         }
 
+        // Resolve target directory early for overwrite check
+        Path targetDir;
+        if (here) {
+            targetDir = Path.of("").toAbsolutePath();
+            projectName = targetDir.getFileName().toString();
+        } else {
+            targetDir = Path.of(projectName).toAbsolutePath();
+        }
+
+        // Overwrite detection (runs before TUI so colors work on error)
+        Path agentsMd = targetDir.resolve("AGENTS.md");
+        Path camelKitDir = targetDir.resolve(".camel-kit");
+        if (!force && (Files.exists(agentsMd) || Files.isDirectory(camelKitDir))) {
+            if (!silent)
+                main.printBanner();
+            printer().println();
+            printer().println(yellow("⚠") + bold(" Project already initialized"));
+            printer().println(dim("  Directory: ") + cyan(targetDir.toString()));
+            if (Files.exists(agentsMd)) {
+                printer().println(dim("  Found:     ") + "AGENTS.md");
+            }
+            if (Files.isDirectory(camelKitDir)) {
+                printer().println(dim("  Found:     ") + ".camel-kit/");
+            }
+            printer().println();
+            printer().println(dim("  To overwrite: ") + bold("--force"));
+            printer().println(dim("  Example:      ") + "camel-kit init " + projectName + " --ai " + ai + " --force");
+            printer().println();
+            return 1;
+        }
+
         if (!silent) {
             // If native image protocol is available and TUI is enabled, run the full
             // split-screen experience. Falls back to normal mode on any failure
@@ -130,40 +161,21 @@ public class InitCommand extends CamelKitCommand {
     }
 
     private Integer doInitWork() throws Exception {
-        // Prerequisite check (non-blocking, skipped in silent mode)
+        // Prerequisite check (non-blocking, informational)
         if (!silent) {
             PrerequisiteChecker.check(printer());
         }
 
         AgentConfig agent = AgentRegistry.get(ai);
-        // Resolve target directory
+
+        // targetDir already resolved and validated in doCall()
         Path targetDir;
         if (here) {
             targetDir = Path.of("").toAbsolutePath();
-            projectName = targetDir.getFileName().toString();
         } else {
             targetDir = Path.of(projectName).toAbsolutePath();
         }
-
-        // Overwrite detection
-        Path agentsMd = targetDir.resolve("AGENTS.md");
         Path camelKitDir = targetDir.resolve(".camel-kit");
-        if (!force && (Files.exists(agentsMd) || Files.isDirectory(camelKitDir))) {
-            printer().println();
-            printer().println(yellow("⚠") + bold(" Project already initialized"));
-            printer().println(dim("  Directory: ") + cyan(targetDir.toString()));
-            if (Files.exists(agentsMd)) {
-                printer().println(dim("  Found:     ") + "AGENTS.md");
-            }
-            if (Files.isDirectory(camelKitDir)) {
-                printer().println(dim("  Found:     ") + ".camel-kit/");
-            }
-            printer().println();
-            printer().println(dim("  To overwrite: ") + bold("--force"));
-            printer().println(dim("  Example:      ") + "camel-kit init " + projectName + " --ai " + ai + " --force");
-            printer().println();
-            return 1;
-        }
 
         // Get Citrus version
         String citrusVer = "default".equals(citrusVersion)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
@@ -1,0 +1,194 @@
+package io.github.luigidemasi.camelkit.util;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.output.Printer;
+
+/**
+ * Checks whether prerequisite tools (Java, JBang, Camel JBang, Camel test plugin) are available on the system. The
+ * check is non-blocking: it prints warnings but never fails the init.
+ */
+public final class PrerequisiteChecker {
+
+    private static final int TIMEOUT_SECONDS = 5;
+    private static final int MIN_JAVA_VERSION = 17;
+
+    private PrerequisiteChecker() {
+        // Utility class
+    }
+
+    /**
+     * Run all prerequisite checks and print a formatted summary.
+     */
+    public static void check(Printer printer) {
+        List<CheckResult> results = new ArrayList<>();
+
+        results.add(checkJava());
+        results.add(checkJBang());
+        results.add(checkCamelJBang());
+        results.add(checkCamelTestPlugin());
+
+        printer.println("Prerequisites:");
+        for (CheckResult r : results) {
+            String icon = r.found ? AnsiColors.green("✓") : AnsiColors.red("✗");
+            String detail
+                    = r.found ? "(" + r.version + ")" : "(not found" + (r.hint != null ? " — " + r.hint : "") + ")";
+            printer.println(String.format(Locale.ROOT, "  %-19s %s %s", r.name, icon, detail));
+        }
+        printer.println();
+    }
+
+    // ------------------------------------------------------------------
+    // Individual checks
+    // ------------------------------------------------------------------
+
+    private static CheckResult checkJava() {
+        try {
+            // java -version writes to stderr
+            ProcessBuilder pb = new ProcessBuilder("java", "-version");
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+
+            String output;
+            try (BufferedReader reader
+                    = new BufferedReader(new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+                output = reader.lines().reduce("", (a, b) -> a + "\n" + b).trim();
+            }
+
+            if (!proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                proc.destroyForcibly();
+                return new CheckResult("Java 17+", false, null, null);
+            }
+
+            String version = parseJavaVersion(output);
+            if (version != null) {
+                int major = parseMajorVersion(version);
+                if (major >= MIN_JAVA_VERSION) {
+                    return new CheckResult("Java 17+", true, version, null);
+                }
+                return new CheckResult("Java 17+", false, null, "found " + version + ", need 17+");
+            }
+            return new CheckResult("Java 17+", false, null, null);
+        } catch (Exception e) {
+            return new CheckResult("Java 17+", false, null, null);
+        }
+    }
+
+    private static CheckResult checkJBang() {
+        return runSimpleCheck("JBang", new String[]{"jbang", "version"}, false);
+    }
+
+    private static CheckResult checkCamelJBang() {
+        return runSimpleCheck("Camel JBang", new String[]{"camel", "--version"}, false);
+    }
+
+    private static CheckResult checkCamelTestPlugin() {
+        CheckResult result = runSimpleCheck("Camel test plugin", new String[]{"camel", "test", "--help"}, true);
+        if (!result.found) {
+            return new CheckResult(result.name, false, null, "/camel-verify will skip test phase");
+        }
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static CheckResult runSimpleCheck(String name, String[] command, boolean ignoreOutput) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+
+            String output;
+            try (BufferedReader reader
+                    = new BufferedReader(new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+                output = reader.lines().reduce("", (a, b) -> a + "\n" + b).trim();
+            }
+
+            if (!proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                proc.destroyForcibly();
+                return new CheckResult(name, false, null, null);
+            }
+
+            if (proc.exitValue() == 0) {
+                String version = ignoreOutput ? "installed" : extractFirstLine(output);
+                return new CheckResult(name, true, version, null);
+            }
+            return new CheckResult(name, false, null, null);
+        } catch (Exception e) {
+            return new CheckResult(name, false, null, null);
+        }
+    }
+
+    /**
+     * Parse the Java version from {@code java -version} output. Handles both the old format
+     * ({@code java version "1.8.0_xxx"}) and the modern format ({@code openjdk version "17.0.1"}).
+     */
+    static String parseJavaVersion(String output) {
+        Pattern pattern = Pattern.compile("version\\s+\"([^\"]+)\"");
+        Matcher matcher = pattern.matcher(output);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Extract the major version number. Handles {@code 1.8.0_xxx} (returns 8) and {@code 17.0.1} (returns 17).
+     */
+    static int parseMajorVersion(String version) {
+        if (version.startsWith("1.")) {
+            // Old-style: 1.8.0_xxx → 8
+            String[] parts = version.split("\\.");
+            if (parts.length >= 2) {
+                try {
+                    return Integer.parseInt(parts[1]);
+                } catch (NumberFormatException e) {
+                    return 0;
+                }
+            }
+        }
+        // Modern: 17.0.1 → 17
+        String[] parts = version.split("[.+\\-]");
+        try {
+            return Integer.parseInt(parts[0]);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static String extractFirstLine(String output) {
+        if (output == null || output.isEmpty()) {
+            return "installed";
+        }
+        String firstLine = output.lines().findFirst().orElse("").trim();
+        return firstLine.isEmpty() ? "installed" : firstLine;
+    }
+
+    // ------------------------------------------------------------------
+    // Result record
+    // ------------------------------------------------------------------
+
+    private static final class CheckResult {
+        final String name;
+        final boolean found;
+        final String version;
+        final String hint;
+
+        CheckResult(String name, boolean found, String version, String hint) {
+            this.name = name;
+            this.found = found;
+            this.version = version;
+            this.hint = hint;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
@@ -36,11 +36,19 @@ public final class PrerequisiteChecker {
         results.add(checkCamelJBang());
         results.add(checkCamelTestPlugin());
 
-        printer.println("Prerequisites:");
+        printer.println(AnsiColors.bold("Prerequisites:"));
         for (CheckResult r : results) {
             String icon = r.found ? AnsiColors.green("✓") : AnsiColors.red("✗");
-            String detail
-                    = r.found ? "(" + r.version + ")" : "(not found" + (r.hint != null ? " — " + r.hint : "") + ")";
+            String detail;
+            if (r.found) {
+                detail = AnsiColors.dim("(" + r.version + ")");
+            } else {
+                String msg = "not found";
+                if (r.hint != null) {
+                    msg += " — " + AnsiColors.yellow(r.hint);
+                }
+                detail = AnsiColors.red("(" + msg + ")");
+            }
             printer.println(String.format(Locale.ROOT, "  %-19s %s %s", r.name, icon, detail));
         }
         printer.println();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
@@ -60,19 +60,12 @@ public final class PrerequisiteChecker {
 
     private static CheckResult checkJava() {
         try {
-            // java -version writes to stderr
             ProcessBuilder pb = new ProcessBuilder("java", "-version");
             pb.redirectErrorStream(true);
             Process proc = pb.start();
 
-            String output;
-            try (BufferedReader reader
-                    = new BufferedReader(new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
-                output = reader.lines().reduce("", (a, b) -> a + "\n" + b).trim();
-            }
-
-            if (!proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                proc.destroyForcibly();
+            String output = drainWithTimeout(proc);
+            if (output == null) {
                 return new CheckResult("Java 17+", false, null, null);
             }
 
@@ -116,14 +109,8 @@ public final class PrerequisiteChecker {
             pb.redirectErrorStream(true);
             Process proc = pb.start();
 
-            String output;
-            try (BufferedReader reader
-                    = new BufferedReader(new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
-                output = reader.lines().reduce("", (a, b) -> a + "\n" + b).trim();
-            }
-
-            if (!proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                proc.destroyForcibly();
+            String output = drainWithTimeout(proc);
+            if (output == null) {
                 return new CheckResult(name, false, null, null);
             }
 
@@ -135,6 +122,33 @@ public final class PrerequisiteChecker {
         } catch (Exception e) {
             return new CheckResult(name, false, null, null);
         }
+    }
+
+    /**
+     * Drain process output in a daemon thread while the main thread holds the timed wait. Returns the output string, or
+     * null if the process timed out.
+     */
+    private static String drainWithTimeout(Process proc) throws InterruptedException {
+        StringBuilder sb = new StringBuilder();
+        Thread drainer = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+                reader.lines().forEach(line -> sb.append(line).append('\n'));
+            } catch (java.io.IOException ignored) {
+            }
+        });
+        drainer.setDaemon(true);
+        drainer.start();
+
+        if (!proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            proc.destroyForcibly();
+            return null;
+        }
+        try {
+            drainer.join(500);
+        } catch (InterruptedException ignored) {
+        }
+        return sb.toString().trim();
     }
 
     /**

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/util/PrerequisiteCheckerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/util/PrerequisiteCheckerTest.java
@@ -1,0 +1,45 @@
+package io.github.luigidemasi.camelkit.util;
+
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PrerequisiteCheckerTest {
+
+    @Test
+    void checkDoesNotThrow() {
+        assertDoesNotThrow(() -> PrerequisiteChecker.check(Printer.noop()));
+    }
+
+    @Test
+    void parseJavaVersionModernFormat() {
+        String output = "openjdk version \"21.0.3\" 2024-04-16 LTS\n"
+                        + "OpenJDK Runtime Environment (build 21.0.3+9-LTS)\n"
+                        + "OpenJDK 64-Bit Server VM (build 21.0.3+9-LTS, mixed mode, sharing)";
+        assertEquals("21.0.3", PrerequisiteChecker.parseJavaVersion(output));
+    }
+
+    @Test
+    void parseJavaVersionOldFormat() {
+        String output = "java version \"1.8.0_401\"";
+        assertEquals("1.8.0_401", PrerequisiteChecker.parseJavaVersion(output));
+    }
+
+    @Test
+    void parseMajorVersionModern() {
+        assertEquals(21, PrerequisiteChecker.parseMajorVersion("21.0.3"));
+        assertEquals(17, PrerequisiteChecker.parseMajorVersion("17.0.1"));
+    }
+
+    @Test
+    void parseMajorVersionOldStyle() {
+        assertEquals(8, PrerequisiteChecker.parseMajorVersion("1.8.0_401"));
+    }
+
+    @Test
+    void parseJavaVersionReturnsNullOnGarbage() {
+        assertNull(PrerequisiteChecker.parseJavaVersion("not a version string"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add prerequisite detection to `init` command: checks Java 17+, JBang, Camel JBang, Camel test plugin and prints a formatted status table. Non-blocking — warns but doesn't fail.
- Add overwrite detection: if `AGENTS.md` or `.camel-kit/` already exists, warns and exits. Add `--force` flag to skip the prompt.
- New `PrerequisiteChecker` utility with `ProcessBuilder`-based detection (5s timeout per check)

## Test plan

- [x] `PrerequisiteCheckerTest` — smoke test + version parsing unit tests
- [x] Full build passes on all modules
- [ ] Manual test: `camel-kit init test-project --ai claude` in clean dir
- [ ] Manual test: run again without `--force` (should warn)
- [ ] Manual test: run again with `--force` (should overwrite)

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--force` flag to reinitialize projects without confirmation; initialization now detects existing setups and will warn/exit unless `--force` is supplied.
  * Initialization performs system prerequisite checks up-front (Java 17+, JBang, Camel JBang, test plugin) and prints a colored status summary before creating project files.

* **Tests**
  * Added tests covering prerequisite detection and Java version parsing across legacy and modern formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->