### PR TITLE
fix #72: add 'When NOT to use' sections to all pipeline and power skills

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -12,6 +12,14 @@ Turn integration ideas into fully formed design specs through collaborative dial
 
 **Core principle:** Understand before designing. Design before planning. Plan before coding.
 
+## When NOT to use this skill
+
+- Quick property changes or version bumps — edit the file directly
+- Adding a single well-known component — no design spec needed for a one-line route change
+- Questions about Apache Camel — use `/camel-knowledge` instead
+- You already have a design spec — use `/camel-plan` to decompose it into tasks
+- Migrating from another platform (MuleSoft, BizTalk, Fuse, Camel 2.x/3.x) — use `/camel-migrate` instead
+
 **Violating the letter of these rules is violating the spirit of these rules.**
 
 <HARD-GATE>

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -12,6 +12,13 @@ Execute the approved implementation plan by dispatching fresh subagents per task
 
 **Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration.
 
+## When NOT to use this skill
+
+- No approved implementation plan exists — use `/camel-plan` first to create one
+- Questions about Apache Camel — use `/camel-knowledge` instead
+- Validation-only tasks (checking existing routes without changing them) — use `/camel-validate` instead
+- You need a design spec — use `/camel-brainstorm` first; this skill implements plans, not ideas
+
 <HARD-RULE>
 AUTONOMOUS EXECUTION: Execute ALL tasks from the plan using wave analysis. Run `{COMMAND_PREFIX} plan analyze` first to get parallel waves. Tasks within a wave can run in parallel if the agent supports it. Tasks across waves run sequentially (wave N completes before wave N+1 starts). If wave analysis is unavailable, fall back to sequential execution. Do NOT stop, pause, or ask the user between tasks or waves. The user approved the entire plan — that is your authorization.
 </HARD-RULE>

--- a/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
@@ -8,6 +8,12 @@ user_invocable: false
 
 > Invocable standalone via `/camel-knowledge` or loaded by pipeline skills for documentation lookup.
 
+## When NOT to use this skill
+
+- Implementation tasks (generating routes, writing code) — use `/camel-execute` instead
+- Route validation or quality analysis — use `/camel-validate` instead
+- Designing integrations — use `/camel-brainstorm` for design work; this skill answers factual questions
+
 ## Purpose
 
 Provides access to Apache Camel documentation via MCP knowledge tools. Used during:

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
@@ -13,6 +13,13 @@ metadata:
 
 You are a **Migration Specialist** that analyses existing integration artifacts, detects the vendor, builds a pre-populated analysis summary, confirms with the user, then dispatches to the vendor-specific migration guide.
 
