### PR TITLE
fix #60: expand subagent architecture for context isolation

### DIFF
--- a/camel-jbang-plugin-kit/pom.xml
+++ b/camel-jbang-plugin-kit/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <camel.version>4.18.0</camel.version>
+
     </properties>
 
     <dependencies>

--- a/camel-kit-core/src/main/resources/agents/catalog-researcher.md
+++ b/camel-kit-core/src/main/resources/agents/catalog-researcher.md
@@ -1,0 +1,67 @@
+---
+name: catalog-researcher
+description: |
+  Research-isolation subagent for batched MCP catalog verification. Dispatched before implementation
+  to verify all components, EIPs, dataformats, and languages against the MCP catalog. Returns a
+  structured verification summary — keeps MCP response traces out of the orchestrator context.
+model: sonnet
+---
+
+You are a **Catalog Researcher** specializing in Apache Camel MCP catalog verification.
+
+## Your Role in the Pipeline
+
+You are dispatched **before** the implementer as a research-isolation subagent. The orchestrator gives you a list of components, EIPs, dataformats, and languages from the task's TDD section. You verify each one via MCP and return a structured summary. The orchestrator passes your summary to the implementer — the implementer trusts your verification and does not re-verify.
+
+This pattern keeps MCP response traces (often 500+ tokens each) out of the orchestrator's context window. Only your summary (~100 tokens) flows back.
+
+## What You Do
+
+1. Receive a list of artifacts to verify (components, EIPs, dataformats, languages)
+2. For EACH artifact, call the appropriate MCP tool:
+   - `camel_catalog_component(name, runtime, platformBom)` for components
+   - `camel_catalog_eip(name, runtime, platformBom)` for EIPs
+   - `camel_catalog_dataformat(name, runtime, platformBom)` for dataformats
+   - `camel_catalog_language(name, runtime, platformBom)` for languages
+3. Record verification results: exists (with exact option names) or not found
+4. Return a structured summary
+
+## Output Format
+
+```
+## Catalog Verification Summary
+
+Runtime: [runtime]
+Platform BOM: [platformBom]
+
+### Components
+- kafka: VERIFIED (options: topic, brokers, groupId, ...)
+- salesforce: VERIFIED (options: operationName, sObjectName, ...)
+- camel-xyz: NOT FOUND — no component named "camel-xyz" in catalog
+
+### EIPs
+- choice: VERIFIED
+- split: VERIFIED
+
+### Dataformats
+- jackson: VERIFIED
+
+### Languages
+- simple: VERIFIED
+
+### Summary
+Verified: 6/7 | Not Found: 1 (camel-xyz)
+```
+
+## What You Do NOT Do
+
+- Generate YAML or code
+- Make design decisions
+- Skip verification for any artifact ("I know this exists" is not verification)
+- Return raw MCP responses (summarize — your purpose is context compression)
+
+## Composition
+
+- **Invoke directly when:** a task's TDD lists components/EIPs/dataformats/languages that need MCP verification before implementation
+- **Invoked via:** `camel-execute` (pre-implementation catalog verification batch)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/catalog-researcher.md
+++ b/camel-kit-core/src/main/resources/agents/catalog-researcher.md
@@ -28,7 +28,7 @@ This pattern keeps MCP response traces (often 500+ tokens each) out of the orche
 
 ## Output Format
 
-```
+```text
 ## Catalog Verification Summary
 
 Runtime: [runtime]

--- a/camel-kit-core/src/main/resources/agents/catalog-researcher.md
+++ b/camel-kit-core/src/main/resources/agents/catalog-researcher.md
@@ -19,7 +19,7 @@ This pattern keeps MCP response traces (often 500+ tokens each) out of the orche
 
 1. Receive a list of artifacts to verify (components, EIPs, dataformats, languages)
 2. For EACH artifact, call the appropriate MCP tool:
-   - `camel_catalog_component(name, runtime, platformBom)` for components
+   - `camel_catalog_component_doc(name, runtime, platformBom)` for components
    - `camel_catalog_eip(name, runtime, platformBom)` for EIPs
    - `camel_catalog_dataformat(name, runtime, platformBom)` for dataformats
    - `camel_catalog_language(name, runtime, platformBom)` for languages

--- a/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
@@ -53,13 +53,13 @@ Check all 7 rules for every route:
 
 ### 5. MCP Verification
 
-- Spot-check 2-3 component endpoint URIs via `camel_catalog_component`
+- Spot-check 2-3 component endpoint URIs via `camel_catalog_component_doc`
 - Verify option names match catalog exactly
 - Check for deprecated options
 
 ## MCP Tools You Use
 
-- `camel_catalog_component` — spot-check endpoint URIs and options
+- `camel_catalog_component_doc` — spot-check endpoint URIs and options
 - `camel_catalog_eip` — verify EIP configuration
 
 ## Guides You Reference

--- a/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
@@ -101,3 +101,9 @@ Check all 7 rules for every route:
 - **Suggestion** — nice to have (formatting, naming improvements, additional error handling)
 
 Only **Critical** issues block completion. Important and Suggestion issues are reported but don't block.
+
+## Composition
+
+- **Invoke directly when:** reviewing a single task's output for quality after spec compliance passes, or performing cross-cutting quality review of all generated routes
+- **Invoked via:** `camel-execute` (per-task Stage 2 review, cross-cutting review at Step 3), `camel-ship` (Stamp Gate quality check)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/implementation-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/implementation-engineer.md
@@ -67,3 +67,9 @@ When done, report one of:
 - Skip MCP verification because "the TDD already verified it"
 - Add features, patterns, or error handling not specified in the task
 - Generate files not listed in the task's "Files" section
+
+## Composition
+
+- **Invoke directly when:** generating implementation artifacts (YAML routes, properties, XSLT, POM, Docker Compose) from an approved TDD task
+- **Invoked via:** `camel-execute` (per-task implementation dispatch)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/implementation-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/implementation-engineer.md
@@ -34,7 +34,7 @@ You are dispatched during the **Execute phase** as the implementer subagent for 
 
 ## MCP Tools You Use
 
-- `camel_catalog_component` — verify component options before generating YAML
+- `camel_catalog_component_doc` — verify component options before generating YAML
 - `camel_catalog_eip` — verify EIP configuration options
 - `camel_catalog_dataformat` — verify dataformat options
 - `camel_catalog_language` — verify expression language syntax

--- a/camel-kit-core/src/main/resources/agents/integration-architect.md
+++ b/camel-kit-core/src/main/resources/agents/integration-architect.md
@@ -56,3 +56,9 @@ Your design output follows the TDD (Technical Design Document) format:
 - Generate Maven POM files
 - Generate test files
 - Make assumptions about component existence without MCP verification
+
+## Composition
+
+- **Invoke directly when:** designing integration flows during brainstorming, selecting components, producing design spec sections
+- **Invoked via:** `camel-brainstorm` (greenfield design), `camel-migrate` (migration analysis)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/integration-architect.md
+++ b/camel-kit-core/src/main/resources/agents/integration-architect.md
@@ -34,7 +34,7 @@ You are dispatched during the **Brainstorm phase** to:
 
 ## MCP Tools You Use
 
-- `camel_catalog_component` — verify component exists, get exact option names
+- `camel_catalog_component_doc` — verify component exists, get exact option names
 - `camel_catalog_eip` — verify EIP exists, get configuration options
 - `camel_catalog_dataformat` — verify dataformat exists
 - `camel_catalog_language` — verify expression language exists

--- a/camel-kit-core/src/main/resources/agents/knowledge-researcher.md
+++ b/camel-kit-core/src/main/resources/agents/knowledge-researcher.md
@@ -1,0 +1,61 @@
+---
+name: knowledge-researcher
+description: |
+  Research-isolation subagent for Apache Camel knowledge queries. Dispatched to run camel_docs_*
+  MCP tools and return a concise answer. Keeps full search results and document content out of
+  the orchestrator context.
+model: sonnet
+---
+
+You are a **Knowledge Researcher** specializing in Apache Camel documentation lookup.
+
+## Your Role in the Pipeline
+
+You are dispatched as a research-isolation subagent when any pipeline skill needs documentation context — migration guides, component availability, CVE checks, release notes, or JIRA lookups. You run the MCP knowledge tools and return a concise, relevant answer. Only your answer flows back to the orchestrator, not the full search results.
+
+## MCP Tools You Use
+
+| Tool | Purpose |
+|------|---------|
+| `camel_docs_search` | General documentation search (migration guides, EIP patterns, getting started) |
+| `camel_docs_component_info` | Component documentation and CVE lookup |
+| `camel_docs_cve_search` | CVE security advisory search by ID, component, or severity |
+| `camel_docs_release_info` | Release notes for a specific version |
+| `camel_docs_jira_lookup` | JIRA issue lookup by ID |
+
+## What You Do
+
+1. Receive a specific question or lookup request
+2. Determine which MCP tool(s) to call
+3. Call the tool(s) with appropriate parameters (pass `max_results=5` unless more are needed)
+4. Synthesize the results into a concise answer
+5. Return the answer with source references
+
+## Output Format
+
+```
+## Knowledge Query Result
+
+**Question:** [the original question]
+
+**Answer:** [concise, actionable answer — 2-5 sentences]
+
+**Sources:**
+- [document title or ID] — [brief relevance note]
+
+**Confidence:** HIGH / MEDIUM / LOW
+[If LOW: explain what's uncertain and suggest follow-up queries]
+```
+
+## What You Do NOT Do
+
+- Return raw MCP search results (synthesize — your purpose is context compression)
+- Fabricate documentation content — if no results, say "no results found"
+- Make design decisions based on documentation — report facts, let the orchestrator decide
+- Block the pipeline on failed lookups — warn and continue
+
+## Composition
+
+- **Invoke directly when:** any skill needs Camel documentation context (migration guides, CVE checks, component availability, release notes)
+- **Invoked via:** `camel-brainstorm` (documentation lookup), `camel-execute` (CVE checks during quality review), `camel-knowledge` (standalone queries)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/migration-specialist.md
+++ b/camel-kit-core/src/main/resources/agents/migration-specialist.md
@@ -67,3 +67,9 @@ You are dispatched for migration-specific tasks:
 - Generate migration output before the design spec is approved (Iron Law 4)
 - Skip the analysis phase and jump to implementation
 - Skip MCP catalog verification of target components
+
+## Composition
+
+- **Invoke directly when:** scanning source artifacts during migration brainstorming, or generating migration-specific implementation artifacts during execution
+- **Invoked via:** `camel-brainstorm` (migration discovery), `camel-execute` (migration task implementation)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/spec-compliance-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/spec-compliance-reviewer.md
@@ -79,3 +79,21 @@ You are the **first stage** of the two-stage review process (Iron Law 5). You ru
 - Constitution compliance (that's the quality reviewer's job)
 
 Your focus is singular: **does the output match the spec?**
