### PR TITLE
fix #61: add tier classification table to camel-start decision tree

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
@@ -47,6 +47,17 @@ Both pipelines share plan → execute → validate. Only the entry point differs
 
 Runtime verification (`camel-verify`) runs automatically as part of `/camel-execute` — it is not a standalone pipeline stage.
 
+### Skill Tiers
+
+| Tier | Skills | Role |
+|------|--------|------|
+| Meta | `camel-start` | Routes to the right pipeline |
+| Tier 1 (Pipeline) | `camel-brainstorm`, `camel-migrate`, `camel-plan`, `camel-execute`, `camel-validate` | The 5 pipeline steps |
+| Tier 2 (Power) | `camel-ship`, `camel-knowledge` | Standalone utilities |
+| Internal | `camel-design`, `camel-implement`, `camel-test`, `camel-verify` | Guide libraries / subagent-only |
+
+Tier 1 skills are the main pipeline stages — invoke them via the decision tree above. Tier 2 skills are standalone utilities available anytime. Internal skills are not user-invocable; they are dispatched as subagents by pipeline skills.
+
 ## When NOT to Use Each Skill
 
 | Skill | Do NOT use for |
@@ -57,9 +68,9 @@ Runtime verification (`camel-verify`) runs automatically as part of `/camel-exec
 | `/camel-execute` | No approved plan, questions, validation-only tasks |
 | `/camel-validate` | Runtime debugging (build failures, startup errors) — use `/camel-execute` which includes runtime verification |
 
-## Also Available
+## Also Available (Tier 2)
 
-These skills are not part of the main pipelines but are accessible via slash command:
+These standalone utilities are not part of the main pipelines but are accessible via slash command:
 
 | Slash Command | Purpose |
 |---|---|

--- a/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
@@ -70,7 +70,7 @@ Tier 1 skills are the main pipeline stages — invoke them via the decision tree
 
 ## Also Available (Tier 2)
 
-These standalone utilities are not part of the main pipelines but are accessible via slash command:
+These standalone utilities are not part of the main pipelines but are accessible via slash command. They can be invoked at any point without affecting the active pipeline state of Tier 1 skills.
 
 | Slash Command | Purpose |
 |---|---|

--- a/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: camel-validate
 description: Static quality analysis of Camel routes — correctness, security, anti-patterns.
-user_invocable: true
+user_invocable: false
 ---
 
 # Camel Validate — Pipeline Quality Gate

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,12 +44,12 @@ user_invocable: false
 | `guides/optional-guide.md` | When condition X | Supplementary guide |
 ```
 
-**Note:** Both `camel-start` and `camel-validate` set `user_invocable: true`.
+**Note:** Only `camel-start` sets `user_invocable: true` — it is the single auto-discovered entry point (meta-router).
 
 The frontmatter fields:
 - `name` -- skill identifier, used in cross-references
 - `description` -- trigger keywords that help agents match user intent to the correct skill
-- `user_invocable` -- `true` for `camel-start` (meta-router) and `camel-validate` (Tier 1 quality gate). All other skills have `user_invocable: false`. Note: slash commands still work for all skills — this is an independent mechanism from skill metadata
+- `user_invocable` -- `true` for `camel-start` (meta-router) only. All other skills have `user_invocable: false` and are routed through the meta-router or invoked via explicit slash commands
 
 ### All Skills
 
@@ -64,11 +64,11 @@ The frontmatter fields:
 | `camel-ship` | No | -- (standalone orchestrator) | Autonomous pipeline — chains brainstorm → plan → execute → validate with configurable oversight |
 | `camel-design` | No | `camel-brainstorm` | Guides for component selection, EIP catalog, TDD assembly |
 | `camel-implement` | No | `camel-execute` | Guides for YAML generation, properties, Docker Compose, DataMapper |
-| `camel-validate` | Yes | `camel-ship` (Stage 3) | Tier 1 quality gate: schema validation, endpoint verification, security analysis |
+| `camel-validate` | No | `camel-ship` (Stage 3) | Tier 1 quality gate: schema validation, endpoint verification, security analysis |
 | `camel-test` | No | `camel-execute` | Guides for route analysis and test generation with Citrus + Testcontainers |
 | `camel-knowledge` | No | `camel-brainstorm`, `camel-execute` | Routes questions to knowledge MCP tools |
 
-**Note:** `camel-start` and `camel-validate` have `user_invocable: true` in their skill metadata. All other skills have `user_invocable: false`. Slash commands still work for all skills (independent mechanism).
+**Note:** Only `camel-start` has `user_invocable: true` in its skill metadata. All other skills have `user_invocable: false` and are routed through the meta-router or invoked via explicit slash commands.
 
 ### Shared Guides
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -341,9 +341,13 @@ $ camel-kit nextId inventory-sync
 
 ## Slash Commands
 
-These commands are used inside your AI coding assistant after project initialization. There are six user-invocable slash commands: `/camel-brainstorm`, `/camel-plan`, `/camel-execute`, `/camel-migrate`, `/camel-validate`, and `/camel-ship`.
+These commands are used inside your AI coding assistant after project initialization. The entry point is `/camel-start`, which routes to the right pipeline skill. Skills are organized into tiers:
 
-Four additional skills (`/camel-implement`, `/camel-verify`, `/camel-test`, `/camel-knowledge`) are internal -- they are orchestrated automatically by `/camel-execute` and should not be run directly.
+**Tier 1 — Pipeline:** `/camel-brainstorm`, `/camel-plan`, `/camel-execute`, `/camel-migrate`, `/camel-validate` — the five pipeline steps, invoked via the `/camel-start` decision tree or directly via slash command.
+
+**Tier 2 — Standalone utilities:** `/camel-ship`, `/camel-knowledge` — can be invoked at any point without affecting pipeline state.
+
+**Internal:** `/camel-implement`, `/camel-verify`, `/camel-test`, `/camel-design` — subagent-only, dispatched automatically by pipeline skills. Not intended for direct use.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the **Skill Tiers** table to `camel-start/SKILL.md`, documenting the four-tier classification (Meta, Tier 1 Pipeline, Tier 2 Power, Internal) defined in issue #61
- Updates the "Also Available" section header to reference Tier 2 for consistency
- This is the last unchecked item from the #61 implementation checklist — all 15 items are now complete

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Skill Tiers" section explaining Meta, Tier 1 pipeline steps, Tier 2 utilities, and internal-only verification skills; clarified Tier 2 guidance and reorganized command reference into explicit tiers.

* **Behavior**
  * Changed validation skill to be non-user-invocable; docs and architecture now show only the meta-router as user-invocable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luigidemasi/camel-kit/pull/70)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->