### PR TITLE
fix #97: add workflow manifest for generated commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ All agents use the same skills — camel-kit generates agent-specific instructio
 ### Knowledge & MCP
 
 - **MCP integration** — real-time catalog queries, route validation, and security analysis via the Apache Camel MCP server. [Learn more →](docs/architecture.md)
-- **Knowledge layer** — hybrid BM25 + vector search over Apache Camel documentation, component catalogs, release notes, and CVE/errata advisories, exposed via 5 MCP tools. [Learn more →](docs/architecture.md)
+- **Knowledge layer** — hybrid BM25 + vector search over Apache Camel documentation, component catalogs, release notes, and CVE/errata advisories. The generated MCP allowlist is defined in the workflow manifest. [Learn more →](docs/architecture.md)
 - **DataMapper** — automatic data transformation with two engines: XSLT for complex schema-driven mappings, Groovy for simple field-level transformations. [Learn more →](docs/architecture.md)
 
 ### Multi-Agent
@@ -203,6 +203,8 @@ All agents use the same skills — camel-kit generates agent-specific instructio
 - **[Command Reference](docs/commands.md)** — all slash commands, CLI options, graph subcommands
 - **[Architecture Guide](docs/architecture.md)** — skills, MCP, graph intelligence, pipeline internals
 - **[Contributing](CONTRIBUTING.md)** — development setup, how to add skills
