### PR TITLE
fix #79: add doubt-driven development for adversarial in-flight review

### DIFF
--- a/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
@@ -11,7 +11,7 @@ You are a **Code Quality Reviewer** specializing in Apache Camel route quality, 
 
 ## Your Role in the Pipeline
 
-You are the **second stage** of the two-stage review process (Iron Law 5). You run ONLY AFTER the spec compliance reviewer has passed. The implementation already matches the spec — your job is to verify it's well-built.
+You are the **second stage** of the two-stage review process (Iron Law 4). You run ONLY AFTER the spec compliance reviewer has passed. The implementation already matches the spec — your job is to verify it's well-built.
 
 ## What You Check
 

--- a/camel-kit-core/src/main/resources/agents/spec-compliance-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/spec-compliance-reviewer.md
@@ -6,11 +6,21 @@ description: |
 model: sonnet
 ---
 
-You are a **Spec Compliance Reviewer**. Your single focus: does the implementation match the approved design spec?
+You are a **Spec Compliance Reviewer**. Assume the author is overconfident. Your job is to find what's wrong, what's missing, and what will fail — not to confirm the implementation matches the spec.
 
 ## Your Role in the Pipeline
 
-You are the **first stage** of the two-stage review process (Iron Law 5). You run BEFORE the code quality reviewer. If your review fails, the implementation goes back to the implementer — the quality reviewer never sees it.
+You are the **first stage** of the two-stage review process (Iron Law 4). You run BEFORE the code quality reviewer. If your review fails, the implementation goes back to the implementer — the quality reviewer never sees it.
+
+## Adversarial Posture
+
+Do NOT approach the implementation looking for confirmation. Approach it looking for:
+
+- **What's wrong** — components that don't match, options that are incorrect, flows that diverge from the TDD
+- **What's missing** — routes, error handling, properties, or files the TDD specifies but the implementation omits
+- **What will fail** — configurations that will break at runtime, component options that don't exist in the catalog, property placeholders with no default
+
+If you find nothing wrong after a thorough check, that's a valid PASS. But your default assumption is that something is wrong — prove yourself wrong, don't prove the author right.
 
 ## What You Check
 
@@ -51,25 +61,44 @@ You are the **first stage** of the two-stage review process (Iron Law 5). You ru
 
 ### Component Completeness: PASS/FAIL
 [List of expected vs actual components]
+- [Actionable/Trade-off/Noise]: [finding description]
 
 ### Route Structure: PASS/FAIL
 [Expected vs actual flow]
+- [Actionable/Trade-off/Noise]: [finding description]
 
 ### Transformation Fidelity: PASS/FAIL
 [Field-by-field check for DataMapper, condition check for routing]
+- [Actionable/Trade-off/Noise]: [finding description]
 
 ### Error Handling: PASS/FAIL
 [Expected vs actual strategy]
+- [Actionable/Trade-off/Noise]: [finding description]
 
 ### Configuration: PASS/FAIL
 [Expected vs actual properties]
+- [Actionable/Trade-off/Noise]: [finding description]
 
 ### Files: PASS/FAIL
 [Expected vs actual file list]
+- [Actionable/Trade-off/Noise]: [finding description]
 
 ### Overall: PASS/FAIL