+## When NOT to use this skill
+
+- Greenfield projects with no existing integration to migrate — use `/camel-brainstorm` instead
+- Camel 4.x minor version upgrades (e.g., 4.10 → 4.14) — these are dependency bumps, not migrations
+- No source artifacts to analyze — this skill requires existing integration code or config files
+- The user just wants to learn about Camel — use `/camel-knowledge` instead
+
 ## Parameters
 
 ```

--- a/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
@@ -12,6 +12,13 @@ Write comprehensive implementation plans assuming the engineer has zero context 
 
 **Core principle:** The plan contains detailed instructions on HOW to generate code, NOT the generated code itself.
 
+## When NOT to use this skill
+
+- Ad-hoc changes or single-file edits — just make the change directly
+- Quick fixes or property tweaks — no plan needed for trivial modifications
+- No approved design spec exists yet — use `/camel-brainstorm` first (Iron Law 3)
+- You want to generate code or YAML — this skill produces plans, not artifacts; use `/camel-execute` for implementation
+
 **Violating the letter of these rules is violating the spirit of these rules.**
 
 <HARD-GATE>

--- a/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-ship/SKILL.md
@@ -10,6 +10,13 @@ Chain the full camel-kit pipeline (brainstorm → plan → execute → validate)
 
 **Announce at start:** "I'm using the camel-ship skill to run the full pipeline."
 
+## When NOT to use this skill
+
+- Single-file changes or quick fixes — invoke the specific skill directly (e.g., `/camel-brainstorm`, `/camel-execute`)
+- Exploratory or ad-hoc work — the full pipeline is for end-to-end delivery, not experimentation
+- You only need one pipeline stage — invoke that stage's skill directly instead of running the entire pipeline
+- Learning or asking questions about Camel — use `/camel-knowledge` instead
+
 **Violating the letter of these rules is violating the spirit of these rules.**
 
 ---

--- a/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
@@ -62,11 +62,13 @@ Tier 1 skills are the main pipeline stages — invoke them via the decision tree
 
 | Skill | Do NOT use for |
 |-------|---------------|
-| `/camel-brainstorm` | Quick property changes, version bumps, single-component additions, Camel questions |
-| `/camel-migrate` | Greenfield projects, Camel 4.x minor version upgrades |
-| `/camel-plan` | Ad-hoc changes, single-file edits, no design spec yet |
-| `/camel-execute` | No approved plan, questions, validation-only tasks |
-| `/camel-validate` | Runtime debugging (build failures, startup errors) — use `/camel-execute` which includes runtime verification |
+| `/camel-brainstorm` | Quick property changes, version bumps, single-component additions, Camel questions, migrations from other platforms |
+| `/camel-migrate` | Greenfield projects, Camel 4.x minor version upgrades, no source artifacts to analyze |
+| `/camel-plan` | Ad-hoc changes, single-file edits, quick fixes, no approved design spec yet |
+| `/camel-execute` | No approved plan, Camel questions, validation-only tasks, design work |
+| `/camel-validate` | Runtime debugging (build failures, startup errors), generating routes, design work, fixing issues |
+| `/camel-ship` | Single-file changes, quick fixes, exploratory work, only one pipeline stage needed |
+| `/camel-knowledge` | Implementation tasks, code generation, route validation, design work |
 
 ## Also Available (Tier 2)
 

--- a/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
@@ -8,6 +8,13 @@ user_invocable: false
 
 > **Tier 1 pipeline step.** Final stage after execute — produces a comprehensive quality report.
 
+## When NOT to use this skill
+
+- Runtime debugging (build failures, startup errors, exceptions) — `camel-verify` handles that within `/camel-execute`
+- Generating or modifying routes — use `/camel-execute` for implementation
+- Design work or architecture decisions — use `/camel-brainstorm` instead
+- Fixing the issues found — this skill reports problems, it does not fix them
+
 ## Invocation Modes
 
 This skill supports two invocation modes (see `shared/pipeline-infrastructure.md` for details):


### PR DESCRIPTION
## Summary

- Added `## When NOT to use this skill` sections to all 5 Tier 1 skills (`camel-brainstorm`, `camel-migrate`, `camel-plan`, `camel-execute`, `camel-validate`) and both Tier 2 skills (`camel-ship`, `camel-knowledge`)
- Updated the `camel-start` meta-router's "When NOT to Use Each Skill" sync table to include `camel-ship` and `camel-knowledge` entries, and enriched existing entries with additional negative triggers
- Each negative trigger is specific and actionable, pointing the agent to the correct alternative skill

## Test plan

- [ ] Verify each SKILL.md has a `## When NOT to use this skill` section with specific negative triggers
- [ ] Verify `camel-start` sync table includes all 7 skills (5 Tier 1 + 2 Tier 2)
- [ ] Verify negative triggers in individual skills are consistent with the summary table in `camel-start`
- [ ] Build passes: `./mvnw clean install -B`

Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Document when not to use each Camel pipeline and knowledge skill and align the camel-start routing table with these negative triggers.

Documentation:
- Add explicit "When NOT to use this skill" guidance to all Tier 1 pipeline skills and Tier 2 skills to clarify appropriate usage and alternatives.
- Update the camel-start SKILL routing table with expanded negative triggers and entries for camel-ship and camel-knowledge to consistently steer users to the right skills.