### PR TITLE
fix #55: add subagent_type and model mapping to Claude Code traits

### DIFF
--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-brainstorm.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-brainstorm.append.md
@@ -16,3 +16,33 @@ Use `WebSearch` to research integration patterns when the user describes unfamil
 ### Interview Progress Tracking
 
 Use `TaskCreate` to create a task for each interview phase (discovery, component selection, design assembly). Mark each as `in_progress` when entering the phase and `completed` when exiting. This gives the user visible progress.
+
+### Typed Subagent Dispatch
+
+When dispatching subagents during brainstorming, use the Claude Code Dispatch Map:
+
+**Integration architect** (design analysis, component selection, flow design):
+
+```text
+Agent({
+  subagent_type: "Plan",
+  model: "opus",
+  description: "Architect: [flow or design topic]",
+  prompt: "[architect prompt with persona from agents/integration-architect.md]"
+})
+```
+
+The `Plan` type provides architectural focus with no Edit/Write access — the architect analyzes and returns design output, the orchestrator writes the design doc.
+
+**Migration specialist** (source artifact scanning, component mapping):
+
+```text
+Agent({
+  subagent_type: "Explore",
+  model: "opus",
+  description: "Migration scan: [source platform]",
+  prompt: "[migration prompt with persona from agents/migration-specialist.md]"
+})
+```
+
+The `Explore` type provides fast read-only search — scanning source artifacts and mapping components without risking file modifications. Use `Explore` only for analysis tasks. If the migration specialist needs to write files (implementation tasks during `camel-execute`), the execute trait switches to `general-purpose`.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
@@ -53,8 +53,8 @@ When dispatching subagents during execution, use this map to set the `subagent_t
 | `code-quality-reviewer` | `code-simplifier` | `opus` |
 
 **Migration-specialist resolution:** Check the task's `**Files:**` section:
-- If it contains only "Read" or "Analyze" entries (no "Create" or "Modify") → `Explore`
-- If it contains any "Create" or "Modify" entries → `general-purpose`
+- If every entry is strictly read-only (e.g., "Read", "Analyze", "Inspect") → `Explore`
+- If any entry implies mutation (e.g., "Create", "Modify", "Update", "Delete", "Rename", "Move") → `general-purpose`
 - If the `**Files:**` section is absent or ambiguous → `general-purpose` (safe default)
 
 **Always set both parameters.** Example:

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
@@ -38,3 +38,35 @@ Use Claude Code's task tracking tools for real-time progress visibility:
 - `TaskUpdate` to mark tasks `completed` after both review stages pass
 - `TaskList` to report progress after each wave completes
 - Track re-plan rounds as tasks when the re-plan loop triggers
+
+### Claude Code Dispatch Map
+
+When dispatching subagents during execution, use this map to set the `subagent_type` and `model` parameters on the `Agent` tool call. Read the persona from the task's `**Agent:**` field in the implementation plan.
+
+| Persona | `subagent_type` | `model` |
+|---------|----------------|---------|
+| `integration-architect` | `Plan` | `opus` |
+| `implementation-engineer` | `general-purpose` | `sonnet` |
+| `migration-specialist` | See resolution rule below | `opus` |
+| `test-engineer` | `general-purpose` | `sonnet` |
+| `spec-compliance-reviewer` | `general-purpose` | `sonnet` |
+| `code-quality-reviewer` | `code-simplifier` | `opus` |
+
+**Migration-specialist resolution:** Check the task's `**Files:**` section:
+- If it contains only "Read" or "Analyze" entries (no "Create" or "Modify") → `Explore`
+- If it contains any "Create" or "Modify" entries → `general-purpose`
+- If the `**Files:**` section is absent or ambiguous → `general-purpose` (safe default)
+
+**Always set both parameters.** Example:
+
+```text
+Agent({
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "Task 3: Purchase ingestion route",
+  prompt: "...",
+  run_in_background: true
+})
+```
+
+If a persona is not in the map, fall back to `general-purpose` with `model: "sonnet"`.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/implementer-context.append.md
@@ -2,6 +2,32 @@
 
 When constructing the implementer subagent prompt, leverage Claude Code-specific features:
 
+### Typed Dispatch
+
+Set `subagent_type` and `model` from the Claude Code Dispatch Map (see `camel-execute.append.md`). For implementation tasks, the typical call is:
+
+```text
+Agent({
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "Task N: [3-5 word summary]",
+  prompt: "[full implementer prompt from implementer-context guide]",
+  run_in_background: true
+})
+```
+
+For `migration-specialist` implementation tasks (where the `**Files:**` section contains "Create" or "Modify"):
+
+```text
+Agent({
+  subagent_type: "general-purpose",
+  model: "opus",
+  description: "Task N: [migration task summary]",
+  prompt: "[full implementer prompt]",
+  run_in_background: true
+})
+```
+
 ### Background Dispatch
 
 Set `run_in_background: true` in the Agent tool call when this task is part of a parallel wave. This allows the orchestrator to dispatch the next independent task without waiting.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/quality-reviewer-criteria.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/quality-reviewer-criteria.append.md
@@ -31,10 +31,11 @@ After the quality reviewer subagent returns, verify no files were modified:
 
 1. Run `git diff --stat`
 2. If output is empty — proceed normally
-3. If files were modified:
-   a. Revert: `git checkout -- <modified files>`
-   b. Log: "Quality reviewer modified files despite review-only override — re-dispatching as general-purpose"
-   c. Re-dispatch the same review with `subagent_type: "general-purpose"` and `model: "opus"`
-   d. Use the re-dispatched result
+3. If files were modified or new files were created:
+   a. Revert tracked changes: `git restore --worktree --staged .`
+   b. Remove untracked files created by the reviewer: `git clean -fd`
+   c. Log: "Quality reviewer modified files despite review-only override — re-dispatching as general-purpose"
+   d. Re-dispatch the same review with `subagent_type: "general-purpose"` and `model: "opus"`
+   e. Use the re-dispatched result
 
 Do NOT use `run_in_background` for review subagents — the orchestrator must wait for the review result before proceeding.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/quality-reviewer-criteria.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/quality-reviewer-criteria.append.md
@@ -1,0 +1,40 @@
+## Agent Optimization: Claude Code
+
+### Typed Quality Review Dispatch
+
+When dispatching the code-quality reviewer subagent, use `code-simplifier` type with `opus` model. The `code-simplifier` type provides built-in quality analysis capabilities (clarity, consistency, maintainability focus) that align with the quality reviewer's role.
+
+```text
+Agent({
+  subagent_type: "code-simplifier",
+  model: "opus",
+  description: "Quality review: Task N",
+  prompt: "[full quality-reviewer prompt from quality-reviewer-criteria guide]"
+})
+```
+
+### Review-Only Override
+
+The `code-simplifier` type has a built-in bias toward modifying files. The quality reviewer must NEVER modify files. Prepend this to the quality reviewer's prompt:
+
+```text
+<HARD-RULE>
+REVIEW-ONLY MODE. You are dispatched as a code-simplifier for your quality analysis
+capabilities. Do NOT use Edit, Write, or any file-modification tool. Your output is a
+structured review report. If you identify improvements, REPORT them — do not apply them.
+</HARD-RULE>
+```
+
+### Safety Fallback
+
+After the quality reviewer subagent returns, verify no files were modified:
+
+1. Run `git diff --stat`
+2. If output is empty — proceed normally
+3. If files were modified:
+   a. Revert: `git checkout -- <modified files>`
+   b. Log: "Quality reviewer modified files despite review-only override — re-dispatching as general-purpose"
+   c. Re-dispatch the same review with `subagent_type: "general-purpose"` and `model: "opus"`
+   d. Use the re-dispatched result
+
+Do NOT use `run_in_background` for review subagents — the orchestrator must wait for the review result before proceeding.

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/spec-reviewer-criteria.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute/spec-reviewer-criteria.append.md
@@ -2,6 +2,17 @@
 
 ### Typed Review Dispatch
 
-When dispatching the spec-compliance reviewer subagent, use the `Agent` tool with `subagent_type: "superpowers:code-reviewer"` if available. This gives the reviewer access to code-review-specific tools and prompts.
+When dispatching the spec-compliance reviewer subagent, use the `Agent` tool with `subagent_type` and `model` from the Claude Code Dispatch Map:
 
-If `subagent_type` is not recognized (the reviewer is a general agent), fall back to the standard dispatch with a detailed review-focused prompt.
+```text
+Agent({
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "Spec review: Task N",
+  prompt: "[full spec-reviewer prompt from spec-reviewer-criteria guide]"
+})
+```
+
+The spec-compliance reviewer uses `general-purpose` because it needs to read full files for field-by-field comparison against the TDD. The `Explore` type reads excerpts and explicitly warns against code review, making it unsuitable.
+
+Do NOT use `run_in_background` for review subagents — the orchestrator must wait for the review result before proceeding (spec review gates quality review per Iron Law 4).


### PR DESCRIPTION
## Summary

- Add dispatch map to Claude execute trait mapping each agent persona to the best-fit `subagent_type` (`Plan`, `Explore`, `code-simplifier`, `general-purpose`) and `model` (`opus`/`sonnet`)
- Wire `subagent_type` + `model` into implementer context, spec reviewer, and brainstorm guide-level traits
- Replace third-party `superpowers:code-reviewer` reference with built-in `general-purpose` type
- Add new quality reviewer trait with `code-simplifier` dispatch, review-only prompt override, and git diff safety fallback

Closes #55

## Test plan

- [x] `./mvnw clean install -B` passes
- [x] `./mvnw -Psourcecheck validate -B` passes
- [x] New `quality-reviewer-criteria.append.md` file appears in `target/classes/`
- [x] Source and target trait files match (no diff)
- [ ] Run `camel-kit init --ai claude` and verify traits are appended correctly
- [ ] Execute a plan and verify subagent status line shows correct types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for AI agent workflows, including structured design interview processes and optimized task dispatching mechanisms.
  * Strengthened quality control procedures with review-focused safeguards to ensure reliable agent output validation and consistency across execution phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->