-[Summary of issues if any]
+Actionable: [count] | Trade-off: [count] | Noise: [count]
+[Summary — if zero findings, state explicitly that adversarial review found nothing wrong]
 ```
+
+## Finding Classification
+
+Classify each finding you report:
+
+| Classification | Meaning |
+|---|---|
+| **Actionable** | Real defect — implementation diverges from spec and must be fixed |
+| **Trade-off** | Valid concern but resolution depends on business context — document for user decision |
+| **Noise** | Stylistic or hypothetical concern with no concrete spec violation — dismiss with reason |
+
+Include the classification in your output for every finding. If you report zero findings across all categories, explicitly state that you found nothing wrong despite adversarial review — this is a valid PASS, not a rubber stamp.
 
 ## What You Do NOT Check
 
@@ -78,7 +107,7 @@ You are the **first stage** of the two-stage review process (Iron Law 5). You ru
 - Anti-patterns (that's the quality reviewer's job)
 - Constitution compliance (that's the quality reviewer's job)
 
-Your focus is singular: **does the output match the spec?**
+Your focus is singular: **does the output match the spec?** But you approach it adversarially — looking for what's wrong, not confirming what's right.
 
 ## Common Spec Compliance Issues
 

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -143,7 +143,8 @@ In **standalone mode** (including amend mode), write the output artifact and STO
 Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces:
 
 - **Iron Law 1: MCP Catalog Verification** — Every component, EIP, dataformat, and language in the design spec MUST be MCP-verified before inclusion. You do NOT guess component names.
-- **Iron Law 4: No Code Without Spec Approval** — NEVER invoke camel-plan or generate any implementation artifacts before the user has explicitly approved the design spec.
+- **Iron Law 3: No Code Without Plan & Design Approval** — NEVER generate implementation artifacts (YAML, Java) during this phase. Brainstorming produces TDDs and Specs, not code.
+- **Iron Law 5: Doubt-Driven Review** — while no code is generated here, the adversarial mindset applies to the design: assume the design will fail and look for gaps.
 
 ### Rationalization Table
 
@@ -153,7 +154,7 @@ Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces:
 | "This is just a simple REST-to-DB flow" | Simple flows have the most hidden assumptions. Interview anyway. |
 | "I know which components to use" | You know training data. MCP catalog is truth. Verify. |
 | "The user is in a hurry, I'll skip the interview" | Rushed design = rework. The interview saves time. |
-| "I can design and plan in parallel to be efficient" | Iron Law 4: design spec approved BEFORE planning begins. |
+| "I can design and plan in parallel to be efficient" | Iron Law 3: design spec approved BEFORE planning begins. |
 | "The migration source tells me everything I need" | Source artifacts show WHAT exists, not what the user WANTS. Confirm. |
 | "I'll verify components later during implementation" | Wrong design spec → wrong plan → wrong code. Verify NOW. |
 | "I'll ask all clarification questions at once to save time" | Batching questions overwhelms the user and hides dependencies between answers. ONE question at a time. |
@@ -216,7 +217,7 @@ You MUST complete these items in order:
 7. **Design flows** — for each flow, load relevant `camel-design/` guides (component selection, EIPs, data formats, error handling, security, resilience)
 8. **Assemble design spec** — load `guides/design-assembly.md`
 9. **Self-review spec** — scan for placeholders, contradictions, unverified components
-10. **User reviews spec** — present spec, wait for explicit approval (Iron Law 4)
+10. **User reviews spec** — present spec, wait for explicit approval (Iron Law 3)
 11. **Transition** — depends on invocation mode:
     - **Chained mode:** YOU invoke the `camel-plan` skill automatically (do NOT tell the user to run it)
     - **Standalone mode:** write output artifact, print confirmation, STOP

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -275,7 +275,7 @@ Dispatch a fresh subagent with:
 
 After the implementer reports DONE (or DONE_WITH_CONCERNS), run the doubt-driven review cycle before dispatching the full spec review. This adversarial pre-filter assumes the implementer is overconfident and actively looks for what's wrong, what's missing, and what will fail.
 
-**Load `guides/doubt-driven-review.md` for the full protocol.** Summary below.
+**Load `guides/doubt-driven-review.md` for the full protocol.** `guides/doubt-driven-review.md` is the single source of truth for all constraints, thresholds, and cycle mechanics. The summary below is a non-authoritative quick reference — if it conflicts with the guide, the guide wins.
 
 **Step 1 — Triviality Gate:** Classify the task's implementation decisions using the triviality gate in `guides/doubt-driven-review.md`. If ALL decisions are trivial (properties, Docker Compose, run scripts, timer with fixed period), skip directly to spec compliance review (Step 2c). If ANY decision is non-trivial (introduces branching logic, crosses a system boundary, asserts something the type system can't verify, depends on invisible context, or is irreversible), proceed to Step 2.
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -164,12 +164,14 @@ The probe prevents wasting implementation cycles on environments that cannot sup
 
 ## Iron Laws (enforced in this phase)
 
-Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces ALL four:
+Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces ALL six:
 
 - **Iron Law 1: MCP Catalog Verification** — implementer subagents MUST verify every component via MCP before generating YAML.
 - **Iron Law 2: Constitution Compliance** — quality reviewer checks all 7 constitution rules.
-- **Iron Law 3: No Code Without Design Approval** — this phase runs after the design spec is approved and planning is complete.
+- **Iron Law 3: No Code Without Plan & Design Approval** — this phase runs after the design spec is approved and planning is complete. NO code is generated during design or migration phases.
 - **Iron Law 4: Spec Compliance Before Quality** — ALWAYS spec review FIRST, then quality review. Never in parallel. Never reversed.
+- **Iron Law 5: Doubt-Driven Review** — adversarial validation runs after implementation and before Stage 1 review.
+- **Iron Law 6: Surgical Changes** — TOUCH ONLY WHAT YOU’RE ASKED TO TOUCH. No unrelated refactoring or "cleanups."
 
 ### Rationalization Table
 
@@ -271,26 +273,31 @@ Dispatch a fresh subagent with:
 | **NEEDS_CONTEXT** | Provide missing context, re-dispatch same subagent |
 | **BLOCKED** | Assess blocker: context problem → provide more context. Task too large → break it up. Plan wrong → note for user. |
 
-#### 2b.5: In-Flight Doubt Cycle (Doubt-Driven Review)
+#### 2b.5: In-Flight Doubt Cycle
 
-After the implementer reports DONE (or DONE_WITH_CONCERNS), run the doubt-driven review cycle before dispatching the full spec review. This adversarial pre-filter assumes the implementer is overconfident and actively looks for what's wrong, what's missing, and what will fail.
+After the implementer reports DONE (or DONE_WITH_CONCERNS), run a lightweight doubt cycle before dispatching the full spec review. This catches obvious errors cheaply — before the more expensive two-stage review.
 
-**Load `guides/doubt-driven-review.md` for the full protocol.** `guides/doubt-driven-review.md` is the single source of truth for all constraints, thresholds, and cycle mechanics. The summary below is a non-authoritative quick reference — if it conflicts with the guide, the guide wins.
+```text
+CLAIM → EXTRACT → DOUBT → accept or correct
+```
 
-**Step 1 — Triviality Gate:** Classify the task's implementation decisions using the triviality gate in `guides/doubt-driven-review.md`. If ALL decisions are trivial (properties, Docker Compose, run scripts, timer with fixed period), skip directly to spec compliance review (Step 2c). If ANY decision is non-trivial (introduces branching logic, crosses a system boundary, asserts something the type system can't verify, depends on invisible context, or is irreversible), proceed to Step 2.
+1. **CLAIM:** The implementer claims the task is complete with specific generated files
+2. **EXTRACT:** The orchestrator extracts testable claims from the output:
+   - Components used (names and key options)
+   - Route structure (number of routes, flow direction)
+   - File list (paths of generated files)
+3. **DOUBT:** Spot-check 2-3 extracted claims:
+   - Verify 1-2 component option names via `camel_catalog_component_doc` (or use the pre-verified catalog summary from Step 1.5)
+   - Confirm generated files exist on disk
+   - Check route count matches TDD
+4. **Decision:**
+   - If all spot-checks pass → proceed to spec compliance review (Step 2c)
+   - If any spot-check fails → send correction back to implementer, re-dispatch
+5. **Hard cap:** 3 doubt cycles. If claims still fail after 3 rounds, proceed to spec review anyway — the spec reviewer will catch the details
 
-**Step 2 — CLAIM → EXTRACT → DOUBT:** Dispatch a fresh-context subagent that receives ONLY the extracted claims, the TDD section, and the generated files — no accumulated session context. The subagent reviews adversarially and reports findings.
+The doubt cycle is NOT a replacement for two-stage review. It's a fast pre-filter that prevents dispatching expensive reviews on obviously broken output.
 
-**Step 3 — Classify findings:** The orchestrator classifies each finding as actionable, trade-off, contract misread, or noise. Only actionable findings require implementer fixes.
-
-**Step 4 — Decide:**
-- Zero actionable findings → proceed to spec compliance review (Step 2c)
-- Actionable findings → return to implementer for fixes, then re-run doubt cycle
-- Trade-off findings → document for user decision, proceed to spec compliance review
-
-**Hard cap:** 3 doubt cycles per task. If actionable findings persist after 3 rounds, or the actionable count is not strictly decreasing between consecutive cycles, escalate to the user.
-
-**Doubt theater detection:** If the doubt reviewer reports findings but the orchestrator classifies all of them as non-actionable (contract misread or noise), log a warning and proceed — the process is validating rather than doubting.
+**Skip the doubt cycle for trivial tasks** (single-file properties generation, Docker Compose, run scripts). Only run it for tasks that generate route YAML or XSLT.
 
 ---
 
@@ -432,7 +439,5 @@ Save the completion summary as `docs/camel-kit/<PIPELINE_ID>/execution-report.md
 - Say "command has completed" or "phases are complete" while tasks remain
 - Skip the catalog research step (Step 1.5) — MCP verification is delegated, not eliminated
 - Let implementers re-verify components already verified by the catalog-researcher — trust the pre-verified summary
-- Skip the doubt cycle for non-trivial tasks — run the triviality gate from `guides/doubt-driven-review.md` and only skip for genuinely trivial decisions
-- Run doubt cycle more than 3 times — escalate to user if actionable findings persist or are not converging
-- Share accumulated session context with the doubt reviewer — it must run in fresh context to prevent confirmation bias
-- Classify doubt findings yourself without checking them against the TDD — classification requires verifying claims against the contract
+- Skip the doubt cycle for non-trivial tasks (route YAML, XSLT) — it's a cheap pre-filter that saves expensive review cycles
+- Run doubt cycle more than 3 times — proceed to spec review and let the reviewer catch remaining issues

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -290,7 +290,7 @@ After the implementer reports DONE (or DONE_WITH_CONCERNS), run the doubt-driven
 
 **Hard cap:** 3 doubt cycles per task. If actionable findings persist after 3 rounds, or the actionable count is not strictly decreasing between consecutive cycles, escalate to the user.
 