+
+Workflow contributors should treat `camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml` as the source of truth for command, skill, stage, artifact, and MCP tool metadata before updating generated templates or reference docs.
 
 ---
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -18,29 +18,27 @@ import io.github.luigidemasi.camelkit.CamelKitMain;
 import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.util.AnsiColors;
 import io.github.luigidemasi.camelkit.util.TemplateUtils;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest.WorkflowCommand;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DefaultGenerator implements AgentGenerator {
 
-    static final List<String> GENERATED_COMMAND_SKILLS = List.of(
-            "camel-start", "camel-brainstorm", "camel-plan", "camel-execute", "camel-validate",
-            "camel-migrate", "camel-knowledge", "camel-ship", "camel-debug");
-
-    static final List<String> KNOWLEDGE_MCP_TOOLS = List.of(
-            "camel_docs_component_info",
-            "camel_docs_search",
-            "camel_docs_cve_search",
-            "camel_docs_release_info",
-            "camel_docs_jira_lookup");
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     @Override
     public void generate(InitContext ctx) throws Exception {
+        WorkflowManifest workflow = WorkflowManifestLoader.loadDefault();
+
         Files.createDirectories(ctx.commandsDir());
         Files.createDirectories(ctx.skillsDir());
         generateAgentsMd(ctx);
-        createCommandTemplates(ctx);
+        createCommandTemplates(ctx, workflow);
         copySkills(ctx);
-        applyTraits(ctx);
-        createMcpConfigs(ctx);
+        applyTraits(ctx, workflow);
+        createMcpConfigs(ctx, workflow);
     }
 
     private void generateAgentsMd(InitContext ctx) throws Exception {
@@ -53,12 +51,15 @@ public class DefaultGenerator implements AgentGenerator {
         ctx.printer().println(AnsiColors.green("✓") + " Generated AGENTS.md with skill routing and iron laws");
     }
 
-    private void createCommandTemplates(InitContext ctx) throws Exception {
+    private void createCommandTemplates(InitContext ctx, WorkflowManifest workflow) throws Exception {
+        List<WorkflowCommand> commands = workflow.generatedCommandStubs();
+
         // Extract agent base folder (e.g., ".bob" from ".bob/commands")
         String agentBaseFolder = ctx.agent().folder().substring(0, ctx.agent().folder().lastIndexOf("/"));
 
-        for (String skillName : GENERATED_COMMAND_SKILLS) {
-            String cmd = shortCommandName(skillName);
+        for (WorkflowCommand command : commands) {
+            String cmd = command.shortName();
+            String skillName = command.skill();
 
             // Create reference to skill file
             String content
@@ -69,16 +70,11 @@ public class DefaultGenerator implements AgentGenerator {
                 content = wrapInToml(cmd, content);
             }
 
-            String filename = skillName + "." + ctx.agent().fileFormat();
+            String filename = command.name() + "." + ctx.agent().fileFormat();
             Files.writeString(ctx.commandsDir().resolve(filename), content);
         }
 
-        ctx.printer().println(AnsiColors.green("✓") + " Created " + GENERATED_COMMAND_SKILLS.size()
-                              + " skill reference commands");
-    }
-
-    private String shortCommandName(String skillName) {
-        return skillName.startsWith("camel-") ? skillName.substring("camel-".length()) : skillName;
+        ctx.printer().println(AnsiColors.green("✓") + " Created " + commands.size() + " skill reference commands");
     }
 
     private String wrapInToml(String cmd, String content) {
@@ -275,7 +271,7 @@ public class DefaultGenerator implements AgentGenerator {
         return data;
     }
 
-    private void createMcpConfigs(InitContext ctx) throws Exception {
+    private void createMcpConfigs(InitContext ctx, WorkflowManifest workflow) throws Exception {
         String agentName = "";
 
         // Knowledge server repos (still uses JBang for now)
@@ -338,13 +334,9 @@ public class DefaultGenerator implements AgentGenerator {
             templateData.put("CAMEL_SPRINGBOOT_SUPPORTED", dist.camelSpringbootSupported());
             templateData.put("CAMEL_QUARKUS_SUPPORTED", dist.camelQuarkusSupported());
 
-            String knowledgeToolsJson = KNOWLEDGE_MCP_TOOLS.stream()
-                    .map(tool -> "\"" + tool + "\"")
-                    .collect(java.util.stream.Collectors.joining(", "));
-            templateData.put("KNOWLEDGE_TOOLS_JSON", knowledgeToolsJson);
-
-            String knowledgeDescription = "camel-kit Knowledge Server - documentation search for Apache Camel";
-            templateData.put("KNOWLEDGE_DESCRIPTION", knowledgeDescription);
+            WorkflowManifest.WorkflowMcpServer knowledgeServer = workflow.mcpServer("camel-knowledge");
+            templateData.put("KNOWLEDGE_TOOLS_JSON", toJsonArray(knowledgeServer.allowedTools()));
+            templateData.put("KNOWLEDGE_DESCRIPTION", knowledgeServer.description());
 
             String processed = qute.renderString(template, templateData);
             Files.writeString(configFile, processed);
@@ -355,14 +347,13 @@ public class DefaultGenerator implements AgentGenerator {
         }
     }
 
-    private void applyTraits(InitContext ctx) throws Exception {
+    private void applyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {
         String traitsBasePath = "templates/traits/" + ctx.agentName() + "/";
         int traitCount = 0;
 
-        List<String> skillNames = List.of(
-                "camel-brainstorm", "camel-execute", "camel-implement", "camel-verify",
-                "camel-validate", "camel-test", "camel-plan", "camel-ship",
-                "camel-migrate", "camel-knowledge", "camel-start", "camel-debug");
+        List<String> skillNames = workflow.skills().stream()
+                .map(WorkflowManifest.WorkflowSkill::name)
+                .toList();
 
         for (String skillName : skillNames) {
             String traitResourcePath = traitsBasePath + skillName + ".append.md";
@@ -381,6 +372,10 @@ public class DefaultGenerator implements AgentGenerator {
             ctx.printer().println(AnsiColors.green("✓") + " Applied " + traitCount
                                   + " agent traits for " + ctx.agentName());
         }
+    }
+
+    private static String toJsonArray(List<String> values) throws IOException {
+        return JSON_MAPPER.writeValueAsString(values);
     }
 
     private int applyGuideTraits(String traitDirPath, Path guidesDir, String agentName) throws Exception {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifest.java
@@ -1,0 +1,116 @@
+package io.github.luigidemasi.camelkit.workflow;
+
+import java.util.List;
+
+/**
+ * Machine-readable Camel-Kit workflow contract.
+ */
+public record WorkflowManifest(
+        String version,
+        String description,
+        List<WorkflowCommand> commands,
+        List<WorkflowSkill> skills,
+        List<WorkflowStage> stages,
+        List<WorkflowArtifact> artifacts,
+        List<WorkflowMcpServer> mcpServers,
+        WorkflowWebsiteReference websiteReference) {
+
+    public WorkflowManifest {
+        commands = List.copyOf(nullToEmpty(commands));
+        skills = List.copyOf(nullToEmpty(skills));
+        stages = List.copyOf(nullToEmpty(stages));
+        artifacts = List.copyOf(nullToEmpty(artifacts));
+        mcpServers = List.copyOf(nullToEmpty(mcpServers));
+    }
+
+    public List<WorkflowCommand> generatedCommandStubs() {
+        return commands.stream()
+                .filter(WorkflowCommand::generatedStub)
+                .toList();
+    }
+
+    public WorkflowMcpServer mcpServer(String id) {
+        return mcpServers.stream()
+                .filter(server -> server.id().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown MCP server in workflow manifest: " + id));
+    }
+
+    private static <T> List<T> nullToEmpty(List<T> value) {
+        return value == null ? List.of() : value;
+    }
+
+    public record WorkflowCommand(
+            String name,
+            List<String> aliases,
+            String skill,
+            boolean generatedStub,
+            boolean userFacing,
+            String tier,
+            String description,
+            boolean standalone,
+            boolean chained) {
+
+        public WorkflowCommand {
+            aliases = List.copyOf(nullToEmpty(aliases));
+        }
+
+        public String shortName() {
+            return name.startsWith("camel-") ? name.substring("camel-".length()) : name;
+        }
+    }
+
+    public record WorkflowSkill(
+            String name,
+            boolean userInvocable,
+            String status,
+            String generatedCommand) {
+    }
+
+    public record WorkflowStage(
+            String id,
+            String skill,
+            String kind,
+            boolean standalone,
+            boolean chained,
+            List<String> inputs,
+            List<String> outputs,
+            List<String> transitions) {
+
+        public WorkflowStage {
+            inputs = List.copyOf(nullToEmpty(inputs));
+            outputs = List.copyOf(nullToEmpty(outputs));
+            transitions = List.copyOf(nullToEmpty(transitions));
+        }
+    }
+
+    public record WorkflowArtifact(
+            String id,
+            String path,
+            List<String> producedBy,
+            List<String> consumedBy) {
+
+        public WorkflowArtifact {
+            producedBy = List.copyOf(nullToEmpty(producedBy));
+            consumedBy = List.copyOf(nullToEmpty(consumedBy));
+        }
+    }
+
+    public record WorkflowMcpServer(
+            String id,
+            String displayName,
+            String description,
+            List<String> allowedTools) {
+
+        public WorkflowMcpServer {
+            allowedTools = List.copyOf(nullToEmpty(allowedTools));
+        }
+    }
+
+    public record WorkflowWebsiteReference(
+            String commandReference,
+            String architectureReference,
+            String userGuide,
+            String readme) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestLoader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestLoader.java
@@ -1,0 +1,38 @@
+package io.github.luigidemasi.camelkit.workflow;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Loads the bundled Camel-Kit workflow manifest.
+ */
+public final class WorkflowManifestLoader {
+
+    public static final String DEFAULT_RESOURCE = "workflow/camel-kit-workflow.yaml";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory())
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private WorkflowManifestLoader() {
+        // Utility class
+    }
+
+    public static WorkflowManifest loadDefault() throws IOException {
+        return load(DEFAULT_RESOURCE);
+    }
+
+    public static WorkflowManifest load(String resourcePath) throws IOException {
+        try (InputStream input = WorkflowManifestLoader.class.getClassLoader().getResourceAsStream(resourcePath)) {
+            if (input == null) {
+                throw new IOException("Workflow manifest not found on classpath: " + resourcePath);
+            }
+            return OBJECT_MAPPER.readValue(input, WorkflowManifest.class);
+        }
+    }
+}

--- a/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
@@ -22,6 +22,8 @@ Provides access to Apache Camel documentation via MCP knowledge tools. Used duri
 
 ## MCP Tools
 
+The generated MCP allowlist is defined in `workflow/camel-kit-workflow.yaml` under the `camel-knowledge` MCP server. Keep this table aligned with that manifest.
+
 | Tool | Purpose | When to Use |
 |------|---------|-------------|
 | `camel_docs_search` | General documentation search | Migration guides, getting started, EIP patterns, general questions |

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/bob-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/bob-mcp.json
@@ -33,8 +33,8 @@
         "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
       ],
       "description": "{KNOWLEDGE_DESCRIPTION}",
-      "autoApprove": [{KNOWLEDGE_TOOLS_JSON}],
-      "alwaysAllow": [{KNOWLEDGE_TOOLS_JSON}]
+      "autoApprove": {KNOWLEDGE_TOOLS_JSON},
+      "alwaysAllow": {KNOWLEDGE_TOOLS_JSON}
     }
   }
 }

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/claude-code-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/claude-code-mcp.json
@@ -33,8 +33,8 @@
         "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
       ],
       "description": "{KNOWLEDGE_DESCRIPTION}",
-      "autoApprove": [{KNOWLEDGE_TOOLS_JSON}],
-      "alwaysAllow": [{KNOWLEDGE_TOOLS_JSON}]
+      "autoApprove": {KNOWLEDGE_TOOLS_JSON},
+      "alwaysAllow": {KNOWLEDGE_TOOLS_JSON}
     }
   }
 }

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/gemini-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/gemini-mcp.json
@@ -33,8 +33,8 @@
         "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
       ],
       "description": "{KNOWLEDGE_DESCRIPTION}",
-      "autoApprove": [{KNOWLEDGE_TOOLS_JSON}],
-      "alwaysAllow": [{KNOWLEDGE_TOOLS_JSON}]
+      "autoApprove": {KNOWLEDGE_TOOLS_JSON},
+      "alwaysAllow": {KNOWLEDGE_TOOLS_JSON}
     }
   }
 }

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/opencode-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/opencode-mcp.json
@@ -36,9 +36,8 @@
         "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
       ],
       "enabled": true,