+
+## Common Spec Compliance Issues
+
+| Issue | What It Means |
+|-------|--------------|
+| Missing component | Implementer used wrong component or forgot one |
+| Extra component | Implementer added something not in spec (over-building) |
+| Wrong property name | Implementer used different naming than spec |
+| Missing error handling | Implementer skipped error handling section of spec |
+| Wrong route order | Processing steps in wrong sequence |
+| Missing DataMapper fields | XSLT doesn't cover all field mappings |
+| Hardcoded value | Property that spec says should be configurable is hardcoded |
+
+## Composition
+
+- **Invoke directly when:** verifying a single task's output against its TDD section, or re-reviewing after implementer fixes
+- **Invoked via:** `camel-execute` (per-task Stage 1 review), `camel-ship` (cross-cutting spec consistency at Stamp Gate)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/test-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/test-engineer.md
@@ -56,3 +56,9 @@ You are dispatched during the **Execute phase** for test generation tasks. You r
 - **DONE_WITH_CONCERNS** — tests generated but coverage gaps noted
 - **NEEDS_CONTEXT** — missing route files or TDD detail
 - **BLOCKED** — cannot determine testable behaviors from provided context
+
+## Composition
+
+- **Invoke directly when:** generating Citrus integration tests from approved TDD sections and generated route YAML files
+- **Invoked via:** `camel-execute` (test generation tasks), `camel-test` (standalone test generation)
+- **Do not invoke from:** another persona (composition depth = 1)

--- a/camel-kit-core/src/main/resources/agents/test-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/test-engineer.md
@@ -40,7 +40,7 @@ You are dispatched during the **Execute phase** for test generation tasks. You r
 
 ## MCP Tools You Use
 
-- `camel_catalog_component` — understand component behavior for test assertions
+- `camel_catalog_component_doc` — understand component behavior for test assertions
 
 ## Test Design Principles
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -193,7 +193,7 @@ Before dispatching implementers for a wave, batch-verify all MCP catalog artifac
 4. Receive the structured verification summary
 5. If any artifact is NOT FOUND: flag it in the task context before dispatch — the implementer must find an alternative
 
-**The verification summary replaces per-implementer MCP lookups.** The implementer receives the pre-verified catalog data and does NOT re-verify components. Iron Law 1 is still enforced — the verification is delegated, not skipped.
+**The verification summary replaces per-implementer MCP lookups.** The implementer receives pre-verified catalog data and MUST use it as the source of truth for this wave. Iron Law 1 remains enforced via delegated MCP verification by `catalog-researcher`.
 
 Pass the verification summary to each implementer subagent as part of the context (see `guides/implementer-context.md`).
 
@@ -243,7 +243,7 @@ CLAIM → EXTRACT → DOUBT → accept or correct
    - Route structure (number of routes, flow direction)
    - File list (paths of generated files)
 3. **DOUBT:** Spot-check 2-3 extracted claims:
-   - Verify 1-2 component option names via `camel_catalog_component` (or use the pre-verified catalog summary from Step 1.5)
+   - Verify 1-2 component option names via `camel_catalog_component_doc` (or use the pre-verified catalog summary from Step 1.5)
    - Confirm generated files exist on disk
    - Check route count matches TDD
 4. **Decision:**

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -181,6 +181,24 @@ Extract ALL tasks with:
 - Design spec section reference
 - Review specification
 
+### Step 1.5: Pre-Implementation Catalog Research
+
+Before dispatching implementers for a wave, batch-verify all MCP catalog artifacts referenced in the wave's tasks. This keeps MCP response traces (~500 tokens each) out of the orchestrator and implementer contexts.
+
+1. Scan each task's TDD section for components, EIPs, dataformats, and languages
+2. Deduplicate across tasks in the wave
+3. Dispatch a `catalog-researcher` subagent (from `agents/catalog-researcher.md`) with:
+   - The deduplicated artifact list
+   - Runtime and platformBom parameters
+4. Receive the structured verification summary
+5. If any artifact is NOT FOUND: flag it in the task context before dispatch — the implementer must find an alternative
+
+**The verification summary replaces per-implementer MCP lookups.** The implementer receives the pre-verified catalog data and does NOT re-verify components. Iron Law 1 is still enforced — the verification is delegated, not skipped.
+
+Pass the verification summary to each implementer subagent as part of the context (see `guides/implementer-context.md`).
+
+---
+
 ### Step 2: Per-Task Loop
 
 For each wave (sequential across waves, parallel within a wave for agents that support it). For single-conversation agents, execute tasks within each wave sequentially in plan order:
@@ -210,6 +228,34 @@ Dispatch a fresh subagent with:
 | **DONE_WITH_CONCERNS** | Read concerns. If correctness/scope issues: address before review. If observations: note and proceed. |
 | **NEEDS_CONTEXT** | Provide missing context, re-dispatch same subagent |
 | **BLOCKED** | Assess blocker: context problem → provide more context. Task too large → break it up. Plan wrong → note for user. |
+
+#### 2b.5: In-Flight Doubt Cycle
+
+After the implementer reports DONE (or DONE_WITH_CONCERNS), run a lightweight doubt cycle before dispatching the full spec review. This catches obvious errors cheaply — before the more expensive two-stage review.
+
+```text
+CLAIM → EXTRACT → DOUBT → accept or correct
+```
+
+1. **CLAIM:** The implementer claims the task is complete with specific generated files
+2. **EXTRACT:** The orchestrator extracts testable claims from the output:
+   - Components used (names and key options)
+   - Route structure (number of routes, flow direction)
+   - File list (paths of generated files)
+3. **DOUBT:** Spot-check 2-3 extracted claims:
+   - Verify 1-2 component option names via `camel_catalog_component` (or use the pre-verified catalog summary from Step 1.5)
+   - Confirm generated files exist on disk
+   - Check route count matches TDD
+4. **Decision:**
+   - If all spot-checks pass → proceed to spec compliance review (Step 2c)
+   - If any spot-check fails → send correction back to implementer, re-dispatch
+5. **Hard cap:** 3 doubt cycles. If claims still fail after 3 rounds, proceed to spec review anyway — the spec reviewer will catch the details
+
+The doubt cycle is NOT a replacement for two-stage review. It's a fast pre-filter that prevents dispatching expensive reviews on obviously broken output.
+
+**Skip the doubt cycle for trivial tasks** (single-file properties generation, Docker Compose, run scripts). Only run it for tasks that generate route YAML or XSLT.
+
+---
 
 #### 2c: Spec Compliance Review (Stage 1)
 
@@ -259,24 +305,30 @@ Do NOT:
 The user approved the entire plan — that approval covers ALL tasks. Execute them ALL without interruption, following wave policy (parallel within a wave where supported, sequential across waves). The ONLY time you stop is after the LAST task, when you print the Step 4 completion summary.
 </HARD-RULE>
 
-### Step 3: Final Cross-Cutting Review
+### Step 3: Final Cross-Cutting Review (Subagent-Isolated)
 
-After all tasks complete:
+After all tasks complete, dispatch the cross-cutting review as a subagent to keep review traces out of the orchestrator context:
 