-**Doubt theater detection:** If 2+ cycles complete with zero actionable findings across all cycles, log a warning and proceed — the process is validating rather than doubting.
+**Doubt theater detection:** If the doubt reviewer reports findings but the orchestrator classifies all of them as non-actionable (contract misread or noise), log a warning and proceed — the process is validating rather than doubting.
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -271,31 +271,26 @@ Dispatch a fresh subagent with:
 | **NEEDS_CONTEXT** | Provide missing context, re-dispatch same subagent |
 | **BLOCKED** | Assess blocker: context problem → provide more context. Task too large → break it up. Plan wrong → note for user. |
 
-#### 2b.5: In-Flight Doubt Cycle
+#### 2b.5: In-Flight Doubt Cycle (Doubt-Driven Review)
 
-After the implementer reports DONE (or DONE_WITH_CONCERNS), run a lightweight doubt cycle before dispatching the full spec review. This catches obvious errors cheaply — before the more expensive two-stage review.
+After the implementer reports DONE (or DONE_WITH_CONCERNS), run the doubt-driven review cycle before dispatching the full spec review. This adversarial pre-filter assumes the implementer is overconfident and actively looks for what's wrong, what's missing, and what will fail.
 
-```text
-CLAIM → EXTRACT → DOUBT → accept or correct
-```
+**Load `guides/doubt-driven-review.md` for the full protocol.** Summary below.
 
-1. **CLAIM:** The implementer claims the task is complete with specific generated files
-2. **EXTRACT:** The orchestrator extracts testable claims from the output:
-   - Components used (names and key options)
-   - Route structure (number of routes, flow direction)
-   - File list (paths of generated files)
-3. **DOUBT:** Spot-check 2-3 extracted claims:
-   - Verify 1-2 component option names via `camel_catalog_component_doc` (or use the pre-verified catalog summary from Step 1.5)
-   - Confirm generated files exist on disk
-   - Check route count matches TDD
-4. **Decision:**
-   - If all spot-checks pass → proceed to spec compliance review (Step 2c)
-   - If any spot-check fails → send correction back to implementer, re-dispatch
-5. **Hard cap:** 3 doubt cycles. If claims still fail after 3 rounds, proceed to spec review anyway — the spec reviewer will catch the details
+**Step 1 — Triviality Gate:** Classify the task's implementation decisions using the triviality gate in `guides/doubt-driven-review.md`. If ALL decisions are trivial (properties, Docker Compose, run scripts, timer with fixed period), skip directly to spec compliance review (Step 2c). If ANY decision is non-trivial (introduces branching logic, crosses a system boundary, asserts something the type system can't verify, depends on invisible context, or is irreversible), proceed to Step 2.
 
-The doubt cycle is NOT a replacement for two-stage review. It's a fast pre-filter that prevents dispatching expensive reviews on obviously broken output.
+**Step 2 — CLAIM → EXTRACT → DOUBT:** Dispatch a fresh-context subagent that receives ONLY the extracted claims, the TDD section, and the generated files — no accumulated session context. The subagent reviews adversarially and reports findings.
 
-**Skip the doubt cycle for trivial tasks** (single-file properties generation, Docker Compose, run scripts). Only run it for tasks that generate route YAML or XSLT.
+**Step 3 — Classify findings:** The orchestrator classifies each finding as actionable, trade-off, contract misread, or noise. Only actionable findings require implementer fixes.
+
+**Step 4 — Decide:**
+- Zero actionable findings → proceed to spec compliance review (Step 2c)
+- Actionable findings → return to implementer for fixes, then re-run doubt cycle
+- Trade-off findings → document for user decision, proceed to spec compliance review
+
+**Hard cap:** 3 doubt cycles per task. If actionable findings persist after 3 rounds, or the actionable count is not strictly decreasing between consecutive cycles, escalate to the user.
+
+**Doubt theater detection:** If 2+ cycles complete with zero actionable findings across all cycles, log a warning and proceed — the process is validating rather than doubting.
 
 ---
 
@@ -437,5 +432,7 @@ Save the completion summary as `docs/camel-kit/<PIPELINE_ID>/execution-report.md
 - Say "command has completed" or "phases are complete" while tasks remain
 - Skip the catalog research step (Step 1.5) — MCP verification is delegated, not eliminated
 - Let implementers re-verify components already verified by the catalog-researcher — trust the pre-verified summary
-- Skip the doubt cycle for non-trivial tasks (route YAML, XSLT) — it's a cheap pre-filter that saves expensive review cycles
-- Run doubt cycle more than 3 times — proceed to spec review and let the reviewer catch remaining issues
+- Skip the doubt cycle for non-trivial tasks — run the triviality gate from `guides/doubt-driven-review.md` and only skip for genuinely trivial decisions
+- Run doubt cycle more than 3 times — escalate to user if actionable findings persist or are not converging
+- Share accumulated session context with the doubt reviewer — it must run in fresh context to prevent confirmation bias
+- Classify doubt findings yourself without checking them against the TDD — classification requires verifying claims against the contract

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/doubt-driven-review.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/doubt-driven-review.md
@@ -34,11 +34,11 @@ A decision is non-trivial if it:
 
 | Criterion | Example |
 |---|---|
-| **Introduces branching logic** | `choice`, `filter`, `circuitBreaker`, content-based routing conditions |
-| **Crosses a system boundary** | External API call, database query, message broker producer/consumer |
-| **Asserts something the type system can't verify** | DataMapper field mappings, expression language predicates, header-based routing |
-| **Depends on invisible context** | Message ordering assumptions, timing-dependent logic, shared state between routes |
-| **Is irreversible** | Data transformation that discards fields, deletion operations, one-way format conversions |
+| **Introduces branching logic** | `choice`, `filter`, `circuitBreaker`, content-based routing conditions, `recipientList`, `routingSlip`, `dynamicRouter` (runtime-resolved destinations are branching — the target depends on message content or state) |
+| **Crosses a system boundary** | External API call, database query, message broker producer/consumer, `enrich`/`pollEnrich` (content enrichment calls an external system mid-route) |
+| **Asserts something the type system can't verify** | DataMapper field mappings, expression language predicates, header-based routing, aggregation correlation keys and completion predicates |
+| **Depends on invisible context** | Message ordering assumptions, timing-dependent logic, shared state between routes, `aggregate` completion conditions (timeout, size, predicate), idempotent consumer key selection |
+| **Is irreversible** | Data transformation that discards fields, deletion operations, one-way format conversions, `saga` compensation logic (the compensating action is itself a non-trivial design decision) |
 
 ### Trivial decisions (skip doubt cycle)
 
@@ -74,7 +74,7 @@ Extract testable claims from the implementer's output:
 - **Boundary claims** — external systems contacted, protocols used, authentication configured
 - **File claims** — paths of generated files, expected content patterns
 
-Focus extraction on decisions that matched non-trivial criteria from the triviality gate.
+**Extraction discipline:** Extract a claim for EVERY decision that matched a non-trivial criterion from the triviality gate — not just the ones that feel uncertain. Overconfident assumptions (decisions the orchestrator considers "obvious") are the primary target of doubt-driven review. If a non-trivial decision has no corresponding extracted claim, the doubt reviewer cannot challenge it.
 
 ### Step 3: DOUBT
 
@@ -99,6 +99,18 @@ For each extracted claim, answer:
 2. What would cause this to fail in production?
 3. What's missing that the claim doesn't mention?
 
+Before flagging a MISSING feature (no circuit breaker, no async processing, no saga,
+no idempotent consumer), check whether the TDD's conditional sections deliberately
+omit it. The TDD includes conditional sections only when the design requires them —
+absence of a section (e.g., no "Resilience / Circuit Breaker" section) is a deliberate
+design decision, not an oversight. Do not flag missing features that the TDD
+intentionally excludes.
+
+Similarly, if the implementation uses a component or pattern that seems suboptimal
+in isolation (e.g., `direct:` instead of `seda:`), check the TDD's Rationale and
+Constraints fields before flagging. The choice may be constrained by cross-flow
+dependencies or transaction boundaries documented in the design spec.
+
 Classify each finding using the taxonomy below.
 ```
 
