### PR TITLE
Fix #93: align Knowledge MCP generated allowlists

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -20,6 +20,13 @@ import io.github.luigidemasi.camelkit.util.AnsiColors;
 import io.github.luigidemasi.camelkit.util.TemplateUtils;
 
 public class DefaultGenerator implements AgentGenerator {
+    static final List<String> KNOWLEDGE_MCP_TOOLS = List.of(
+            "camel_docs_component_info",
+            "camel_docs_search",
+            "camel_docs_cve_search",
+            "camel_docs_release_info",
+            "camel_docs_jira_lookup");
+
     @Override
     public void generate(InitContext ctx) throws Exception {
         Files.createDirectories(ctx.commandsDir());
@@ -332,15 +339,10 @@ public class DefaultGenerator implements AgentGenerator {
             templateData.put("CAMEL_SPRINGBOOT_SUPPORTED", dist.camelSpringbootSupported());
             templateData.put("CAMEL_QUARKUS_SUPPORTED", dist.camelQuarkusSupported());
 
-            String knowledgeToolPrefix = "camel_docs_";
             String knowledgeToolsJson = String.join(", ",
-                    "\"" + knowledgeToolPrefix + "component_info\"",
-                    "\"" + knowledgeToolPrefix + "search\"",
-                    "\"" + knowledgeToolPrefix + "jira_lookup\"",
-                    "\"" + knowledgeToolPrefix + "cve_search\"",
-                    "\"" + knowledgeToolPrefix + "bugfix_search\"",
-                    "\"" + knowledgeToolPrefix + "release_info\"",
-                    "\"" + knowledgeToolPrefix + "supported_configs\"");
+                    KNOWLEDGE_MCP_TOOLS.stream()
+                            .map(tool -> "\"" + tool + "\"")
+                            .toList());
             templateData.put("KNOWLEDGE_TOOLS_JSON", knowledgeToolsJson);
 
             String knowledgeDescription = "camel-kit Knowledge Server - documentation search for Apache Camel";

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -3,12 +3,16 @@ package io.github.luigidemasi.camelkit.generator;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.output.Printer;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -71,6 +75,30 @@ class DefaultGeneratorTest {
         new DefaultGenerator().generate(ctx);
 
         assertTrue(Files.exists(tempDir.resolve(".bob/mcp.json")));
+    }
+
+    @Test
+    void knowledgeMcpAllowlistMatchesImplementedServerToolsContract() throws Exception {
+        // camel-kit-knowledge is a sibling repository, so keep its tool contract local and explicit here.
+        List<String> implementedKnowledgeTools = List.of(
+                "camel_docs_component_info",
+                "camel_docs_search",
+                "camel_docs_cve_search",
+                "camel_docs_release_info",
+                "camel_docs_jira_lookup");
+        assertEquals(implementedKnowledgeTools, DefaultGenerator.KNOWLEDGE_MCP_TOOLS);
+
+        ObjectMapper mapper = new ObjectMapper();
+        for (String agentName : List.of("bob", "claude", "gemini", "qwen", "opencode")) {
+            InitContext ctx = createContext(agentName);
+            new DefaultGenerator().generate(ctx);
+
+            JsonNode knowledgeServer = readKnowledgeServerConfig(mapper, agentName);
+            assertEquals(implementedKnowledgeTools, jsonArrayToList(knowledgeServer.path("autoApprove")),
+                    agentName + " autoApprove must only include implemented Knowledge MCP tools");
+            assertEquals(implementedKnowledgeTools, jsonArrayToList(knowledgeServer.path("alwaysAllow")),
+                    agentName + " alwaysAllow must only include implemented Knowledge MCP tools");
+        }
     }
 
     @Test
@@ -236,5 +264,28 @@ class DefaultGeneratorTest {
         String content = Files.readString(geminiCmd);
         assertTrue(content.contains("description ="));
         assertTrue(content.contains("prompt ="));
+    }
+
+    private JsonNode readKnowledgeServerConfig(ObjectMapper mapper, String agentName) throws IOException {
+        Path configPath = switch (agentName) {
+            case "bob" -> tempDir.resolve(".bob/mcp.json");
+            case "claude" -> tempDir.resolve(".mcp.json");
+            case "gemini" -> tempDir.resolve(".gemini/settings.json");
+            case "qwen" -> tempDir.resolve(".qwen/settings.json");
+            case "opencode" -> tempDir.resolve("opencode.json");
+            default -> throw new IllegalArgumentException("Unknown agent: " + agentName);
+        };
+
+        JsonNode config = mapper.readTree(configPath.toFile());
+        if ("opencode".equals(agentName)) {
+            return config.path("mcp").path("camel-knowledge");
+        }
+        return config.path("mcpServers").path("camel-knowledge");
+    }
+
+    private List<String> jsonArrayToList(JsonNode array) {
+        List<String> values = new ArrayList<>();
+        array.forEach(value -> values.add(value.asText()));
+        return values;
     }
 }


### PR DESCRIPTION
## Summary

  - Align generated Knowledge MCP allowlists with the tools actually implemented by the Knowledge MCP server.
  - Remove stale generated entries for `camel_docs_bugfix_search` and `camel_docs_supported_configs`.
  - Add generator coverage to verify Bob, Claude, Gemini, Qwen, and OpenCode configs expose only the supported Knowledge tools.

  ## Verification

  - `./mvnw -pl camel-kit-core test`

  Closes #93

## Summary by Sourcery

Align Knowledge MCP tool allowlists with the implemented tool set and verify generated agent configs match this contract.

Enhancements:
- Centralize the list of supported Knowledge MCP tools in a shared constant used for MCP config generation.

Tests:
- Add tests ensuring Knowledge MCP allowlists for Bob, Claude, Gemini, Qwen, and OpenCode only include implemented tools and match the shared tool list.