### PR TITLE
fix #71: add standalone debugging skill (/camel-debug)

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -44,7 +44,7 @@ public class DefaultGenerator implements AgentGenerator {
     private void createCommandTemplates(InitContext ctx) throws Exception {
         List<String> commands
                 = List.of("start", "brainstorm", "plan", "execute", "verify", "validate", "migrate", "knowledge",
-                        "ship");
+                        "ship", "debug");
 
         // Extract agent base folder (e.g., ".bob" from ".bob/commands")
         String agentBaseFolder = ctx.agent().folder().substring(0, ctx.agent().folder().lastIndexOf("/"));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -362,7 +362,7 @@ public class DefaultGenerator implements AgentGenerator {
         List<String> skillNames = List.of(
                 "camel-brainstorm", "camel-execute", "camel-implement", "camel-verify",
                 "camel-validate", "camel-test", "camel-plan", "camel-ship",
-                "camel-migrate", "camel-knowledge", "camel-start");
+                "camel-migrate", "camel-knowledge", "camel-start", "camel-debug");
 
         for (String skillName : skillNames) {
             String traitResourcePath = traitsBasePath + skillName + ".append.md";

--- a/camel-kit-core/src/main/resources/skills/camel-debug/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-debug/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: camel-debug
+description: Ad-hoc troubleshooting for broken Camel routes outside of a pipeline run.
+user_invocable: false
+---
+
+# Camel Debug — Standalone Troubleshooting
+
+> Diagnose and fix a broken Camel route using a structured STOP → PRESERVE → DIAGNOSE → FIX → GUARD workflow.
+
+**Announce:** "Let me debug this using the camel-debug skill."
+
+## When to Use
+
+- A route was working but is now broken (startup failures, runtime exceptions, unexpected behavior)
+- A user arrives with "my route is broken" outside of an active pipeline run
+- Ad-hoc troubleshooting — no pipeline context required
+
+## When NOT to Use
+
+- Build/test failures during pipeline execution — `camel-verify` handles this (dispatched by `camel-execute`)
+- Quality validation of generated routes — use `/camel-validate`
+- Designing new integrations — use `/camel-brainstorm`
+- Planning or executing implementation — use `/camel-plan` or `/camel-execute`
+
+**Violating the letter of these rules is violating the spirit of these rules.**
+
+## Prerequisites
+
+- `.camel-kit/config.properties` must exist (for runtime and version detection)
+- The project must have existing route files to debug
+
+## Guides
+
+| Guide | When to Load | Purpose |
+|-------|-------------|---------|
+| `guides/debug-workflow.md` | Always | Full debugging workflow — STOP, PRESERVE, DIAGNOSE, FIX, GUARD |
+| `camel-verify/guides/error-taxonomy.md` | Always (reference) | Error classification tables — patterns, categories, fix actions |
+
+## Shared Guides
+
+Load these shared guides at workflow start:
+- `shared/iron-laws.md` — Iron Law 1 (MCP verification) applies during diagnosis
+- `shared/mcp-setup.md` — MCP tool configuration for catalog queries
+
+## Subagent Isolation
+
+Diagnosis steps (Step 3 in the workflow) MUST run as subagents to keep diagnostic output out of the main context. Only the classification result and fix recommendation flow back to the main conversation.
+
+| Subagent | Purpose | Input | Output |
+|----------|---------|-------|--------|
+| Route analyzer | Inspect route YAML for structural issues | Route file paths, error message | Structural findings list |
+| MCP verifier | Verify components/endpoints against catalog | Component names from routes | Verification results (exists/missing/wrong options) |
+| Log analyzer | Parse and classify error output | Raw log/stack trace text | Classified error with taxonomy match |

--- a/camel-kit-core/src/main/resources/skills/camel-debug/guides/debug-workflow.md
+++ b/camel-kit-core/src/main/resources/skills/camel-debug/guides/debug-workflow.md
@@ -1,0 +1,233 @@
+# Debug Workflow
+
+Structured troubleshooting guide for ad-hoc Camel route debugging. Follows a strict 5-step sequence: **STOP → PRESERVE → DIAGNOSE → FIX → GUARD**.
+
+**Always load `camel-verify/guides/error-taxonomy.md` alongside this guide** — it contains the error classification tables used in Step 3.
+
+---
+
+## Step 1: STOP — Understand Before Acting
+
+**Do NOT change any file before completing Step 3 (DIAGNOSE).**
+
+### Gather Context
+
+1. Read `.camel-kit/config.properties` → extract:
+   - `project.runtime` (quarkus | springboot | jbang)
+   - `camel.version`
+2. Ask the user (if not already provided):
+   - What is the symptom? (build failure, startup error, runtime exception, unexpected behavior, no error but wrong output)
+   - When did it start? (after a change, after upgrade, intermittent, always)
+   - What changed recently? (new route, dependency update, config change, nothing)
+3. If the user provides an error message or stack trace, capture it verbatim — do NOT paraphrase or truncate
+
+### Environment Check
+
+Check which tools are available (same as verify-loop prerequisites):
+
+```text
+ENVIRONMENT CHECK
+Runtime:        {runtime from config.properties}
+Camel version:  {version from config.properties}
+Maven:          {./mvnw (wrapper) | mvn (system) | not found}
+Docker:         {docker {version} | not found}
+JDK:            {{vendor} {version} | not found}
+```
+
+---
+
+## Step 2: PRESERVE — Capture Current State
+
+Before any investigation that might change state, preserve the starting point.
+
+### Steps
+
+1. **Record file state:** run `git status` and `git diff --stat` to capture uncommitted changes
+2. **Note the user's working branch:** run `git branch --show-current`
+3. If there are uncommitted changes, warn the user:
+   ```text
+   You have uncommitted changes. I will not modify any files until diagnosis is complete.
+   If a fix is needed, I will explain the change and ask for your approval first.
+   ```
+
+### What NOT to Do
+
+- Do NOT run the build yet (Step 3 handles that)
+- Do NOT modify any files
+- Do NOT add dependencies
+- Do NOT "try a quick fix"
+
+---
+
+## Step 3: DIAGNOSE — Classify the Error
+
+This is the core diagnostic phase. **Run diagnosis steps as subagents** to keep verbose output out of the main context.
+
+### 3.1 Reproduce the Error
+
+Attempt to reproduce the reported symptom:
+
+| Symptom Type | Reproduction Command |
+|---|---|
+| Build failure | `{MAVEN_CMD} compile -q` |
+| Startup error | `{MAVEN_CMD} compile -q`, then check for `FailedToCreateRouteException` patterns |
+| Runtime exception | Ask user to share the failing scenario or trigger |
+| Wrong output | Ask user for expected vs actual output |
+| Intermittent | Ask user for conditions under which it fails |
+
+If the error cannot be reproduced, report this to the user and ask for more context. Do NOT guess.
+
+### 3.2 Classify the Error
+
+**Dispatch as subagent: Log Analyzer**
+
+Using the error output from 3.1, classify the error against `camel-verify/guides/error-taxonomy.md`:
+
+1. Match the error message or stack trace against the taxonomy patterns
+2. Extract:
+   - **Phase:** Build | Startup | Runtime
+   - **Category:** the error family (e.g., Missing dependency, Route creation failure)
+   - **Fix target:** Self-repair | camel-validate | camel-implement | Escalate
+   - **Fix action:** what the taxonomy recommends
+3. If no pattern matches → classification is **Unclassified**
+
+### 3.3 Verify Components Against MCP Catalog
+
+**Dispatch as subagent: MCP Verifier**
+
+For errors related to components, endpoints, or data formats:
+
+1. Identify all components referenced in the affected route files
+2. For each component, call the MCP catalog tool:
+   ```
+   camel_catalog_component(name="{component}", runtime="{runtime}", platformBom="{bom}")
+   ```
+3. Check:
+   - Does the component exist for this runtime and version?
+   - Are the endpoint options used in the route valid?
+   - Are there known issues or CVEs?
+
+### 3.4 Inspect Route Structure
+
+**Dispatch as subagent: Route Analyzer**
+
+Read the affected route files and check for:
+
+1. **YAML structure errors** — malformed YAML, wrong indentation, missing required fields
+2. **Component URI issues** — wrong URI format, missing required options
+3. **Expression errors** — invalid Simple, XPath, or Groovy expressions
+4. **Missing error handlers** — routes without error handling for external calls
+5. **Missing beans** — references to beans not declared in the project
+
+### 3.5 Present Diagnosis
+
+After all subagents complete, synthesize the results into a diagnosis report:
+
+```text
+DIAGNOSIS REPORT
+Symptom:        {user-reported symptom}
+Reproduced:     {yes | no | partially}
+Classification: {category from error-taxonomy.md | Unclassified}
+Phase:          {Build | Startup | Runtime | Unknown}
+Root cause:     {one-sentence explanation}
+Confidence:     {High | Medium | Low}
+
+MCP verification:
+  {component}: {exists | MISSING | wrong options: {details}}
+
+Route analysis:
+  {finding 1}
+  {finding 2}
+```
+
+**If confidence is Low:** tell the user what you found and what you're unsure about. Ask if they want to proceed with the suggested fix or provide more context.
+
+---
+
+## Step 4: FIX — Targeted Repair
+
+Only proceed to this step after Step 3 is complete and the diagnosis is presented to the user.
+
+### Fix Routing
+
+Apply the fix target from the error classification:
+
+| Fix Target | Action |
+|---|---|
+| Self-repair | Edit the file directly (pom.xml, application.properties, route YAML) |
+| camel-validate | Load `camel-validate` to re-validate the affected route against MCP catalog |
+| camel-implement | Load `camel-implement` to re-generate the affected route from its TDD |
+| Escalate | Present the raw error and diagnosis to the user — do NOT attempt a fix |
+| Unclassified | Present the raw error and diagnosis to the user — do NOT attempt a fix |
+
+### Fix Protocol
+
+1. **Explain before changing:** describe the proposed fix and why it addresses the root cause
+2. **Minimal change:** fix only the identified issue — do NOT refactor, clean up, or improve surrounding code
+3. **One fix at a time:** if multiple issues were found, fix them sequentially. Verify each fix before moving to the next
+4. **Verify the fix:** after applying each fix, re-run the reproduction command from Step 3.1
+   - If the error is resolved → proceed to Step 5
+   - If the same error persists → the fix did not work. Report to the user and ask for guidance
+   - If a NEW error appears → classify the new error (go back to Step 3.2) and fix it
+
+### Iteration Limit
+
+If 5 fix attempts fail to resolve the issue, stop and escalate:
+
+```text
+I've attempted 5 fixes without resolving the issue. Here's what I tried:
+  1. {fix 1} — result: {still failing / new error}
+  2. {fix 2} — result: {still failing / new error}
+  ...
+
+The underlying issue may require architectural changes or manual investigation.
+```
+
+---
+
+## Step 5: GUARD — Prevent Recurrence
+
+After the fix is verified, suggest preventive measures. These are recommendations — do NOT apply them without user approval.
+
+### Guard Recommendations
+
+Based on the error category, suggest one or more of:
+
+| Error Category | Guard Suggestion |
+|---|---|
+| Missing dependency | "Add a build verification step to your CI that checks all component dependencies resolve" |
+| Wrong endpoint options | "Run `/camel-validate` after changes to verify endpoint options against the MCP catalog" |
+| Route creation failure | "Add a Citrus integration test for this route to catch startup failures early" |
+| Expression failure | "Add test cases with edge-case input data to your Citrus tests" |
+| External service | "Add a health check or circuit breaker to handle service unavailability" |
+| Type conversion | "Add explicit type declarations in the route to catch conversion issues at startup" |
+| Unclassified | "Consider adding this error pattern to the project's error handling documentation" |
+
+### Guard Format
+
+```text
+GUARD — Recurrence Prevention
+Fix applied:    {one-line summary of the fix}
+Category:       {error category}
+
+Suggested guard:
+  {recommendation from table above}
+
+To apply: {specific command or file change, if applicable}
+```
+
+---
+
+## Summary Report
+
+At the end of the workflow, present a complete summary:
+
+```text
+DEBUG SUMMARY
+Symptom:        {original symptom}
+Root cause:     {one-sentence root cause}
+Classification: {category}
+Fix applied:    {description of fix}
+Files changed:  {list of modified files}
+Guard:          {suggested preventive measure}
+```

--- a/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
@@ -20,7 +20,7 @@ Answer these questions in order. The first "yes" is your destination.
 | 2 | Is there an approved design spec ready for task decomposition? | Plan it | `/camel-plan` |
 | 3 | Is there an approved implementation plan ready for execution? | Execute it | `/camel-execute` |
 | 4 | Are there generated routes that need quality validation? | Validate them | `/camel-validate` |
-| 5 | Is something broken — build fails, startup errors, runtime exceptions? | Re-execute with verification | `/camel-execute` |
+| 5 | Is something broken — build fails, startup errors, runtime exceptions — outside of a pipeline run? | Debug it | `/camel-debug` |
 | 6 | None of the above — new integration, new feature, or unclear? | Design it | `/camel-brainstorm` |
 
 ### Mid-Pipeline Entry
@@ -29,7 +29,7 @@ Users may arrive partway through a pipeline:
 - "I already have a design spec" → skip brainstorm, go to `/camel-plan`
 - "The plan is approved, start building" → skip brainstorm+plan, go to `/camel-execute`
 - "I have generated routes that need checking" → go to `/camel-validate`
-- "It was working but now it's broken" → go to `/camel-execute` (includes runtime verification via `camel-verify`)
+- "It was working but now it's broken" → go to `/camel-debug` (standalone troubleshooting)
 
 ### Pipeline Overview
 
@@ -53,7 +53,7 @@ Runtime verification (`camel-verify`) runs automatically as part of `/camel-exec
 |------|--------|------|
 | Meta | `camel-start` | Routes to the right pipeline |
 | Tier 1 (Pipeline) | `camel-brainstorm`, `camel-migrate`, `camel-plan`, `camel-execute`, `camel-validate` | The 5 pipeline steps |
-| Tier 2 (Power) | `camel-ship`, `camel-knowledge` | Standalone utilities |
+| Tier 2 (Power) | `camel-ship`, `camel-knowledge`, `camel-debug` | Standalone utilities |
 | Internal | `camel-design`, `camel-implement`, `camel-test`, `camel-verify` | Guide libraries / subagent-only |
 
 Tier 1 skills are the main pipeline stages — invoke them via the decision tree above. Tier 2 skills are standalone utilities available anytime. Internal skills are not user-invocable; they are dispatched as subagents by pipeline skills.
@@ -68,6 +68,7 @@ Tier 1 skills are the main pipeline stages — invoke them via the decision tree
 | `/camel-execute` | No approved plan, Camel questions, validation-only tasks, design work |
 | `/camel-validate` | Runtime debugging (build failures, startup errors), generating routes, design work, fixing issues |
 | `/camel-ship` | Single-file changes, quick fixes, exploratory work, only one pipeline stage needed |
+| `/camel-debug` | Build/test failures during pipeline execution (use `/camel-execute` which dispatches `camel-verify`), quality validation, designing integrations |
 | `/camel-knowledge` | Implementation tasks, code generation, route validation, design work |
 
 ## Also Available (Tier 2)
@@ -78,3 +79,4 @@ These standalone utilities are not part of the main pipelines but are accessible
 |---|---|
 | `/camel-ship` | Run the full pipeline autonomously with configurable oversight (`--ask always\|smart\|never`) |
 | `/camel-knowledge` | Look up Apache Camel documentation, components, CVEs, errata, versions |
+| `/camel-debug` | Ad-hoc troubleshooting for broken routes outside of a pipeline run |

--- a/camel-kit-core/src/main/resources/templates/bob/custom_modes.yaml
+++ b/camel-kit-core/src/main/resources/templates/bob/custom_modes.yaml
@@ -100,6 +100,25 @@ customModes:
       - read
       - mcp
 
+  - slug: camel-debug
+    name: "\U0001F50D Camel Debug"
+    roleDefinition: >
+      You are a Camel integration debugger diagnosing broken routes using a
+      structured STOP, PRESERVE, DIAGNOSE, FIX, GUARD workflow. You do NOT
+      change any files until diagnosis is complete and the user approves.
+    whenToUse: >
+      Use this mode when a Camel route is broken outside of a pipeline run.
+      For build/test failures during pipeline execution, use camel-execute instead.
+    customInstructions: >
+      Follow the 5-step workflow strictly. Do NOT modify files before Step 4 (FIX).
+      Run diagnosis subagents for route analysis, MCP verification, and log classification.
+      Present the diagnosis report and wait for user approval before applying fixes.
+    groups:
+      - read
+      - edit
+      - command
+      - mcp
+
   - slug: camel-test
     name: "\U0001F9EA Camel Test"
     roleDefinition: >

--- a/camel-kit-core/src/main/resources/templates/shared/agents-md.md
+++ b/camel-kit-core/src/main/resources/templates/shared/agents-md.md
@@ -1,7 +1,7 @@
 # Camel-Kit Project
 
 Integration work → `/camel-start`
-Direct skill invocation → `/camel-brainstorm`, `/camel-migrate`, `/camel-plan`, `/camel-execute`, `/camel-verify`
+Direct skill invocation → `/camel-brainstorm`, `/camel-migrate`, `/camel-plan`, `/camel-execute`, `/camel-verify`, `/camel-debug`
 
 ## Laws (NEVER violate)
 

--- a/camel-kit-core/src/main/resources/templates/shared/agents-md.md
+++ b/camel-kit-core/src/main/resources/templates/shared/agents-md.md
@@ -1,7 +1,7 @@
 # Camel-Kit Project
 
 Integration work → `/camel-start`
-Direct skill invocation → `/camel-brainstorm`, `/camel-migrate`, `/camel-plan`, `/camel-execute`, `/camel-verify`, `/camel-debug`
+Direct skill invocation → `/camel-brainstorm`, `/camel-migrate`, `/camel-plan`, `/camel-execute`, `/camel-validate`, `/camel-ship`, `/camel-knowledge`, `/camel-debug`
 
 ## Laws (NEVER violate)
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -154,6 +154,16 @@ class DefaultGeneratorTest {
     }
 
     @Test
+    void generatesDebugCommand() throws Exception {
+        InitContext ctx = createContext("bob");
+        new DefaultGenerator().generate(ctx);
+
+        assertTrue(Files.exists(ctx.commandsDir().resolve("camel-debug.md")));
+        String content = Files.readString(ctx.commandsDir().resolve("camel-debug.md"));
+        assertTrue(content.contains("SKILL.md"));
+    }
+
+    @Test
     void copiesDebugSkill() throws Exception {
         InitContext ctx = createContext("bob");
         new DefaultGenerator().generate(ctx);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -154,6 +154,16 @@ class DefaultGeneratorTest {
     }
 
     @Test
+    void copiesDebugSkill() throws Exception {
+        InitContext ctx = createContext("bob");
+        new DefaultGenerator().generate(ctx);
+
+        assertTrue(Files.exists(ctx.skillsDir().resolve("camel-debug/SKILL.md")));
+        assertTrue(Files.isDirectory(ctx.skillsDir().resolve("camel-debug/guides")));
+        assertTrue(Files.exists(ctx.skillsDir().resolve("camel-debug/guides/debug-workflow.md")));
+    }
+
+    @Test
     void substitutesVersionPlaceholdersInSkillFiles() throws Exception {
         InitContext ctx = createContext("bob");
         new DefaultGenerator().generate(ctx);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,7 @@ The frontmatter fields:
 | `camel-validate` | No | `camel-ship` (Stage 3) | Tier 1 quality gate: schema validation, endpoint verification, security analysis |
 | `camel-test` | No | `camel-execute` | Guides for route analysis and test generation with Citrus + Testcontainers |
 | `camel-knowledge` | No | `camel-brainstorm`, `camel-execute` | Routes questions to knowledge MCP tools |
+| `camel-debug` | No | `camel-start` (ad-hoc troubleshooting) | Standalone debugging: STOP → PRESERVE → DIAGNOSE → FIX → GUARD workflow |
 
 **Note:** Only `camel-start` has `user_invocable: true` in its skill metadata. All other skills have `user_invocable: false` and are routed through the meta-router or invoked via explicit slash commands.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,12 +44,12 @@ user_invocable: false
 | `guides/optional-guide.md` | When condition X | Supplementary guide |
 ```
 
-**Note:** Only `camel-start` sets `user_invocable: true` — it is the single auto-discovered entry point (meta-router).
+**Note:** Only `camel-start` sets `user_invocable: true` — it is the single auto-discovered entry point (meta-router). Pipeline and standalone skills (Tier 1/2) are invoked via explicit slash commands. Internal skills are dispatched only by pipeline skills.
 
 The frontmatter fields:
 - `name` -- skill identifier, used in cross-references
 - `description` -- trigger keywords that help agents match user intent to the correct skill
-- `user_invocable` -- `true` for `camel-start` (meta-router) only. All other skills have `user_invocable: false` and are routed through the meta-router or invoked via explicit slash commands
+- `user_invocable` -- `true` for `camel-start` (meta-router) only. Pipeline and standalone skills (Tier 1/2) have explicit slash commands despite `user_invocable: false`. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills
 
 ### All Skills
 
@@ -69,7 +69,7 @@ The frontmatter fields:
 | `camel-knowledge` | No | `camel-brainstorm`, `camel-execute` | Routes questions to knowledge MCP tools |
 | `camel-debug` | No | `camel-start` (ad-hoc troubleshooting) | Standalone debugging: STOP → PRESERVE → DIAGNOSE → FIX → GUARD workflow |
 
-**Note:** Only `camel-start` has `user_invocable: true` in its skill metadata. All other skills have `user_invocable: false` and are routed through the meta-router or invoked via explicit slash commands.
+**Note:** Only `camel-start` has `user_invocable: true` in its skill metadata. Pipeline and standalone skills have explicit slash commands despite `user_invocable: false`. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills.
 
 ### Shared Guides
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@ This document is the reference for all Camel-Kit commands: the `camel-kit` CLI a
   - [/camel-migrate](#camel-migrate)
   - [/camel-validate](#camel-validate)
   - [/camel-ship](#camel-ship)
+  - [/camel-debug](#camel-debug)
   - [/camel-verify (internal)](#camel-verify)
 - [Command Cheat Sheet](#command-cheat-sheet)
 
@@ -448,7 +449,7 @@ These commands are used inside your AI coding assistant after project initializa
 
 **Tier 1 — Pipeline:** `/camel-brainstorm`, `/camel-plan`, `/camel-execute`, `/camel-migrate`, `/camel-validate` — the five pipeline steps, invoked via the `/camel-start` decision tree or directly via slash command.
 
-**Tier 2 — Standalone utilities:** `/camel-ship`, `/camel-knowledge` — can be invoked at any point without affecting pipeline state.
+**Tier 2 — Standalone utilities:** `/camel-ship`, `/camel-knowledge`, `/camel-debug` — can be invoked at any point without affecting pipeline state.
 
 **Internal:** `/camel-implement`, `/camel-verify`, `/camel-test`, `/camel-design` — subagent-only, dispatched automatically by pipeline skills. Not intended for direct use.
 
@@ -748,6 +749,45 @@ When `--resume` is used, camel-ship scans all pipeline artifacts for staleness m
 
 ---
 
+### /camel-debug
+
+**Purpose:** Ad-hoc troubleshooting for broken Camel routes outside of a pipeline run. Follows a structured STOP → PRESERVE → DIAGNOSE → FIX → GUARD workflow.
+
+**When to use:** When a route was working but is now broken, or when a user needs help debugging a Camel application outside of an active pipeline. For build/test failures during pipeline execution, `/camel-execute` dispatches `camel-verify` automatically.
+
+**Examples:**
+
+```bash
+# Debug a broken route
+/camel-debug
+
+# Debug with context
+/camel-debug my route is failing with a ClassNotFoundException
+```
+
+**How it works (5-step workflow):**
+
+1. **STOP** -- gather context (runtime, Camel version, error message, recent changes). Do NOT modify files yet.
+2. **PRESERVE** -- capture current state via `git status`/`git diff`. Warn if uncommitted changes exist.
+3. **DIAGNOSE** -- reproduce the error, classify it against the error taxonomy, verify components via MCP catalog, inspect route structure. Diagnosis steps run as subagents to keep verbose output out of the main context.
+4. **FIX** -- explain the proposed fix, apply minimal targeted changes, verify the fix resolves the issue. Up to 5 fix attempts before escalating.
+5. **GUARD** -- suggest a preventive measure (test, validation rule, CI check) to prevent recurrence.
+
+**Error classification:** Reuses the same 14-pattern error taxonomy as `/camel-verify`:
+
+| Category | Examples | Fix Target |
+|---|---|---|
+| Missing dependency | `ClassNotFoundException`, missing Camel component | Self-repair (add to pom.xml) |
+| Route creation | `FailedToCreateRouteException` | Re-generate route |
+| Wrong endpoint options | `ResolveEndpointFailedException` | Re-validate via MCP catalog |
+| Expression failure | `ExpressionEvaluationException` | Fix expression |
+| External service | `Connection refused` | Fix service configuration |
+| Unclassified | No matching pattern | Escalate to user |
+
+**Subagent isolation:** Diagnosis dispatches three subagents (route analyzer, MCP verifier, log analyzer) to keep raw diagnostic output out of the main conversation. Only the structured diagnosis report flows back.
+
+---
+
 ### /camel-verify
 
 > **Internal skill** -- dispatched automatically by `/camel-execute`. Not intended for standalone use. For quality checks after the pipeline completes, use `/camel-validate`.
@@ -825,4 +865,7 @@ camel-kit init my-project --ai claude
 
 # Validate (standalone, any project)
 /camel-validate                          # Validate routes in current project
+
+# Debug (ad-hoc troubleshooting)
+/camel-debug                             # Diagnose and fix a broken route
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -847,7 +847,7 @@ If verification fails after multiple fix iterations (the verify loop runs inside
 4. For connection errors, verify that external services are actually running and reachable
 5. For component errors, ask your AI assistant to check whether the component exists in your Camel version
 
-### Ad-Hoc Route Debugging
+### Ad-hoc Route Debugging
 
 If a route breaks outside of a pipeline run (e.g., after a manual edit, dependency upgrade, or configuration change), use the standalone debug skill:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -846,3 +846,13 @@ If verification fails after multiple fix iterations (the verify loop runs inside
 3. Check if the error is classified as "Escalate" -- these require manual intervention
 4. For connection errors, verify that external services are actually running and reachable
 5. For component errors, ask your AI assistant to check whether the component exists in your Camel version
+
+### Ad-Hoc Route Debugging
+
+If a route breaks outside of a pipeline run (e.g., after a manual edit, dependency upgrade, or configuration change), use the standalone debug skill:
+
+```
+/camel-debug
+```
+
+This runs a structured troubleshooting workflow (STOP → PRESERVE → DIAGNOSE → FIX → GUARD) that captures state before making changes, classifies the error, and applies targeted fixes. Unlike the pipeline verification loop (`camel-verify`), the debug skill is designed for ad-hoc use and does not require an active pipeline.


### PR DESCRIPTION
## Summary

- Add new Tier 2 standalone skill `/camel-debug` for ad-hoc troubleshooting of broken Camel routes outside pipeline runs
- Implements a structured STOP → PRESERVE → DIAGNOSE → FIX → GUARD workflow with subagent isolation for diagnosis steps
- Reuses existing `error-taxonomy.md` from `camel-verify` for error classification
- Routes "my route is broken" from `camel-start` decision tree to `/camel-debug`
- Registers slash command across all agent platforms (Claude, Bob, Gemini, OpenCode, Qwen)

## Changes

**New files:**
- `skills/camel-debug/SKILL.md` — skill manifest with subagent isolation table
- `skills/camel-debug/guides/debug-workflow.md` — 5-step debugging workflow

**Modified files:**
- `camel-start/SKILL.md` — decision tree row #5 now routes to `/camel-debug`; added to Tier 2 table
- `templates/shared/agents-md.md` — registered `/camel-debug` slash command
- `templates/bob/custom_modes.yaml` — added Bob mode for `camel-debug`
- `DefaultGenerator.java` — added `"camel-debug"` to `skillNames` for trait support
- `DefaultGeneratorTest.java` — added `copiesDebugSkill` test
- `docs/commands.md` — full documentation section for `/camel-debug`
- `docs/architecture.md` — added to skill table
- `docs/user-guide.md` — added troubleshooting section for ad-hoc debugging

## Test plan

- [x] `copiesDebugSkill` test verifies SKILL.md and guides are copied during init
- [x] Full test suite passes (`./mvnw test -B` — BUILD SUCCESS)
- [x] Full build passes (`./mvnw clean install -B` — BUILD SUCCESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new standalone /camel-debug skill for ad-hoc Camel route troubleshooting and wire it into the existing skill ecosystem, docs, and generator tooling.

New Features:
- Add the camel-debug Tier 2 standalone skill with a structured STOP → PRESERVE → DIAGNOSE → FIX → GUARD debugging workflow and subagent isolation.
- Expose /camel-debug as a direct slash command across agents, including a dedicated Bob custom mode for Camel route debugging.

Enhancements:
- Route broken-route scenarios from the camel-start decision tree to the new /camel-debug skill instead of reusing the execution pipeline.
- Include camel-debug in the skill trait generation list so its guides and traits are available on project init.
- Document /camel-debug usage, workflow, and positioning versus camel-verify in the commands, architecture, and user guide references.

Tests:
- Add a generator test ensuring the camel-debug skill manifest and debug workflow guide are copied during project initialization.