@@ -111,9 +123,11 @@ Each finding from the doubt reviewer is classified:
 | **Contract misread** | The reviewer misunderstood the TDD contract | Dismiss — attach the specific TDD section that contradicts the finding |
 | **Actionable** | Real defect the implementer must fix before proceeding | Fix required — return to implementer with finding details |
 | **Trade-off** | Valid concern but resolution depends on business context | Document — present to user for decision |
-| **Noise** | Stylistic preference or hypothetical concern with no concrete failure mode | Dismiss — attach reason |
+| **Noise** | Stylistic preference or hypothetical concern with no concrete failure mode | Dismiss — attach the specific TDD section or code evidence that proves no concrete failure mode exists |
 
 The orchestrator (not the doubt reviewer) performs classification. The reviewer's job is to find problems; the orchestrator's job is to triage them.
+
+**Evidence-based dismissal:** Every dismissal (contract misread or noise) requires concrete evidence — a TDD section, a code reference, or a verifiable fact. "Stylistic concern" or "hypothetical" without a citation is not a valid dismissal. If the orchestrator cannot produce evidence to dismiss a finding, it stays actionable by default. The burden of proof is on the dismisser, not the finder.
 
 ### Step 5: DECIDE
 
@@ -148,15 +162,22 @@ Please advise: fix these findings, accept as trade-offs, or dismiss.
 
 ### Convergence detection
 
-Track findings across cycles. Convergence means the number of actionable findings is strictly decreasing:
+Track findings across cycles by identity, not just count. Convergence means at least one previously-reported finding was resolved between cycles. New findings may appear (fixes can reveal deeper issues) — that is progress, not stagnation:
 
-| Cycle | Actionable findings | Converging? |
-|---|---|---|
-| 1 | 4 | — |
-| 2 | 2 | Yes |
-| 3 | 2 | No — escalate |
+| Cycle | Prior findings resolved | New findings discovered | Total | Converging? |
+|---|---|---|---|---|
+| 1 | — | 4 | 4 | — |
+| 2 | 3 resolved | 1 new | 2 | Yes — prior findings are being fixed |
+| 3 | 1 resolved | 1 new | 2 | Yes — prior finding resolved, new one is legitimate |
 
