### PR TITLE
fix #51: enforce .camel.yaml naming convention in all agent skills

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
@@ -17,7 +17,7 @@ Test tasks come after all implementation and validation tasks. Generate one test
 **Agent:** test-engineer
 
 **Files:**
-- Create: `[MODULE_DIR]src/test/java/[package]/[FlowName]IntegrationTest.java`
+- Create: `[MODULE_DIR]src/test/resources/[flow-name].camel.it.yaml`
 - Create: `[MODULE_DIR]src/test/resources/test-data/[flow-name]-input.[ext]`
 - Create: `[MODULE_DIR]src/test/resources/test-data/[flow-name]-expected.[ext]`
 - Modify: `[MODULE_DIR]pom.xml` (add test dependencies if not present)
@@ -41,8 +41,8 @@ Test tasks come after all implementation and validation tasks. Generate one test
   - Happy path: [data flows from source to sink correctly]
   - Error path: [error handling triggers correctly]
   - Edge cases: [empty messages, malformed data, timeouts]
-- [ ] Load test-generation.md to create test class:
-  - Citrus test runner setup
+- [ ] Load test-generation.md to create test file:
+  - Citrus YAML DSL test structure
   - Mock endpoints for external systems
   - Test data preparation
 - [ ] Load test-configuration.md to set up infrastructure:
@@ -51,15 +51,15 @@ Test tasks come after all implementation and validation tasks. Generate one test
 - [ ] Create test data files:
   - Input: representative test message in [format]
   - Expected: expected output message
-- [ ] Generate test methods:
-  - `test[FlowName]HappyPath()` — end-to-end success
-  - `test[FlowName]ErrorHandling()` — error triggers DLQ/retry
-  - `test[FlowName]InvalidInput()` — malformed input handled
+- [ ] Generate test scenarios in the `.camel.it.yaml` file:
+  - Happy path — end-to-end success
+  - Error handling — error triggers DLQ/retry
+  - Invalid input — malformed input handled
 - [ ] Add test dependencies to pom.xml if not present:
   - `org.citrusframework:citrus-*`
   - `org.testcontainers:testcontainers`
   - `org.testcontainers:[module]` for each external service
-- [ ] Verify: `mvn test -pl [module] -Dtest=[FlowName]IntegrationTest` compiles
+- [ ] Verify: `camel test run src/test/resources/[flow-name].camel.it.yaml` passes
 
 **Review:**
 - [ ] Spec compliance: tests cover all behaviors in design spec

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
@@ -229,8 +229,8 @@ Generated Files:
   - src/main/resources/camel/inventory-sync.camel.yaml
   - src/main/resources/application.properties
   - pom.xml (updated)
-  - src/test/java/.../routes/OrderProcessingRouteTest.java
-  - src/test/java/.../routes/InventorySyncRouteTest.java
+  - src/test/resources/order-processing.camel.it.yaml
+  - src/test/resources/inventory-sync.camel.it.yaml
   - docker-compose.yml
   - docs/test-report.md
 

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-implement.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-implement.md
@@ -82,13 +82,13 @@ For EACH route in the plan:
    - Load runtime-specific guide: `guides/pom-spring-boot.md` or `guides/pom-quarkus.md`
    - Add component dependencies to `pom.xml`
 7. **Run the test:**
-   - Execute: `mvn test -Dtest=<RouteTest>`
+   - Execute: `camel test run src/test/resources/<flow-name>.camel.it.yaml`
    - Test MUST pass
 8. **Self-validate the route:**
    - Load `guides/route-validation.md`
    - Check: YAML syntax, component options, endpoint URIs, constitution compliance
 9. **Commit:**
-   - Stage: `git add src/main/resources/camel/<flow-name>.camel.yaml src/main/resources/application.properties pom.xml src/test/java/**/<RouteTest>.java`
+   - Stage: `git add src/main/resources/camel/<flow-name>.camel.yaml src/main/resources/application.properties pom.xml src/test/resources/<flow-name>.camel.it.yaml`
    - Commit: `git commit -m "feat: implement <flow-name> route"`
 </Step>
 
@@ -98,7 +98,7 @@ For EACH route in the plan:
 **When DataMapper is needed:**
 - Read the TDD's DataMapper section for approach (A or B)
 - Load `guides/datamapper-approach-a.md` (useJsonBody) or `guides/datamapper-approach-b.md` (header param)
-- Generate XSLT at `src/main/resources/xslt/<transform-name>.xslt`
+- Generate XSLT at `src/main/resources/xslt/<transform-name>.xsl`
 - Load `guides/datamapper-validation.md` and self-validate XSLT against TDD field mappings
 
 **When Docker Compose services are needed:**

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-test.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-test.md
@@ -414,7 +414,7 @@ Present the report to the user.
 After all tests pass:
 
 ```bash
-git add src/test/java src/test/resources docs/test-report.md
+git add src/test/resources docs/test-report.md
 git commit -m "test: add integration tests for all routes"
 ```
 </Step>

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-test.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-test.md
@@ -123,76 +123,90 @@ Load `guides/test-generation.md`.
 
 ### Test Generation Process
 
