### PR TITLE
Fix #95: route init next steps through camel-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ Camel-Kit adds structured slash commands to your AI assistant that guide you thr
 ```
 Entry:        /camel-start         (routes to the right skill based on context)
 
-Greenfield:   /camel-brainstorm → /camel-plan → /camel-execute → /camel-verify
+Greenfield:   /camel-brainstorm → /camel-plan → /camel-execute → /camel-validate
                                                       ├── implements (camel-implement)
-                                                      ├── validates (camel-validate)
+                                                      ├── verifies (camel-verify, internal)
                                                       └── tests (camel-test)
 
-Migration:    /camel-migrate    → /camel-plan → /camel-execute → /camel-verify
+Migration:    /camel-migrate    → /camel-plan → /camel-execute → /camel-validate
 
 Utilities:    /camel-validate      (endpoint validation only)
               /camel-ship          (autonomous full pipeline with oversight levels)
               /camel-knowledge     (documentation Q&A)
+              /camel-debug         (standalone troubleshooting)
 ```
 
 | Command | Purpose |
@@ -39,9 +40,9 @@ Utilities:    /camel-validate      (endpoint validation only)
 | `/camel-migrate` | Migration from MuleSoft, Microsoft BizTalk, legacy Camel, or JBoss Fuse to modern Camel |
 | `/camel-plan` | Reviews approved design, creates a detailed implementation plan with wave analysis for parallel execution |
 | `/camel-execute` | Orchestrated execution — environment probe, then implements, validates, tests, and verifies all flows |
-| `/camel-verify` | Runtime verification — 3-phase loop (build, Citrus tests, report) with error classification and fix routing |
 | `/camel-validate` | Standalone endpoint validation — checks component configuration without full implementation |
-| `/camel-ship` | Autonomous pipeline — runs brainstorm, plan, execute, and verify end-to-end with configurable oversight (`always`, `smart`, `never`) |
+| `/camel-debug` | Standalone troubleshooting for broken routes, build failures, startup errors, and runtime exceptions |
+| `/camel-ship` | Autonomous pipeline — runs brainstorm, plan, execute, and validate end-to-end with configurable oversight (`always`, `smart`, `never`) |
 | `/camel-knowledge` | Documentation Q&A — semantic search over Apache Camel docs, CVEs, errata, and component catalog |
 
 [Command Reference →](docs/commands.md)
@@ -134,7 +135,7 @@ camel-kit init my-integration --ai qwen     # Qwen (requires dev build)
 camel-kit init my-integration --ai opencode # OpenCode (requires dev build)
 
 # 2. Override configuration if needed
-camel-kit init my-integration --ai claude -p "camel.version=4.18.0"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
 
 # 3. Open in your AI assistant
 cd my-integration

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -272,18 +272,21 @@ public class InitCommand extends CamelKitCommand {
         printer().println(meta);
         printer().println();
 
-        // Next steps
+        printNextSteps(projectName, agent.name());
+
+        return 0;
+    }
+
+    void printNextSteps(String projectName, String agentName) {
         String divider = "  " + "\u2500".repeat(34);
         printer().println("  " + bold("Next steps"));
         printer().println(divider);
-        printer().println("  1  Open " + cyan(projectName) + " in " + agent.name());
-        printer()
-                .println("  2  " + cyan("/camel-design") + "   \u2014 design an integration (greenfield or migration)");
-        printer().println("     " + cyan("/camel-migrate") + "  \u2014 migration shortcut");
-        printer().println("  3  " + cyan("/camel-verify") + "   \u2014 build, run, and diagnose");
+        printer().println("  1  Open " + cyan(projectName) + " in " + agentName);
+        printer().println("  2  " + cyan("/camel-start") + "  \u2014 route integration work");
+        printer().println("     " + cyan("/camel-migrate") + " \u2014 migration shortcut");
+        printer().println("  3  " + cyan("/camel-debug") + "  \u2014 troubleshoot broken routes");
+        printer().println("     " + cyan("/camel-knowledge") + " \u2014 ask Camel documentation questions");
         printer().println();
-
-        return 0;
     }
 
     private String detectProjectType(ProjectGraph graph) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