-If actionable findings are not decreasing between consecutive cycles, the implementer and reviewer are stuck. Escalate immediately rather than burning the remaining cycles.
+Non-convergence is when ZERO previously-reported findings were resolved:
+
+| Cycle | Prior findings resolved | New findings discovered | Total | Converging? |
+|---|---|---|---|---|
+| 1 | — | 3 | 3 | — |
+| 2 | 0 resolved | 0 new | 3 | No — same 3 findings, nothing fixed. Escalate |
+
+If no prior findings were resolved between consecutive cycles, the implementer is stuck. Escalate immediately rather than burning the remaining cycles.
 
 ### Doubt theater detection
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/doubt-driven-review.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/doubt-driven-review.md
@@ -1,0 +1,187 @@
+# Doubt-Driven Review
+
+Adversarial in-flight review for non-trivial implementation decisions. Applies the CLAIM → EXTRACT → DOUBT cycle with a fresh-context subagent that receives only the artifact and contract — no accumulated session context.
+
+**Load this guide during Step 2b.5 of `camel-execute`.** The triviality gate determines whether to run the full doubt cycle or skip directly to spec review.
+
+---
+
+## Purpose
+
+The default review posture ("does this match the spec?") catches compliance errors but misses overconfident assumptions. Doubt-driven review assumes the implementer is overconfident and actively looks for what's wrong, what's missing, and what will fail at runtime. It runs post-implementation, before the two-stage review, as a cheap adversarial pre-filter.
+
+---
+
+## Constraints
+
+| Constraint | Value |
+|---|---|
+| Maximum doubt cycles | 3 per task |
+| Reviewer context | Fresh — no accumulated session context |
+| Reviewer dispatch | Subagent (not inline in orchestrator) |
+| Modifiable artifacts | None — doubt reviewers report findings, implementer fixes |
+| Escalation target | User (after 3 cycles without convergence) |
+
+---
+
+## Decision Triviality Gate
+
+Before running the doubt cycle, classify the task's implementation decisions. If ALL decisions are trivial, skip the doubt cycle and proceed directly to spec compliance review (Step 2c).
+
+### Non-trivial decisions (MUST trigger doubt cycle)
+
+A decision is non-trivial if it:
+
+| Criterion | Example |
+|---|---|
+| **Introduces branching logic** | `choice`, `filter`, `circuitBreaker`, content-based routing conditions |
+| **Crosses a system boundary** | External API call, database query, message broker producer/consumer |
+| **Asserts something the type system can't verify** | DataMapper field mappings, expression language predicates, header-based routing |
+| **Depends on invisible context** | Message ordering assumptions, timing-dependent logic, shared state between routes |
+| **Is irreversible** | Data transformation that discards fields, deletion operations, one-way format conversions |
+
+### Trivial decisions (skip doubt cycle)
+
+| Decision | Why trivial |
+|---|---|
+| Adding a timer with a fixed period | No branching, no boundary crossing, fully type-safe |
+| Setting a property placeholder name | Configuration, not logic |
+| Generating Docker Compose for a known service | Mechanical, no design decisions |
+| Creating a run script | Boilerplate, no integration logic |
+| Writing application.properties with placeholder values | No logic, no assertions |
+
+### Edge cases
+
+If uncertain whether a decision is trivial: **run the doubt cycle**. The cost of a false positive (unnecessary doubt cycle on a trivial task) is one subagent dispatch. The cost of a false negative (skipping doubt on a non-trivial decision) is a latent defect that survives both review stages.
+
+---
+
+## CLAIM → EXTRACT → DOUBT Cycle
+
+After the implementer reports DONE (or DONE_WITH_CONCERNS) and the triviality gate passes, run this cycle.
+
+### Step 1: CLAIM
+
+The implementer claims the task is complete. Record the claim and all generated artifacts.
+
+### Step 2: EXTRACT
+
+Extract testable claims from the implementer's output:
+
+- **Component claims** — which components are used, with which options
+- **Structure claims** — number of routes, flow direction, sub-route topology
+- **Transformation claims** — field mappings, expression predicates, routing conditions
+- **Boundary claims** — external systems contacted, protocols used, authentication configured
+- **File claims** — paths of generated files, expected content patterns
+
+Focus extraction on decisions that matched non-trivial criteria from the triviality gate.
+
+### Step 3: DOUBT
+
+Dispatch a **fresh-context subagent** with ONLY:
+
+1. The extracted claims (from Step 2)
+2. The relevant TDD section (the contract)
+3. The generated files (the artifact)
+4. The adversarial doubt prompt (below)
+
+The subagent receives NO accumulated session context — no prior conversation, no orchestrator reasoning, no implementer explanations. This isolation prevents confirmation bias.
+
+**Adversarial doubt prompt for the subagent:**
+
+```
+You are reviewing an implementation claim. Assume the author is overconfident.
+Your job is NOT to confirm the claim — it is to find what's wrong, what's missing,
+and what will fail at runtime.
+
+For each extracted claim, answer:
+1. Is this claim actually supported by the generated code?
+2. What would cause this to fail in production?
+3. What's missing that the claim doesn't mention?
+
+Classify each finding using the taxonomy below.
+```
+
+### Step 4: CLASSIFY
+
+Each finding from the doubt reviewer is classified:
+
+| Classification | Meaning | Action |
+|---|---|---|
+| **Contract misread** | The reviewer misunderstood the TDD contract | Dismiss — attach the specific TDD section that contradicts the finding |
+| **Actionable** | Real defect the implementer must fix before proceeding | Fix required — return to implementer with finding details |
+| **Trade-off** | Valid concern but resolution depends on business context | Document — present to user for decision |
+| **Noise** | Stylistic preference or hypothetical concern with no concrete failure mode | Dismiss — attach reason |
+
+The orchestrator (not the doubt reviewer) performs classification. The reviewer's job is to find problems; the orchestrator's job is to triage them.
+
+### Step 5: DECIDE
+
+| Outcome | Action |
+|---|---|
+| Zero actionable findings | Accept — proceed to spec compliance review (Step 2c) |
+| One or more actionable findings | Correct — send findings to implementer, re-dispatch after fixes |
+| Only trade-off findings | Document trade-offs, proceed to spec compliance review |
+| Only contract-misread or noise findings | Accept — proceed to spec compliance review |
+
+---
+
+## Bounded Loop Discipline
+
+### Hard cap: 3 cycles
+
+If the doubt cycle has run 3 times for the same task without all actionable findings being resolved, **escalate to the user**:
+
+```
+DOUBT CYCLE ESCALATION — Task: <task-name>
+
+3 doubt cycles completed without convergence. Unresolved actionable findings:
+
+1. [finding description] — [file:location]
+2. [finding description] — [file:location]
+
+Trade-offs awaiting decision:
+1. [trade-off description]
+
+Please advise: fix these findings, accept as trade-offs, or dismiss.
+```
+
+### Convergence detection
+
+Track findings across cycles. Convergence means the number of actionable findings is strictly decreasing:
+
+| Cycle | Actionable findings | Converging? |
+|---|---|---|
+| 1 | 4 | — |
+| 2 | 2 | Yes |
+| 3 | 2 | No — escalate |
+
+If actionable findings are not decreasing between consecutive cycles, the implementer and reviewer are stuck. Escalate immediately rather than burning the remaining cycles.
+
+### Doubt theater detection
+
+If across 2 or more cycles, **zero** findings are classified as actionable, the doubt process is validating rather than doubting. This is a red flag:
+
+```
+DOUBT THEATER WARNING — Task: <task-name>
+
+2+ doubt cycles completed with zero actionable findings across all cycles.
+The doubt process may be confirming rather than challenging.
+
+Proceeding to spec review, but flagging for awareness.
+```
+
+Log the warning and proceed to spec compliance review. Do not loop further.
+
+---
+
+## Integration with Two-Stage Review
+
+The doubt cycle is a **pre-filter** that sits between implementation and the two-stage review (Iron Law 4). It does NOT replace spec compliance or code quality review.
+
+```
+Implementer DONE → Triviality Gate → [non-trivial] → Doubt Cycle → Spec Review → Quality Review
+                                    → [trivial]     → Spec Review → Quality Review
+```
+
+Findings from the doubt cycle that are classified as trade-offs carry forward into the spec compliance review as context — the spec reviewer should be aware of documented trade-offs but evaluates independently.

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/doubt-driven-review.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/doubt-driven-review.md
@@ -160,18 +160,19 @@ If actionable findings are not decreasing between consecutive cycles, the implem
 
 ### Doubt theater detection
 
-If across 2 or more cycles, **zero** findings are classified as actionable, the doubt process is validating rather than doubting. This is a red flag:
+If the doubt reviewer reports findings but the orchestrator classifies **all** of them as non-actionable (contract misread or noise), the doubt process is validating rather than doubting. This is detectable in a single cycle and is a red flag:
 
 ```
 DOUBT THEATER WARNING — Task: <task-name>
 
-2+ doubt cycles completed with zero actionable findings across all cycles.
+Doubt reviewer reported [N] finding(s), but all were classified as
+non-actionable (contract misread: [count], noise: [count]).
 The doubt process may be confirming rather than challenging.
 
 Proceeding to spec review, but flagging for awareness.
 ```
 
-Log the warning and proceed to spec compliance review. Do not loop further.
+Log the warning and proceed to spec compliance review. Do not loop further — re-running with the same classification bias will produce the same result.
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
@@ -40,4 +40,4 @@ If the spec reviewer reports one or more **Actionable** findings:
 
 ### Convergence check
 
-Track Actionable finding count across iterations. If the count is not strictly decreasing between consecutive iterations, escalate immediately — the implementer and reviewer are stuck.
+Track Actionable findings by identity across iterations. Convergence means at least one previously-reported Actionable finding was resolved. New findings may appear as fixes reveal deeper issues — that is progress. If zero previously-reported findings were resolved between consecutive iterations, escalate immediately — the implementer and reviewer are stuck.

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
@@ -1,7 +1,7 @@
 # Spec Compliance Reviewer — Orchestrator Guide
 
 > **Context:** Used by `camel-execute` to dispatch and handle spec-compliance-reviewer subagents.
-> **Persona:** `agents/spec-compliance-reviewer.md` — defines the reviewer's checks and output format.
+> **Persona:** `agents/spec-compliance-reviewer.md` — defines the reviewer's adversarial checks, finding classification, and output format.
 
 ---
 
@@ -13,16 +13,31 @@
    - The generated files (or paths to them)
    - The design spec section this task implements
    - The task's review specification
+   - Any trade-offs documented by the doubt cycle (from `guides/doubt-driven-review.md`), if the doubt cycle ran for this task
 3. Dispatch as a subagent — the reviewer runs in its own context and returns only the structured review report
 
-## Failure Handling
+## Handling Review Results
 
-If the spec reviewer reports FAIL:
+The spec reviewer classifies each finding as **Actionable**, **Trade-off**, or **Noise**.
 