-1. **Create test class:**
-   - Location: `src/test/java/.../routes/<RouteNameTest>.java`
-   - Naming: `<RouteName>Test` (e.g., `OrderProcessingRouteTest`)
+1. **Create test file:**
+   - Location: `src/test/resources/<flow-name>.camel.it.yaml`
+   - Naming: `<flow-name>.camel.it.yaml` (e.g., `order-processing.camel.it.yaml`)
 
 2. **Write happy path test:**
-   ```java
-   @Test
-   @CitrusTest
-   void shouldProcessValidOrder(@CitrusResource TestRunner runner) {
-       runner.given(
-           send(inputQueue)
-               .message()
-               .body("<order><id>123</id></order>")
-       );
-       
-       runner.when(
-           receive(outputQueue)
-               .message()
-               .body("<orderConfirmation><id>123</id></orderConfirmation>")
-       );
-       
-       runner.then(
-           // Verify database state, external API calls, etc.
-       );
-   }
+   ```yaml
+   name: <flow-name>-happy-path
+   variables:
+     - name: kafka.brokers
+       value: localhost:9092
+
+   actions:
+     - camel:
+         jbang:
+           run:
+             integration:
+               file: "../main/resources/camel/<flow-name>.camel.yaml"
+             wait:
+               for:
+                 log:
+                   message: "started and consuming"
+               timeout: 30000
+
+     - send:
+         endpoint:
+           uri: <source-endpoint>
+         message:
+           body:
+             file: test-data/valid-input.json
+
+     - receive:
+         endpoint:
+           uri: <sink-endpoint>
+         timeout: 10000
+         message:
+           body:
+             file: test-data/expected-output.json
    ```
 
 3. **Write error path tests:**
-   ```java
-   @Test
-   @CitrusTest
-   void shouldHandleInvalidOrderGracefully(@CitrusResource TestRunner runner) {
-       runner.given(
-           send(inputQueue)
-               .message()
-               .body("<order><invalid/></order>")
-       );
-       
-       runner.when(
-           receive(errorQueue)
-               .message()
-               .body(contains("Validation failed"))
-       );
-   }
+   ```yaml
+     - send:
+         endpoint:
+           uri: <source-endpoint>
+         message:
+           body:
+             data: '{"invalid": "data"}'
+
+     - receive:
+         endpoint:
+           uri: <dead-letter-endpoint>
+         timeout: 10000
    ```
 
 4. **Write edge case tests:**
-   ```java
-   @Test
-   @CitrusTest
-   void shouldHandleEmptyInput(@CitrusResource TestRunner runner) {
-       // Test empty body
-   }
-   
-   @Test
-   @CitrusTest
-   void shouldHandleLargePayload(@CitrusResource TestRunner runner) {
-       // Test 10MB+ payload
-   }
+   ```yaml
+     - send:
+         endpoint:
+           uri: <source-endpoint>
+         message:
+           body:
+             data: ''
+
+     - send:
+         endpoint:
+           uri: <source-endpoint>
+         message:
+           body:
+             file: test-data/large-payload.json
    ```
 
 5. **Write external service failure tests:**
-   ```java
-   @Test
-   @CitrusTest
-   void shouldRetryOnExternalServiceTimeout(@CitrusResource TestRunner runner) {
-       // Mock external API timeout
-       // Verify circuit breaker activates
-       // Verify retry logic
-   }
+   ```yaml
+     - send:
+         endpoint:
+           uri: <source-endpoint>
+         message:
+           body:
+             file: test-data/valid-input.json
+
+     - receive:
+         endpoint:
+           uri: <fallback-endpoint>
+         timeout: 30000
    ```
 
 Follow TDD's test criteria from the route's TDD file.
@@ -201,10 +215,10 @@ Follow TDD's test criteria from the route's TDD file.
 <Step>
 ## Run Tests
 
-For each test class:
+For each test file:
 
 ```bash
-mvn test -Dtest=<RouteNameTest>
+camel test run src/test/resources/<flow-name>.camel.it.yaml
 ```
 
 **Expected outcome:**
@@ -260,61 +274,66 @@ Write integration tests that:
 2. Verify Route B receives and processes the message
 3. Verify end-to-end data flow
 