@@ -94,9 +94,13 @@ public final class PrerequisiteChecker {
     private static CheckResult checkCamelTestPlugin() {
         CheckResult result = runSimpleCheck("Camel test plugin", new String[]{"camel", "test", "--help"}, true);
         if (!result.found) {
-            return new CheckResult(result.name, false, null, "/camel-verify will skip test phase");
+            return new CheckResult(result.name, false, null, missingCamelTestPluginHint());
         }
         return result;
+    }
+
+    static String missingCamelTestPluginHint() {
+        return "runtime verification will skip Citrus test phase";
     }
 
     // ------------------------------------------------------------------

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
@@ -1,0 +1,52 @@
+package io.github.luigidemasi.camelkit.command;
+
+import io.github.luigidemasi.camelkit.CamelKitMain;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InitCommandTest {
+
+    @Test
+    void nextStepsUseCurrentSkillRouterCommands() {
+        CapturingPrinter printer = new CapturingPrinter();
+        CamelKitMain main = new CamelKitMain();
+        main.setOut(printer);
+
+        InitCommand command = new InitCommand(main);
+        command.printNextSteps("orders", "Claude Code");
+
+        String output = printer.output();
+        assertTrue(output.contains("/camel-start"));
+        assertTrue(output.contains("/camel-migrate"));
+        assertTrue(output.contains("/camel-debug"));
+        assertTrue(output.contains("/camel-knowledge"));
+        assertFalse(output.contains("/camel-design"));
+        assertFalse(output.contains("/camel-verify"));
+    }
+
+    private static final class CapturingPrinter implements Printer {
+        private final StringBuilder output = new StringBuilder();
+
+        @Override
+        public void println() {
+            output.append(System.lineSeparator());
+        }
+
+        @Override
+        public void println(String line) {
+            output.append(line).append(System.lineSeparator());
+        }
+
+        @Override
+        public void print(String value) {
+            output.append(value);
+        }
+
+        String output() {
+            return output.toString();
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/util/PrerequisiteCheckerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/util/PrerequisiteCheckerTest.java
@@ -14,6 +14,13 @@ class PrerequisiteCheckerTest {
     }
 
     @Test
+    void missingCamelTestPluginHintDoesNotAdvertiseInternalVerifyCommand() {
+        String hint = PrerequisiteChecker.missingCamelTestPluginHint();
+        assertTrue(hint.contains("runtime verification"));
+        assertFalse(hint.contains("/camel-verify"));
+    }
+
+    @Test
     void parseJavaVersionModernFormat() {
         String output = "openjdk version \"21.0.3\" 2024-04-16 LTS\n"
                         + "OpenJDK Runtime Environment (build 21.0.3+9-LTS)\n"

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -122,9 +122,9 @@ Bob has the most template files (17+) because it cannot chain skill references -
 ### How It Works
 
 ```
-User: /camel-design
+User: /camel-start
   └── Bob loads gate file (Advanced mode -- can read all files)
-      └── Step 1: Switch to camel-design mode
+      └── Step 1: Route to camel-brainstorm or camel-migrate
           └── Tool restrictions activate (read + .md edit + mcp only)
               └── Follows gate instructions with restricted tools
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,11 +48,10 @@ camel-kit init --here [options]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--ai`, `-a` | `bob` | AI coding assistant to configure (`bob`, `gemini`, `claude`, `qwen`, `opencode`) |
-| `--camel-version`, `-v` | latest version | Apache Camel version to target |
 | `--citrus-version` | `4.9.2` | Citrus Framework version for test schemas |
 | `--here` | `false` | Initialize in current directory |
 | `--no-fetch` | `false` | Skip external catalog fetching |
-| `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.version=4.18.0"` |
+| `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.main.version=4.18.2"` |
 | `-c`, `--config` | `~/.camel-kit/config.properties` | Path to a custom config properties file |
 | `--source-platform` | `auto` | Source platform for migration: `mulesoft`, `camel`, `biztalk`, `auto` |
 | `--force` | `false` | Overwrite existing project without prompting (skips overwrite detection) |
@@ -77,17 +76,14 @@ camel-kit init my-integration --ai qwen
 # Create new project for OpenCode
 camel-kit init my-integration --ai opencode
 
-# Use a specific Camel version
-camel-kit init my-integration --camel-version 4.18.0
-
 # Initialize in current directory
 camel-kit init --here --ai bob
 
 # Override config properties via CLI
-camel-kit init my-integration --ai claude -p "camel.version=4.18.0"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
 
 # Override multiple properties
-camel-kit init my-integration --ai claude -p "camel.version=4.18.0" -p "quarkus.bom.version=3.30.0"
+camel-kit init my-integration --ai claude -p "camel.quarkus.version=4.18.2" -p "quarkus.platform.version=3.33.1"
 
 # Use a custom config file
 camel-kit init my-integration --ai claude -c /path/to/my-config.properties
@@ -117,7 +113,7 @@ Prerequisites:
   Java 17+          ✓ (21.0.3)
   JBang             ✓ (0.136.0)
   Camel JBang       ✓ (4.18.1)
-  Camel test plugin ✗ (not found — /camel-verify will skip test phase)
+  Camel test plugin ✗ (not found — runtime verification will skip Citrus test phase)
 ```
 
 The check is non-blocking -- it warns but never fails the init. Design and planning work without Camel JBang; only execution and verification need it.
@@ -156,9 +152,11 @@ Any property from `distribution.properties` can be overridden at layers 2 or 3. 
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `camel.version` | `4.20.0` | Apache Camel version for generated projects |
+| `camel.main.version` | `4.20.0` | Apache Camel version for Camel Main / JBang projects |
+| `camel.springboot.version` | `4.20.0` | Apache Camel version for Spring Boot projects |
 | `springboot.bom.version` | `4.20.0` | Spring Boot BOM version |
-| `quarkus.bom.version` | `3.33.0` | Quarkus platform BOM version |
+| `camel.quarkus.version` | `4.18.2` | Apache Camel version for Quarkus projects |
+| `quarkus.platform.version` | `3.33.1` | Quarkus platform BOM version |
 | `camel.mcp.version` | `4.20.0` | Camel MCP server version |
 
 **Output:**
@@ -176,7 +174,7 @@ my-integration/
 ├── docs/
 │   └── flows/                   # Flow definitions
 ├── .camel-kit/
-│   ├── config.yaml              # Project configuration
+│   ├── config.properties        # Project configuration
 │   ├── project-graph.json       # Auto-detected project graph
 │   ├── .cache/                  # Downloaded catalogs and schemas
 │   │   ├── components-{version}.json
@@ -489,7 +487,7 @@ When invoked with a `<PIPELINE_ID>` argument:
 
 1. **Detect invocation mode** -- check for `<PIPELINE_ID>` argument and existing design spec
 2. **Detect project type** -- greenfield or migration (based on keywords like "create", "build" vs "migrate", "convert")
-3. **Load context** -- reads `docs/constitution.md` and `.camel-kit/config.yaml` if they exist
+3. **Load context** -- reads `docs/constitution.md` and `.camel-kit/config.properties` if they exist
 4. **Run interview or discovery** -- Socratic interview (one question at a time) for greenfield; artifact scanning and confirmation for migration
 5. **Select Camel version** -- presents available versions for selection
 6. **Design flows** -- for each flow, verifies components, EIPs, data formats, and languages against the MCP catalog. Asks conditional questions only when relevant:
@@ -802,9 +800,7 @@ When `--resume` is used, camel-ship scans all pipeline artifacts for staleness m
 
 **Example:**
 
-```
-/camel-verify
-```
+No direct user invocation. `/camel-execute` dispatches this skill internally during its verification phase.
 
 **How it works (3-phase loop):**
 

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -1,6 +1,6 @@
 # Camel-Kit Constitution
 
-> Seven non-negotiable rules enforced on every generated route. All other design guidance (error handling strategy, retry policy, throttling, resilience patterns, idempotency, transactions, data format choices, deployment) lives in `/camel-design` and `/camel-migrate`, where it is applied context-specifically during flow design.
+> Seven non-negotiable rules enforced on every generated route. All other design guidance (error handling strategy, retry policy, throttling, resilience patterns, idempotency, transactions, data format choices, deployment) lives in `/camel-brainstorm` and `/camel-migrate`, where it is applied context-specifically during flow design.
 
 ---
 
@@ -94,7 +94,7 @@ Every component used in a route MUST be verified as **available** in the target 
   1. Raise a WARNING to the user explaining the availability status.
   2. Search for an alternative that provides equivalent functionality.
   3. Present the warning and the suggested alternative to the user before proceeding. Let the user decide whether to accept the component or switch to the alternative.
-- **Automated verification:** `/camel-verify` checks component availability at build and startup time, catching missing components that passed design-time validation.
+- **Automated verification:** `/camel-execute` dispatches internal runtime verification to check component availability at build and startup time, catching missing components that passed design-time validation.
 - **Violation:** WARNING — this is not a validation blocker, but users must be clearly informed of the availability implications.
 
 ---

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -157,14 +157,15 @@ All defaults (Camel version, BOM versions, MCP server versions) are read from a 
 
 **Per-invocation overrides** (highest priority):
 ```bash
-camel-kit init my-integration --ai claude -p "camel.version=4.18.0"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
 ```
 
 **Persistent user config** (applies to all invocations):
 Create `~/.camel-kit/config.properties` with your overrides:
 ```properties
-camel.version=4.18.0
-quarkus.bom.version=3.30.0
+camel.main.version=4.18.2
+camel.quarkus.version=4.18.2
+quarkus.platform.version=3.33.1
 ```
 
 Or point to a custom config file:
@@ -185,7 +186,7 @@ In terminals without image support, the output falls back to an ASCII art banner
 ```
 order-processing/
   .camel-kit/
-    config.yaml              # Project config (Camel version, runtime)
+    config.properties        # Project config (Camel version, runtime)
   docs/
     constitution.md          # 7 route quality rules
   .mcp.json                  # MCP server config (agent-specific location)
@@ -357,8 +358,8 @@ Suppose you need an order processing integration that reads orders from Kafka, v
 camel-kit init order-processing --ai claude
 cd order-processing
 
-# 2. Start the design (in your AI assistant)
-/camel-brainstorm
+# 2. Start the workflow (in your AI assistant)
+/camel-start
 
 # The AI asks about your business requirements, systems, and data flows.
 # After the interview, it presents a design spec with:
@@ -367,7 +368,7 @@ cd order-processing
 #   - Error handling: dead letter queue on kafka:orders-dlq
 # You review and approve the design.
 
-# 3. The pipeline auto-transitions to /camel-plan
+# 3. /camel-start routes to /camel-brainstorm, then the pipeline auto-transitions to /camel-plan
 # The AI creates an implementation plan with tasks:
 #   Task 1: Project scaffolding (pom.xml, application.properties)
 #   Task 2: Order ingestion route (Kafka source, SQL sink)

--- a/examples/order-processing/README.md
+++ b/examples/order-processing/README.md
@@ -17,7 +17,7 @@ camel-kit init my-integration --ai opencode   # OpenCode
 You can also override configuration at init time:
 ```bash
 # With custom Camel version
-camel-kit init my-integration --ai claude -p "camel.version=4.18.0"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
 
 # With custom config file
 camel-kit init my-integration --ai claude -c team-config.properties
@@ -33,19 +33,19 @@ Customer orders are received on a Kafka topic as JSON messages. Valid orders (am
 
 ### 1. Design the Integration
 
-Start an interactive design session:
+Start the Camel-Kit workflow:
 ```
-/camel-design
+/camel-start
 ```
 
-The assistant asks questions one at a time about:
+For a new integration, `/camel-start` routes to the interactive design session. The assistant asks questions one at a time about:
 - Business purpose (automate order fulfillment)
 - Systems involved (Kafka, PostgreSQL)
 - Data flows (orders from Kafka topic to database)
 - Business rules (only orders >= $50)
 - Error handling (DLQ with retries)
 
-**Result:** BRD and TDD saved to `.camel-kit/`
+**Result:** Design artifacts saved under `docs/camel-kit/<PIPELINE_ID>/`
 
 ### 2. Plan the Implementation
 
@@ -95,20 +95,24 @@ order-processing/
 │   ├── jbang.properties
 │   └── data/
 └── .camel-kit/
-    ├── config.yaml
-    ├── business-requirements.md
-    └── flows/
-        └── order-ingestion/
-            └── order-ingestion.tdd.md
+    └── config.properties
+└── docs/
+    └── camel-kit/
+        └── 001-order-processing/
+            ├── design-spec.md
+            ├── implementation-plan.md
+            ├── execution-report.md
+            └── validation-report.md
 ```
 
 ## Workflow Summary
 
 ```
-/camel-design              # Design the integration (interview + spec)
+/camel-start               # Route to the right Camel-Kit workflow
 /camel-plan                # Create implementation plan (auto after design)
-/camel-execute             # Implement, validate, test, verify (auto after plan)
-/camel-verify              # Build, start, diagnose, fix (standalone or automatic)
+/camel-execute             # Implement, test, and run internal verification
+/camel-validate            # Final quality gate (auto after execution)
+/camel-debug               # Standalone troubleshooting if something breaks later
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

  Fixes #95

  Updates `camel-kit init` guidance so new users are routed through the current `/camel-start` workflow instead of stale `/camel-design` and `/camel-verify` commands.

  ## Changes

  - Updated init summary output to recommend `/camel-start`, `/camel-migrate`, `/camel-debug`, and `/camel-knowledge`
  - Removed init-time wording that presented `/camel-verify` as a standalone user-facing command
  - Updated local docs and the order-processing example to match the current workflow
  - Added tests for init next-step output and prerequisite warning text

  ## Verification

  - [x] `mvn -pl camel-kit-core -Dtest=InitCommandTest,PrerequisiteCheckerTest test`
  - [x] `mvn -pl camel-kit-core test`

## Summary by Sourcery

Route init next-step guidance and docs through the current /camel-start workflow and internal verification model while updating config property names and defaults for Camel versions.

Bug Fixes:
- Align init next-step hints and prerequisite warnings with the current workflow so users are routed through /camel-start instead of deprecated /camel-design and /camel-verify commands.

Enhancements:
- Update InitCommand next-step output to recommend /camel-start, /camel-migrate, /camel-debug, and /camel-knowledge instead of legacy commands.
- Adjust configuration properties and generated project layout to use config.properties and distinct Camel version properties for Main, Spring Boot, and Quarkus targets.

Documentation:
- Refresh README, command reference, user guide, constitution, agent architecture, and example docs to describe the /camel-start–centric workflow, internal verification, and updated config properties.

Tests:
- Add InitCommand tests to pin the next-step commands shown after init and prerequisite checker tests to ensure the missing Camel test plugin hint no longer advertises /camel-verify.