-      "autoApprove": [{KNOWLEDGE_TOOLS_JSON}],
-      "alwaysAllow": [{KNOWLEDGE_TOOLS_JSON}]
+      "autoApprove": {KNOWLEDGE_TOOLS_JSON},
+      "alwaysAllow": {KNOWLEDGE_TOOLS_JSON}
     }
   }
 }
-

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/qwen-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/qwen-mcp.json
@@ -33,8 +33,8 @@
         "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
       ],
       "description": "{KNOWLEDGE_DESCRIPTION}",
-      "autoApprove": [{KNOWLEDGE_TOOLS_JSON}],
-      "alwaysAllow": [{KNOWLEDGE_TOOLS_JSON}]
+      "autoApprove": {KNOWLEDGE_TOOLS_JSON},
+      "alwaysAllow": {KNOWLEDGE_TOOLS_JSON}
     }
   }
 }

--- a/camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml
+++ b/camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml
@@ -1,0 +1,280 @@
+version: "1.0"
+description: "Authoritative Camel-Kit workflow contract for generated skills, commands, stages, artifacts, and MCP tools."
+
+commands:
+  - name: camel-start
+    aliases: [start]
+    skill: camel-start
+    generated_stub: true
+    user_facing: true
+    tier: entry
+    description: "Route to the right camel-kit skill for integration work."
+    standalone: true
+    chained: false
+  - name: camel-brainstorm
+    aliases: [brainstorm]
+    skill: camel-brainstorm
+    generated_stub: true
+    user_facing: true
+    tier: pipeline
+    description: "Design and plan Camel integrations through collaborative dialogue."
+    standalone: true
+    chained: true
+  - name: camel-migrate
+    aliases: [migrate]
+    skill: camel-migrate
+    generated_stub: true
+    user_facing: true
+    tier: pipeline
+    description: "Migrate an existing integration from another product to Apache Camel."
+    standalone: true
+    chained: true
+  - name: camel-plan
+    aliases: [plan]
+    skill: camel-plan
+    generated_stub: true
+    user_facing: true
+    tier: pipeline
+    description: "Break a design spec into implementation tasks with wave analysis."
+    standalone: true
+    chained: true
+  - name: camel-execute
+    aliases: [execute]
+    skill: camel-execute
+    generated_stub: true
+    user_facing: true
+    tier: pipeline
+    description: "Execute an approved implementation plan with two-stage review."
+    standalone: true
+    chained: true
+  - name: camel-validate
+    aliases: [validate]
+    skill: camel-validate
+    generated_stub: true
+    user_facing: true
+    tier: pipeline
+    description: "Static quality analysis of Camel routes: correctness, security, and anti-patterns."
+    standalone: true
+    chained: true
+  - name: camel-ship
+    aliases: [ship]
+    skill: camel-ship
+    generated_stub: true
+    user_facing: true
+    tier: utility
+    description: "Run the full pipeline autonomously with configurable oversight."
+    standalone: true
+    chained: false
+  - name: camel-knowledge
+    aliases: [knowledge]
+    skill: camel-knowledge
+    generated_stub: true
+    user_facing: true
+    tier: utility
+    description: "Look up Camel documentation, components, CVEs, errata, and versions."
+    standalone: true
+    chained: false
+  - name: camel-debug
+    aliases: [debug]
+    skill: camel-debug
+    generated_stub: true
+    user_facing: true
+    tier: utility
+    description: "Ad-hoc troubleshooting for broken Camel routes outside of a pipeline run."
+    standalone: true
+    chained: false
+  - name: camel-verify
+    aliases: [verify]
+    skill: camel-verify
+    generated_stub: false
+    user_facing: false
+    tier: internal
+    description: "Build, test, diagnose, and fix a Camel application iteratively."
+    standalone: false
+    chained: true
+
+skills:
+  - name: camel-start
+    user_invocable: true
+    status: router
+    generated_command: camel-start
+  - name: camel-brainstorm
+    user_invocable: false
+    status: pipeline
+    generated_command: camel-brainstorm
+  - name: camel-migrate
+    user_invocable: false
+    status: pipeline
+    generated_command: camel-migrate
+  - name: camel-plan
+    user_invocable: false
+    status: pipeline
+    generated_command: camel-plan
+  - name: camel-execute
+    user_invocable: false
+    status: pipeline
+    generated_command: camel-execute
+  - name: camel-validate
+    user_invocable: false
+    status: pipeline
+    generated_command: camel-validate
+  - name: camel-ship
+    user_invocable: false
+    status: standalone
+    generated_command: camel-ship
+  - name: camel-knowledge
+    user_invocable: false
+    status: standalone
+    generated_command: camel-knowledge
+  - name: camel-debug
+    user_invocable: false
+    status: standalone
+    generated_command: camel-debug
+  - name: camel-verify
+    user_invocable: false
+    status: internal
+    generated_command: null
+  - name: camel-design
+    user_invocable: false
+    status: internal
+    generated_command: null
+  - name: camel-implement
+    user_invocable: false
+    status: internal
+    generated_command: null
+  - name: camel-test
+    user_invocable: false
+    status: internal
+    generated_command: null
+
+stages:
+  - id: route
+    skill: camel-start
+    kind: entry
+    standalone: true
+    chained: false
+    inputs: [user-request]
+    outputs: [selected-workflow]
+    transitions: [brainstorm, migrate, plan, execute, validate, debug]
+  - id: brainstorm
+    skill: camel-brainstorm
+    kind: greenfield-design
+    standalone: true
+    chained: true
+    inputs: [user-request, project-context]
+    outputs: [design-spec, brd, tdds]
+    transitions: [plan]
+  - id: migrate
+    skill: camel-migrate
+    kind: migration-design
+    standalone: true
+    chained: true
+    inputs: [source-integration-artifacts, project-context]
+    outputs: [migration-analysis, design-spec, brd, tdds]
+    transitions: [plan]
+  - id: plan
+    skill: camel-plan
+    kind: planning
+    standalone: true
+    chained: true
+    inputs: [approved-design-spec, brd, tdds]
+    outputs: [implementation-plan, wave-analysis]
+    transitions: [execute]
+  - id: execute
+    skill: camel-execute
+    kind: implementation
+    standalone: true
+    chained: true
+    inputs: [approved-implementation-plan, tdds]
+    outputs: [routes, application-properties, pom, tests, execution-report, verification-report]
+    transitions: [validate]
+  - id: validate
+    skill: camel-validate
+    kind: quality-gate
+    standalone: true
+    chained: true
+    inputs: [routes, execution-report, verification-report]
+    outputs: [validation-report]
+    transitions: []
+  - id: ship
+    skill: camel-ship
+    kind: autonomous-orchestration
+    standalone: true
+    chained: false
+    inputs: [user-request, pipeline-state]
+    outputs: [pipeline-artifacts]
+    transitions: [brainstorm, migrate, plan, execute, validate]
+  - id: debug
+    skill: camel-debug
+    kind: troubleshooting
+    standalone: true
+    chained: false
+    inputs: [broken-route, logs, error]
+    outputs: [debug-report, fixes]
+    transitions: []
+  - id: verify
+    skill: camel-verify
+    kind: internal-runtime-verification
+    standalone: false
+    chained: true
+    inputs: [generated-application, tests]
+    outputs: [verification-report]
+    transitions: [execute, validate]
+
+artifacts:
+  - id: design-spec
+    path: docs/camel-kit/<pipeline-id>/design-spec.md
+    produced_by: [camel-brainstorm, camel-migrate]
+    consumed_by: [camel-plan]
+  - id: implementation-plan
+    path: docs/camel-kit/<pipeline-id>/implementation-plan.md
+    produced_by: [camel-plan]
+    consumed_by: [camel-execute]
+  - id: execution-report
+    path: docs/camel-kit/<pipeline-id>/execution-report.md
+    produced_by: [camel-execute]
+    consumed_by: [camel-validate]
+  - id: verification-report
+    path: docs/camel-kit/<pipeline-id>/verification-report.md
+    produced_by: [camel-verify]
+    consumed_by: [camel-execute, camel-validate]
+  - id: validation-report
+    path: docs/camel-kit/<pipeline-id>/validation-report.md
+    produced_by: [camel-validate]
+    consumed_by: [camel-ship]
+
+mcp_servers:
+  - id: camel
+    display_name: "Camel Catalog MCP"
+    description: "Apache Camel MCP Server - Component catalog, validation, and security analysis"
+    allowed_tools:
+      - camel_catalog_component
+      - camel_catalog_components
+      - camel_catalog_component_doc
+      - camel_catalog_eip
+      - camel_catalog_eips
+      - camel_catalog_eip_doc
+      - camel_catalog_dataformat
+      - camel_catalog_dataformats
+      - camel_catalog_dataformat_doc
+      - camel_catalog_language
+      - camel_catalog_languages
+      - camel_catalog_language_doc
+      - camel_validate_route
+      - camel_route_context
+      - camel_route_harden_context
+  - id: camel-knowledge
+    display_name: "Camel-Kit Knowledge MCP"
+    description: "camel-kit Knowledge Server - documentation search for Apache Camel"
+    allowed_tools:
+      - camel_docs_component_info
+      - camel_docs_search
+      - camel_docs_cve_search
+      - camel_docs_release_info
+      - camel_docs_jira_lookup
+
+website_reference:
+  command_reference: docs/commands.md
+  architecture_reference: docs/architecture.md
+  user_guide: docs/user-guide.md
+  readme: README.md

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -10,6 +10,7 @@ import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -86,7 +87,9 @@ class DefaultGeneratorTest {
                 "camel_docs_cve_search",
                 "camel_docs_release_info",
                 "camel_docs_jira_lookup");