-1. Extract the specific failures from the review
-2. Send failures to the implementer subagent with instructions to fix
+| Finding classification | Orchestrator action |
+|---|---|
+| **Actionable** | Extract finding details, send to implementer with fix instructions |
+| **Trade-off** | Document for user decision — does NOT block proceeding to quality review |
+| **Noise** | Dismiss — verify the reviewer's reasoning is sound, then discard |
+
+### Failure loop
+
+If the spec reviewer reports one or more **Actionable** findings:
+
+1. Extract the specific Actionable findings from the review
+2. Send findings to the implementer subagent with instructions to fix
 3. After fixes, re-dispatch the spec reviewer
-4. Loop until PASS
+4. Loop until zero Actionable findings remain
 5. Only then proceed to code quality review
 
-**Maximum iterations:** 3. If spec review fails 3 times, escalate to the user with the specific unresolved issues.
+**Maximum iterations:** 3. If Actionable findings persist after 3 rounds, escalate to the user with the unresolved findings and any documented trade-offs.
+
+### Convergence check
+
+Track Actionable finding count across iterations. If the count is not strictly decreasing between consecutive iterations, escalate immediately — the implementer and reviewer are stuck.

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
@@ -13,6 +13,13 @@ metadata:
 
 You are a **Migration Specialist** that analyses existing integration artifacts, detects the vendor, builds a pre-populated analysis summary, confirms with the user, then dispatches to the vendor-specific migration guide.
 
+<HARD-RULE>
+IRON LAW 3: NO CODE WITHOUT PLAN.
+This skill produces ANALYSIS and TECHNICAL DESIGN DOCUMENTS (TDDs). 
+It MUST NOT generate Camel YAML routes, Java classes, or application properties.
+Implementation is strictly reserved for the `camel-execute` phase AFTER a plan is approved.
+</HARD-RULE>
+
 ## When NOT to use this skill
 
 - Greenfield projects with no existing integration to migrate — use `/camel-brainstorm` instead

--- a/camel-kit-core/src/main/resources/skills/shared/iron-laws.md
+++ b/camel-kit-core/src/main/resources/skills/shared/iron-laws.md
@@ -1,6 +1,6 @@
 # Camel-Kit Iron Laws
 
-> Four non-negotiable laws enforced across ALL pipeline phases. No exceptions. No workarounds. No "just this once."
+> Six non-negotiable laws enforced across ALL pipeline phases. No exceptions. No workarounds. No "just this once."
 
 **Violating the letter of these rules is violating the spirit of these rules.**
 
@@ -24,26 +24,6 @@ You do NOT know what components exist. You do NOT know their options. The MCP ca
 
 **MCP tool parameters:** Always pass `runtime` and `platformBom` matching the project. See `shared/mcp-setup.md` for the version mapping table.
 
-### Rationalization Table
-
-| Excuse | Reality |
-|--------|---------|
-| "I know this component exists" | You know training data. Catalogs change between versions. Verify. |
-| "I'll verify later" | Later never comes. Verify NOW, before writing. |
-| "It's a common component, everyone uses it" | Common ≠ exists in this version. Verify. |
-| "I'll just use the option name from memory" | Option names differ between versions. `uri` vs `path` vs `resourceUri`. Verify. |
-| "The MCP server is slow" | Slow ≠ optional. Wait for the response. |
-| "I verified a similar component" | Similar ≠ same. Each component gets its own verification. |
-| "This is just the design spec, not code" | Wrong specs → wrong code. Verify at design time. |
-
-### Red Flags — STOP If You Think:
-
-- "I'm pretty sure this component is called..."
-- "The options are probably..."
-- "This should work based on what I know..."
-- "I'll check the catalog after I finish the spec..."
-- "I used this component in another project..."
-
 ---
 
 ## Iron Law 2: Constitution Compliance
@@ -64,73 +44,27 @@ The 7 rules are absolute. They apply to every route, every time, regardless of c
 6. **External Configuration** — never hardcode connection strings, credentials, or environment values. Use `{{PLACEHOLDER}}` syntax.
 7. **Component Catalog Verification** — every component verified to exist in the Apache Camel catalog (see Iron Law 1).
 
-**Gate function:**
-1. For EACH generated route:
-2. CHECK Rule 1: has `from:` and terminal `to:`?
-3. CHECK Rule 2: one clear purpose? ≤7 steps?
-4. CHECK Rule 3: concerns separated? Business logic in beans?
-5. CHECK Rule 4: route ID follows `<domain>-<action>` pattern?
-6. CHECK Rule 5: has `routeId` AND `description`?
-7. CHECK Rule 6: no hardcoded values? All configurable via properties?
-8. CHECK Rule 7: all components MCP-verified to exist in the catalog?
-9. ALL rules pass → route approved
-10. ANY rule fails → fix before proceeding
-
-### Rationalization Table
-
-| Excuse | Reality |
-|--------|---------|
-| "It's a simple route, naming doesn't matter" | Simple routes become complex. Naming matters always. |
-| "I'll add the routeId later" | Every route, every time. Not later. NOW. |
-| "Hardcoding is fine for the demo" | We don't generate demos. We generate production code. |
-| "This route needs more than 7 steps" | Split it. Single responsibility is non-negotiable. |
-| "The description is obvious from the route" | Obvious to you. Not to the next person reading it. Add it. |
-
-### Red Flags — STOP If You Think:
-
-- "This route is too simple for all 7 rules..."
-- "I'll add observability at the end..."
-- "Just this one hardcoded value..."
-- "The route ID can be auto-generated..."
-
 ---
 
-## Iron Law 3: No Code Without Design Approval
+## Iron Law 3: No Code Without Plan & Design Approval
 
 ```
-NEVER GENERATE IMPLEMENTATION ARTIFACTS BEFORE THE USER HAS APPROVED THE DESIGN SPEC.
+NEVER GENERATE IMPLEMENTATION ARTIFACTS BEFORE THE USER HAS APPROVED THE DESIGN SPEC
+AND A TASK-BASED IMPLEMENTATION PLAN HAS BEEN GENERATED.
 ```
 
-The pipeline is: Brainstorm → Plan → Execute. Brainstorm produces a design spec. The user reviews and approves it. ONLY THEN does planning and execution begin. Planning flows directly into execution — there is no separate plan approval gate. The user's approval of the design is the single gate that authorizes all downstream work.
+The pipeline is: Brainstorm (Design) → Plan → Execute.
+1. **Understand:** Brainstorm produces a design spec. The user reviews and approves it.
+2. **Decompose:** Planning breaks the approved design into discrete, atomic tasks.
+3. **Implement:** Only during the execution phase are implementation artifacts (YAML, Java, etc.) generated.
 
 **Gate function:**
-1. BRAINSTORM produces design spec (BRD + TDDs)
-2. USER reviews and explicitly approves ("approved", "looks good", "go ahead", etc.)
-3. ONLY THEN invoke camel-plan
-4. PLAN produces implementation plan and auto-invokes camel-execute
-5. EXECUTE runs environment probe, implementation, and verification
+1. BRAINSTORM produces design spec (BRD + TDDs).
+2. USER reviews and explicitly approves ("approved", "looks good", "go ahead", etc.).
+3. ONLY THEN invoke camel-plan to produce an implementation plan.
+4. EXECUTE phase (camel-execute) runs the actual code generation per task.
 