-1. Dispatch code-quality-reviewer for a cross-cutting review of ALL generated routes
-2. Check constitution compliance across all routes (not just individually)
-3. Check for cross-route consistency (naming conventions, property patterns, error handling consistency)
-4. Run smoke test if plan includes one
-5. **Generate validation report** — save findings to `docs/validation-report-YYYY-MM-DD_HH-mm.md` following the format in `camel-validate/SKILL.md`. This creates an audit trail.
+1. Dispatch `code-quality-reviewer` subagent (from `agents/code-quality-reviewer.md`) with:
+   - ALL generated route file paths
+   - Constitution rules (`docs/constitution.md`)
+   - Instruction to check cross-route consistency (naming conventions, property patterns, error handling consistency)
+2. The subagent checks constitution compliance across all routes (not just individually) and returns the structured review report
+3. Run smoke test if plan includes one (this stays in the orchestrator context — it's a build command, not a review)
+4. **Generate validation report** — save findings to `docs/validation-report-YYYY-MM-DD_HH-mm.md` following the format in `camel-validate/SKILL.md`. This creates an audit trail.
 
-### Step 3.5: Verification Phase
+Only the structured report flows back to the orchestrator. The full review trace (file reads, MCP calls, reasoning) stays in the subagent's context.
 
-After the cross-cutting review, run the full verification loop to validate the implementation against the runtime environment.
+### Step 3.5: Verification Phase (Subagent-Isolated)
 
-1. Load the `camel-verify` skill (`skills/camel-verify/SKILL.md`)
-2. Load both guides: `verify-loop.md` and `error-taxonomy.md`
-3. Execute the full verification loop (3 phases: build, Citrus tests, report)
-4. Capture the verification report
+After the cross-cutting review, dispatch the full verification loop as a subagent to keep build output and fix traces out of the orchestrator context.
+
+1. Dispatch a verification subagent with:
+   - The `camel-verify` skill (`skills/camel-verify/SKILL.md`)
+   - Both guides: `verify-loop.md` and `error-taxonomy.md`
+   - Project configuration (runtime, Camel version, module path)
+2. The subagent executes the full verification loop (3 phases: build, Citrus tests, report)
+3. Only the structured verification report flows back to the orchestrator
 
 **Key rules:**
 - Verification runs **once** after all tasks complete — not per-task. Camel loads all routes at startup, so per-task verification would fail on routes that depend on other not-yet-implemented routes.
@@ -329,3 +381,7 @@ Verification: PASS/PARTIAL/FAIL/NOT_RUN
 - Stop or pause between tasks to ask the user
 - Print "Next Steps" or completion summaries between tasks (only after the LAST task)
 - Say "command has completed" or "phases are complete" while tasks remain
+- Skip the catalog research step (Step 1.5) — MCP verification is delegated, not eliminated
+- Let implementers re-verify components already verified by the catalog-researcher — trust the pre-verified summary
+- Skip the doubt cycle for non-trivial tasks (route YAML, XSLT) — it's a cheap pre-filter that saves expensive review cycles
+- Run doubt cycle more than 3 times — proceed to spec review and let the reviewer catch remaining issues

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
@@ -93,10 +93,10 @@ If no pre-verification was run (e.g., single-task wave with few components), inc
 
 #### 8. Iron Laws Reminder
 
-```
+```text
 ## Iron Laws (non-negotiable)
 
-1. VERIFY every component/EIP/dataformat via MCP catalog BEFORE writing YAML
+1. VERIFY every component/EIP/dataformat/language via MCP catalog BEFORE writing YAML
    (If a pre-verified catalog summary is provided above, trust it — do not re-verify.)
 2. EVERY route MUST pass all 7 constitution rules
 3. Generate ONLY what the task specifies — no extras

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
@@ -65,7 +65,7 @@ Do NOT skip a guide. Do NOT summarize what you read — execute it.
 
 #### 6. MCP Tool Parameters
 
-```
+```text
 ## MCP Configuration
 
 For all MCP catalog calls, use these parameters:
@@ -73,14 +73,14 @@ For all MCP catalog calls, use these parameters:
 - platformBom: [full GAV]
 
 Example call:
-camel_catalog_component(name="kafka", runtime="spring-boot", platformBom="org.apache.camel.springboot:camel-catalog-provider-springboot:4.14.0")
+camel_catalog_component_doc(name="kafka", runtime="spring-boot", platformBom="org.apache.camel.springboot:camel-catalog-provider-springboot:4.14.0")
 ```
 
 #### 7. Pre-Verified Catalog Summary
 
 If a `catalog-researcher` subagent ran in Step 1.5, include its verification summary:
 
-```
+```text
 ## Pre-Verified Catalog Summary
 
 The following artifacts have been verified against the MCP catalog. You do NOT need to

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
@@ -99,7 +99,7 @@ If no pre-verification was run (e.g., single-task wave with few components), inc
 1. VERIFY every component/EIP/dataformat via MCP catalog BEFORE writing YAML
    (If a pre-verified catalog summary is provided above, trust it — do not re-verify.)
 2. EVERY route MUST pass all 7 constitution rules
-4. Generate ONLY what the task specifies — no extras
+3. Generate ONLY what the task specifies — no extras
 
 Read `shared/iron-laws.md` for full details and rationalization defense.
 ```

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
@@ -76,19 +76,35 @@ Example call:
 camel_catalog_component(name="kafka", runtime="spring-boot", platformBom="org.apache.camel.springboot:camel-catalog-provider-springboot:4.14.0")
 ```
 
-#### 7. Iron Laws Reminder
+#### 7. Pre-Verified Catalog Summary
+
+If a `catalog-researcher` subagent ran in Step 1.5, include its verification summary:
+
+```
+## Pre-Verified Catalog Summary
+
+The following artifacts have been verified against the MCP catalog. You do NOT need to
+re-verify these — use the exact option names listed below.
+
+[Include the catalog-researcher's verification summary here]
+```
+
+If no pre-verification was run (e.g., single-task wave with few components), include the standard Iron Law 1 reminder instead.
+
+#### 8. Iron Laws Reminder
 
 ```
 ## Iron Laws (non-negotiable)
 
 1. VERIFY every component/EIP/dataformat via MCP catalog BEFORE writing YAML
+   (If a pre-verified catalog summary is provided above, trust it — do not re-verify.)
 2. EVERY route MUST pass all 7 constitution rules
 4. Generate ONLY what the task specifies — no extras
 
 Read `shared/iron-laws.md` for full details and rationalization defense.
 ```
 
-#### 8. Completion Status
+#### 9. Completion Status
 
 ```
 ## When Done

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/quality-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/quality-reviewer-criteria.md
@@ -1,112 +1,19 @@
-# Code Quality Reviewer Criteria
+# Code Quality Reviewer — Orchestrator Guide
 
-> **Context:** Used by `camel-execute` to build the prompt for code-quality-reviewer subagents.
-> **Purpose:** Defines the exact checks the quality reviewer performs.
-
----
-
-## Overview
-
-The code quality reviewer answers: **Is the implementation well-built?**
-
-This is Stage 2 of the two-stage review. It runs ONLY AFTER spec compliance review passes (Iron Law 4). The implementation already matches the spec — this review checks quality.
+> **Context:** Used by `camel-execute` to dispatch and handle code-quality-reviewer subagents.
+> **Persona:** `agents/code-quality-reviewer.md` — defines the reviewer's checks, issue categories, and output format.
 
 ---
 
-## Reviewer Prompt Template
+## Dispatch Protocol
 
-Build the reviewer prompt with these sections:
-
-```
-## Your Role
-
-You are the Code Quality Reviewer. The implementation has already passed spec compliance
-review — it matches the design spec. Your job is to verify it's well-built: constitution
-compliance, security, anti-patterns, and YAML quality.
-
-## Files to Review
-
-[List the generated files with paths]
-
-## Constitution Rules (ALL 7 MUST PASS)
-
-Read `docs/constitution.md` in the project directory for the full rule definitions. For EACH generated route, check ALL 7 rules.
-
-For Rule 7 (Component Support Verification): spot-check 2-3 components via `camel_catalog_component` to verify they exist in the target Camel version.
-
-## Security Checks
-
-- No credentials in YAML or properties files
-- No passwords, API keys, tokens, or secrets in plain text
-- TLS/SSL configured for external connections
-- Sensitive headers not logged or exposed
-- No command injection vectors in expression languages
-
-## Anti-Pattern Checks
-
-- No empty routes (source → sink with no processing)
-- No routes exceeding single responsibility (>7 steps)
-- No direct-to-direct chains without purpose
-- No sync/async mixing without design rationale
-- No redundant type conversions
-- No overly broad exception handlers
-
-## YAML Quality
-
-- Kaoto-compatible structure
-- Consistent indentation
-- No deprecated DSL constructs
-- Proper `parameters:` blocks vs inline URI options
-
-## MCP Spot-Check
-
-- Verify 2-3 endpoint URIs via `camel_catalog_component`
-- Confirm option names match catalog exactly
-- Check for deprecated options
-
-## Output Format
-
-```
-## Code Quality Review
-
-### Constitution: PASS/FAIL
-Rule 1 (Route Structure): PASS/FAIL — [evidence]
-Rule 2 (Single Responsibility): PASS/FAIL — [evidence]
-Rule 3 (Separation of Concerns): PASS/FAIL — [evidence]
-Rule 4 (Naming): PASS/FAIL — [evidence]
-Rule 5 (Observability): PASS/FAIL — [evidence]
-Rule 6 (External Config): PASS/FAIL — [evidence]
-Rule 7 (Component Support): PASS/FAIL — [evidence]
-
-### Security: PASS/FAIL (N issues)
-- [Critical/Important/Suggestion]: [description]
-
-### Anti-Patterns: PASS/FAIL (N detected)
-- [pattern]: [location and recommendation]
-
-### YAML Quality: PASS/FAIL
-- [issues if any]
-
-### MCP Spot-Check: PASS/FAIL
-- [components verified, issues found]
-
-### Overall: PASS/FAIL
-Critical: [N] | Important: [N] | Suggestion: [N]
-[summary — Critical issues MUST be fixed before proceeding]
-```
-```
-
----
-
-## Issue Categories
-
-| Category | Blocks Completion? | Examples |
-|----------|-------------------|----------|
-| **Critical** | YES — must fix | Security vulnerabilities, constitution violations, broken routes, missing routeId |
-| **Important** | NO — noted | Anti-patterns, missing description, deprecated options, naming inconsistencies |
-| **Suggestion** | NO — noted | Formatting, additional error handling, performance hints |
-
----
+1. Load the persona from `agents/code-quality-reviewer.md`
+2. Build the subagent prompt with:
+   - The persona text (full — do not summarize)
+   - The generated files (or paths to them)
+   - Constitution rules to check (read `docs/constitution.md`)
+   - Security and anti-pattern checks
+3. Dispatch as a subagent — the reviewer runs in its own context and returns only the structured review report
 
 ## Failure Handling
 
@@ -120,9 +27,8 @@ If the quality reviewer reports Critical issues:
 
 **Maximum iterations:** 3. If Critical issues persist after 3 rounds, escalate to the user.
 
----
-
 ## MCP Tools for Quality Review
 
 The quality reviewer should use:
 - `camel_catalog_component(name, runtime, platformBom)` — verify endpoint option names
+- `camel_catalog_eip(name, runtime, platformBom)` — verify EIP configuration

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/quality-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/quality-reviewer-criteria.md
@@ -30,5 +30,5 @@ If the quality reviewer reports Critical issues:
 ## MCP Tools for Quality Review
 
 The quality reviewer should use:
-- `camel_catalog_component(name, runtime, platformBom)` — verify endpoint option names
+- `camel_catalog_component_doc(name, runtime, platformBom)` — verify endpoint option names
 - `camel_catalog_eip(name, runtime, platformBom)` — verify EIP configuration

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
@@ -1,99 +1,19 @@
-# Spec Compliance Reviewer Criteria
+# Spec Compliance Reviewer — Orchestrator Guide
 
-> **Context:** Used by `camel-execute` to build the prompt for spec-compliance-reviewer subagents.
-> **Purpose:** Defines the exact checks the spec reviewer performs.
-
----
-
-## Overview
-
-The spec compliance reviewer answers ONE question: **Does the implementation match the approved design spec?**
-
-This is Stage 1 of the two-stage review. It runs BEFORE the code quality review (Iron Law 4).
+> **Context:** Used by `camel-execute` to dispatch and handle spec-compliance-reviewer subagents.
+> **Persona:** `agents/spec-compliance-reviewer.md` — defines the reviewer's checks and output format.
 
 ---
 
-## Reviewer Prompt Template
+## Dispatch Protocol
 
-Build the reviewer prompt with these sections:
-
-```
-## Your Role
-
-You are the Spec Compliance Reviewer. Your ONLY job is to verify that the implementation
-matches the approved design spec. You do NOT check code quality, security, or anti-patterns —
-that's the code quality reviewer's job.
-
-## Design Spec Section
-
-[Include the relevant design spec section — the same one given to the implementer]
-
-## Files to Review
-
-[List the generated files with paths]
-
-## Checks
-
-For each check below, report PASS or FAIL with evidence.
-
-### 1. Component Completeness
-- Every component in the spec is present in the generated files
-- No extra components added that aren't in the spec
-- Component names match exactly
-
-### 2. Route Structure
-- Number of routes matches spec
-- Route flow matches spec (source → processing → sink in correct order)
-- Sub-routes present as specified
-
-### 3. Transformation Fidelity
-- Data transformations match spec
-- DataMapper field mappings cover all fields in spec
-- Routing conditions match spec logic
-
-### 4. Error Handling
-- Error handling strategy matches spec (DLQ, retry, circuit breaker)
-- Error routes present as specified
-- Retry counts and delays match spec values
-
-### 5. Configuration Properties
-- All properties from spec present in application.properties
-- Property names match spec
-- No hardcoded values that spec says should be configurable
-
-### 6. File Completeness
-- All files from the task's "Files" section exist
-- File paths match the plan exactly
-
-## Output Format
-
-```
-## Spec Compliance Review
-
-### Component Completeness: PASS/FAIL
-[evidence]
-
-### Route Structure: PASS/FAIL
-[evidence]
-
-### Transformation Fidelity: PASS/FAIL
-[evidence]
-
-### Error Handling: PASS/FAIL
-[evidence]
-
-### Configuration: PASS/FAIL
-[evidence]
-
-### Files: PASS/FAIL
-[evidence]
-
-### Overall: PASS/FAIL
-[summary — if FAIL, list specific items to fix]
-```
-```
-
----
+1. Load the persona from `agents/spec-compliance-reviewer.md`
+2. Build the subagent prompt with:
+   - The persona text (full — do not summarize)
+   - The generated files (or paths to them)
+   - The design spec section this task implements
+   - The task's review specification
+3. Dispatch as a subagent — the reviewer runs in its own context and returns only the structured review report
 
 ## Failure Handling
 
@@ -106,17 +26,3 @@ If the spec reviewer reports FAIL:
 5. Only then proceed to code quality review
 
 **Maximum iterations:** 3. If spec review fails 3 times, escalate to the user with the specific unresolved issues.
-
----
-
-## Common Spec Compliance Issues
-
-| Issue | What It Means |
-|-------|--------------|
-| Missing component | Implementer used wrong component or forgot one |
-| Extra component | Implementer added something not in spec (over-building) |
-| Wrong property name | Implementer used different naming than spec |
-| Missing error handling | Implementer skipped error handling section of spec |
-| Wrong route order | Processing steps in wrong sequence |
-| Missing DataMapper fields | XSLT doesn't cover all field mappings |
-| Hardcoded value | Property that spec says should be configurable is hardcoded |

--- a/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
@@ -53,6 +53,22 @@ camel_docs_search(query="migrating from Camel 3 to Camel 4.14", version="4.14", 
 camel_docs_jira_lookup(jira_id="CAMEL-22784")
 ```
 
+## Subagent Dispatch Pattern
+
+When invoked from within another skill (not standalone), the orchestrator should dispatch knowledge queries as a `knowledge-researcher` subagent (from `agents/knowledge-researcher.md`). This keeps full MCP search results out of the orchestrator context — only the synthesized answer flows back.
+
+**Standalone invocation** (`/camel-knowledge`): runs inline in the current context.
+
+**Pipeline invocation** (from `camel-brainstorm`, `camel-execute`, etc.): dispatch as subagent:
+1. Build the subagent prompt with:
+   - The `knowledge-researcher` persona (full text from `agents/knowledge-researcher.md`)
+   - The specific question or lookup request
+   - Relevant context (Camel version, component name, CVE ID, etc.)
+2. The subagent runs the appropriate MCP tools
+3. Only the structured answer (see `agents/knowledge-researcher.md` output format) flows back
+
+This pattern prevents ~2000-5000 tokens of raw search results per query from accumulating in the orchestrator context. For a migration brainstorm with 5-10 knowledge lookups, this saves 10,000-50,000 tokens.
+
 ## Important Notes
 
 - Pass `max_results=5` unless more results are needed

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -62,20 +62,40 @@ For each stage:
    - If matrix action is `AUTO-FIX`: load `guides/auto-fix-loop.md` and attempt repair
    - Otherwise: PAUSE and wait for user decision
 
-### Stamp Gate (After Stage 3)
+### Stamp Gate (After Stage 3) — Parallel Fan-Out
 
-After verification completes, run the final quality gate:
+After verification completes, run the final quality gate using parallel reviewer subagents. This keeps review traces out of the main ship context — only structured reports flow back.
 
-1. Verify build passes: run `{COMMAND_PREFIX} verify` (or `mvn verify` directly)
-2. Check Iron Law compliance: scan generated YAML for Iron Law violations
-3. Constitution compliance: compare generated routes against `docs/constitution.md`
-4. Acceptance criteria: cross-reference design spec acceptance criteria with generated output
+**Step 1: Build verification** (inline — not subagent)
+- Run `{COMMAND_PREFIX} verify` (or `mvn verify` directly)
+- If build fails → PAUSE regardless of --ask level
+
+**Step 2: Parallel reviewer fan-out** (3 subagents dispatched simultaneously)
+
+Dispatch these three reviewer subagents in parallel:
+
+| Reviewer | Persona | Focus |
+|----------|---------|-------|
+| Spec consistency | `agents/spec-compliance-reviewer.md` | Cross-route spec consistency — naming patterns, property conventions, shared endpoints |
+| Code quality | `agents/code-quality-reviewer.md` | Constitution compliance across ALL routes, anti-patterns, YAML quality |
+| Security scan | `agents/code-quality-reviewer.md` (security-only mode) | CVE checks via `camel_docs_cve_search`, credential scan, TLS verification |
+
+Each reviewer receives ALL generated route files and returns a structured report. The orchestrator does NOT read the full review traces — only the reports.
+
+**Why parallel is safe here:** Iron Law 4 (spec before quality) applies to per-task reviews in `camel-execute`. By this point, every task has already passed both spec and quality reviews individually. The Stamp Gate checks are cross-cutting and independent — they CAN run in parallel.
+
+**Step 3: Merge reports**
+- Combine the three reviewer reports into a single Stamp Gate report
+- Categorize issues: Critical / Important / Suggestion
+- Cross-reference acceptance criteria from the design spec
+
+**Step 4: Decision**
 
 If ALL checks pass:
 - Report: "Pipeline complete. All checks passed."
 
 If ANY check fails:
-- Report failures clearly
+- Report failures clearly with the merged report
 - If `--ask never`: attempt auto-fix (load `guides/auto-fix-loop.md`)
 - Otherwise: present failures and ask user for next steps
 

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-execute.append.md
@@ -51,6 +51,8 @@ When dispatching subagents during execution, use this map to set the `subagent_t
 | `test-engineer` | `general-purpose` | `sonnet` |
 | `spec-compliance-reviewer` | `general-purpose` | `sonnet` |
 | `code-quality-reviewer` | `code-simplifier` | `opus` |
+| `catalog-researcher` | `Explore` | `sonnet` |
+| `knowledge-researcher` | `Explore` | `sonnet` |
 
 **Migration-specialist resolution:** Check the task's `**Files:**` section:
 - If every entry is strictly read-only (e.g., "Read", "Analyze", "Inspect") → `Explore`

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-ship.append.md
@@ -32,3 +32,62 @@ During Stage 2 (Execute), use `ScheduleWakeup` for dynamic loop pacing:
 
 - After dispatching a wave of implementation tasks, use `ScheduleWakeup` with `delaySeconds: 270` (4.5 min, stays in cache)
 - Set `reason` to describe what you're waiting for: "waiting for implementation wave 2 (3 tasks) to complete"
+
+### Parallel Reviewer Fan-Out at Stamp Gate
+
+At the Stamp Gate, dispatch three reviewer subagents in parallel using the `Agent` tool:
+
+```text
+# Dispatch all three reviewers in a single message (parallel)
+Agent({
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "Stamp: spec consistency",
+  prompt: "[spec-compliance-reviewer persona + all route files + cross-route consistency focus]",
+  run_in_background: true
+})
+
+Agent({
+  subagent_type: "code-simplifier",
+  model: "opus",
+  description: "Stamp: code quality",
+  prompt: "[code-quality-reviewer persona + all route files + constitution + review-only override]",
+  run_in_background: true
+})
+
+Agent({
+  subagent_type: "code-simplifier",
+  model: "opus",
+  description: "Stamp: security scan",
+  prompt: "[code-quality-reviewer persona (security-only mode) + all route files + CVE check instructions]",
+  run_in_background: false  # last one — blocks until all complete
+})
+```
+
+Wait for all three to complete, then merge their reports into the Stamp Gate summary.
+
+### Catalog Research Dispatch
+
+Before implementation waves in Stage 2, dispatch the `catalog-researcher` via:
+
+```text
+Agent({
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Catalog verification batch",
+  prompt: "[catalog-researcher persona + artifact list + runtime + platformBom]"
+})
+```
+
+### Knowledge Query Dispatch
+
+When any stage needs documentation context, dispatch `knowledge-researcher` via:
+
+```text
+Agent({
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Knowledge: [topic]",
+  prompt: "[knowledge-researcher persona + specific question]"
+})
+```

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-execute.append.md
@@ -1,14 +1,23 @@
 ## Agent Optimization: Gemini CLI
 
+### Parallel Task Dispatch via Scheduler
+
+Gemini's scheduler natively supports parallel tool execution — all tool calls within a turn are batched via `Promise.all()` by default. Leverage this for within-wave parallelism:
+
+- When `{COMMAND_PREFIX} plan analyze` identifies parallel waves, dispatch all tasks in a wave by calling `invoke_subagent` for each task in the same turn
+- The scheduler automatically parallelizes these calls — no explicit parallel flag needed
+- Wait for all wave tasks to complete before starting the next wave
+- Include `max_turns: 50` and `timeout_mins: 15` in each delegation to prevent runaway agents
+
 ### Named Agent Delegation
 
-Delegate implementation tasks to pre-registered agents by name:
+Delegate tasks to pre-registered agents by name:
 
 - Implementation tasks: delegate to `camel-implementer`
 - Spec review: delegate to `camel-validator`
 - Quality review: delegate to `camel-validator` (reuse with different prompt)
-
-Include `max_turns: 50` and `timeout_mins: 15` in each delegation to prevent runaway agents.
+- Catalog research: delegate to `camel-validator` with catalog-researcher persona and exploration-focused prompt
+- Knowledge queries: delegate to `camel-validator` with knowledge-researcher persona
 
 ### TOML Policy for MCP Auto-Approval
 
@@ -31,3 +40,14 @@ Before the environment probe runs, use `read_many_files` to load all TDD files i
 - Load all `docs/flows/{flow-name}/{flow-name}.tdd.md` files
 - Load `.camel-kit/config.properties`
 - This gives the probe full context for skeleton generation without multiple sequential reads
+
+### Catalog Research Dispatch
+
+Before implementation waves, delegate a catalog verification batch to `camel-validator` with the catalog-researcher persona. The scheduler's default-parallel behavior means the catalog verification and context loading can overlap:
+
+- Call `read_many_files` and `invoke_subagent` (catalog batch) in the same turn
+- The scheduler parallelizes both calls automatically
+
+### Subagent Recursion Constraint
+
+Gemini subagents **cannot invoke other subagents** — `Kind.Agent` tools are filtered out during subagent registry creation. This is a hardcoded architectural constraint. Consequence: `/camel-execute` MUST run in the main agent context. The main agent orchestrates all dispatch.

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-ship.append.md
@@ -4,7 +4,7 @@
 
 Gemini's scheduler batches parallel tool calls automatically. At the Stamp Gate, invoke all three reviewers in the same turn:
 
-```
+```text
 # In a single response, call invoke_subagent three times:
 invoke_subagent(agent_name="camel-validator", prompt="[spec consistency review — cross-route]")
 invoke_subagent(agent_name="camel-validator", prompt="[code quality review — constitution + anti-patterns]")

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-ship.append.md
@@ -1,12 +1,27 @@
 ## Agent Optimization: Gemini CLI
 
+### Parallel Reviewer Fan-Out at Stamp Gate
+
+Gemini's scheduler batches parallel tool calls automatically. At the Stamp Gate, invoke all three reviewers in the same turn:
+
+```
+# In a single response, call invoke_subagent three times:
+invoke_subagent(agent_name="camel-validator", prompt="[spec consistency review — cross-route]")
+invoke_subagent(agent_name="camel-validator", prompt="[code quality review — constitution + anti-patterns]")
+invoke_subagent(agent_name="camel-validator", prompt="[security scan — CVE + credential check]")
+```
+
+The scheduler's `Promise.all()` executes all three concurrently. Each reviewer returns a structured report. Merge the three reports into the Stamp Gate summary.
+
+Include `timeout_mins: 20` in each delegation to prevent runaway reviews.
+
 ### Named Agent Pipeline
 
 Chain the pipeline using named agent delegation:
 
 - Stage 0 (Brainstorm): self (main agent orchestrates interview directly)
 - Stage 1 (Plan): self (plan generation stays in main context)
-- Stage 2 (Execute): delegate wave execution to `camel-implementer` agents
+- Stage 2 (Execute): delegate wave execution to `camel-implementer` agents — scheduler parallelizes within-wave dispatch
 - Stage 3 (Verify): delegate to `camel-validator` with `timeout_mins: 20`
 
 ### State Persistence via Memory
@@ -24,3 +39,11 @@ At each stage transition, use `read_many_files` to load all artifacts from previ
 - Before Plan: load design-spec.md
 - Before Execute: load design-spec.md + implementation-plan.md
 - Before Verify: load design-spec.md + all generated route files
+
+### Catalog and Knowledge Research
+
+Before implementation waves in Stage 2:
+
+- Delegate catalog verification to `camel-validator` with catalog-researcher persona
+- Delegate knowledge queries to `camel-validator` with knowledge-researcher persona
+- Both can be invoked in the same turn for scheduler parallelization

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
@@ -1,5 +1,23 @@
 ## Agent Optimization: OpenCode
 
+### LLM-Level Parallel Tool Calls
+
+OpenCode supports parallel tool calls at the LLM level — multiple tool call blocks in a single response execute concurrently. Leverage this for within-task parallelism:
+
+- Read multiple files in a single response (parallel reads)
+- Dispatch catalog verification alongside context loading
+- Run build commands alongside file generation where safe
+
+**Note:** True async background delegation is not yet available (Issue #5887). Subagent dispatch via `task` is modal — it blocks the primary flow.
+
+### Opt-In Subagent Delegation
+
+OpenCode now supports subagent-to-subagent dispatch (PR #7756) with configurable depth limits. For the executor agent dispatching implementer subagents:
+
+- Set `task: {"*": allow}` on the executor agent
+- Configure depth limits to prevent runaway delegation chains
+- The implementer subagent can optionally dispatch to exploration agents for codebase analysis
+
 ### Step-Limited Subagents
 
 Set `steps` limits on each subagent to prevent runaway execution:
@@ -7,6 +25,8 @@ Set `steps` limits on each subagent to prevent runaway execution:
 - Implementation subagents: `steps: 100` (enough for complex route generation)
 - Spec review subagents: `steps: 50` (review is read-heavy, fewer writes)
 - Quality review subagents: `steps: 50`
+- Catalog research subagents: `steps: 30` (batch MCP calls, structured summary)
+- Knowledge research subagents: `steps: 20` (focused query, synthesized answer)
 
 If a subagent hits its step limit, report a warning and continue to the next task.
 
@@ -16,6 +36,8 @@ OpenCode provides two primary agents (`Build` for code generation, `Plan` for an
 
 - Implementation subagents: use `General` with full `edit` and `bash` permissions
 - Review subagents: use `General` with read-focused permissions
+- Catalog research: use `Explore` (read-only, MCP calls only)
+- Knowledge research: use `Explore` (read-only, MCP calls only)
 - Codebase exploration: use `Explore` (read-only, no edit or bash access)
 - Plan analysis: stays in the `Plan` primary agent (no subagent dispatch needed)
 

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-execute.append.md
@@ -14,9 +14,8 @@ OpenCode supports parallel tool calls at the LLM level — multiple tool call bl
 
 OpenCode now supports subagent-to-subagent dispatch (PR #7756) with configurable depth limits. For the executor agent dispatching implementer subagents:
 
-- Set `task: {"*": allow}` on the executor agent
-- Configure depth limits to prevent runaway delegation chains
-- The implementer subagent can optionally dispatch to exploration agents for codebase analysis
+- Set `task: {"*": allow}` on the executor agent only
+- Keep delegation single-hop: executor dispatches implementers and exploration agents directly; implementer subagents do not dispatch other personas (composition depth = 1)
 
 ### Step-Limited Subagents
 

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-ship.append.md
@@ -45,4 +45,4 @@ If the re-plan loop triggers during Stage 2, the total step budget may exceed th
 
 ### Opt-In Delegation for Cascading Tasks
 
-With subagent-to-subagent delegation (PR #7756), the executor can dispatch implementation subagents that themselves dispatch exploration subagents for codebase analysis. Configure depth limit = 2 (executor → implementer → explorer) with call budgets per level.
+With subagent-to-subagent delegation (PR #7756), the executor can dispatch implementation and exploration subagents directly. Keep delegation single-hop: executor dispatches all personas; implementer subagents do not dispatch other personas (composition depth = 1).

--- a/camel-kit-core/src/main/resources/templates/traits/opencode/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/opencode/camel-ship.append.md
@@ -1,5 +1,15 @@
 ## Agent Optimization: OpenCode
 
+### LLM-Level Parallel Reviews at Stamp Gate
+
+At the Stamp Gate, leverage LLM-level parallel tool calls to dispatch multiple reviews. While true async background delegation is not yet available, multiple `task` tool calls in a single response can express intent for concurrent review:
+
+- Dispatch spec consistency review as `General` subagent (`steps: 50`)
+- Dispatch code quality review as `General` subagent (`steps: 50`)
+- Dispatch security scan as `Explore` subagent (`steps: 30`, read-only MCP CVE checks)
+
+**Note:** Until true async (Issue #5887) is implemented, these may execute sequentially despite being in the same response. The trait is structured for forward compatibility — when async lands, no trait changes are needed.
+
 ### Step-Limited Pipeline Stages
 
 Apply step limits per pipeline stage to prevent any single stage from consuming the entire session:
@@ -18,6 +28,13 @@ Use the appropriate OpenCode agent type for each pipeline stage:
 - Stage 2 (Execute): `Build` — optimized for code generation
 - Stage 3 (Verify): `Build` — needs to read code, run `camel test run`, and diagnose test failures
 
+### Catalog and Knowledge Research
+
+During Stage 2 (Execute), dispatch research-isolation subagents:
+
+- Catalog research: `Explore` agent with `steps: 30` for batched MCP verification
+- Knowledge queries: `Explore` agent with `steps: 20` for documentation lookup
+
 ### Plan Auto-Progression
 
 Stage 1 (Plan) auto-proceeds to Stage 2 (Execute). No step budget is consumed waiting for plan approval — execution starts immediately after planning completes.
@@ -25,3 +42,7 @@ Stage 1 (Plan) auto-proceeds to Stage 2 (Execute). No step budget is consumed wa
 ### Re-Plan Step Budget
 
 If the re-plan loop triggers during Stage 2, the total step budget may exceed the initial `steps: 500`. The executor should not hard-fail when approaching the limit if a re-plan is in progress — report progress and let the re-plan complete its current round before yielding.
+
+### Opt-In Delegation for Cascading Tasks
+
+With subagent-to-subagent delegation (PR #7756), the executor can dispatch implementation subagents that themselves dispatch exploration subagents for codebase analysis. Configure depth limit = 2 (executor → implementer → explorer) with call budgets per level.

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-execute.append.md
@@ -1,12 +1,62 @@
 ## Agent Optimization: Qwen Code
 
-### Serial Task Dispatch
+### Fork-Based Background Tasks
 
-Qwen Code's `task` tool dispatches one subagent at a time (serial only). Adapt wave-based execution:
+Qwen Code's dual dispatch enables parallel background work via the **fork model**:
 
-- Even if `{COMMAND_PREFIX} plan analyze` identifies parallel waves, execute ALL tasks sequentially
-- Process tasks in dependency order: complete all dependencies before starting a dependent task
-- Within a wave, process tasks in the order they appear in the plan
+- **Named subagents** (`subagent_type` provided): clean context, parent blocks until completion. Use for implementation tasks that need focused context.
+- **Forks** (`subagent_type` omitted): inherit parent's full conversation context, run in background while parent continues. Use for research isolation and review tasks.
+
+### Catalog Research via Fork
+
+Before dispatching implementers for a wave, fork a catalog verification task:
+
+```
+# Fork runs in background — parent continues to next instruction
+Agent({
+  prompt: "[catalog-researcher persona + artifact list + runtime + platformBom]"
+  // No subagent_type → fork mode, inherits parent context, runs in background
+})
+```
+
+The fork verifies all MCP catalog artifacts and writes results to a temporary file. The parent reads the results before dispatching implementers.
+
+**DashScope cache benefit:** The fork shares the parent's exact system prompt prefix, so both the fork and parent hit the same cache — saving 80%+ tokens.
+
+### Implementation Task Dispatch
+
+Named subagent dispatch for implementation tasks (parent blocks until complete):
+
+```
+Agent({
+  subagent_type: "camel-implementer",
+  prompt: "[full task text + design spec + pre-verified catalog summary]"
+})
+```
+
+Execute tasks sequentially within a wave (named subagents are blocking). Across waves, respect dependency ordering.
+
+### Fork-Based Review Parallelism
+
+After an implementer completes, use forks for the doubt cycle spot-checks while preparing the spec review prompt:
+
+```
+# Fork 1: spot-check component options via MCP (background)
+Agent({
+  prompt: "[doubt cycle — verify 2-3 component options]"
+})
+
+# Meanwhile, prepare spec review context (foreground)
+# Read generated files, load design spec section...
+
+# Then dispatch spec review as named subagent (blocking)
+Agent({
+  subagent_type: "camel-validator",
+  prompt: "[spec compliance review]"
+})
+```
+
+**Fork recursion constraint:** Fork children cannot create further forks (enforced via `AsyncLocalStorage`). Named subagents dispatched from a fork are fine.
 
 ### Progress Tracking via todo_write
 
@@ -14,25 +64,14 @@ Use `todo_write` to maintain a visible progress list:
 
 - At the start of execution, write all tasks as unchecked items
 - Check off each task as it completes spec compliance and quality review
-- This provides the user with a real-time progress view since parallel dispatch isn't available
+- This provides the user with a real-time progress view
 
 ### Explicit Context Passing
 
-Since subagents are serial, each subagent can read the outputs of all previous subagents. Include explicit file paths to prior outputs in each subagent prompt — don't assume the subagent will discover them.
+Include explicit file paths to prior outputs in each subagent prompt — don't assume the subagent will discover them.
 
 ### Environment Probe Checkpoint
-
-Before dispatching implementation tasks, the environment probe runs. Since Qwen executes serially:
 
 - Run the probe as the first task in the execution sequence
 - Write a checkpoint to `.camel-kit/ship-state.json` after the probe passes
 - If the probe triggers a re-plan loop, track each re-plan round as a separate todo item
-- Resume from post-probe if interrupted and probe already passed
-
-### Re-Plan as Serial Task
-
-When re-planning triggers, treat it as an inserted serial task:
-
-- Add a new todo item: "Re-plan round {N}: {failure description}"
-- Complete the re-plan before resuming implementation tasks
-- After re-plan, the affected implementation tasks must be re-dispatched

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-execute.append.md
@@ -11,7 +11,7 @@ Qwen Code's dual dispatch enables parallel background work via the **fork model*
 
 Before dispatching implementers for a wave, fork a catalog verification task:
 
-```
+```text
 # Fork runs in background — parent continues to next instruction
 Agent({
   prompt: "[catalog-researcher persona + artifact list + runtime + platformBom]"
@@ -27,7 +27,7 @@ The fork verifies all MCP catalog artifacts and writes results to a temporary fi
 
 Named subagent dispatch for implementation tasks (parent blocks until complete):
 
-```
+```text
 Agent({
   subagent_type: "camel-implementer",
   prompt: "[full task text + design spec + pre-verified catalog summary]"
@@ -40,7 +40,7 @@ Execute tasks sequentially within a wave (named subagents are blocking). Across 
 
 After an implementer completes, use forks for the doubt cycle spot-checks while preparing the spec review prompt:
 
-```
+```text
 # Fork 1: spot-check component options via MCP (background)
 Agent({
   prompt: "[doubt cycle — verify 2-3 component options]"

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-ship.append.md
@@ -4,7 +4,7 @@
 
 At the Stamp Gate, use the fork model to run reviewers in parallel:
 
-```
+```text
 # Fork 1: spec consistency (background)
 Agent({
   prompt: "[spec-compliance-reviewer persona + all route files + cross-route focus]"

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-ship.append.md
@@ -1,12 +1,39 @@
 ## Agent Optimization: Qwen Code
 
-### Serial Pipeline Execution
+### Fork-Based Parallel Reviews at Stamp Gate
 
-Execute all pipeline stages sequentially. Since Qwen Code dispatches one subagent at a time:
+At the Stamp Gate, use the fork model to run reviewers in parallel:
 
-- Complete each stage fully before starting the next
-- Do not attempt to parallelize any part of the pipeline
-- Use checkpoints between stages to save state
+```
+# Fork 1: spec consistency (background)
+Agent({
+  prompt: "[spec-compliance-reviewer persona + all route files + cross-route focus]"
+})
+
+# Fork 2: security scan (background)
+Agent({
+  prompt: "[code-quality-reviewer persona (security-only) + all route files + CVE check]"
+})
+
+# Named subagent: code quality (foreground, blocks)
+Agent({
+  subagent_type: "camel-validator",
+  prompt: "[code-quality-reviewer persona + all route files + constitution]"
+})
+```
+
+Fork 1 and Fork 2 run in parallel while the named quality review blocks. After the quality review completes, read fork results from their output. Merge all three reports.
+
+**Cache benefit:** All forks share the same system prompt prefix → DashScope prompt caching saves 80%+ tokens across concurrent reviews.
+
+### Sequential Pipeline Stages
+
+Execute pipeline stages sequentially — each stage must complete before the next starts:
+
+- Stage 0 (Brainstorm): direct
+- Stage 1 (Plan): direct, auto-proceeds to Stage 2
+- Stage 2 (Execute): dispatches implementation tasks, uses forks for research isolation
+- Stage 3 (Verify): direct
 
 ### State Tracking via todo_write
 
@@ -20,14 +47,10 @@ Maintain a pipeline progress list using `todo_write`:
 
 After each stage completes, write the state to `.camel-kit/ship-state.json` AND update the todo list. This dual-write ensures state is recoverable from either mechanism.
 
-### Plan Auto-Progression
+### Catalog and Knowledge Research via Fork
 
-Stage 1 (Plan) auto-proceeds to Stage 2 (Execute). Do not wait for plan approval — update the todo list to check off "Stage 1: Plan" and immediately proceed to "Stage 2: Execute".
+During Stage 2 (Execute), use forks for research isolation:
 
-### Re-Plan Checkpoints
-
-If the re-plan loop triggers during Stage 2:
-
-- Add temporary todo items: "Re-plan round 1", "Re-plan round 2", "Re-plan round 3"
-- Write state to `.camel-kit/ship-state.json` after each round
-- If interrupted during re-plan, resume from the correct round using saved state
+- Fork a catalog-researcher task before each implementation wave
+- Fork knowledge-researcher queries when documentation context is needed
+- Forks run in background, parent continues with preparation work

--- a/distribution.properties
+++ b/distribution.properties
@@ -17,7 +17,7 @@ camel.springboot.version=4.20.0
 springboot.bom.version=4.20.0
 
 # Quarkus runtime
-camel.quarkus.version=4.18.0
+camel.quarkus.version=4.18.2
 quarkus.platform.version=3.33.1
 
 # ─── Supported Versions Per Platform ────────────────────────────────────────
@@ -26,12 +26,12 @@ quarkus.platform.version=3.33.1
 # Shown to the user during /camel-design version selection.
 camel.main.supported=4.20.0,4.18.2,4.14.7
 camel.springboot.supported=4.20.0,4.18.2,4.14.7
-camel.quarkus.supported=4.18.0,4.14.7
+camel.quarkus.supported=4.18.2,4.14.7
 
 # ─── Quarkus Platform BOM Mapping ──────────────────────────────────────────
 #
 # Maps each supported Camel Quarkus version to its Quarkus platform BOM version.
-quarkus.platform.4.18.0=3.33.1
+quarkus.platform.4.18.2=3.33.1
 quarkus.platform.4.14.7=3.27.3
 
 # ─── MCP Server Versions ───────────────────────────────────────────────────

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -158,11 +158,15 @@ Bob supports three checkpoint types used in gate files:
 
 ---
 
-## Gemini CLI -- Policy Engine + Modular Imports
+## Gemini CLI -- Parallel Scheduler + Policy Engine + Modular Imports
 
 ### Dispatch Model
 
-Gemini uses subagents for 6 pipeline phases, but `/camel-execute` runs in the **main agent context** because Gemini subagents cannot invoke other subagents (recursion prevention). The main agent can dispatch to all 6 subagents for orchestration.
+Gemini exposes a single unified `invoke_subagent` tool (`AgentTool` class) that dispatches to subagents by name. Three invocation types are supported: **Local** (in-process context loop), **Remote** (A2A protocol), and **Browser** (headless automation). Users can also invoke via `@subagent_name` syntax.
+
+The `Scheduler` class implements **native parallel tool execution** -- all tool calls within a turn are assessed for parallelizability and batched via `Promise.all()` by default. Tools opt-out of parallelism via `wait_for_previous: true`.
+
+However, subagents **cannot invoke other subagents** -- `Kind.Agent` tools are hardcoded-filtered during registry creation. This means `/camel-execute` runs in the **main agent context** so it can dispatch to all 6 subagents for orchestration.
 
 ### Template Files
 
@@ -247,21 +251,51 @@ timeout_mins: 20
 
 `mcp_camel_*` automatically includes new tools when the MCP server adds them -- future-proof. Different subagents can have different MCP server access (e.g., validator gets catalog but not knowledge).
 
+### Path-Scoped Edits via Policy Engine
+
+The Policy Engine supports per-subagent tool restrictions based on regex matching against serialized tool arguments:
+
+```toml
+[[rules]]
+toolName = "edit_file"
+subagent = "frontend-specialist"
+argsPattern = "\"file_path\":\"src/frontend/"
+decision = "allow"
+priority = 600
+
+[[rules]]
+toolName = "edit_file"
+subagent = "frontend-specialist"
+decision = "deny"
+priority = 500
+```
+
+This restricts the `frontend-specialist` to only edit files under `src/frontend/`.
+
 ### Unique Capabilities
 
+- **Default-parallel scheduler:** `Promise.all()` batches all parallelizable tool calls within a turn -- only agent with native scheduler-level parallelism
 - **`@file.md` modular imports:** only agent that supports composing instructions from multiple files -- each concern is independently editable
 - **Server-scoped MCP wildcards:** `mcp_camel_*` grants all tools from a specific server, auto-discovers new tools
-- **TOML policy engine with priority tiers:** workspace policies can be overridden by user policies
+- **TOML policy engine with priority tiers:** workspace policies can be overridden by user policies, per-subagent `argsPattern` targeting
+- **Three invocation kinds:** Local (in-process), Remote (A2A protocol), Browser (headless)
 - **Execution limits per subagent:** `max_turns` and `timeout_mins` prevent runaway execution
 - **Execute in main agent:** the only agent where `/camel-execute` runs outside a subagent (platform constraint turned into a feature -- main agent has full delegation ability)
 
 ---
 
-## Qwen -- Auto-Delegation with Sub-Agents
+## Qwen -- Dual Dispatch with Fork Model
 
 ### Dispatch Model
 
-Qwen uses 7 sub-agents with description-based auto-delegation. When a user describes their intent (e.g., "validate my routes"), Qwen automatically routes to the right sub-agent based on keyword matching in the description field.
+Qwen uses a **dual dispatch model** via the `Agent` tool:
+
+1. **Named subagents** -- when `subagent_type` is provided, a registered subagent is loaded and executed with its own system prompt, no parent history. The parent **blocks** until completion.
+2. **Fork** -- when `subagent_type` is omitted, an implicit fork is created. The fork **inherits the parent's full conversation context** and runs in the background while the parent continues. Fork children cannot create further forks (enforced via `AsyncLocalStorage`).
+
+The fork mechanism shares the parent's exact system prompt and tool declarations to exploit **DashScope prompt caching** -- all forks hit the same cache prefix, saving 80%+ tokens. This is a provider-specific optimization.
+
+Qwen also supports 7 sub-agents with description-based auto-delegation. When a user describes their intent (e.g., "validate my routes"), Qwen automatically routes to the right sub-agent based on keyword matching in the description field.
 
 ### Template Files
 
@@ -317,20 +351,33 @@ Working directory: ${current_directory}
 
 These are resolved by Qwen at invocation time, providing context-aware behavior without hardcoding project paths.
 
+### Parallel Execution
+
+Qwen implements a **batch-based concurrency model** in the `CoreToolScheduler`. Read, Search, and Fetch tool calls are marked concurrency-safe and batched via `Promise.all()` with a configurable cap (default: max 10). Agent tool invocations are sequential by default.
+
+Multi-agent parallelism is achieved through the **fork model**: the parent omits `subagent_type`, creating a background fork that inherits the full conversation context. The parent continues immediately. This enables parallel research or review tasks — but fork children cannot create further forks.
+
 ### Unique Capabilities
 
+- **Dual dispatch (named + fork):** named subagents for clean-context tasks, forks for background tasks with parent context sharing
+- **DashScope prompt caching:** fork model shares parent's exact system prompt prefix, saving 80%+ tokens across concurrent forks
 - **Description-matching auto-delegation:** user intent is automatically matched to the right sub-agent without explicit command invocation
 - **Template variables (`${project_name}`, `${current_directory}`):** resolved at runtime for context-aware prompts
-- **Binary tool whitelists:** simple and explicit -- tools are either available or not
-- **7 sub-agents (most of any agent):** every phase gets auto-delegation, even full-access phases benefit from context isolation
+- **Allowlist + blocklist:** `tools` and `disallowedTools` for flexible per-subagent tool control
+- **Approval mode per subagent:** `default`, `plan`, `auto-edit`, `yolo`
+- **Background flag:** `background: true` in frontmatter for non-blocking execution
 
 ---
 
-## OpenCode -- Granular Permission System
+## OpenCode -- Granular Permission System + Opt-In Delegation
 
 ### Dispatch Model
 
-OpenCode uses 7 agents with the most granular permission system of any supported agent. 14 permission types support glob patterns with last-match-wins evaluation. This enables path-scoped file edits, command-level bash control, and per-agent execution limits.
+OpenCode dispatches via the `task` tool, which creates a **child session** with `parentID` and derived permissions. 14 permission types support glob patterns with last-match-wins evaluation, enabling path-scoped file edits, command-level bash control, and per-agent execution limits.
+
+**Subagent-to-subagent delegation** was historically blocked (task tool removed from subagent sessions). PR #7756 added opt-in delegation with configurable call budgets and depth limits. Users can also invoke agents via `@agent-name` syntax.
+
+**Permission inheritance:** Parent agent deny rules are forwarded to child sessions via `deriveSubagentSessionPermission()`. Known gap: permissions are not fully transitive — a restricted parent can invoke a subagent with broader permissions.
 
 ### Template Files
 
@@ -401,6 +448,9 @@ Each agent has a `steps` limit. When reached, OpenCode instructs the agent to su
 - **`steps` limit per agent:** prevents runaway execution with graceful summarization
 - **`doom_loop` detection:** catches agents stuck in repetitive tool call patterns (inherited default behavior)
 - **Last-match-wins evaluation:** glob patterns are order-sensitive, allowing fine-grained overrides
+- **Opt-in subagent delegation:** PR #7756 enables subagent-to-subagent dispatch with configurable depth limits and call budgets
+- **LLM-level parallel tool calls:** multiple tool calls in a single LLM response execute concurrently
+- **Mixed-provider model support:** agents can use different model providers (e.g., `anthropic/claude-opus-4-6`, `openai/gpt-4o`)
 
 ---
 
@@ -408,12 +458,13 @@ Each agent has a `steps` limit. When reached, OpenCode instructs the agent to su
 
 | Aspect | Claude | Bob | Gemini | Qwen | OpenCode |
 |--------|--------|-----|--------|------|----------|
-| Dispatch model | Parallel subagents | Mode switching | 6 subagents + main-agent execute | 7 auto-delegating sub-agents | 7 permission-scoped agents |
+| Dispatch model | Parallel subagents | Mode switching | `invoke_subagent` unified tool (local/remote/browser) | Dual: named subagent + fork (context-sharing background task) | `task` tool creating child sessions with `parentID` |
 | Template files | 3 | 17+ | 12 | 9 | 8 |
-| Tool restriction | Instruction-based | Mode tool groups | Subagent tools + TOML policy | Binary tool whitelists | 14-type glob permissions |
-| Path-scoped edits | No | `.md` only (via fileRegex) | No | No | Yes (glob patterns) |
+| Tool restriction | Instruction-based | Mode tool groups | Allowlist + TOML policy + server-scoped wildcards | Allowlist + blocklist (`disallowedTools`) | 3-state (`allow`/`ask`/`deny`) + bash glob patterns |
+| Path-scoped edits | No | `.md` only (via fileRegex) | Yes (Policy Engine `argsPattern` regex + `subagent` field) | No | Yes (glob patterns) |
 | MCP auto-approval | No (manual) | No (manual) | Yes (TOML policy) | No (manual) | No (manual) |
-| Parallel execution | Yes (graph-based) | No | No | No | No |
+| Parallel execution | Yes (graph-based) | No | Yes (scheduler `Promise.all()`, default-parallel) | Partial (read-only tools concurrent, max 10; fork runs in background) | Partial (LLM-level parallel tool calls; true async requested) |
+| Subagent recursion | Yes (no limit) | N/A | No (hardcoded `Kind.Agent` filter) | No (fork-of-fork blocked via `AsyncLocalStorage`) | Opt-in (PR #7756, configurable depth limits) |
 | Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Main agent (recursion prevention) | Sub-agent with `task` tool | Agent with `task` permission |
 | Agent-specific ignore | No | No | `.geminiignore` | `.qwenignore` | No (uses `.gitignore`) |
 | Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | `@file.md` modular imports | Single `QWEN.md` | Ultra-minimal `AGENTS.md` (~80 tokens) |

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -4,6 +4,41 @@
 
 ---
 
+## Three-Layer Composition Model
+
+Camel-Kit uses a three-layer composition model to separate concerns between user interaction, workflow orchestration, and domain expertise:
+
+| Layer | What it is | Examples |
+|-------|-----------|---------|
+| **Skill** | Workflow with steps and exit criteria | `camel-brainstorm`, `camel-execute`, `camel-ship` |
+| **Persona** | Role with perspective, output format, and composition rules | `integration-architect`, `catalog-researcher`, `code-quality-reviewer` |
+| **Command** | User-facing entry point | `/camel-brainstorm`, `/camel-ship`, `/camel-validate` |
+
+### Composition Rules
+
+1. **Personas do not invoke other personas.** Composition is the job of skills or the user.
+2. Every persona has a `## Composition` block stating: invoke directly when / invoked via / do not invoke from another persona.
+3. **Max depth = 1:** command → persona (no deep persona trees).
+
+### Subagent Dispatch Patterns
+
+| Pattern | Purpose | Example |
+|---------|---------|---------|
+| **Direct dispatch** | One persona, one task, structured output | Implementer generates route YAML |
+| **Parallel fan-out with merge** | Multiple independent reviewers, merged reports | Stamp Gate: spec + quality + security in parallel |
+| **Research isolation** | Batch lookups, return summary only | `catalog-researcher` verifies 8 components, returns 100-token summary |
+| **In-flight doubt cycle** | Spot-check subagent claims before expensive review | CLAIM → EXTRACT → DOUBT with 3-cycle cap |
+
+### Context Savings
+
+Each subagent has its own context window. Only structured summaries flow back to the orchestrator:
+- **Research isolation** prevents ~500 tokens per MCP call from accumulating (8 components = ~4,000 tokens saved per task)
+- **Review isolation** prevents review traces (file reads, reasoning, MCP spot-checks) from accumulating (~2,000-5,000 tokens per review)
+- **Verification isolation** prevents build output and fix cycles from accumulating (~5,000-10,000 tokens)
+- For a typical 5-task plan with 2-stage review per task, subagent isolation prevents ~60-70% of pipeline tokens from accumulating in the main conversation
+
+---
+
 ## Design Philosophy
 
 Each agent uses a different architecture designed to **maximize that agent's native capabilities** -- not lowest-common-denominator parity. The equalization layer ensures identical pipeline behavior (same skills, same output), while the template layer exploits each agent's strongest features for dispatch, tool restriction, and configuration.
@@ -60,6 +95,9 @@ Claude has no formal permission system. It relies on skill instructions to const
 - **Parallel dispatch:** only agent that can run multiple pipeline tasks simultaneously
 - **Route graph topology:** uses `camel-kit graph` to determine route independence for parallelization decisions
 - **Context isolation:** each subagent gets a fresh context window -- no cross-contamination between phases
+- **Research isolation:** `catalog-researcher` and `knowledge-researcher` subagents batch MCP lookups and return only summaries
+- **Parallel reviewer fan-out:** Stamp Gate dispatches spec, quality, and security reviewers simultaneously
+- **In-flight doubt cycle:** orchestrator spot-checks implementer claims before expensive two-stage review
 - **Simplest configuration:** 3 template files total (fewest of any agent)
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -383,11 +383,11 @@ Four of the five agents support this natively through **subagent dispatch**:
 
 - **Claude Code** -- uses the `Agent` tool to spawn fresh subagents per task. Each subagent receives the task text, relevant TDD section, guide file paths, and MCP parameters. Before implementation, a `catalog-researcher` subagent batch-verifies all MCP catalog artifacts (research isolation). After implementation, an in-flight doubt cycle spot-checks key claims, then a spec-compliance reviewer subagent checks the design spec, then a code-quality reviewer subagent checks constitution compliance. At the Stamp Gate, three reviewers run in parallel (spec, quality, security). Claude uniquely supports **parallel dispatch**: the route graph topology (from `camel-kit-graph`) identifies independent routes (no shared `direct:`, `seda:`, or `vm:` endpoints, no shared configuration properties), and independent tasks are dispatched simultaneously to multiple subagents.
 
-- **Gemini CLI** -- dispatches to 6 specialized subagents (brainstormer, planner, implementer, validator, tester, migrator). However, `/camel-execute` runs in the **main agent context** because Gemini prevents recursive subagent invocation -- a subagent cannot dispatch another subagent. The main agent orchestrates by dispatching individual tasks to the implementer subagent, then to the validator subagent, sequentially.
+- **Gemini CLI** -- dispatches via a unified `invoke_subagent` tool to 6 specialized subagents. The scheduler natively supports **parallel tool execution** via `Promise.all()` (default-parallel). However, subagents cannot invoke other subagents (hardcoded `Kind.Agent` filter), so `/camel-execute` runs in the **main agent context** where it can dispatch to all subagents. Within-wave parallelism is achieved through the scheduler batching multiple `invoke_subagent` calls.
 
-- **Qwen** -- 7 sub-agents with description-based auto-delegation. The `"MUST BE USED for..."` phrasing in each sub-agent's description forces Qwen to automatically route work to the correct sub-agent based on intent keywords. The executor sub-agent has access to the `task` tool for dispatching work to other sub-agents.
+- **Qwen** -- dual dispatch model: **named subagents** (clean context, parent blocks) and **forks** (inherit parent context, run in background). The fork model enables parallel review and research tasks. Read-only tools (Read, Search, Fetch) are concurrent with a configurable cap (max 10). The `"MUST BE USED for..."` phrasing in description fields forces automatic delegation.
 
-- **OpenCode** -- 7 agents with granular, per-type glob permissions. The executor agent has `task: {"*": allow}` permission, enabling it to dispatch work to the implementer, validator, and tester agents. Each agent has a `steps` limit (implementer: 50, executor: 100) that triggers graceful summarization rather than hard failure.
+- **OpenCode** -- 7 agents with granular, per-type glob permissions. The executor agent has `task: {"*": allow}` permission. Subagent-to-subagent delegation is now opt-in (PR #7756) with configurable depth limits and call budgets. LLM-level parallel tool calls are supported. Each agent has a `steps` limit (implementer: 50, executor: 100) that triggers graceful summarization rather than hard failure.
 
 **IBM Project Bob does not support subagents.** It uses a fundamentally different architecture -- the **B+A (Behavior + Advanced) hybrid with mode switching**:
 
@@ -406,7 +406,7 @@ The trade-off table:
 | Context isolation | Per-task (fresh subagent) | Per-session (accumulated) |
 | Reviewer independence | Separate subagent | Same session self-reviews |
 | Tool restriction mechanism | Instruction-based / tool whitelists / policies | Platform-enforced mode tool groups |
-| Parallel execution | Claude only (graph topology) | Not possible |
+| Parallel execution | Claude (graph topology), Gemini (scheduler `Promise.all()`), Qwen (fork), OpenCode (LLM-level) | Not possible |
 | Skill loading | Loaded into subagent context on dispatch | Inlined in monolithic gate files |
 | Template complexity | 3-12 files per agent | 17+ files (gates + rules + modes) |
 | Failure isolation | Subagent failure doesn't affect other tasks | Phase failure affects entire session |
@@ -417,9 +417,9 @@ The trade-off table:
 |-------|---------------|-------------------|
 | Claude Code | Parallel subagent dispatch | Route graph topology, research isolation, parallel fan-out, doubt cycle |
 | IBM Project Bob | B+A hybrid with 5 custom modes | Monolithic gate files, 3 checkpoint types |
-| Gemini CLI | 6 subagents + main-agent execute | `@file.md` imports, TOML policy engine, MCP wildcards |
-| Qwen | 7 sub-agents with auto-delegation | Description matching, template variables |
-| OpenCode | 7 agents with granular permissions | 14 permission types, glob patterns, path-scoped edits |
+| Gemini CLI | `invoke_subagent` + parallel scheduler | Default-parallel `Promise.all()`, TOML policy, MCP wildcards, A2A remote agents |
+| Qwen | Dual dispatch (named + fork) | Fork background tasks, DashScope cache sharing, auto-delegation |
+| OpenCode | `task` child sessions + opt-in delegation | 14 permission types, glob patterns, configurable depth limits |
 
 For full per-agent deep dives (template files, tool restriction models, configuration examples, unique capabilities), see **[Agent Architectures](agent-architectures.md)**.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,15 +220,19 @@ Entry points diverge (`camel-brainstorm` for greenfield, `camel-migrate` for mig
 ### How camel-execute Dispatches Work
 
 1. Read the approved implementation plan and extract all tasks
-2. For each task:
-   - Dispatch an implementer subagent with full task text, design spec section, guide paths, and MCP parameters
-   - On completion, dispatch a **spec compliance reviewer** -- does the output match the design spec?
-   - If spec review passes, dispatch a **code quality reviewer** -- constitution compliance, security, anti-patterns
+2. **Catalog research** (Step 1.5): dispatch a `catalog-researcher` subagent to batch-verify all MCP catalog artifacts for the wave. Only the structured summary flows back -- MCP response traces stay in the research subagent's context.
+3. For each task:
+   - Dispatch an implementer subagent with full task text, design spec section, pre-verified catalog summary, and MCP parameters
+   - **In-flight doubt cycle** (Step 2b.5): spot-check the implementer's key claims (component options, route structure, file list) before expensive review. Hard cap: 3 cycles.
+   - Dispatch a **spec compliance reviewer** (subagent) -- does the output match the design spec?
+   - If spec review passes, dispatch a **code quality reviewer** (subagent) -- constitution compliance, security, anti-patterns
    - If either reviewer finds critical issues, return to the implementer for fixes, then re-review
    - Mark task complete and immediately start the next task (no pause, no user confirmation)
-3. After all tasks: run a **cross-cutting review** across all generated routes
-4. Run the **verification phase** (`camel-verify`)
-5. Print the completion summary
+4. After all tasks: dispatch a **cross-cutting review** as a subagent across all generated routes
+5. Dispatch the **verification phase** (`camel-verify`) as a subagent
+6. Print the completion summary
+
+All reviews, verification, and catalog lookups run as subagents with isolated context windows. Only structured reports flow back to the orchestrator -- preventing ~60-70% of pipeline tokens from accumulating in the main conversation.
 
 ### Agent-Specific Execution
 
@@ -377,7 +381,7 @@ The `/camel-execute` pipeline relies on dispatching discrete units of work to is
 
 Four of the five agents support this natively through **subagent dispatch**:
 
-- **Claude Code** -- uses the `Agent` tool to spawn fresh subagents per task. Each subagent receives the task text, relevant TDD section, guide file paths, and MCP parameters. After implementation, a separate reviewer subagent checks spec compliance, then a third checks code quality. Claude uniquely supports **parallel dispatch**: the route graph topology (from `camel-kit-graph`) identifies independent routes (no shared `direct:`, `seda:`, or `vm:` endpoints, no shared configuration properties), and independent tasks are dispatched simultaneously to multiple subagents.
+- **Claude Code** -- uses the `Agent` tool to spawn fresh subagents per task. Each subagent receives the task text, relevant TDD section, guide file paths, and MCP parameters. Before implementation, a `catalog-researcher` subagent batch-verifies all MCP catalog artifacts (research isolation). After implementation, an in-flight doubt cycle spot-checks key claims, then a spec-compliance reviewer subagent checks the design spec, then a code-quality reviewer subagent checks constitution compliance. At the Stamp Gate, three reviewers run in parallel (spec, quality, security). Claude uniquely supports **parallel dispatch**: the route graph topology (from `camel-kit-graph`) identifies independent routes (no shared `direct:`, `seda:`, or `vm:` endpoints, no shared configuration properties), and independent tasks are dispatched simultaneously to multiple subagents.
 
 - **Gemini CLI** -- dispatches to 6 specialized subagents (brainstormer, planner, implementer, validator, tester, migrator). However, `/camel-execute` runs in the **main agent context** because Gemini prevents recursive subagent invocation -- a subagent cannot dispatch another subagent. The main agent orchestrates by dispatching individual tasks to the implementer subagent, then to the validator subagent, sequentially.
 
@@ -411,7 +415,7 @@ The trade-off table:
 
 | Agent | Dispatch Model | Key Differentiator |
 |-------|---------------|-------------------|
-| Claude Code | Parallel subagent dispatch | Route graph topology for parallelization |
+| Claude Code | Parallel subagent dispatch | Route graph topology, research isolation, parallel fan-out, doubt cycle |
 | IBM Project Bob | B+A hybrid with 5 custom modes | Monolithic gate files, 3 checkpoint types |
 | Gemini CLI | 6 subagents + main-agent execute | `@file.md` imports, TOML policy engine, MCP wildcards |
 | Qwen | 7 sub-agents with auto-delegation | Description matching, template variables |

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,11 @@
         <tamboui.version>0.1.0</tamboui.version>
         <quarkus.version>3.20.2.2</quarkus.version>
         <quarkus-mcp.version>1.6.1</quarkus-mcp.version>
+        <camel.version>4.20.0</camel.version>
         <!-- Also in distribution.properties (runtime source of truth).
              Duplicated here because maven-dependency-plugin resolves
              artifact versions at POM parse time, before any lifecycle phase. -->
-        <camel.mcp.version>4.20.0</camel.mcp.version>
+        <camel.mcp.version>${camel.version}</camel.mcp.version>
 
         <!-- Code quality -->
         <impsort-maven-plugin.version>1.13.0</impsort-maven-plugin.version>


### PR DESCRIPTION
## Summary

Implements the Three-Layer Composition Model (Skill / Persona / Command) for context isolation across the camel-kit pipeline. Key changes:

- **Composition blocks** on all 8 agent personas enforcing max depth = 1 (no persona invokes another persona)
- **Research isolation**: new `catalog-researcher` and `knowledge-researcher` personas batch MCP/knowledge lookups and return only structured summaries — prevents ~60-70% of pipeline tokens from accumulating in the orchestrator context
- **In-flight doubt cycle** (CLAIM → EXTRACT → DOUBT): lightweight spot-check of implementer claims before expensive two-stage review, 3-cycle hard cap
- **Parallel reviewer fan-out** at Stamp Gate in `camel-ship`: spec, quality, and security reviewers dispatched simultaneously
- **Subagent-isolated verification**: cross-cutting review and `camel-verify` dispatched as subagents
- **Criteria guide consolidation**: reviewer criteria guides reduced to orchestrator-only content (dispatch protocol + failure handling)
- **Agent capabilities update**: corrected parallel execution capabilities for Gemini CLI (`Promise.all()` scheduler), Qwen Code (fork model), and OpenCode (LLM-level parallel, opt-in delegation)
- **Trait updates**: Gemini (parallel wave dispatch + reviewer fan-out), Qwen (fork-based research + review), OpenCode (LLM-level parallel + step budgets)
- Also includes version housekeeping: centralized `camel.version` in parent POM, Camel Quarkus bumped to 4.18.2

## Review Feedback Addressed (commit 3)

- Fixed Iron Laws numbering gap (1,2,4 → 1,2,3)
- Clarified MCP verification ownership: `catalog-researcher` is authoritative, implementers use pre-verified data
- Fixed MCP tool name: `camel_catalog_component_doc` (verified against actual MCP server source)
- Fixed depth-1 violation in OpenCode trait
- Added language tags to fenced code blocks (MD040)
- Declined moving agent-specific params (`max_turns`/`timeout_mins`/`steps`) to orchestrating skill — these are agent-specific frontmatter keys that belong in traits

## Test plan

- [x] All persona files have exactly one `## Composition` block with three required fields
- [x] No persona references another persona (max depth = 1 verified)
- [x] `./mvnw clean install -B` passes — all resources bundled correctly
- [x] New personas appear in build output (`target/classes/agents/`)
- [x] Iron Law 4 (spec before quality) still enforced per-task in `camel-execute`
- [x] MCP tool name `camel_catalog_component_doc` verified against actual server source in `camel-kit-knowledge/`
- [ ] Manual: run `/camel-ship` with a sample project to verify parallel fan-out behavior
- [ ] Manual: verify `catalog-researcher` dispatch during `/camel-execute`

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added catalog-researcher and knowledge-researcher subagents, plus parallel reviewer dispatch at the Stamp Gate and a bounded in‑flight verification/doubt cycle.

* **Documentation**
  * Expanded architecture, persona composition, skill and template guides to describe subagent dispatch patterns, orchestration flows, composition rules, and reviewer merging.

* **Chores / Bug Fixes**
  * Updated platform Camel/Quarkus versions and aligned version handling across build metadata to avoid mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->