### PR TITLE
fix #84: add graph-accelerated analysis for MuleSoft and BizTalk migrations

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -98,7 +98,10 @@ digraph brainstorm {
         label="Migration Path";
         mg_discovery [label="Load migration-discovery.md\nScan artifacts, detect vendor", shape=box];
         mg_graph [label="Project graph available?", shape=diamond];
-        mg_graph_analysis [label="Load migration-graph-analysis.md\nGraph-accelerated analysis", shape=box];
+        mg_vendor [label="Detect vendor from\ngraph stats nodesByType", shape=diamond];
+        mg_graph_camel [label="Load migration-graph-analysis.md\nCamel graph analysis", shape=box];
+        mg_graph_mule [label="Load migration-mule-graph-analysis.md\nMuleSoft graph analysis", shape=box];
+        mg_graph_biztalk [label="Load migration-biztalk-graph-analysis.md\nBizTalk graph analysis", shape=box];
         mg_confirm [label="Confirm analysis with user\nFill unknowns", shape=box];
     }
     
@@ -115,9 +118,15 @@ digraph brainstorm {
     gf_interview -> version;
     
     mg_discovery -> mg_graph;
-    mg_graph -> mg_graph_analysis [label="yes"];
+    mg_graph -> mg_vendor [label="yes"];
     mg_graph -> mg_confirm [label="no"];
-    mg_graph_analysis -> mg_confirm;
+    mg_vendor -> mg_graph_camel [label="CAMEL_ROUTE"];
+    mg_vendor -> mg_graph_mule [label="MULE_FLOW"];
+    mg_vendor -> mg_graph_biztalk [label="BIZTALK_ORCHESTRATION"];
+    mg_vendor -> mg_confirm [label="unknown"];
+    mg_graph_camel -> mg_confirm;
+    mg_graph_mule -> mg_confirm;
+    mg_graph_biztalk -> mg_confirm;
     mg_confirm -> version;
     
     version -> design;

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-biztalk-graph-analysis.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-biztalk-graph-analysis.md
@@ -1,0 +1,245 @@
+# BizTalk Migration Graph Analysis Guide
+
+> **Context:** Loaded by `migration-discovery.md` when `.camel-kit/project-graph.json` exists and contains `BIZTALK_ORCHESTRATION` nodes.
+> **Purpose:** Replace manual `.odx`/`.btm`/`.btp` deep-dives with instant graph queries for accelerated BizTalk migration analysis.
+> **Output:** `.camel-kit/project-snapshot.md` + pre-populated analysis summary for user confirmation.
+
+This guide uses CLI commands under `{COMMAND_PREFIX} graph`. If any command fails (exit code != 0), fall back gracefully — skip that section and note it as `? Unknown` in the summary.
+
+<HARD-RULE>
+NEVER read `.camel-kit/project-graph.json` directly. Always use `{COMMAND_PREFIX} graph` CLI commands. The JSON file is thousands of lines and will overflow your context window.
+</HARD-RULE>
+
+Read `.camel-kit/config.properties` to get the `project.command-prefix` property (default: `camel-kit`).
+
+---
+
+## Step 0.1 — Project Overview
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph stats
+```
+
+This returns JSON with the project's structural summary. For a BizTalk project, expect node types like `BIZTALK_ORCHESTRATION`, `BIZTALK_SHAPE`, `BIZTALK_MAP`, `BIZTALK_FUNCTOID`, `BIZTALK_SCHEMA`, `BIZTALK_PIPELINE`, `BIZTALK_PIPELINE_COMPONENT`, `BIZTALK_PORT`, `BIZTALK_ADAPTER`, and `BIZTALK_MESSAGE`.
+
+Record:
+- Total node and edge counts
+- Number of orchestrations, shapes, maps, functoids
+- Number of schemas, pipelines, pipeline components
+- Number of ports, adapters, messages
+
+---
+
+## Step 0.2 — Orchestration Inventory
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_ORCHESTRATION
+```
+
+For each orchestration, query its children:
+```bash
+{COMMAND_PREFIX} graph neighbors <orchestrationId> --direction out --edge-type BIZTALK_ORCHESTRATION_CONTAINS
+```
+
+This returns `BIZTALK_SHAPE`, `BIZTALK_PORT`, and `BIZTALK_MESSAGE` nodes. For each orchestration, list:
+- Orchestration name and source file
+- Shapes in order (Receive, Send, Decide, Transform, Construct Message, Expression, Loop, etc.)
+- Ports (Receive Ports, Send Ports) with adapter types
+- Messages with their schemas
+
+---
+
+## Step 0.3 — Map & Schema Inventory
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_MAP
+```
+
+For each map, query its schema references and functoid chains:
+```bash
+{COMMAND_PREFIX} graph neighbors <mapId> --direction out --edge-type BIZTALK_USES_SCHEMA
+{COMMAND_PREFIX} graph neighbors <mapId> --direction out --edge-type BIZTALK_FUNCTOID_CHAIN
+```
+
+List all schemas:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_SCHEMA
+```
+
+For each map, record:
+- Source schema and target schema
+- Functoids used (from `BIZTALK_FUNCTOID` nodes)
+- Complexity rating:
+  - Simple: No functoids (direct links only)
+  - Medium: Basic functoids (String, Math, Logical)
+  - Complex: Scripting functoids, Database Lookup, custom XSLT
+
+Which orchestration shapes reference each map:
+```bash
+{COMMAND_PREFIX} graph neighbors <mapId> --direction in --edge-type BIZTALK_USES_MAP
+```
+
+---
+
+## Step 0.4 — Pipeline Inventory
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_PIPELINE
+```
+
+For each pipeline, query its stages and components:
+```bash
+{COMMAND_PREFIX} graph neighbors <pipelineId> --direction out --edge-type BIZTALK_PIPELINE_STAGE
+```
+
+Record:
+- Pipeline name and type (Receive or Send)
+- Components per stage (XML Disassembler, JSON Encoder, MIME Decoder, etc.)
+- Custom components (flag for manual review)
+
+---
+
+## Step 0.5 — Port & Adapter Inventory
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_PORT
+```
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_ADAPTER
+```
+
+For each port, check its adapter bindings:
+```bash
+{COMMAND_PREFIX} graph neighbors <portId> --direction out --edge-type BIZTALK_PORT_BINDING
+```
+
+Record:
+- Port name, direction (Receive/Send), and adapter type
+- Adapter configuration (protocol, address, authentication)
+- Port-to-pipeline assignments
+
+---
+
+## Step 0.6 — Orchestration Call Graph
+
+Check for inter-orchestration calls:
+```bash
+{COMMAND_PREFIX} graph find --type BIZTALK_ORCHESTRATION
+```
+
+For each orchestration, check outbound call edges:
+```bash
+{COMMAND_PREFIX} graph neighbors <orchestrationId> --direction out --edge-type BIZTALK_CALLS_ORCHESTRATION
+```
+
+Build the orchestration-to-orchestration call graph. This reveals:
+- Which orchestrations call sub-orchestrations
+- Shared orchestrations invoked by multiple callers
+- Independent orchestrations with no inter-orchestration dependencies
+
+---
+
+## Step 0.7 — Structural Analysis
+
+Using the orchestration call graph and port/adapter data:
+
+1. **Entry-point orchestrations:** Have Receive Ports with external adapters (FILE, HTTP, FTP, MSMQ, etc.)
+2. **Sub-orchestrations:** Called only via `BIZTALK_CALLS_ORCHESTRATION` from other orchestrations
+3. **Leaf orchestrations:** No outbound `BIZTALK_CALLS_ORCHESTRATION` edges
+
+**Migration ordering** — reverse dependency order:
+1. Sub-orchestrations first (can be migrated as independent Camel routes)
+2. Orchestrations depending only on already-migrated sub-orchestrations
+3. Entry-point orchestrations last
+
+**Structural warnings:**
+- **Orphaned orchestrations:** No Receive Port and no inbound `BIZTALK_CALLS_ORCHESTRATION` edges
+- **Complex maps:** Maps with Scripting functoids or Database Lookup (require manual conversion)
+- **Custom pipeline components:** `BIZTALK_PIPELINE_COMPONENT` nodes not matching standard BizTalk components
+- **Unresolved references:** Shapes referencing maps that have no corresponding `BIZTALK_MAP` node
+- **Proprietary adapters:** Adapters with no direct Camel equivalent (MSMQ, WCF-Custom, third-party)
+
+---
+
+## Step 0.8 — Persist Snapshot & Build Summary
+
+Write to `.camel-kit/project-snapshot.md`:
+
+```markdown
+# Project Snapshot
+
+Generated: [timestamp]
+Graph: .camel-kit/project-graph.json
+Source Platform: Microsoft BizTalk Server [version]
+
+## Project Overview
+- Orchestrations: [N] | Shapes: [N] | Maps: [N] | Functoids: [N]
+- Schemas: [N] | Pipelines: [N] | Pipeline Components: [N]
+- Ports: [N] | Adapters: [N] | Messages: [N]
+
+## Orchestration Inventory
+| Orchestration | File | Receive Ports | Send Ports | Shapes | Maps Used |
+|---------------|------|---------------|------------|--------|-----------|
+| [name] | [file] | [port names] | [port names] | [count] | [map names] |
+
+## Orchestration Call Graph
+| Orchestration | Calls | Called By |
+|---------------|-------|----------|
+| [name] | [sub-orch names or —] | [caller names or —] |
+
+## Map Complexity Assessment
+| Map Name | Source Schema | Target Schema | Functoid Count | Complexity | Manual Review |
+|----------|--------------|---------------|----------------|------------|---------------|
+| [name] | [schema] | [schema] | [count] | Simple/Medium/Complex | [yes/no] |
+
+## Pipeline Inventory
+| Pipeline | Type | Stages | Components | Custom |
+|----------|------|--------|------------|--------|
+| [name] | Receive/Send | [stage list] | [component list] | [yes/no] |
+
+## Port & Adapter Inventory
+| Port | Direction | Adapter Type | Protocol | Orchestration |
+|------|-----------|-------------|----------|---------------|
+| [name] | Receive/Send | [adapter] | [protocol] | [orch name] |
+
+## Migration Ordering
+1. [sub-orchestration name] (leaf — no outbound calls)
+2. [orchestration name] (depends on [sub-orch names])
+...
+
+## Structural Warnings
+- [any complex maps, custom pipelines, proprietary adapters, orphaned orchestrations]
+
+## Dependencies
+| GroupId | ArtifactId | Version |
+|---------|-----------|---------|
+| [groupId] | [artifactId] | [version] |
+```
+
+Build the pre-populated analysis summary:
+
+```
+MIGRATION ANALYSIS SUMMARY
+===========================================================
+Vendor & Version:    Microsoft BizTalk Server [version from graph]
+Source Product:      Microsoft BizTalk Server
+Orchestrations:      [N] orchestration(s) detected
+Maps:                [M] map(s) detected ([X] complex)
+Pipelines:           [P] pipeline(s) detected
+Failure Behaviour:   [inferred from error handler shapes]
+Target Camel:        Camel version (default: latest)
+Target Runtime:      [to be selected]
+API Compatibility:   Assumed (same HTTP paths, queue names, contracts)
+Project Layout:      [single or multi from graph]
+Flows to migrate:    ALL ([N] orchestrations with migration ordering)
+===========================================================
+```
+
+**Return to `migration-discovery.md` Step 5** for user confirmation, then Step 5a (concerns wizard), Step 5b (clarifications wizard), and Step 5c (proceed gate).

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-discovery.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-discovery.md
@@ -42,8 +42,16 @@ Check if `.camel-kit/project-graph.json` exists (check existence only — do NOT
 NEVER read `.camel-kit/project-graph.json` directly. It is a large JSON file (thousands of lines) that will overflow your context window. Always use `{COMMAND_PREFIX} graph` CLI commands to query the graph.
 </HARD-RULE>
 
-- **If yes:** Load `guides/migration-graph-analysis.md` for accelerated analysis. The graph provides instant route topology, component inventory, and migration ordering via CLI commands. Skip Steps 2-4 (the graph covers them).
-- **If no:** Continue with manual scanning below.
+- **If no:** Continue with manual scanning below (Steps 2-4).
+- **If yes:** Run `{COMMAND_PREFIX} graph stats` and inspect the `nodesByType` field to detect the vendor, then load the correct guide. Skip Steps 2-4 (the graph covers them).
+
+| Node type in stats | Vendor | Guide to load |
+|--------------------|--------|---------------|
+| `CAMEL_ROUTE` | Apache Camel | `guides/migration-graph-analysis.md` |
+| `MULE_FLOW` | MuleSoft Mule | `guides/migration-mule-graph-analysis.md` |
+| `BIZTALK_ORCHESTRATION` | Microsoft BizTalk | `guides/migration-biztalk-graph-analysis.md` |
+
+If the graph contains none of these node types, it may be incomplete or from an unsupported vendor. Continue with manual scanning below (Steps 2-4).
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-mule-graph-analysis.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-mule-graph-analysis.md
@@ -1,0 +1,234 @@
+# MuleSoft Migration Graph Analysis Guide
+
+> **Context:** Loaded by `migration-discovery.md` when `.camel-kit/project-graph.json` exists and contains `MULE_FLOW` nodes.
+> **Purpose:** Replace manual XML deep-dives with instant graph queries for accelerated MuleSoft migration analysis.
+> **Output:** `.camel-kit/project-snapshot.md` + pre-populated analysis summary for user confirmation.
+
+This guide uses CLI commands under `{COMMAND_PREFIX} graph`. If any command fails (exit code != 0), fall back gracefully — skip that section and note it as `? Unknown` in the summary.
+
+<HARD-RULE>
+NEVER read `.camel-kit/project-graph.json` directly. Always use `{COMMAND_PREFIX} graph` CLI commands. The JSON file is thousands of lines and will overflow your context window.
+</HARD-RULE>
+
+Read `.camel-kit/config.properties` to get the `project.command-prefix` property (default: `camel-kit`).
+
+---
+
+## Step 0.1 — Project Overview
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph stats
+```
+
+This returns JSON with the project's structural summary. For a MuleSoft project, expect node types like `MULE_FLOW`, `MULE_SUB_FLOW`, `MULE_ENDPOINT`, `MULE_CONNECTOR`, `MULE_PROCESSOR`, `MULE_TRANSFORM`, `MULE_ERROR_HANDLER`, and `DATAWEAVE_SCRIPT`.
+
+Record:
+- Total node and edge counts
+- Number of flows, sub-flows, endpoints, connectors, processors, transforms
+- Number of DataWeave scripts and error handlers
+- Number of Maven artifacts and config properties
+
+---
+
+## Step 0.2 — Vendor & Version Detection
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type MAVEN_ARTIFACT
+```
+
+Scan for MuleSoft vendor signals:
+
+| Signal | Detection |
+|--------|-----------|
+| groupId `org.mule` or `com.mulesoft` | MuleSoft Mule |
+| `mule-core` version 3.x | Mule 3.x |
+| `mule-core` version 4.x | Mule 4.x |
+| `mule-artifact.json` present | Mule 4.x |
+| Anypoint connector groupId `org.mule.connectors` | Mule 4.x connectors |
+| Connector groupId `org.mule.transports` | Mule 3.x transports |
+
+Extract Mule version from `mule-core` or Mule BOM artifact.
+
+---
+
+## Step 0.3 — Flow Inventory
+
+Run the command to list all flows:
+```bash
+{COMMAND_PREFIX} graph find --type MULE_FLOW
+```
+
+Run the command to list all sub-flows:
+```bash
+{COMMAND_PREFIX} graph find --type MULE_SUB_FLOW
+```
+
+For each flow, query its children to extract endpoints, processors, and transforms:
+```bash
+{COMMAND_PREFIX} graph neighbors <flowId> --direction out --edge-type MULE_FLOW_CONTAINS
+```
+
+For each flow, list:
+- Source endpoint (first `MULE_ENDPOINT` child — the listener/consumer)
+- Sink endpoints (subsequent `MULE_ENDPOINT` children — requests/publishers)
+- Processors in order (by edge `order` property)
+- Transforms (DataWeave)
+- Error handlers
+
+Build the **Component Inventory**: extract all unique endpoint element types (e.g., `http:listener`, `jms:consume`, `db:select`) with usage counts and which flows use them.
+
+---
+
+## Step 0.4 — Flow Connectivity (Sub-flow Call Graph)
+
+Query the sub-flow call edges:
+```bash
+{COMMAND_PREFIX} graph find --type MULE_FLOW
+```
+
+For each flow, check outbound `MULE_CALLS_SUBFLOW` edges:
+```bash
+{COMMAND_PREFIX} graph neighbors <flowId> --direction out --edge-type MULE_CALLS_SUBFLOW
+```
+
+Build the flow-to-sub-flow call graph. This reveals:
+- Which flows call which sub-flows
+- Shared sub-flows used by multiple flows
+- Isolated flows with no sub-flow dependencies
+
+---
+
+## Step 0.5 — Connector Configuration
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type MULE_CONNECTOR
+```
+
+For each connector, find which endpoints reference it:
+```bash
+{COMMAND_PREFIX} graph neighbors <connectorId> --direction in --edge-type MULE_USES_CONNECTOR
+```
+
+Record connector names, types, and which endpoints use each connector. This identifies shared configuration (e.g., a single HTTP listener config used by multiple flows).
+
+---
+
+## Step 0.6 — DataWeave Transformation Inventory
+
+Run the command:
+```bash
+{COMMAND_PREFIX} graph find --type MULE_TRANSFORM
+```
+
+For each transform, check for external DWL references:
+```bash
+{COMMAND_PREFIX} graph neighbors <transformId> --direction out --edge-type MULE_REFERENCES_DWL
+```
+
+List all DataWeave scripts:
+```bash
+{COMMAND_PREFIX} graph find --type DATAWEAVE_SCRIPT
+```
+
+Record:
+- Total number of transforms
+- How many reference external `.dwl` files vs inline DataWeave
+- DWL file paths for external scripts
+
+---
+
+## Step 0.7 — Structural Analysis
+
+Using the flow connectivity data:
+
+1. **Entry-point flows:** Flows with an inbound endpoint (listener, consumer) — these are externally triggered
+2. **Internal sub-flows:** `MULE_SUB_FLOW` nodes — only invoked via `<flow-ref>`
+3. **Leaf flows:** Flows with no outbound `MULE_CALLS_SUBFLOW` edges
+
+**Migration ordering** — reverse dependency order:
+1. Sub-flows first (can be migrated as independent Camel routes with `direct:` endpoints)
+2. Flows that only call already-migrated sub-flows
+3. Entry-point flows last
+
+**Structural warnings:**
+- **Orphaned sub-flows:** `MULE_SUB_FLOW` nodes with no inbound `MULE_CALLS_SUBFLOW` edges (never called)
+- **Missing connectors:** Endpoints with `config-ref` but no matching `MULE_CONNECTOR` node
+- **Unresolved flow-refs:** `MULE_CALLS_SUBFLOW` edges pointing to non-existent sub-flows
+
+---
+
+## Step 0.8 — Persist Snapshot & Build Summary
+
+Write to `.camel-kit/project-snapshot.md`:
+
+```markdown
+# Project Snapshot
+
+Generated: [timestamp]
+Graph: .camel-kit/project-graph.json
+Source Platform: MuleSoft Mule [version]
+
+## Project Overview
+- Flows: [N] | Sub-flows: [N] | Endpoints: [N] | Connectors: [N]
+- Processors: [N] | Transforms: [N] | DataWeave Scripts: [N]
+- Error Handlers: [N] | Maven Artifacts: [N]
+
+## Vendor & Platform
+- Vendor: MuleSoft Mule [3.x or 4.x]
+- Connector Type: [Anypoint connectors / community transports]
+
+## Flow Topology
+| Flow | Type | Source Endpoint | Sink Endpoints | Calls Sub-flows |
+|------|------|-----------------|----------------|-----------------|
+| [name] | flow | [source endpoint] | [sink endpoints] | [sub-flow names or —] |
+| [name] | sub-flow | — | [endpoints] | [sub-flow names or —] |
+
+## Component Inventory
+| Element | Type | Usage Count | Flows |
+|---------|------|-------------|-------|
+| [element name] | endpoint/processor/transform | [count] | [flow list] |
+
+## Connector Configuration
+| Connector Name | Element | Used By Endpoints |
+|----------------|---------|-------------------|
+| [name] | [element type] | [endpoint list] |
+
+## DataWeave Scripts
+| Transform | External DWL | DWL Path |
+|-----------|-------------|----------|
+| [transform id] | yes/no | [path or inline] |
+
+## Migration Ordering
+1. [sub-flow name] (leaf sub-flow — no outbound calls)
+2. [flow name] (depends on [sub-flow names])
+...
+
+## Structural Warnings
+- [any orphaned sub-flows, missing connectors, unresolved flow-refs]
+
+## Dependencies
+| GroupId | ArtifactId | Version |
+|---------|-----------|---------|
+| [groupId] | [artifactId] | [version] |
+```
+
+Build the pre-populated analysis summary:
+
+```
+MIGRATION ANALYSIS SUMMARY
+===========================================================
+Vendor & Version:    MuleSoft Mule [version from graph]
+Source Product:      MuleSoft Anypoint Platform
+Failure Behaviour:   [inferred from error handler presence]
+Target Camel:        Camel version (default: latest)
+Target Runtime:      [to be selected]
+API Compatibility:   Assumed (same HTTP paths, queue names, contracts)
+Project Layout:      [single or multi from graph]
+Flows to migrate:    ALL ([N] flows + [M] sub-flows detected with migration ordering)
+===========================================================
+```
+
+**Return to `migration-discovery.md` Step 5** for user confirmation, then Step 5a (concerns wizard), Step 5b (clarifications wizard), and Step 5c (proceed gate).

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
@@ -48,7 +48,7 @@ No arguments. The command asks for the path interactively.
 
 | Node type in stats | Vendor | Guide to load |
 |--------------------|--------|---------------|
-| `CAMEL_ROUTE` | Apache Camel | `guides/camel-version-graph-analysis.md` |
+| `CAMEL_ROUTE` | Apache Camel | `camel-brainstorm/guides/migration-graph-analysis.md` |
 | `MULE_FLOW` | MuleSoft Mule | `camel-brainstorm/guides/migration-mule-graph-analysis.md` |
 | `BIZTALK_ORCHESTRATION` | Microsoft BizTalk | `camel-brainstorm/guides/migration-biztalk-graph-analysis.md` |
 
@@ -168,9 +168,9 @@ After user confirms the analysis summary, dispatch to the vendor-specific guide.
 
 | Step | Guide | Shared Guide | ~Tokens | When |
 |------|-------|-------------|---------|------|
-| B0 | guides/camel-version-graph-analysis.md | — | 2K | Graph exists + Camel detected |
+| B0 | camel-brainstorm/guides/migration-graph-analysis.md | — | 2K | Graph exists + Camel detected |
 | A0 | camel-brainstorm/guides/migration-mule-graph-analysis.md | — | 2.5K | Graph exists + MuleSoft detected |
-| C0 | camel-brainstorm/guides/migration-biztalk-graph-analysis.md | — | 2.5K | Graph exists + BizTalk detected |
+| C0 | camel-brainstorm/guides/migration-biztalk-graph-analysis.md | — | 2.8K | Graph exists + BizTalk detected |
 | A1 | guides/mulesoft-phase1.md | guides/mule-component-mapping.md | 3.5K | MuleSoft detected |
 | A2 | guides/mulesoft-phase2.md | guides/mule-dataweave-conversion.md | 4K | MuleSoft detected |
 | A2 | guides/mulesoft-phase2.md | shared/datamapper-canonicalize.md | 1.2K | MuleSoft with DataMapper |

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/SKILL.md
@@ -43,12 +43,18 @@ No arguments. The command asks for the path interactively.
 
 **If graph exists AND `graph_stats` MCP tool is available:**
 
-1. Call `graph_stats` to verify the graph is loaded and contains Camel route data
-2. If `CAMEL_ROUTE` nodes are present (confirming this is a Camel project):
-   - Load `guides/camel-version-graph-analysis.md`
-   - Follow its Phase 0 steps (produces `.camel-kit/project-snapshot.md` + pre-populated analysis summary)
-   - **Skip directly to Step 5** (user confirmation) — Steps 1-4 are replaced by Phase 0
-3. If no `CAMEL_ROUTE` nodes found, proceed with Steps 1-4 as normal
+1. Call `graph_stats` to verify the graph is loaded and inspect the `nodesByType` field
+2. Dispatch to the correct vendor-specific graph analysis guide based on node types present:
+
+| Node type in stats | Vendor | Guide to load |
+|--------------------|--------|---------------|
+| `CAMEL_ROUTE` | Apache Camel | `guides/camel-version-graph-analysis.md` |
+| `MULE_FLOW` | MuleSoft Mule | `camel-brainstorm/guides/migration-mule-graph-analysis.md` |
+| `BIZTALK_ORCHESTRATION` | Microsoft BizTalk | `camel-brainstorm/guides/migration-biztalk-graph-analysis.md` |
+
+3. Follow the guide's steps (produces `.camel-kit/project-snapshot.md` + pre-populated analysis summary)
+4. **Skip directly to Step 5** (user confirmation) — Steps 1-4 are replaced by graph analysis
+5. If none of the above node types are found, the graph may be incomplete or from an unsupported vendor — proceed with Steps 1-4 as normal
 
 **If no graph exists or `graph_stats` tool is not available:**
 
@@ -163,6 +169,8 @@ After user confirms the analysis summary, dispatch to the vendor-specific guide.
 | Step | Guide | Shared Guide | ~Tokens | When |
 |------|-------|-------------|---------|------|
 | B0 | guides/camel-version-graph-analysis.md | — | 2K | Graph exists + Camel detected |
+| A0 | camel-brainstorm/guides/migration-mule-graph-analysis.md | — | 2.5K | Graph exists + MuleSoft detected |
+| C0 | camel-brainstorm/guides/migration-biztalk-graph-analysis.md | — | 2.5K | Graph exists + BizTalk detected |
 | A1 | guides/mulesoft-phase1.md | guides/mule-component-mapping.md | 3.5K | MuleSoft detected |
 | A2 | guides/mulesoft-phase2.md | guides/mule-dataweave-conversion.md | 4K | MuleSoft detected |
 | A2 | guides/mulesoft-phase2.md | shared/datamapper-canonicalize.md | 1.2K | MuleSoft with DataMapper |


### PR DESCRIPTION
## Summary

Fixes #84 — graph-accelerated analysis now works for MuleSoft and BizTalk migrations, not just Camel-to-Camel upgrades.

**Root cause:** The skill guides (`migration-discovery.md`, `camel-migrate/SKILL.md`) only checked for `CAMEL_ROUTE` nodes in the project graph. When the graph contained MuleSoft (`MULE_FLOW`) or BizTalk (`BIZTALK_ORCHESTRATION`) nodes, the graph was detected but ignored, falling back to slower file scanning.

**Fix (skill guides only, no Java changes):**
- **New `migration-mule-graph-analysis.md`** — queries `MULE_FLOW`, `MULE_SUB_FLOW`, `MULE_ENDPOINT`, `MULE_CONNECTOR`, `MULE_TRANSFORM`, `DATAWEAVE_SCRIPT` nodes via generic `graph find`/`graph neighbors` CLI commands
- **New `migration-biztalk-graph-analysis.md`** — queries `BIZTALK_ORCHESTRATION`, `BIZTALK_SHAPE`, `BIZTALK_MAP`, `BIZTALK_PIPELINE`, `BIZTALK_PORT`, `BIZTALK_ADAPTER` nodes
- **Updated `migration-discovery.md` Step 1** — detects vendor from `graph stats` `nodesByType` and dispatches to the correct guide
- **Updated `camel-migrate/SKILL.md` Step 0** — same vendor-aware dispatch with manifest table
- **Updated `camel-brainstorm/SKILL.md`** — process flow diagram now shows vendor-specific graph analysis paths

## Changes

| File | Action |
|------|--------|
| `camel-brainstorm/guides/migration-mule-graph-analysis.md` | **New** — MuleSoft graph analysis (flow topology, connector inventory, DataWeave scripts, migration ordering) |
| `camel-brainstorm/guides/migration-biztalk-graph-analysis.md` | **New** — BizTalk graph analysis (orchestrations, maps, pipelines, ports, adapters, migration ordering) |
| `camel-brainstorm/guides/migration-discovery.md` | Updated Step 1 with vendor detection table |
| `camel-migrate/SKILL.md` | Updated Step 0 dispatch + guide manifest (A0, C0 entries) |
| `camel-brainstorm/SKILL.md` | Updated process flow diagram |

## Test plan

- [ ] Run MuleSoft migration on a project with `project-graph.json` containing `MULE_FLOW` nodes — should load `migration-mule-graph-analysis.md` instead of falling back to file scanning
- [ ] Run BizTalk migration on a project with `project-graph.json` containing `BIZTALK_ORCHESTRATION` nodes — should load `migration-biztalk-graph-analysis.md`
- [ ] Run Camel-to-Camel migration — should still load `migration-graph-analysis.md` (no regression)
- [ ] Run migration without `project-graph.json` — should fall through to manual scanning (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add vendor-aware graph-accelerated migration analysis for MuleSoft and BizTalk projects alongside existing Camel support.

New Features:
- Introduce a MuleSoft migration graph analysis guide that drives flow topology, connector, DataWeave, and ordering analysis from the project graph.
- Introduce a BizTalk migration graph analysis guide that extracts orchestrations, maps, pipelines, ports, adapters, and migration ordering from the project graph.

Enhancements:
- Update migration discovery and Camel migration skills to detect the integration vendor from graph stats node types and dispatch to the appropriate vendor-specific analysis guide instead of always using the Camel guide or falling back to manual scanning.
- Refine the brainstorming skill’s process diagram to show separate graph-analysis paths for Camel, MuleSoft, and BizTalk based on graph vendor detection.

Documentation:
- Document vendor-specific graph analysis workflows for MuleSoft and BizTalk, including snapshot contents and pre-populated analysis summaries.