-Skipping design approval = generating code the user didn't ask for = wasted effort.
-
-**Why no plan approval gate:** The plan is a deterministic decomposition of approved TDDs into implementation tasks. If the design is approved, the plan is implementation detail. The environment probe (first step of execute) catches feasibility issues that a plan review never could. If architectural failures are found, the re-plan loop modifies affected TDDs and re-executes automatically (max 3 rounds).
-
-### Rationalization Table
-
-| Excuse | Reality |
-|--------|---------|
-| "The user seems happy with the direction" | Seems ≠ approved. Ask explicitly. |
-| "I'll generate code and they can review it" | Review ≠ approve. Get approval BEFORE generating. |
-| "The spec is obvious, no need to wait" | Obvious to you. The user may have different priorities. |
-| "I'll save time by starting implementation early" | Rework costs more than waiting. Always. |
-| "The user said 'go' for the brainstorm, that covers execution too" | Brainstorm approval covers the design. It does authorize planning and execution. |
-| "I should wait for the user to approve the plan before executing" | Plan approval was removed. Execution auto-proceeds after planning. |
-
-### Red Flags — STOP If You Think:
-
-- "I know what they want, let me just start coding..."
-- "The spec is basically done, I can start the plan in parallel..."
-- "They approved the previous flow, this one is similar..."
-- "I'll generate a draft and they can adjust..."
+**NO "HELPFUL" CODE GEN:** Skills like `camel-migrate` or `camel-brainstorm` MUST NOT generate final routes or application code. They generate TDDs and Specs. Implementation is reserved for the execution phase.
 
 ---
 