-Example:
-```java
-@Test
-@CitrusTest
-void shouldProcessOrderEndToEnd(@CitrusResource TestRunner runner) {
-    runner.given(
-        http()
-            .client("orderApi")
-            .send()
-            .post("/orders")
-            .body("<order><id>123</id></order>")
-    );
-    
-    runner.when(
-        receive(orderQueue)
-            .message()
-            .body("<order><id>123</id></order>")
-    );
-    
-    runner.then(
-        receive(confirmationQueue)
-            .message()
-            .body("<confirmation><id>123</id></confirmation>")
-    );
-}
+Example (`end-to-end.camel.it.yaml`):
+```yaml
+name: order-end-to-end
+
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "../main/resources/camel/order-processing.camel.yaml"
+          wait:
+            for:
+              log:
+                message: "started and consuming"
+            timeout: 30000
+
+  - send:
+      endpoint:
+        uri: http://localhost:8080/orders
+      message:
+        body:
+          data: '{"id": "123"}'
+
+  - receive:
+      endpoint:
+        uri: kafka:order-queue
+      timeout: 10000
+      message:
+        body:
+          data: '{"id": "123"}'
+
+  - receive:
+      endpoint:
+        uri: kafka:confirmation-queue
+      timeout: 10000
+      message:
+        body:
+          data: '{"id": "123", "status": "confirmed"}'
 ```
 </Step>
 
 <Step>
 ## Test Documentation
 
-For each test class, add JavaDoc:
+Each test file should include a descriptive `name` field and inline comments:
 
-```java
-/**
- * Integration tests for the Order Processing route.
- * 
- * <p>This route consumes orders from the input queue, validates them,
- * transforms them, and sends confirmations to the output queue.</p>
- * 
- * <p>Test coverage:</p>
- * <ul>
- *   <li>Happy path: valid order → confirmation</li>
- *   <li>Error path: invalid order → error queue</li>
- *   <li>Edge case: empty order → validation error</li>
- *   <li>Failure case: external API timeout → retry</li>
- * </ul>
- * 
- * @see OrderProcessingRoute
- */
-@CitrusSpringSupport
-@SpringBootTest
-class OrderProcessingRouteTest {
-    // tests...
-}
+```yaml
+# Integration tests for the Order Processing route.
+#
+# This route consumes orders from the input queue, validates them,
+# transforms them, and sends confirmations to the output queue.
+#
+# Test coverage:
+#   - Happy path: valid order → confirmation
+#   - Error path: invalid order → error queue
+#   - Edge case: empty order → validation error
+#   - Failure case: external API timeout → retry
+
+name: order-processing-integration-tests
+# ...test actions...
 ```
 </Step>
 
@@ -366,7 +385,7 @@ Create a test report at `docs/test-report.md`:
 ### Route: <route-name>
 
 **File:** `src/main/resources/camel/<route-name>.camel.yaml`
-**Test Class:** `src/test/java/.../routes/<RouteNameTest>.java`
+**Test File:** `src/test/resources/<route-name>.camel.it.yaml`
 
 **Tests:**
 - ✓ Happy path: valid input → expected output

--- a/camel-kit-core/src/main/resources/templates/bob/rules-camel-test/testing.md
+++ b/camel-kit-core/src/main/resources/templates/bob/rules-camel-test/testing.md
@@ -8,7 +8,7 @@
 ## Test Conventions
 
 - Integration tests use Citrus framework when configured.
-- Test file naming: `{route-id}.test.yaml` (Citrus) or `{RouteId}Test.java` (JUnit).
+- Test file naming: `{route-id}.camel.it.yaml` (Citrus YAML DSL).
 - Test data goes in `test/data/` directory.
 - Each route gets at least one happy-path test and one error-path test.
 


### PR DESCRIPTION
## Summary

- Replace `.xslt` with `.xsl` in camel-implement gate (1 occurrence)
- Replace `.test.yaml` with `.camel.it.yaml` in Bob test rules (1 occurrence)
- Replace all Java test class references (`RouteNameTest.java`, `IntegrationTest.java`) with Citrus YAML DSL test files (`<flow-name>.camel.it.yaml`) across 4 files
- Update test execution commands from `mvn test -Dtest=<RouteNameTest>` to `camel test run <flow-name>.camel.it.yaml`
- Convert Java Citrus code examples in camel-test gate to YAML DSL equivalents

### Files changed

| File | Changes |
|------|---------|
| `templates/bob/gates/camel-implement.md` | `.xslt` → `.xsl`, Java test refs → `.camel.it.yaml` |
| `templates/bob/gates/camel-test.md` | Full Java→YAML test example conversion, file paths, execution commands |
| `templates/bob/gates/camel-execute.md` | Java test file paths → `.camel.it.yaml` |
| `templates/bob/rules-camel-test/testing.md` | `.test.yaml` → `.camel.it.yaml` |
| `skills/camel-plan/guides/task-template-testing.md` | Java test class → `.camel.it.yaml`, test commands |

## Test plan

- [x] Full build passes (`./mvnw clean install -B`) — 122 tests pass
- [x] No remaining `.xslt`, `.test.yaml`, or `RouteTest.java` references in skill/template files
- [x] 114 correct `.camel.yaml` / `.camel.it.yaml` / `.xsl` references verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated integration test generation templates to support Citrus YAML DSL format
  * Test generation now produces `.camel.it.yaml` files instead of Java test classes

* **Tests**
  * Changed test execution method from Maven commands to `camel test run`
  * Standardized test naming convention to `{route-id}.camel.it.yaml`
  * Test artifacts stored in `src/test/resources/`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->