-        assertEquals(implementedKnowledgeTools, DefaultGenerator.KNOWLEDGE_MCP_TOOLS);
+        assertEquals(implementedKnowledgeTools, WorkflowManifestLoader.loadDefault()
+                .mcpServer("camel-knowledge")
+                .allowedTools());
 
         ObjectMapper mapper = new ObjectMapper();
         for (String agentName : List.of("bob", "claude", "gemini", "qwen", "opencode")) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -82,7 +83,11 @@ class ResourceConsistencyTest {
                         .collect(Collectors.toCollection(LinkedHashSet::new));
             }
 
-            assertEquals(new LinkedHashSet<>(DefaultGenerator.GENERATED_COMMAND_SKILLS), generatedCommands,
+            Set<String> expectedCommands = WorkflowManifestLoader.loadDefault().generatedCommandStubs().stream()
+                    .map(command -> command.name())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            assertEquals(expectedCommands, generatedCommands,
                     "Generated command stubs for " + agentName + " must match the public slash-command surface");
             assertFalse(generatedCommands.contains("camel-verify"), "camel-verify is internal to camel-execute");
             assertFalse(generatedCommands.contains("camel-implement"), "camel-implement is an internal guide skill");
@@ -105,13 +110,17 @@ class ResourceConsistencyTest {
         }
     }
 
