### PR TITLE
chore: document init command improvements (--force, --version, prerequisite check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Standalone:   /camel-verify        (runtime verification only)
 
 Camel JBang and its test plugin are needed for the full pipeline (environment probe, endpoint validation, runtime verification). The design and planning phases work without them.
 
+`camel-kit init` automatically checks for these prerequisites and reports their status. Missing tools produce warnings but don't block initialization.
+
 ### Standalone (JBang)
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -106,7 +106,7 @@ camel-kit --version
 
 On startup, `init` checks for required tools and reports their status:
 
-```
+```text
 Prerequisites:
   Java 17+          ✓ (21.0.3)
   JBang             ✓ (0.136.0)
@@ -120,7 +120,7 @@ The check is non-blocking -- it warns but never fails the init. Design and plann
 
 If the target directory already contains `AGENTS.md` or `.camel-kit/`, init warns and exits:
 
-```
+```text
 ⚠ Project already initialized
   Directory: /path/to/my-integration
   Found:     AGENTS.md

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,7 +49,9 @@ camel-kit init --here [options]
 | `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.version=4.18.0"` |
 | `-c`, `--config` | `~/.camel-kit/config.properties` | Path to a custom config properties file |
 | `--source-platform` | `auto` | Source platform for migration: `mulesoft`, `camel`, `biztalk`, `auto` |
+| `--force` | `false` | Overwrite existing project without prompting (skips overwrite detection) |
 | `--silent` | `false` | Suppress all output (no banner, no TUI, no progress, no summary) -- useful for CI/scripted environments |
+| `-V`, `--version` | -- | Print camel-kit version and exit |
 
 **Examples:**
 
@@ -92,7 +94,43 @@ camel-kit init my-integration --ai claude --source-platform biztalk
 
 # Skip catalog fetch (faster)
 camel-kit init my-integration --ai bob --no-fetch
+
+# Overwrite an existing project
+camel-kit init my-integration --ai claude --force
+
+# Check version
+camel-kit --version
 ```
+
+**Prerequisite check:**
+
+On startup, `init` checks for required tools and reports their status:
+
+```
+Prerequisites:
+  Java 17+          ✓ (21.0.3)
+  JBang             ✓ (0.136.0)
+  Camel JBang       ✓ (4.18.1)
+  Camel test plugin ✗ (not found — /camel-verify will skip test phase)
+```
+
+The check is non-blocking -- it warns but never fails the init. Design and planning work without Camel JBang; only execution and verification need it.
+
+**Overwrite detection:**
+
+If the target directory already contains `AGENTS.md` or `.camel-kit/`, init warns and exits:
+
+```
+⚠ Project already initialized
+  Directory: /path/to/my-integration
+  Found:     AGENTS.md
+  Found:     .camel-kit/
+
+  To overwrite: --force
+  Example:      camel-kit init my-integration --ai claude --force
+```
+
+Use `--force` to overwrite an existing project.
 
 **TUI experience:**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -193,7 +193,7 @@ order-processing/
   mvnw / mvnw.cmd            # Maven wrapper
 ```
 
-The init command copies skill files, configures MCP, and sets up the Maven wrapper so you can start designing immediately.
+The init command checks prerequisites (Java, JBang, Camel JBang, test plugin), copies skill files, configures MCP, and sets up the Maven wrapper so you can start designing immediately. If the target directory already contains a camel-kit project (`AGENTS.md` or `.camel-kit/`), init warns and exits — use `--force` to overwrite.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `--force` and `--version` to options table in `docs/commands.md`
- Add prerequisite check and overwrite detection sections with output examples
- Update `docs/user-guide.md` init description to mention new features
- Add automatic prerequisite check note to `README.md`

Follow-up documentation for the init improvements in PR #45.

## Test plan

- [x] Documentation only — no code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added `--force` flag to `camel-kit init` for overwriting existing projects
* Prerequisite tool checks are now non-blocking, producing warnings instead of stopping initialization
* Init command detects and warns about existing camel-kit projects
* New `camel-kit --version` command available for version checking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->