### PR TITLE
fix #65: file-based handoff — standalone mode, staleness markers, and camel-ship integration

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -35,7 +35,7 @@ Invoked with a `<PIPELINE_ID>` argument (e.g., `/camel-brainstorm 001-order-proc
 
 **Detection at start:**
 
-```
+```text
 if <PIPELINE_ID> argument provided:
     resolve pipeline directory
     if design-spec.md exists → AMEND MODE
@@ -120,10 +120,12 @@ digraph brainstorm {
 }
 ```
 
-**The terminal state is YOU invoking camel-plan.** Do NOT invoke camel-execute, generate YAML, or take any implementation action.
+**The terminal state depends on invocation mode.** In chained mode: YOU invoke camel-plan. In standalone mode: write output and STOP. In both modes: do NOT invoke camel-execute, generate YAML, or take any implementation action.
 
 <HARD-RULE>
-When the user approves the design spec, YOU must invoke/activate the `camel-plan` skill immediately and automatically. Do NOT tell the user to run it manually. Do NOT print "please run camel-plan" or "run /camel-plan". YOU do it — the transition is automatic.
+When the user approves the design spec in **chained mode**, YOU must invoke/activate the `camel-plan` skill immediately and automatically. Do NOT tell the user to run it manually. Do NOT print "please run camel-plan" or "run /camel-plan". YOU do it — the transition is automatic.
+
+In **standalone mode** (including amend mode), write the output artifact and STOP. Do NOT auto-invoke camel-plan.
 </HARD-RULE>
 
 ---

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -18,6 +18,54 @@ Turn integration ideas into fully formed design specs through collaborative dial
 Do NOT invoke camel-plan, generate any implementation artifacts, write any YAML routes, or take any implementation action until you have presented a design spec and the user has explicitly approved it. This applies to EVERY project regardless of perceived simplicity.
 </HARD-GATE>
 
+## Invocation Modes
+
+This skill supports two invocation modes (see `shared/pipeline-infrastructure.md` for details):
+
+### Chained Mode (default)
+
+Auto-invoked by `camel-start` or invoked directly without a `<PIPELINE_ID>` argument when no existing design spec is found. Runs the full interview → design → approval → auto-invoke plan flow.
+
+### Standalone Mode
+
+Invoked with a `<PIPELINE_ID>` argument (e.g., `/camel-brainstorm 001-order-processing`). Two sub-cases:
+
+1. **New pipeline** — `design-spec.md` does NOT exist in `docs/camel-kit/<PIPELINE_ID>/`. Runs the full interview flow, writes output to the pipeline directory, then STOPS (does NOT auto-invoke plan).
+2. **Amend mode** — `design-spec.md` already exists. Enters re-iteration: loads the existing spec, presents it for amendment, writes the updated spec, marks downstream artifacts stale, then STOPS.
+
+**Detection at start:**
+
+```
+if <PIPELINE_ID> argument provided:
+    resolve pipeline directory
+    if design-spec.md exists → AMEND MODE
+    else → STANDALONE NEW
+else:
+    → CHAINED MODE (normal flow)
+```
+
+In standalone mode, the `<HARD-RULE>` auto-transition to `camel-plan` is suppressed. The skill writes its output and stops.
+
+---
+
+## Amend Mode (Re-iteration)
+
+When amending an existing design spec:
+
+1. Read `docs/camel-kit/<PIPELINE_ID>/design-spec.md`
+2. Present the existing spec to the user with: "This pipeline already has a design spec. What would you like to change?"
+3. Apply the user's requested changes — this may involve:
+   - Re-running parts of the interview for affected flows
+   - Adding, removing, or modifying flows
+   - Re-verifying components via MCP for changed flows
+4. Self-review the amended spec (same review criteria as the original)
+5. Present the amended spec for user approval
+6. On approval, overwrite `design-spec.md` with the amended version
+7. **Mark downstream artifacts stale** — for each existing file in the pipeline directory (`implementation-plan.md`, `execution-report.md`, `validation-report.md`, `stamp-report.md`), prepend the staleness marker per `shared/pipeline-infrastructure.md`
+8. STOP — do NOT auto-invoke plan (standalone mode)
+
+---
+
 ## Anti-Pattern: "This Is Too Simple To Need A Design"
 
 Every integration goes through this process. A single-route REST-to-database flow, a file watcher, a simple bridge — all of them. "Simple" integrations are where unexamined assumptions cause the most wasted work. The design spec can be short for truly simple projects, but you MUST present it and get approval.
@@ -99,7 +147,10 @@ Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces:
 | "The migration source tells me everything I need" | Source artifacts show WHAT exists, not what the user WANTS. Confirm. |
 | "I'll verify components later during implementation" | Wrong design spec → wrong plan → wrong code. Verify NOW. |
 | "I'll ask all clarification questions at once to save time" | Batching questions overwhelms the user and hides dependencies between answers. ONE question at a time. |
-| "I'll tell the user to run camel-plan next" | NO. YOU invoke camel-plan automatically after approval. The pipeline is seamless. |
+| "I'll tell the user to run camel-plan next" | NO. In chained mode, YOU invoke camel-plan automatically. In standalone mode, STOP after writing output. |
+| "The existing spec is fine, I'll skip the amend review" | Amend mode still requires self-review and user approval. Same standards apply. |
+| "I'll auto-invoke plan after amending the spec" | NO. Amend mode is standalone — write output and STOP. The caller manages transitions. |
+| "I don't need to mark downstream artifacts stale" | If you amend the design spec and downstream artifacts exist, they MUST be marked stale. |
 
 ### Red Flags — STOP If You Think:
 
@@ -144,18 +195,21 @@ Are you building a new integration from scratch, or migrating an existing one fr
 
 You MUST complete these items in order:
 
-1. **Detect project type** — greenfield or migration
-2. **Resolve pipeline** — read `shared/pipeline-infrastructure.md` for pipeline resolution logic. If no active pipeline exists, prompt the user to run `{COMMAND_PREFIX} nextId <slug>` to create one. The pipeline ID determines where artifacts are saved.
-3. **Load context** — read `docs/constitution.md` (if it exists), `.camel-kit/config.properties` (if it exists)
-4. **Run interview/discovery** — load the appropriate guide:
+1. **Detect invocation mode** — check for `<PIPELINE_ID>` argument and existing `design-spec.md` (see Invocation Modes above). If amend mode, skip to the Amend Mode section.
+2. **Detect project type** — greenfield or migration
+3. **Resolve pipeline** — read `shared/pipeline-infrastructure.md` for pipeline resolution logic. If no active pipeline exists, prompt the user to run `{COMMAND_PREFIX} nextId <slug>` to create one. The pipeline ID determines where artifacts are saved.
+4. **Load context** — read `docs/constitution.md` (if it exists), `.camel-kit/config.properties` (if it exists)
+5. **Run interview/discovery** — load the appropriate guide:
    - Greenfield: `guides/greenfield-interview.md`
    - Migration: `guides/migration-discovery.md`
-5. **Select Camel version** — load `guides/version-selection.md`
-6. **Design flows** — for each flow, load relevant `camel-design/` guides (component selection, EIPs, data formats, error handling, security, resilience)
-7. **Assemble design spec** — load `guides/design-assembly.md`
-8. **Self-review spec** — scan for placeholders, contradictions, unverified components
-9. **User reviews spec** — present spec, wait for explicit approval (Iron Law 4)
-10. **Transition** — YOU invoke the `camel-plan` skill automatically (do NOT tell the user to run it)
+6. **Select Camel version** — load `guides/version-selection.md`
+7. **Design flows** — for each flow, load relevant `camel-design/` guides (component selection, EIPs, data formats, error handling, security, resilience)
+8. **Assemble design spec** — load `guides/design-assembly.md`
+9. **Self-review spec** — scan for placeholders, contradictions, unverified components
+10. **User reviews spec** — present spec, wait for explicit approval (Iron Law 4)
+11. **Transition** — depends on invocation mode:
+    - **Chained mode:** YOU invoke the `camel-plan` skill automatically (do NOT tell the user to run it)
+    - **Standalone mode:** write output artifact, print confirmation, STOP
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -20,6 +20,35 @@ AUTONOMOUS EXECUTION: Execute ALL tasks from the plan using wave analysis. Run `
 
 ---
 
+## Invocation Modes
+
+This skill supports two invocation modes (see `shared/pipeline-infrastructure.md` for details):
+
+### Chained Mode (default)
+
+Auto-invoked by `camel-plan` after planning completes. The plan content is available in conversation context. After execution, auto-invokes `camel-validate`.
+
+### Standalone Mode
+
+Invoked directly (e.g., `/camel-execute` or `/camel-execute <PIPELINE_ID>`) in a new session. No conversation context — reads the implementation plan from `docs/camel-kit/<PIPELINE_ID>/implementation-plan.md`.
+
+**Detection at start:**
+
+1. If auto-invoked by plan in this conversation → **chained mode**
+2. If invoked independently and `implementation-plan.md` exists in the pipeline directory → **standalone mode**
+3. If `implementation-plan.md` does not exist → error: "No implementation plan found. Run /camel-plan first."
+
+**Standalone behavior:**
+
+- Read `implementation-plan.md` from disk as the input
+- Also read `design-spec.md` (needed for spec compliance reviews)
+- Check both files for staleness markers (`⚠️ **STALE**`) — if found, warn but proceed
+- Execute the full task loop (Step 0 through Step 4)
+- Write `execution-report.md` to the pipeline directory
+- Do NOT auto-invoke `camel-validate` (standalone mode suppresses auto-transitions)
+
+---
+
 ## Process Flow
 
 ```dot
@@ -148,6 +177,7 @@ Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces ALL four:
 | "The subagent can read the plan file itself" | Provide full task text. Don't make subagents read plan files. |
 | "I should ask before proceeding to the next task" | The user approved the ENTIRE plan. Execute ALL tasks without asking. |
 | "Let me check if the user wants to continue" | They already said yes — to the whole plan. Keep going. |
+| "The input plan is stale but I'll ignore the warning" | Always warn about staleness. Execution will produce fresh output, but the user should know the plan may be outdated. |
 | "Let me summarize what was completed so far" | No mid-plan summaries. Print ONE LINE per task. Summary only at the END (Step 4). |
 | "The scaffolding phase is complete, ready for implementation" | Scaffolding is ONE task. The plan has N tasks. Execute all N. Don't stop at 1. |
 | "Next Steps: Ready to proceed with Task N" | There are no "Next Steps" — you ARE executing the next step RIGHT NOW. |
@@ -372,6 +402,11 @@ Verification: PASS/PARTIAL/FAIL/NOT_RUN
 ```
 
 Save the completion summary as `docs/camel-kit/<PIPELINE_ID>/execution-report.md`.
+
+**Post-completion transition (invocation mode dependent):**
+
+- **Chained mode:** auto-invoke `camel-validate` (the pipeline continues to Stage 3)
+- **Standalone mode:** print confirmation and STOP. Do NOT auto-invoke validate.
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -403,6 +403,8 @@ Verification: PASS/PARTIAL/FAIL/NOT_RUN
 
 Save the completion summary as `docs/camel-kit/<PIPELINE_ID>/execution-report.md`.
 
+**Mark downstream artifacts stale** — per `shared/pipeline-infrastructure.md`, check for existing downstream artifacts (`validation-report.md`, `stamp-report.md`) and prepend the staleness marker if they exist.
+
 **Post-completion transition (invocation mode dependent):**
 
 - **Chained mode:** auto-invoke `camel-validate` (the pipeline continues to Stage 3)

--- a/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
@@ -20,6 +20,34 @@ Do NOT generate any implementation artifacts (YAML, properties, POM, Docker Comp
 
 ---
 
+## Invocation Modes
+
+This skill supports two invocation modes (see `shared/pipeline-infrastructure.md` for details):
+
+### Chained Mode (default)
+
+Auto-invoked by `camel-brainstorm` after design spec approval. The design spec content is available in conversation context. After planning, auto-invokes `camel-execute`.
+
+### Standalone Mode
+
+Invoked directly (e.g., `/camel-plan` or `/camel-plan <PIPELINE_ID>`) in a new session. No conversation context — reads the design spec from `docs/camel-kit/<PIPELINE_ID>/design-spec.md`.
+
+**Detection at start:**
+
+1. If auto-invoked by brainstorm in this conversation → **chained mode**
+2. If invoked independently and `design-spec.md` exists in the pipeline directory → **standalone mode**
+3. If `design-spec.md` does not exist → error: "No design spec found. Run /camel-brainstorm first."
+
+**Standalone behavior:**
+
+- Read `design-spec.md` from disk as the input
+- Check for staleness marker (`⚠️ **STALE**`) — if found, warn but proceed (the regenerated plan will be fresh)
+- Execute the full planning workflow
+- Write `implementation-plan.md` to the pipeline directory
+- Do NOT auto-invoke `camel-execute` (standalone mode suppresses auto-transitions)
+
+---
+
 ## Process Flow
 
 ```dot
@@ -68,8 +96,9 @@ Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces:
 | "I'll combine multiple flows into one task" | One task = one outcome. Split flows into separate tasks. |
 | "Testing can be added later" | Test tasks are in the plan. Not later. NOW. |
 | "I'll skip the review specification" | Every task gets two-stage review. Spec compliance then quality. No exceptions. |
-| "I'll tell the user to run camel-execute next" | NO. YOU invoke camel-execute automatically after approval. The pipeline is seamless. |
-| "I should wait for the user to approve the plan before executing" | Plan approval gate was removed. Execution auto-proceeds after planning. |
+| "I'll tell the user to run camel-execute next" | In chained mode: NO, YOU invoke camel-execute automatically. In standalone mode: STOP after writing the plan. |
+| "I should wait for the user to approve the plan before executing" | Plan approval gate was removed. In chained mode, execution auto-proceeds. In standalone mode, the caller manages transitions. |
+| "The input spec is stale but I'll ignore the warning" | Always warn about staleness. The plan will be fresh, but the user should know. |
 
 ### Red Flags — STOP If You Think:
 
@@ -196,9 +225,13 @@ Fix any issues inline.
 After saving the plan:
 
 1. Save the implementation plan to `docs/camel-kit/<PIPELINE_ID>/implementation-plan.md`
-2. **If agent-specific handoff instructions exist below** (appended by traits), follow those instead of step 3
-3. **Default (no trait override):** auto-invoke `camel-execute` immediately
+2. **Check invocation mode:**
+   - **Standalone mode:** print confirmation and STOP. Do NOT auto-invoke execute.
+   - **Chained mode:** continue to step 3.
+3. **If agent-specific handoff instructions exist below** (appended by traits), follow those instead of step 4
+4. **Default (no trait override):** auto-invoke `camel-execute` immediately
 
+**Chained mode output:**
 ```text
 Plan saved to docs/camel-kit/<PIPELINE_ID>/implementation-plan.md
 
@@ -206,6 +239,15 @@ Plan complete. Proceeding to execution — dispatching subagents for each task
 with two-stage review (spec compliance → code quality) between tasks.
 ```
 
+**Standalone mode output:**
+```text
+Plan saved to docs/camel-kit/<PIPELINE_ID>/implementation-plan.md
+
+Plan complete. Run /camel-execute or /camel-ship --start-from execute to proceed.
+```
+
 <HARD-RULE>
-After the plan is complete, YOU must transition to execution. Do NOT tell the user to run it manually. Do NOT print "please run camel-execute" or "run /camel-execute". The transition is automatic — either through the agent-specific handoff mechanism (if trait instructions exist below) or by directly invoking camel-execute.
+In chained mode: after the plan is complete, YOU must transition to execution. Do NOT tell the user to run it manually. Do NOT print "please run camel-execute" or "run /camel-execute". The transition is automatic — either through the agent-specific handoff mechanism (if trait instructions exist below) or by directly invoking camel-execute.
+
+In standalone mode: write the plan artifact and STOP. Do NOT auto-invoke execute. Print the standalone mode output above.
 </HARD-RULE>

--- a/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
@@ -225,11 +225,12 @@ Fix any issues inline.
 After saving the plan:
 
 1. Save the implementation plan to `docs/camel-kit/<PIPELINE_ID>/implementation-plan.md`
-2. **Check invocation mode:**
+2. **Mark downstream artifacts stale** — per `shared/pipeline-infrastructure.md`, check for existing downstream artifacts (`execution-report.md`, `validation-report.md`, `stamp-report.md`) and prepend the staleness marker if they exist
+3. **Check invocation mode:**
    - **Standalone mode:** print confirmation and STOP. Do NOT auto-invoke execute.
-   - **Chained mode:** continue to step 3.
-3. **If agent-specific handoff instructions exist below** (appended by traits), follow those instead of step 4
-4. **Default (no trait override):** auto-invoke `camel-execute` immediately
+   - **Chained mode:** continue to step 4.
+4. **If agent-specific handoff instructions exist below** (appended by traits), follow those instead of step 5
+5. **Default (no trait override):** auto-invoke `camel-execute` immediately
 
 **Chained mode output:**
 ```text

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -35,7 +35,12 @@ Stage 0: BRAINSTORM  →  Stage 1: PLAN  →  Stage 2: EXECUTE  →  Stage 3: VA
 
 ### Before Starting
 
-1. Check for `--resume` flag. If set, read `.camel-kit/pipeline.json`, verify `mode = "ship"`, and jump to `currentStage`. Skip steps 2-6.
+1. Check for `--resume` flag. If set:
+   a. Read `.camel-kit/pipeline.json`, verify `mode = "ship"`
+   b. **Run staleness detection** (see Staleness Detection on Resume below)
+   c. If stale artifacts found → re-run from the earliest stale stage (overrides `currentStage`)
+   d. If no staleness → jump to `currentStage`
+   e. Skip steps 2-6
 2. Generate pipeline ID: run `{COMMAND_PREFIX} nextId <slug>` (derive slug from input file name or user request).
 3. Check for `--start-from` flag. If set, verify prerequisite artifacts exist in `docs/camel-kit/<activePipeline>/`:
    - `plan` requires `design-spec.md`
@@ -99,6 +104,49 @@ If ANY check fails:
 - Report failures clearly with the merged report
 - If `--ask never`: attempt auto-fix (load `guides/auto-fix-loop.md`)
 - Otherwise: present failures and ask user for next steps
+
+---
+
+## Staleness Detection on Resume
+
+When `--resume` is used, camel-ship checks all pipeline artifacts for staleness markers before continuing.
+
+### Detection Algorithm
+
+1. Read all artifacts in `docs/camel-kit/<activePipeline>/`:
+   - `design-spec.md` (Stage 0 output)
+   - `implementation-plan.md` (Stage 1 output)
+   - `execution-report.md` (Stage 2 output)
+   - `validation-report.md` (Stage 3 output)
+   - `stamp-report.md` (Stamp gate output)
+2. For each artifact, check for the staleness marker: `⚠️ **STALE**` in the first 5 lines
+3. Find the **earliest stale stage** — the lowest stage number whose artifact is marked stale
+
+### Re-run Decision
+
+| Scenario | Action |
+|---|---|
+| No stale artifacts | Resume from `currentStage` (normal behavior) |
+| Stale artifacts found | Report stale stages to user, then re-run from the earliest stale stage |
+| `design-spec.md` itself is stale | This should not happen (design spec is the root). If found, warn and re-run from Stage 0. |
+
+### Re-run Behavior
+
+When re-running stale stages:
+
+1. Update `currentStage` in `.camel-kit/pipeline.json` to the earliest stale stage
+2. Report to the user:
+   ```text
+   ⚠️ Staleness detected in pipeline <PIPELINE_ID>:
+     - implementation-plan.md: STALE (design-spec.md modified on YYYY-MM-DD)
+     - execution-report.md: STALE
+     - validation-report.md: STALE
+   
+   Re-running from Stage 1 (plan) to regenerate stale artifacts.
+   ```
+3. Execute stages sequentially from the earliest stale stage
+4. Each regenerated artifact is written fresh (no staleness marker)
+5. Downstream artifacts are regenerated in order — their staleness markers are naturally cleared
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -119,7 +119,7 @@ When `--resume` is used, camel-ship checks all pipeline artifacts for staleness 
    - `execution-report.md` (Stage 2 output)
    - `validation-report.md` (Stage 3 output)
    - `stamp-report.md` (Stamp gate output)
-2. For each artifact, check for the staleness marker in the first 5 lines: a blockquote line containing `⚠️ **STALE**` followed by upstream artifact reference and timestamp (see `shared/pipeline-infrastructure.md` for the full marker format)
+2. For each artifact, check the first 10 lines for a blockquote containing `⚠️ **STALE**` (see `shared/pipeline-infrastructure.md` for the full marker format)
 3. Find the **earliest stale stage** — the lowest stage number whose artifact is marked stale
 
 ### Re-run Decision

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -119,7 +119,7 @@ When `--resume` is used, camel-ship checks all pipeline artifacts for staleness 
    - `execution-report.md` (Stage 2 output)
    - `validation-report.md` (Stage 3 output)
    - `stamp-report.md` (Stamp gate output)
-2. For each artifact, check for the staleness marker: `⚠️ **STALE**` in the first 5 lines
+2. For each artifact, check for the staleness marker in the first 5 lines: a blockquote line containing `⚠️ **STALE**` followed by upstream artifact reference and timestamp (see `shared/pipeline-infrastructure.md` for the full marker format)
 3. Find the **earliest stale stage** — the lowest stage number whose artifact is marked stale
 
 ### Re-run Decision
@@ -128,7 +128,7 @@ When `--resume` is used, camel-ship checks all pipeline artifacts for staleness 
 |---|---|
 | No stale artifacts | Resume from `currentStage` (normal behavior) |
 | Stale artifacts found | Report stale stages to user, then re-run from the earliest stale stage |
-| `design-spec.md` itself is stale | This should not happen (design spec is the root). If found, warn and re-run from Stage 0. |
+| `design-spec.md` itself is stale | Edge case (e.g., manual marker addition). Warn that the design spec is the root artifact and should not be marked stale, then re-run from Stage 0. |
 
 ### Re-run Behavior
 

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
@@ -124,7 +124,7 @@ When `--resume` is specified, the state management layer adds a staleness check 
 1. Read `.camel-kit/pipeline.json`
 2. Verify `mode` is `"ship"`
 3. Scan all artifacts in `docs/camel-kit/<activePipeline>/` for staleness markers
-4. If any artifact has `⚠️ **STALE**` in its first 5 lines:
+4. If any artifact has `⚠️ **STALE**` in its first 10 lines:
    a. Map each stale artifact to its stage number (see Stage Numbers table)
    b. Find the minimum stale stage number
    c. Set `currentStage` to that minimum (overrides the stored value)

--- a/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/guides/state-management.md
@@ -115,6 +115,40 @@ When `--start-from <stage>` is specified:
 
 ---
 
+## Staleness-Aware Resume
+
+When `--resume` is specified, the state management layer adds a staleness check before jumping to `currentStage`.
+
+### Extended Resume Flow
+
+1. Read `.camel-kit/pipeline.json`
+2. Verify `mode` is `"ship"`
+3. Scan all artifacts in `docs/camel-kit/<activePipeline>/` for staleness markers
+4. If any artifact has `⚠️ **STALE**` in its first 5 lines:
+   a. Map each stale artifact to its stage number (see Stage Numbers table)
+   b. Find the minimum stale stage number
+   c. Set `currentStage` to that minimum (overrides the stored value)
+   d. Mark previously completed stages >= minimum as needing re-run in stageResults
+5. Restore `--ask` level from state
+6. Continue normal stage execution from the (possibly adjusted) `currentStage`
+
+### State After Staleness Adjustment
+
+When staleness forces a re-run, update the state file:
+
+```json
+{
+  "currentStage": 1,
+  "staleRerun": true,
+  "staleDetectedAt": "ISO-8601 timestamp",
+  "staleArtifacts": ["implementation-plan.md", "execution-report.md", "validation-report.md"]
+}
+```
+
+The `staleRerun`, `staleDetectedAt`, and `staleArtifacts` fields are informational — they record that this resume was triggered by staleness detection rather than a normal continuation. They are cleared (removed) when the pipeline completes successfully.
+
+---
+
 ## Cleanup
 
 After successful pipeline completion (all stages complete, stamp gate passes):

--- a/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
@@ -8,12 +8,36 @@ user_invocable: true
 
 > **Tier 1 pipeline step.** Final stage after execute — produces a comprehensive quality report.
 
-## Invocation
+## Invocation Modes
 
-- **User:** `/camel-validate` — run standalone on any project with generated routes
-- **Pipeline:** invoked as Stage 3 by `camel-ship` after execute completes (including verification)
+This skill supports two invocation modes (see `shared/pipeline-infrastructure.md` for details):
 
-When invoked standalone, validates routes in the current project. When invoked as a pipeline stage, reads the generated routes from the execute phase and produces the validation report.
+### Chained Mode
+
+Invoked as Stage 3 by `camel-ship` after execute completes, or auto-invoked by `camel-execute` at the end of its task loop. Pipeline context is available in the conversation.
+
+### Standalone Mode
+
+Invoked directly by the user: `/camel-validate` or `/camel-validate <PIPELINE_ID>`.
+
+**Detection at start:**
+
+1. If auto-invoked by execute or ship in this conversation → **chained mode** (pipeline)
+2. If invoked with `<PIPELINE_ID>` and pipeline artifacts exist → **standalone mode** (pipeline-scoped)
+3. If invoked without `<PIPELINE_ID>` and no `.camel-kit/pipeline.json` → **standalone mode** (project-scoped, validates routes in current project)
+
+**Standalone behavior (pipeline-scoped):**
+
+- Read prior artifacts from `docs/camel-kit/<PIPELINE_ID>/` for cross-reference
+- Check input artifacts for staleness markers (`⚠️ **STALE**`) — if found, warn but proceed
+- Execute the full validation workflow
+- Write `validation-report.md` to the pipeline directory
+- STOP (no further stage transitions)
+
+**Standalone behavior (project-scoped — no pipeline):**
+
+- Validate routes found in the current project
+- Write a timestamped report to `docs/validation-report-YYYY-MM-DD_HH-mm.md`
 
 **Announce at start:** "I'm using the camel-validate skill to analyze route quality."
 

--- a/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
@@ -138,6 +138,8 @@ ALWAYS generate the validation report.
 This creates an audit trail of validation results over time.
 </HARD-RULE>
 
+**Mark downstream artifacts stale** — per `shared/pipeline-infrastructure.md`, after saving the validation report, check for an existing `stamp-report.md` in the pipeline directory and prepend the staleness marker if it exists.
+
 ## Iron Laws
 
 All guides in this skill enforce:

--- a/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
@@ -24,7 +24,8 @@ Invoked directly by the user: `/camel-validate` or `/camel-validate <PIPELINE_ID
 
 1. If auto-invoked by execute or ship in this conversation → **chained mode** (pipeline)
 2. If invoked with `<PIPELINE_ID>` and pipeline artifacts exist → **standalone mode** (pipeline-scoped)
-3. If invoked without `<PIPELINE_ID>` and no `.camel-kit/pipeline.json` → **standalone mode** (project-scoped, validates routes in current project)
+3. If invoked without `<PIPELINE_ID>` and `.camel-kit/pipeline.json` exists → **standalone mode** (pipeline-scoped, use `activePipeline`)
+4. If invoked without `<PIPELINE_ID>` and no `.camel-kit/pipeline.json` → **standalone mode** (project-scoped, validates routes in current project)
 
 **Standalone behavior (pipeline-scoped):**
 
@@ -55,7 +56,7 @@ Before running validation, resolve the active pipeline using `shared/pipeline-in
    - `execution-report.md` — for verifying generated file list, review results, and verification status
 3. Save the validation report to `docs/camel-kit/<activePipeline>/validation-report.md`
 
-When invoked standalone (no pipeline context), fall back to scanning routes in the current project and saving the report to `docs/validation-report-YYYY-MM-DD_HH-mm.md` (existing behavior).
+When invoked standalone without pipeline context (project-scoped), fall back to scanning routes in the current project and saving the report to `docs/validation-report-YYYY-MM-DD_HH-mm.md`.
 
 ## Guide Manifest
 
@@ -73,10 +74,10 @@ When invoked standalone (no pipeline context), fall back to scanning routes in t
 
 After completing all validation checks, generate a markdown report saved to:
 
-- **Pipeline mode:** `docs/camel-kit/<PIPELINE_ID>/validation-report.md`
-- **Standalone mode:** `docs/validation-report-YYYY-MM-DD_HH-mm.md`
+- **Chained mode and standalone pipeline-scoped:** `docs/camel-kit/<PIPELINE_ID>/validation-report.md`
+- **Standalone project-scoped (no pipeline):** `docs/validation-report-YYYY-MM-DD_HH-mm.md`
 
-Use the current date and time for the filename (e.g., `validation-report-2026-04-22_14-30.md`).
+Use the current date and time for the timestamped filename (e.g., `validation-report-2026-04-22_14-30.md`).
 
 ### Report Format
 
@@ -131,7 +132,10 @@ Use the current date and time for the filename (e.g., `validation-report-2026-04
 ```
 
 <HARD-RULE>
-ALWAYS generate the validation report. In pipeline mode, save to `docs/camel-kit/<PIPELINE_ID>/validation-report.md`. In standalone mode, save a timestamped report to `docs/validation-report-YYYY-MM-DD_HH-mm.md`. This creates an audit trail of validation results over time.
+ALWAYS generate the validation report.
+- In chained mode and standalone pipeline-scoped mode, save to `docs/camel-kit/<PIPELINE_ID>/validation-report.md`.
+- In standalone project-scoped mode (no pipeline), save to `docs/validation-report-YYYY-MM-DD_HH-mm.md`.
+This creates an audit trail of validation results over time.
 </HARD-RULE>
 
 ## Iron Laws

--- a/camel-kit-core/src/main/resources/skills/shared/pipeline-infrastructure.md
+++ b/camel-kit-core/src/main/resources/skills/shared/pipeline-infrastructure.md
@@ -145,3 +145,119 @@ Append-only audit trail for verify cycles. Each iteration follows this format:
 ```
 
 Created by the verify skill during execute. Append new iterations at the end of the file.
+
+---
+
+## Standalone Mode Detection
+
+Each pipeline skill supports **two invocation modes**:
+
+### Chained Mode (default)
+
+The skill is auto-invoked by the previous stage within the same conversation. Conversation context provides the input data.
+
+- brainstorm auto-invokes plan after spec approval
+- plan auto-invokes execute after planning
+- execute auto-invokes validate after task completion
+- HARD-RULEs for automatic transitions remain enforced
+
+### Standalone Mode
+
+The skill is invoked independently (new session, CI/CD, or manual re-entry). No conversation context exists — the skill reads input from pipeline artifacts on disk.
+
+**Detection logic (checked at skill start):**
+
+1. If the skill was auto-invoked by the previous stage in this conversation → **chained mode**
+2. If the skill is invoked with `<PIPELINE_ID>` as argument or `.camel-kit/pipeline.json` exists, AND the required input artifact exists on disk → **standalone mode**
+3. If neither → prompt the user (normal first-run behavior)
+
+**Standalone input artifacts per skill:**
+
+| Skill | Required Input Artifact | Output Artifact |
+|---|---|---|
+| brainstorm | _(none — starts from scratch or amends existing)_ | `design-spec.md` |
+| plan | `design-spec.md` | `implementation-plan.md` |
+| execute | `implementation-plan.md` | `execution-report.md` |
+| validate | `execution-report.md` (or generated routes in `src/`) | `validation-report.md` |
+
+**Standalone behavior:**
+
+- Read the input artifact from `docs/camel-kit/<PIPELINE_ID>/`
+- Execute the skill's full workflow using the file contents as input
+- Write the output artifact to the same pipeline directory
+- Do NOT auto-invoke the next stage (the caller manages stage transitions in standalone mode)
+
+**When to suppress auto-transition:**
+
+In standalone mode, the skill must NOT auto-invoke the next stage. The `<HARD-RULE>` auto-transitions (e.g., brainstorm → plan, plan → execute) apply ONLY in chained mode. In standalone mode, the skill writes its output artifact and stops.
+
+---
+
+## Re-iteration (Amend Mode)
+
+When `/camel-brainstorm <PIPELINE_ID>` is invoked on a pipeline that already has a `design-spec.md`:
+
+1. Read the existing `design-spec.md` as the starting point
+2. Present it to the user for amendment (not a full re-interview)
+3. After the user approves the amended spec, overwrite `design-spec.md`
+4. Mark all downstream artifacts as **stale** (see Staleness Markers below)
+
+This enables iterative refinement without restarting the entire pipeline.
+
+---
+
+## Staleness Markers
+
+When an upstream artifact is modified (e.g., `design-spec.md` is amended), all downstream artifacts become potentially invalid. Staleness markers embed this signal directly in the downstream files.
+
+### Marker Format
+
+Insert at the top of the file, immediately after any YAML frontmatter or title:
+
+```markdown
+> ⚠️ **STALE** — upstream artifact `design-spec.md` was modified on YYYY-MM-DD HH:MM.
+> This document was generated from an earlier version and may be out of date.
+> Re-run the corresponding pipeline stage to regenerate.
+```
+
+### Staleness Cascade
+
+When `design-spec.md` is amended:
+
+| Downstream Artifact | Marked Stale? |
+|---|---|
+| `implementation-plan.md` | Yes |
+| `execution-report.md` | Yes |
+| `validation-report.md` | Yes |
+| `stamp-report.md` | Yes |
+
+When `implementation-plan.md` is regenerated (stale marker cleared):
+
+| Downstream Artifact | Marked Stale? |
+|---|---|
+| `execution-report.md` | Yes (if not already) |
+| `validation-report.md` | Yes (if not already) |
+| `stamp-report.md` | Yes (if not already) |
+
+### Applying Staleness Markers
+
+When a skill writes or amends an artifact, it must:
+
+1. Identify all downstream artifacts that exist in `docs/camel-kit/<PIPELINE_ID>/`
+2. For each existing downstream artifact, prepend the staleness marker (if not already present)
+3. Record the modification timestamp in the marker
+
+### Clearing Staleness Markers
+
+When a skill regenerates an artifact (full re-run, not an amendment):
+
+1. The regenerated artifact is written fresh — no staleness marker
+2. The staleness markers on further-downstream artifacts remain until those stages are also re-run
+
+### Detecting Staleness
+
+Any skill can detect staleness in its input by checking for the `⚠️ **STALE**` marker at the top of the file. If found:
+
+- **Chained mode:** Warn the user but proceed (the regeneration will produce a fresh artifact)
+- **Standalone mode:** Warn the user and ask whether to proceed with stale input or abort
+- **Ship --resume:** Automatically re-run from the earliest stale stage (see camel-ship)

--- a/camel-kit-core/src/main/resources/skills/shared/pipeline-infrastructure.md
+++ b/camel-kit-core/src/main/resources/skills/shared/pipeline-infrastructure.md
@@ -256,7 +256,7 @@ When a skill regenerates an artifact (full re-run, not an amendment):
 
 ### Detecting Staleness
 
-Any skill can detect staleness in its input by checking for the `⚠️ **STALE**` marker at the top of the file. If found:
+Any skill can detect staleness in its input by checking the first 10 lines for a blockquote containing `⚠️ **STALE**`. The marker is always inserted immediately after the title, so it appears within the first few lines of any pipeline artifact. If found:
 
 - **Chained mode:** Warn the user but proceed (the regeneration will produce a fresh artifact)
 - **Standalone mode:** Warn the user and ask whether to proceed with stale input or abort

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-plan.append.md
@@ -2,7 +2,7 @@
 
 ### Override: Use Native Plan Mode for Execution Handoff
 
-**This replaces the default handoff in Step 3 above.**
+**This replaces the default handoff in Step 5 above.**
 
 When the implementation plan is ready:
 

--- a/camel-kit-core/src/main/resources/templates/traits/claude/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/claude/camel-plan.append.md
@@ -2,7 +2,7 @@
 
 ### Override: Use Native Plan Mode for Execution Handoff
 
-**This replaces the default handoff in Step 5 above.**
+**This replaces the default handoff in Step 5 above.** This override applies in chained mode only; in standalone mode the skill stops at Step 3.
 
 When the implementation plan is ready:
 

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-plan.append.md
@@ -2,7 +2,7 @@
 
 ### Override: Approval Mode Selection Before Execution
 
-**This replaces the default handoff in Step 3 above.**
+**This replaces the default handoff in Step 5 above.**
 
 When the implementation plan is ready:
 

--- a/camel-kit-core/src/main/resources/templates/traits/gemini/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/gemini/camel-plan.append.md
@@ -2,7 +2,7 @@
 
 ### Override: Approval Mode Selection Before Execution
 
-**This replaces the default handoff in Step 5 above.**
+**This replaces the default handoff in Step 5 above.** This override applies in chained mode only; in standalone mode the skill stops at Step 3.
 
 When the implementation plan is ready:
 

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-plan.append.md
@@ -2,7 +2,7 @@
 
 ### Override: Approval Mode Selection Before Execution
 
-**This replaces the default handoff in Step 3 above.**
+**This replaces the default handoff in Step 5 above.**
 
 When the implementation plan is ready:
 

--- a/camel-kit-core/src/main/resources/templates/traits/qwen/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/qwen/camel-plan.append.md
@@ -2,7 +2,7 @@
 
 ### Override: Approval Mode Selection Before Execution
 
-**This replaces the default handoff in Step 5 above.**
+**This replaces the default handoff in Step 5 above.** This override applies in chained mode only; in standalone mode the skill stops at Step 3.
 
 When the implementation plan is ready:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -629,6 +629,29 @@ docs/camel-kit/<PIPELINE_ID>/
 
 For manual pipelines, the stage is determined by which artifacts exist in the pipeline directory — no explicit stage tracking. This follows the spec-kit pattern where artifact presence IS the state.
 
+### Dual-Mode Invocation
+
+Every pipeline skill (brainstorm, plan, execute, validate) supports two invocation modes:
+
+- **Chained mode** — the skill is auto-invoked by the previous stage within the same conversation. HARD-RULE auto-transitions are enforced (brainstorm → plan → execute → validate).
+- **Standalone mode** — the skill is invoked independently (new session, CI/CD, or manual re-entry). It reads its input from pipeline artifacts on disk and writes its output to the same directory. Auto-transitions are suppressed — the caller manages stage progression.
+
+Detection is automatic: if the skill was auto-invoked in conversation context, it runs in chained mode. If invoked independently with pipeline artifacts available, it runs in standalone mode.
+
+### Re-iteration and Staleness Markers
+
+When `/camel-brainstorm <PIPELINE_ID>` is invoked on a pipeline that already has a design spec, the skill enters **amend mode**: it loads the existing spec, lets the user modify it, and writes the updated version back. All downstream artifacts (`implementation-plan.md`, `execution-report.md`, `validation-report.md`, `stamp-report.md`) are marked stale.
+
+Staleness markers are embedded directly in the artifact file:
+
+```markdown
+> ⚠️ **STALE** — upstream artifact `design-spec.md` was modified on YYYY-MM-DD HH:MM.
+> This document was generated from an earlier version and may be out of date.
+> Re-run the corresponding pipeline stage to regenerate.
+```
+
+When `camel-ship --resume` detects stale artifacts, it automatically re-runs from the earliest stale stage instead of the stored `currentStage`. This ensures the pipeline produces consistent output after upstream amendments.
+
 ### Verify Iteration Log
 
 `.camel-kit/verify-log.md` is an append-only audit trail of verify cycles, recording findings, severity, and actions taken per iteration.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -381,17 +381,17 @@ When invoked with a `<PIPELINE_ID>` argument:
 
 1. **Detect invocation mode** -- check for `<PIPELINE_ID>` argument and existing design spec
 2. **Detect project type** -- greenfield or migration (based on keywords like "create", "build" vs "migrate", "convert")
-2. **Load context** -- reads `docs/constitution.md` and `.camel-kit/config.yaml` if they exist
-3. **Run interview or discovery** -- Socratic interview (one question at a time) for greenfield; artifact scanning and confirmation for migration
-4. **Select Camel version** -- presents available versions for selection
-5. **Design flows** -- for each flow, verifies components, EIPs, data formats, and languages against the MCP catalog. Asks conditional questions only when relevant:
+3. **Load context** -- reads `docs/constitution.md` and `.camel-kit/config.yaml` if they exist
+4. **Run interview or discovery** -- Socratic interview (one question at a time) for greenfield; artifact scanning and confirmation for migration
+5. **Select Camel version** -- presents available versions for selection
+6. **Design flows** -- for each flow, verifies components, EIPs, data formats, and languages against the MCP catalog. Asks conditional questions only when relevant:
    - Circuit breaker configuration (if HTTP components detected)
    - Idempotent consumer (if message broker components detected)
    - Transaction boundaries (if multiple sinks detected)
-6. **Assemble design spec** -- compiles the full BRD and TDD files
-7. **Self-review** -- scans for placeholders, contradictions, unverified components
-8. **User approval** -- presents the spec and waits for explicit approval
-9. **Transition** -- in chained mode, invokes `/camel-plan` automatically after approval. In standalone/amend mode, writes output and stops.
+7. **Assemble design spec** -- compiles the full BRD and TDD files
+8. **Self-review** -- scans for placeholders, contradictions, unverified components
+9. **User approval** -- presents the spec and waits for explicit approval
+10. **Transition** -- in chained mode, invokes `/camel-plan` automatically after approval. In standalone/amend mode, writes output and stops.
 
 **MCP tools used:**
 
@@ -409,11 +409,11 @@ When invoked with a `<PIPELINE_ID>` argument:
 **When to use:** After `/camel-brainstorm` has produced an approved design spec. Usually invoked automatically by `/camel-brainstorm`, but can also be run directly if a design spec already exists.
 
 **Produces:**
-- `docs/implementation-plan.md`
+- `docs/camel-kit/<PIPELINE_ID>/implementation-plan.md`
 
 **Example:**
 
-```
+```bash
 /camel-plan
 ```
 
@@ -457,7 +457,7 @@ The plan is a recipe, not the meal -- it contains instructions on how to generat
 
 **How it works:**
 
-1. **Read plan** -- extracts all tasks from `docs/implementation-plan.md`
+1. **Read plan** -- extracts all tasks from `docs/camel-kit/<PIPELINE_ID>/implementation-plan.md`
 2. **Per-task loop** (autonomous, uninterrupted -- the user approved the entire plan):
    - **Dispatch implementer** -- fresh subagent with full task context, guide paths, and MCP parameters
    - **Spec compliance review** -- verifies the generated artifacts match the design spec exactly

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,7 @@ This document is the reference for all Camel-Kit commands: the `camel-kit` CLI a
   - [/camel-execute](#camel-execute)
   - [/camel-migrate](#camel-migrate)
   - [/camel-validate](#camel-validate)
+  - [/camel-ship](#camel-ship)
   - [/camel-verify (internal)](#camel-verify)
 - [Command Cheat Sheet](#command-cheat-sheet)
 
@@ -357,15 +358,29 @@ Four additional skills (`/camel-implement`, `/camel-verify`, `/camel-test`, `/ca
 - `.camel-kit/flows/{flow-name}/{flow-name}.tdd.md` (one TDD per flow)
 - `docs/constitution.md`
 
-**Example:**
+**Examples:**
 
 ```
+# Start a new design (chained mode — auto-invokes plan after approval)
 /camel-brainstorm
+
+# Start a new design in standalone mode (writes output, does not auto-invoke plan)
+/camel-brainstorm 001-order-processing
+
+# Amend an existing design spec (re-iteration)
+/camel-brainstorm 001-order-processing
 ```
+
+**Standalone and amend mode:**
+
+When invoked with a `<PIPELINE_ID>` argument:
+- If `design-spec.md` does not exist → runs the full interview in standalone mode (no auto-transition to plan)
+- If `design-spec.md` already exists → enters **amend mode**: loads the existing spec, lets you modify it, marks downstream artifacts stale, then stops
 
 **How it works:**
 
-1. **Detect project type** -- greenfield or migration (based on keywords like "create", "build" vs "migrate", "convert")
+1. **Detect invocation mode** -- check for `<PIPELINE_ID>` argument and existing design spec
+2. **Detect project type** -- greenfield or migration (based on keywords like "create", "build" vs "migrate", "convert")
 2. **Load context** -- reads `docs/constitution.md` and `.camel-kit/config.yaml` if they exist
 3. **Run interview or discovery** -- Socratic interview (one question at a time) for greenfield; artifact scanning and confirmation for migration
 4. **Select Camel version** -- presents available versions for selection
@@ -589,6 +604,43 @@ For connectors with no direct equivalent, the command stops and asks the user be
 
 ---
 
+### /camel-ship
+
+**Purpose:** Run the full pipeline autonomously (brainstorm → plan → execute → validate → stamp) with configurable oversight.
+
+**When to use:** When you want the AI to run the entire pipeline end-to-end with minimal intervention.
+
+**Arguments:**
+
+| Argument | Default | Description |
+|---|---|---|
+| `[input-file]` | none | Requirements document, design spec, or brainstorm notes |
+| `--ask` | `smart` | Oversight level: `always`, `smart`, or `never` |
+| `--resume` | false | Continue from `.camel-kit/pipeline.json` with staleness detection |
+| `--start-from <stage>` | none | Skip to stage: `brainstorm`, `plan`, `execute`, `validate` |
+
+**Examples:**
+
+```
+# Run full pipeline from requirements doc
+/camel-ship requirements.md
+
+# Run with always-ask oversight
+/camel-ship requirements.md --ask always
+
+# Resume a previously interrupted pipeline
+/camel-ship --resume
+
+# Start from execution (design spec and plan must already exist)
+/camel-ship --start-from execute
+```
+
+**Staleness detection on resume:**
+
+When `--resume` is used, camel-ship scans all pipeline artifacts for staleness markers (`⚠️ **STALE**`). If stale artifacts are found, it automatically re-runs from the earliest stale stage instead of continuing from the stored `currentStage`. This handles the case where `/camel-brainstorm <PIPELINE_ID>` amended the design spec between sessions — downstream artifacts are automatically regenerated.
+
+---
+
 ### /camel-verify
 
 > **Internal skill** -- dispatched automatically by `/camel-execute`. Not intended for standalone use. For quality checks after the pipeline completes, use `/camel-validate`.
@@ -644,15 +696,26 @@ During **Test Verification** (Phase 2), test failures may also route to `/camel-
 # CLI
 camel-kit init my-project --ai claude
 
-# Greenfield (in AI assistant)
-/camel-brainstorm                        # Design integration
-/camel-plan                          # Create implementation plan
-/camel-execute                       # Implement, test, verify (internal)
-/camel-validate                      # Final quality gate
+# Greenfield (in AI assistant) — chained mode
+/camel-brainstorm                        # Design → auto plan → auto execute → auto validate
+
+# Greenfield — standalone mode (each stage independently)
+/camel-brainstorm 001-order-processing   # Design (standalone, no auto-transition)
+/camel-plan 001-order-processing         # Plan from existing spec (standalone)
+/camel-execute 001-order-processing      # Execute from existing plan (standalone)
+/camel-validate 001-order-processing     # Validate (standalone)
+
+# Re-iteration (amend existing design, marks downstream stale)
+/camel-brainstorm 001-order-processing   # Amend design-spec.md → downstream marked stale
+
+# Autonomous pipeline
+/camel-ship requirements.md              # Full pipeline end-to-end
+/camel-ship --resume                     # Resume with staleness detection
+/camel-ship --start-from execute         # Skip to execution stage
 
 # Migration
-/camel-migrate                       # Analyze legacy project
-/camel-plan                          # Plan migration
-/camel-execute                       # Execute migration
-/camel-validate                      # Final quality gate
+/camel-migrate                           # Analyze legacy project → auto plan → auto execute
+
+# Validate (standalone, any project)
+/camel-validate                          # Validate routes in current project
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -360,14 +360,14 @@ Four additional skills (`/camel-implement`, `/camel-verify`, `/camel-test`, `/ca
 
 **Examples:**
 
-```
+```bash
 # Start a new design (chained mode — auto-invokes plan after approval)
 /camel-brainstorm
 
-# Start a new design in standalone mode (writes output, does not auto-invoke plan)
+# Start a new design in standalone mode (if design-spec.md does not exist)
 /camel-brainstorm 001-order-processing
 
-# Amend an existing design spec (re-iteration)
+# Amend an existing design spec (if design-spec.md already exists)
 /camel-brainstorm 001-order-processing
 ```
 
@@ -391,7 +391,7 @@ When invoked with a `<PIPELINE_ID>` argument:
 6. **Assemble design spec** -- compiles the full BRD and TDD files
 7. **Self-review** -- scans for placeholders, contradictions, unverified components
 8. **User approval** -- presents the spec and waits for explicit approval
-9. **Automatic transition** -- after approval, invokes `/camel-plan` automatically (the user does not need to run it manually)
+9. **Transition** -- in chained mode, invokes `/camel-plan` automatically after approval. In standalone/amend mode, writes output and stops.
 
 **MCP tools used:**
 
@@ -621,7 +621,7 @@ For connectors with no direct equivalent, the command stops and asks the user be
 
 **Examples:**
 
-```
+```bash
 # Run full pipeline from requirements doc
 /camel-ship requirements.md
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -292,7 +292,7 @@ When brainstorm detects that `design-spec.md` already exists, it enters **amend 
 3. Marks all downstream artifacts (`implementation-plan.md`, `execution-report.md`, etc.) as **stale**
 
 Stale artifacts have a marker at the top:
-```
+```markdown
 > ⚠️ **STALE** — upstream artifact `design-spec.md` was modified on 2026-05-12 14:30.
 > This document was generated from an earlier version and may be out of date.
 > Re-run the corresponding pipeline stage to regenerate.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -259,6 +259,49 @@ The pipeline state is tracked in `.camel-kit/pipeline.json`, which records the a
 
 **Session resilience:** Because all artifacts are saved to disk, you can close your session and resume later. The pipeline picks up where you left off based on which artifacts already exist.
 
+### Standalone Mode
+
+Every pipeline skill supports **standalone invocation** — you can run any stage independently in a new session by passing the pipeline ID:
+
+```bash
+# Run plan standalone (reads design-spec.md from disk)
+/camel-plan 001-order-processing
+
+# Run execute standalone (reads implementation-plan.md from disk)
+/camel-execute 001-order-processing
+```
+
+In standalone mode, skills read their input from pipeline artifacts on disk instead of conversation context, and they do NOT auto-invoke the next stage. This enables:
+
+- **Session resilience** — close your session, come back later, and pick up any stage
+- **CI/CD integration** — trigger individual pipeline stages from automation
+- **Selective re-runs** — re-run just the stages you need after changes
+
+### Re-iteration (Amending a Design)
+
+If you need to change a design spec after downstream artifacts have been generated:
+
+```bash
+# Amend an existing design spec
+/camel-brainstorm 001-order-processing
+```
+
+When brainstorm detects that `design-spec.md` already exists, it enters **amend mode**:
+1. Loads the existing spec and presents it for modification
+2. After you approve the amendments, overwrites the design spec
+3. Marks all downstream artifacts (`implementation-plan.md`, `execution-report.md`, etc.) as **stale**
+
+Stale artifacts have a marker at the top:
+```
+> ⚠️ **STALE** — upstream artifact `design-spec.md` was modified on 2026-05-12 14:30.
+> This document was generated from an earlier version and may be out of date.
+> Re-run the corresponding pipeline stage to regenerate.
+```
+
+To regenerate stale artifacts, either:
+- Run each stale stage standalone: `/camel-plan 001-order-processing`, then `/camel-execute 001-order-processing`
+- Use `camel-ship --resume` — it automatically detects staleness and re-runs from the earliest stale stage
+
 ### Phase 1: Design (`/camel-brainstorm`)
 
 The design phase is an interactive interview that produces the design spec. The AI asks questions one at a time -- never in batches -- to understand your integration before designing it.


### PR DESCRIPTION
## Summary

- **Standalone mode detection** added to all 4 pipeline skills (brainstorm, plan, execute, validate): when invoked independently with a `<PIPELINE_ID>` argument, skills read input from pipeline artifacts on disk and suppress auto-transitions
- **Dual-mode invocation**: chained mode (auto-invoke, HARD-RULEs preserved) + standalone mode (reads from files, writes output, stops) — detection is automatic based on conversation context
- **Re-iteration support**: `/camel-brainstorm <PIPELINE_ID>` on an existing pipeline enters amend mode — loads existing design spec for modification, marks downstream artifacts stale
- **Staleness markers**: `⚠️ STALE` markers embedded in downstream artifacts when upstream changes, with cascade rules for the full pipeline chain
- **camel-ship --resume staleness detection**: automatically scans pipeline artifacts for staleness markers on resume and re-runs from the earliest stale stage
- **Documentation updated**: architecture.md (Section 8), commands.md (/camel-ship section, standalone examples, cheat sheet), user-guide.md (standalone mode, re-iteration guide)

## Test plan

- [ ] Verify `./mvnw clean install -B` passes (confirmed locally)
- [ ] Review pipeline-infrastructure.md standalone mode detection logic
- [ ] Review staleness marker format and cascade rules
- [ ] Review brainstorm amend mode flow
- [ ] Review camel-ship staleness detection on --resume
- [ ] Verify documentation consistency across architecture.md, commands.md, and user-guide.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Dual-Mode Invocation docs (Chained vs Standalone) with start-time mode detection and amend/re-iteration behavior.
  * Standardized staleness marker rules, cascade/clear procedures, and downstream-stale handling across brainstorm/plan/execute/validate/ship.
  * Updated resume to detect earliest stale stage and re-run from there; refreshed command reference, user guide, and templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luigidemasi/camel-kit/pull/68)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->