-    private static void assertKnowledgeTools(String agentName, String field, JsonNode allowlist) {
+    private static void assertKnowledgeTools(String agentName, String field, JsonNode allowlist) throws IOException {
         assertNotNull(allowlist, "Missing " + field + " allowlist for " + agentName);
         assertTrue(allowlist.isArray(), field + " allowlist for " + agentName + " must be an array");
 
         Set<String> actual = new LinkedHashSet<>();
         allowlist.forEach(node -> actual.add(node.asText()));
-        assertEquals(new LinkedHashSet<>(DefaultGenerator.KNOWLEDGE_MCP_TOOLS), actual,
+        assertEquals(new LinkedHashSet<>(
+                WorkflowManifestLoader.loadDefault()
+                        .mcpServer("camel-knowledge")
+                        .allowedTools()),
+                actual,
                 field + " allowlist for " + agentName + " must match KnowledgeMcpServer tools");
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
@@ -1,0 +1,182 @@
+package io.github.luigidemasi.camelkit.workflow;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.generator.DefaultGenerator;
+import io.github.luigidemasi.camelkit.generator.InitContext;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WorkflowManifestTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadsBundledWorkflowManifest() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+
+        assertEquals("1.0", manifest.version());
+        assertFalse(manifest.commands().isEmpty());
+        assertFalse(manifest.skills().isEmpty());
+        assertFalse(manifest.stages().isEmpty());
+        assertFalse(manifest.mcpServer("camel-knowledge").allowedTools().isEmpty());
+    }
+
+    @Test
+    void generatedCommandStubsMatchManifest() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+        InitContext ctx = createContext("bob");
+
+        new DefaultGenerator().generate(ctx);
+
+        Set<String> expected = manifest.generatedCommandStubs().stream()
+                .map(command -> command.name() + "." + ctx.agent().fileFormat())
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+        Set<String> actual;
+        try (var stream = Files.list(ctx.commandsDir())) {
+            actual = stream
+                    .filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .collect(Collectors.toCollection(java.util.TreeSet::new));
+        }
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void internalVerifySkillIsNotGeneratedAsCommandStub() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+        WorkflowManifest.WorkflowCommand verifyCommand = manifest.commands().stream()
+                .filter(command -> "camel-verify".equals(command.name()))
+                .findFirst()
+                .orElseThrow();
+        WorkflowManifest.WorkflowSkill verifySkill = manifest.skills().stream()
+                .filter(skill -> "camel-verify".equals(skill.name()))
+                .findFirst()
+                .orElseThrow();
+
+        assertFalse(verifyCommand.generatedStub());
+        assertFalse(verifyCommand.userFacing());
+        assertNull(verifySkill.generatedCommand());
+
+        InitContext ctx = createContext("bob");
+        new DefaultGenerator().generate(ctx);
+
+        assertFalse(Files.exists(ctx.commandsDir().resolve("camel-verify." + ctx.agent().fileFormat())));
+        assertTrue(Files.isRegularFile(ctx.skillsDir().resolve("camel-verify/SKILL.md")));
+    }
+
+    @Test
+    void skillFrontmatterMatchesManifest() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+        Map<String, WorkflowManifest.WorkflowSkill> expectedSkills = manifest.skills().stream()
+                .collect(Collectors.toMap(
+                        WorkflowManifest.WorkflowSkill::name,
+                        skill -> skill,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+        Path skillsDir = resourcePath("skills");
+
+        Set<String> actualSkillNames;
+        try (var stream = Files.list(skillsDir)) {
+            actualSkillNames = stream
+                    .filter(Files::isDirectory)
+                    .filter(path -> Files.exists(path.resolve("SKILL.md")))
+                    .map(path -> path.getFileName().toString())
+                    .collect(Collectors.toCollection(java.util.TreeSet::new));
+        }
+
+        assertEquals(expectedSkills.keySet(), actualSkillNames);
+
+        for (String skillName : actualSkillNames) {
+            Map<String, Object> frontmatter = readFrontmatter(skillsDir.resolve(skillName).resolve("SKILL.md"));
+            WorkflowManifest.WorkflowSkill expected = expectedSkills.get(skillName);
+            assertEquals(expected.name(), frontmatter.get("name"), skillName + " name");
+            assertEquals(expected.userInvocable(), frontmatter.get("user_invocable"),
+                    skillName + " user_invocable");
+        }
+    }
+
+    @Test
+    void generatedKnowledgeMcpAllowlistMatchesManifest() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+        InitContext ctx = createContext("bob");
+
+        new DefaultGenerator().generate(ctx);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> config = mapper.readValue(
+                Files.readString(tempDir.resolve(".bob/mcp.json")),
+                new TypeReference<>() {
+                });
+        Map<String, Object> servers = map(config.get("mcpServers"));
+        Map<String, Object> knowledge = map(servers.get("camel-knowledge"));
+
+        assertEquals(manifest.mcpServer("camel-knowledge").allowedTools(), knowledge.get("autoApprove"));
+        assertEquals(manifest.mcpServer("camel-knowledge").allowedTools(), knowledge.get("alwaysAllow"));
+    }
+
+    @Test
+    void knowledgeMcpAllowlistOnlyContainsImplementedTools() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+
+        assertEquals(List.of(
+                "camel_docs_component_info",
+                "camel_docs_search",
+                "camel_docs_cve_search",
+                "camel_docs_release_info",
+                "camel_docs_jira_lookup"),
+                manifest.mcpServer("camel-knowledge").allowedTools());
+    }
+
+    private InitContext createContext(String agentName) {
+        AgentConfig agent = AgentRegistry.get(agentName);
+        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
+        Path commandsDir = tempDir.resolve(agent.folder());
+        Path skillsDir = tempDir.resolve(agentBaseFolder + "/skills");
+        return new InitContext(
+                agent, agentName, commandsDir, skillsDir, tempDir,
+                "camel-kit", Printer.noop());
+    }
+
+    private static Path resourcePath(String resource) throws Exception {
+        URI uri = WorkflowManifestTest.class.getClassLoader().getResource(resource).toURI();
+        return Path.of(uri);
+    }
+
+    private static Map<String, Object> readFrontmatter(Path skillFile) throws Exception {
+        String content = Files.readString(skillFile);
+        int start = content.indexOf("---");
+        int end = content.indexOf("---", start + 3);
+        assertEquals(0, start, "Expected frontmatter at start of " + skillFile);
+        assertTrue(end > start, "Expected closing frontmatter marker in " + skillFile);
+        String yaml = content.substring(start + 3, end);
+        return new ObjectMapper(new YAMLFactory())
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .readValue(yaml, new TypeReference<>() {
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> map(Object value) {
+        return (Map<String, Object>) value;
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,8 @@ Camel-Kit combines two mechanisms to give AI agents accurate, efficient access t
 
 Together they enable AI-powered integration development targeting Apache Camel. Skills carry the process knowledge (how to design a flow, how to generate YAML, how to validate a route), while MCP provides the data knowledge (which components exist, what options they accept, whether an endpoint URI is valid).
 
+The authoritative workflow contract lives in `camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml`. It defines command names and aliases, generated command stubs, skill visibility, pipeline stages, artifacts, transitions, MCP servers, allowed tools, and documentation references. Generator code reads this manifest for command stub generation and the Knowledge MCP allowlist, and tests validate skill frontmatter against it. When changing workflow behavior, update the manifest first and then update the Markdown skill bodies and docs to match.
+
 ---
 
 ## 2. Skills Architecture
@@ -22,6 +24,8 @@ Together they enable AI-powered integration development targeting Apache Camel. 
 A skill is a directory containing a manifest file (`SKILL.md`) and an optional `guides/` subdirectory with instruction files loaded on demand. The manifest uses YAML frontmatter to declare metadata and a table listing which guides exist and when to load them.
 
 **Skill location:** `camel-kit-core/src/main/resources/skills/{skill-name}/`
+
+**Workflow manifest:** `camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml` is the source of truth for skill visibility and generated slash-command stubs. The `SKILL.md` frontmatter must match the manifest.
 
 ### SKILL.md Format
 
@@ -725,13 +729,17 @@ user_invocable: false
 
 3. **Write guide files** in `guides/`. Each guide is a self-contained markdown instruction file loaded by the agent when the skill is active.
 
-4. **If registering slash commands:** update agent templates to register the command. Each agent needs the slash command added to its instruction file:
+4. **Update the workflow manifest first:** add or modify the entry in `camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml`. Set `generated_stub: true` only for commands that should be emitted into each agent's commands directory. Add or update the corresponding skill entry, stage/artifact metadata, transitions, and MCP tool allowlists if the workflow contract changes.
+
+5. **If registering slash commands:** update agent-specific guidance only where the command needs custom behavior beyond the generated stub. The default generator creates command stubs from the manifest. Agent templates still need updates when they contain human-readable command tables, custom modes, policies, or subagent dispatch:
    - Claude Code: update `templates/claude/claude-md.md`
    - IBM Project Bob: update `templates/bob/custom_modes.yaml` and add rules directory
    - Gemini CLI: update `templates/gemini/gemini-md.md`
    - Qwen: update `templates/qwen/qwen-md.md`
    - OpenCode: update `templates/opencode/agents-md.md`
 
-5. **If internal:** update the loading skill's `SKILL.md` to reference the new guides (e.g., add a guide reference to `camel-execute`'s guide manifest).
+6. **If internal:** update the loading skill's `SKILL.md` to reference the new guides (e.g., add a guide reference to `camel-execute`'s guide manifest).
 
-6. **Update `docs/commands.md`** if the skill is user-invocable.
+7. **Update `docs/commands.md`** if the skill is user-facing.
+
+8. **Run manifest consistency tests** in `camel-kit-core` to verify generated stubs, skill metadata, and MCP allowlists still match the manifest.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -445,6 +445,8 @@ camel-kit doc unstale docs/camel-kit/001-order-processing/implementation-plan.md
 
 These commands are used inside your AI coding assistant after project initialization. The entry point is `/camel-start`, which routes to the right pipeline skill. Skills are organized into tiers:
 
+The machine-readable source of truth for command names, generated stubs, skill visibility, pipeline stages, transitions, artifacts, and MCP tool allowlists is `camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml`. Generated command stubs and consistency tests read that manifest; update it before changing this reference text or any skill frontmatter.
+
 **Tier 1 — Pipeline:** `/camel-brainstorm`, `/camel-plan`, `/camel-execute`, `/camel-migrate`, `/camel-validate` — the five pipeline steps, invoked via the `/camel-start` decision tree or directly via slash command.
 
 **Tier 2 — Standalone utilities:** `/camel-ship`, `/camel-knowledge`, `/camel-debug` — can be invoked at any point without affecting pipeline state.


### PR DESCRIPTION
## Summary

  - Add `camel-kit-workflow.yaml` as the source of truth for workflow commands, skills, stages, artifacts, and MCP allowlists.
  - Load the workflow manifest from `DefaultGenerator` to generate command stubs, skill traits, and Knowledge MCP allowlists.
  - Update docs and `camel-knowledge` guidance to point contributors at the manifest before changing generated workflow behavior.
  - Add manifest consistency tests and update existing generator/resource tests to validate against the manifest.

  ## Testing

  - `./mvnw -pl camel-kit-core -Dtest=WorkflowManifestTest test`

  Closes #97

## Summary by Sourcery

Introduce a centralized workflow manifest as the source of truth for generated commands, skills, stages, artifacts, and MCP servers, and wire the generator, tests, and docs to consume it.

Enhancements:
- Update the default generator to read workflow commands, skills, and Knowledge MCP metadata from the workflow manifest instead of hard-coded lists.
- Add a machine-readable workflow manifest model and loader for commands, skills, stages, artifacts, and MCP servers, plus tests to validate manifest loading and generator behavior.

Documentation:
- Document the workflow manifest as the authoritative contract for commands, skills, stages, artifacts, and MCP allowlists in architecture, README, commands, and skill docs.

Tests:
- Add workflow manifest consistency tests to ensure generated command stubs, skill frontmatter, and Knowledge MCP allowlists stay aligned with the manifest.