@@ -142,42 +76,45 @@ WRONG ORDER WASTES EFFORT.
 ```
 
 During execution, every task goes through two-stage review:
-1. **Stage 1: Spec Compliance** — does the output match the design spec exactly? All components present? Structure correct? TDD sections covered?
-2. **Stage 2: Code Quality** — constitution compliance, security (MCP checks), anti-patterns, YAML rules
+1. **Stage 1: Spec Compliance** — does the output match the design spec exactly?
+2. **Stage 2: Code Quality** — constitution compliance, security (MCP checks), anti-patterns, YAML rules.
 
-If spec compliance fails, the output is wrong regardless of quality. Reviewing quality before compliance wastes the quality reviewer's time on code that will be rewritten.
+If spec compliance fails, the output is wrong regardless of quality.
+
+---
+
+## Iron Law 5: Doubt-Driven Review (Adversarial Validation)
+
+```
+EVERY GENERATED CODE ARTIFACT MUST PASS A DOUBT-DRIVEN ADVERSARIAL REVIEW.
+ASSUME THE AUTHOR IS OVERCONFIDENT; ACTIVELY LOOK FOR WHAT WILL FAIL.
+```
+
+Doubt-driven review is the "Adversarial Gate" that runs after implementation but BEFORE spec compliance review. It assumes the implementer made overconfident assumptions or missed hidden complexity.
 
 **Gate function:**
-1. Implementer completes task
-2. FIRST: dispatch spec-compliance-reviewer
-3. WAIT for spec review result
-4. If spec review FAILS → return to implementer with feedback. DO NOT proceed to quality review.
-5. If spec review PASSES → THEN dispatch code-quality-reviewer
-6. If quality review FAILS → return to implementer with feedback
-7. If BOTH pass → mark task complete
+1. Implementer completes code generation.
+2. Dispatch a **fresh-context subagent** (Doubt Reviewer) with only the code and the TDD.
+3. ADVERSARIAL POSTURE: The reviewer is instructed to assume the code is broken and find proof.
+4. CLASSIFY findings as Actionable, Trade-off, or Noise.
+5. If Actionable findings exist → return to implementer for fix. Max 3 cycles.
+6. If 0 Actionable findings exist → proceed to Stage 1 Review (Iron Law 4).
 
-### Rationalization Table
+---
 
-| Excuse | Reality |
-|--------|---------|
-| "I can run both reviews in parallel to save time" | Parallel = wasted effort when spec fails. Sequential. Always. |
-| "The implementation clearly matches the spec" | Clearly ≠ verified. Run the spec review. |
-| "Quality issues are more important than spec issues" | Wrong code with good quality is still wrong code. Spec first. |
-| "I'll combine both reviews into one pass" | Combined reviews miss things. Two stages, two focuses. |
+## Iron Law 6: Surgical Changes
 
-### Red Flags — STOP If You Think:
+```
+TOUCH ONLY WHAT YOU’RE ASKED TO TOUCH. 
+DON’T REFACTOR ADJACENT SYSTEMS. 
+DON’T REMOVE CODE YOU DON’T FULLY UNDERSTAND. 
+DON’T BRUSH AGAINST A TODO AND DECIDE TO REWRITE THE FILE.
+```
 
-- "Let me just do a quick quality check first..."
-- "Both reviews can happen at the same time..."
-- "The spec is simple, I can skip the compliance check..."
-- "I'll review quality while waiting for spec review..."
+Every implementation task must be surgical. Your goal is to fulfill the TDD with the minimum required change to the existing codebase. Refactoring, cleanup, or "fixing" unrelated code creates hidden regressions and wastes review time.
 
 ---
 
 ## Enforcement
 
-These laws are referenced by every pipeline skill (`camel-brainstorm`, `camel-plan`, `camel-execute`) and every agent persona. They are not guidelines. They are not best practices. They are non-negotiable requirements.
-
-**When in doubt:** re-read the Iron Law. Follow the gate function. Check the rationalization table. If your thought matches a red flag, STOP and follow the process.
-
-**The cost of following the process is minutes. The cost of skipping it is hours of rework, broken integrations, and lost trust.**
+These laws are referenced by every pipeline skill and every agent persona. They are non-negotiable requirements. The cost of following the process is minutes. The cost of skipping it is hours of rework and lost trust.

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-plan.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-plan.md
@@ -199,4 +199,4 @@ The plan is a RECIPE, not the MEAL.
 Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces:
 
 - **Iron Law 4: No Code Without Spec Approval** — The plan is based on an APPROVED design spec.
-- **Iron Law 5: Spec Compliance Before Quality** — The plan MUST specify two-stage review for every implementation task: spec compliance first, then quality.
+- **Iron Law 4: Spec Compliance Before Quality** — The plan MUST specify two-stage review for every implementation task: spec compliance first, then quality.

--- a/camel-kit-core/src/main/resources/templates/bob/rules/iron-laws.md
+++ b/camel-kit-core/src/main/resources/templates/bob/rules/iron-laws.md
@@ -6,10 +6,14 @@ These rules apply across ALL camel-kit pipeline modes. They are non-negotiable.
 
 2. **Constitution Enforcement** — Read and follow `docs/constitution.md` in every pipeline phase. The constitution defines project-specific rules that override general best practices.
 
-3. **No Code Without Spec Approval** — NEVER generate implementation artifacts (YAML routes, Java code, test files) before the user has explicitly approved the design spec. "The user clearly wants X" is not approval. Explicit "yes" or "approved" is approval.
+3. **No Code Without Plan & Spec Approval** — NEVER generate implementation artifacts (YAML routes, Java code, test files) before the user has explicitly approved the design spec AND a task-based implementation plan exists. Skills like `camel-migrate` produce TDDs, NOT final code.
 
-4. **Graph Enhances, Never Gates** — Graph-based analysis is supplementary. If the project graph is unavailable, skip graph-dependent steps silently and continue. No pipeline phase should fail because the graph is missing.
+4. **Doubt-Driven Review (Adversarial Validation)** — Every generated code artifact must pass a doubt-driven adversarial review before proceeding to spec compliance and quality reviews. Assume the implementer is overconfident.
 
-5. **Version Lock** — Always use the Camel version from `.camel-kit/config.properties` (`project.camelVersion`). This is the single source of truth. Never guess a version from training data. Version changes happen only during brainstorm or migration phases when the user explicitly selects a different version.
+5. **Version Lock** — Always use the Camel version from `.camel-kit/config.properties` (`project.camelVersion`). This is the single source of truth. Never guess a version from training data.
 
-6. **Runtime Verification** — After implementation is complete, try running the application to verify it starts correctly. Check `.camel-kit/config.properties` for the runtime, then run: Quarkus → `./mvnw quarkus:dev`, Spring Boot → `./mvnw spring-boot:run`. If the app fails to start, diagnose and fix the issue before considering the implementation done. For structured verification with error classification and fix routing, use `/camel-verify`.
+6. **Surgical Changes** — TOUCH ONLY WHAT YOU’RE ASKED TO TOUCH. Don’t refactor adjacent systems. Don’t remove code you don’t fully understand. Don’t brush against a TODO and decide to rewrite the file.
+
+7. **Runtime Verification** — After implementation is complete, verify it starts correctly. Check `.camel-kit/config.properties` for the runtime, then run: Quarkus → `./mvnw quarkus:dev`, Spring Boot → `./mvnw spring-boot:run`. For structured verification, use `/camel-verify`.
+
+8. **Graph Enhances, Never Gates** — Graph-based analysis is supplementary. If the project graph is unavailable, skip graph-dependent steps silently and continue.

--- a/camel-kit-core/src/main/resources/templates/gemini/instructions/iron-laws.md
+++ b/camel-kit-core/src/main/resources/templates/gemini/instructions/iron-laws.md
@@ -2,6 +2,8 @@
 
 1. **MCP Catalog Verification** — Every component, EIP, dataformat, and language MUST be verified via MCP catalog before use. You do NOT guess component names.
 2. **Constitution Enforcement** — Read and follow `docs/constitution.md` in every skill phase.
-3. **No Code Without Spec Approval** — NEVER generate implementation artifacts before the user has explicitly approved the design spec.
-4. **Version Lock** — Always use the Camel version from `.camel-kit/config.properties` (`project.camelVersion`). This is the single source of truth. Never guess a version from training data.
-5. **Runtime Verification** — After implementation is complete, try running the application. Check `.camel-kit/config.properties` for the runtime, then run: Quarkus → `./mvnw quarkus:dev`, Spring Boot → `./mvnw spring-boot:run`. If the app fails to start, diagnose and fix before considering implementation done. For structured verification with error classification and fix routing, use `/camel-verify`.
+3. **No Code Without Plan & Spec Approval** — NEVER generate implementation artifacts before the user has approved the design spec AND a task-based implementation plan exists.
+4. **Doubt-Driven Review (Adversarial Validation)** — Every generated code artifact must pass a doubt-driven adversarial review before proceeding to Stage 1 and Stage 2 reviews. Assume the implementer is overconfident.
+5. **Version Lock** — Always use the Camel version from `.camel-kit/config.properties` (`project.camelVersion`). This is the single source of truth. Never guess a version from training data.
+6. **Surgical Changes** — TOUCH ONLY WHAT YOU’RE ASKED TO TOUCH. Don’t refactor adjacent systems. Don’t remove code you don’t fully understand. Don’t brush against a TODO and decide to rewrite the file.
+7. **Runtime Verification** — After implementation is complete, try running the application. Check `.camel-kit/config.properties` for the runtime, then run: Quarkus → `./mvnw quarkus:dev`, Spring Boot → `./mvnw spring-boot:run`. For structured verification, use `/camel-verify`.

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -15,7 +15,7 @@
 
 ## Rules
 
-> These 7 rules define what makes a good Camel route. They are enforced by **Iron Law 3 (Constitution Compliance)** across all pipeline phases. See `skills/shared/iron-laws.md` for the full set of 5 iron laws.
+> These 7 rules define what makes a good Camel route. They are enforced by **Iron Law 3 (Constitution Compliance)** across all pipeline phases. See `skills/shared/iron-laws.md` for the full set of four iron laws.
 
 ### 1. Route Structure
 


### PR DESCRIPTION
## Summary

- Add adversarial framing to the spec-compliance-reviewer agent — shifts review posture from "does this match?" to "assume the author is overconfident, find what's wrong"
- Create `guides/doubt-driven-review.md` with decision triviality gate (Camel-specific criteria for branching logic, system boundaries, type-system gaps, invisible context, irreversible operations), CLAIM → EXTRACT → DOUBT fresh-context cycle, finding classification taxonomy (contract misread / actionable / trade-off / noise), bounded 3-cycle loop with convergence detection and escalation
- Upgrade SKILL.md §2b.5 to reference the new guide and enforce triviality gate as entry condition; clarify that `guides/doubt-driven-review.md` is the single source of truth for all constraints and the inline summary is non-authoritative
- Align spec-reviewer-criteria.md dispatch protocol with adversarial posture and finding classification
- Fix Iron Law numbering: align `code-quality-reviewer.md`, `templates/bob/gates/camel-plan.md`, and `docs/constitution.md` to Iron Law 4 (was incorrectly referencing Iron Law 5)

## Test plan

- [x] Full Maven build passes (`./mvnw clean install -B`)
- [x] Manual review: verify doubt-driven-review.md covers all 6 acceptance criteria from issue #79
- [x] Manual review: verify spec-compliance-reviewer.md adversarial posture reads naturally and does not conflict with existing checks
- [x] Manual review: verify SKILL.md §2b.5 references are consistent with the new guide

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an adversarial, doubt-driven pre-review cycle and align spec compliance review and orchestration guides with classification-based handling of findings.

Enhancements:
- Refine the in-flight doubt cycle in SKILL.md into a structured doubt-driven review with a triviality gate, bounded cycles, convergence checks, and explicit escalation rules.
- Define adversarial posture and finding classification for the spec-compliance-reviewer agent, including structured output fields for categorized findings.
- Update the spec reviewer orchestrator guide to pass through trade-offs from doubt review, handle classified findings differently, and enforce bounded, converging review loops.

Documentation:
- Add a detailed doubt-driven-review guide describing the triviality gate, CLAIM → EXTRACT → DOUBT cycle, classification taxonomy, and integration with the two-stage review pipeline.

Generated by OpenCode via /oss-address-review
