### PR TITLE
fix #94: Add doctor diagnostics and align MCP configs

### DIFF
--- a/camel-jbang-plugin-kit/pom.xml
+++ b/camel-jbang-plugin-kit/pom.xml
@@ -34,6 +34,13 @@
             <artifactId>camel-kit-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
+++ b/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
@@ -4,6 +4,8 @@ import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CamelJBangPlugin;
 import org.apache.camel.dsl.jbang.core.common.Plugin;
 
+import io.github.luigidemasi.camelkit.CamelKitMain;
+import io.github.luigidemasi.camelkit.command.DoctorCommand;
 import io.github.luigidemasi.camelkit.command.graph.GraphCommand;
 import io.github.luigidemasi.camelkit.command.plan.PlanCommand;
 
@@ -18,8 +20,11 @@ public class CamelKitPlugin implements Plugin {
     @Override
     public void customize(CommandLine commandLine, CamelJBangMain main) {
         // Add the 'kit' subcommand with nested commands
+        CamelKitMain camelKitMain = new CamelKitMain();
+        camelKitMain.disableTui();
         CommandLine kitCommand = new CommandLine(new KitCommand(main))
                 .addSubcommand("init", new CommandLine(new KitInitCommand(main)))
+                .addSubcommand("doctor", new CommandLine(new DoctorCommand(camelKitMain)))
                 .addSubcommand("graph", new CommandLine(new GraphCommand()))
                 .addSubcommand("plan", new CommandLine(new PlanCommand()));
 

--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
@@ -1,0 +1,26 @@
+package io.github.luigidemasi.camelkit.jbang;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CamelKitPluginTest {
+
+    @Test
+    void registersDoctorUnderKitCommand() {
+        CamelJBangMain main = new CamelJBangMain();
+        CommandLine root = new CommandLine(main);
+
+        new CamelKitPlugin().customize(root, main);
+
+        CommandLine kit = root.getSubcommands().get("kit");
+        assertNotNull(kit);
+        assertTrue(kit.getSubcommands().containsKey("init"));
+        assertTrue(kit.getSubcommands().containsKey("doctor"));
+        assertTrue(kit.getSubcommands().containsKey("graph"));
+        assertTrue(kit.getSubcommands().containsKey("plan"));
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/CamelKitMain.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/CamelKitMain.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
+import io.github.luigidemasi.camelkit.command.DoctorCommand;
 import io.github.luigidemasi.camelkit.command.InitCommand;
 import io.github.luigidemasi.camelkit.command.doc.DocCommand;
 import io.github.luigidemasi.camelkit.command.graph.GraphCommand;
@@ -142,6 +143,7 @@ public class CamelKitMain implements Callable<Integer> {
     public static void run(CamelKitMain main, String... args) {
         CommandLine commandLine = new CommandLine(main)
                 .addSubcommand("init", new InitCommand(main))
+                .addSubcommand("doctor", new DoctorCommand(main))
                 .addSubcommand("doc", new CommandLine(new DocCommand()))
                 .addSubcommand("graph", new CommandLine(new GraphCommand()))
                 .addSubcommand("plan", new CommandLine(new PlanCommand()))

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/DoctorCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/DoctorCommand.java
@@ -1,0 +1,630 @@
+package io.github.luigidemasi.camelkit.command;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.github.luigidemasi.camelkit.CamelKitMain;
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.graph.GraphBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Validate a generated Camel-Kit workspace.
+ */
+@Command(name = "doctor", description = "Validate a generated Camel-Kit workspace")
+public class DoctorCommand extends CamelKitCommand {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration PREREQUISITE_TIMEOUT = Duration.ofSeconds(3);
+
+    private static final List<String> REQUIRED_CONFIG_KEYS = List.of(
+            "project.name", "project.command-prefix", "agent.name", "agent.folder");
+
+    private static final List<String> STALE_REFERENCES = List.of(
+            "/camel-design", ".camel-kit/business-requirements.md", ".camel-kit/flows/");
+
+    private final DoctorExpectations expectations;
+
+    @Option(names = {"--project-dir"}, description = "Workspace directory to validate", defaultValue = ".")
+    Path projectDir;
+
+    @Option(names = {"--json"}, description = "Print machine-readable JSON output")
+    boolean json;
+
+    public DoctorCommand(CamelKitMain main) {
+        super(main);
+        this.expectations = DoctorExpectations.loadDefault();
+    }
+
+    @Override
+    public Integer doCall() throws Exception {
+        Path root = projectDir.toAbsolutePath().normalize();
+        List<Finding> findings = new ArrayList<>();
+
+        Properties config = checkConfig(root, findings);
+        AgentConfig agent = checkAgentConfig(config, findings);
+        checkGeneratedWorkspace(root, agent, findings);
+        checkMcp(root, config, findings);
+        checkGraph(root, findings);
+        checkCommandPrefix(config, findings);
+        checkPrerequisites(root, findings);
+        checkStaleReferences(root, agent, findings);
+
+        if (json) {
+            printer().println(toJson(root, findings));
+        } else {
+            printText(root, findings);
+        }
+
+        return findings.stream().anyMatch(f -> f.status() == Status.FAIL) ? 1 : 0;
+    }
+
+    private Properties checkConfig(Path root, List<Finding> findings) {
+        Path configFile = root.resolve(".camel-kit/config.properties");
+        if (!Files.isRegularFile(configFile)) {
+            findings.add(Finding.fail("config", relativize(root, configFile),
+                    ".camel-kit/config.properties is missing",
+                    "Run camel-kit init --here --ai <agent> from the workspace root."));
+            return new Properties();
+        }
+
+        Properties config = new Properties();
+        try (InputStream in = Files.newInputStream(configFile)) {
+            config.load(in);
+        } catch (IOException e) {
+            findings.add(Finding.fail("config", relativize(root, configFile),
+                    "Could not read .camel-kit/config.properties: " + e.getMessage(),
+                    "Recreate the file with camel-kit init --here --force or restore it from source control."));
+            return config;
+        }
+
+        List<String> missing = REQUIRED_CONFIG_KEYS.stream()
+                .filter(key -> config.getProperty(key, "").isBlank())
+                .toList();
+        if (missing.isEmpty()) {
+            findings.add(Finding.pass("config", relativize(root, configFile),
+                    ".camel-kit/config.properties contains the required keys",
+                    "No action required."));
+        } else {
+            findings.add(Finding.fail("config", relativize(root, configFile),
+                    ".camel-kit/config.properties is missing keys: " + String.join(", ", missing),
+                    "Restore the missing keys or re-run camel-kit init --here --ai <agent> --force."));
+        }
+        return config;
+    }
+
+    private AgentConfig checkAgentConfig(Properties config, List<Finding> findings) {
+        String agentName = config.getProperty("agent.name", "").trim();
+        if (agentName.isEmpty()) {
+            findings.add(Finding.fail("config", ".camel-kit/config.properties",
+                    "agent.name is not configured",
+                    "Set agent.name to one of: " + String.join(", ", AgentRegistry.names()) + "."));
+            return null;
+        }
+        if (!AgentRegistry.contains(agentName)) {
+            findings.add(Finding.fail("config", ".camel-kit/config.properties",
+                    "Unknown agent.name '" + agentName + "'",
+                    "Set agent.name to one of: " + String.join(", ", AgentRegistry.names()) + "."));
+            return null;
+        }
+
+        AgentConfig agent = AgentRegistry.get(agentName);
+        String folder = config.getProperty("agent.folder", "").trim();
+        if (agent.folder().equals(folder)) {
+            findings.add(Finding.pass("config", ".camel-kit/config.properties",
+                    "Agent configuration selects " + agent.name(),
+                    "No action required."));
+        } else {
+            findings.add(Finding.fail("config", ".camel-kit/config.properties",
+                    "agent.folder is '" + folder + "' but " + agentName + " expects '" + agent.folder() + "'",
+                    "Set agent.folder=" + agent.folder() + " or re-run camel-kit init for " + agentName + "."));
+        }
+        return agent;
+    }
+
+    private void checkGeneratedWorkspace(Path root, AgentConfig agent, List<Finding> findings) {
+        if (agent == null) {
+            findings.add(Finding.fail("workspace", null,
+                    "Cannot validate generated commands and skills without a valid agent",
+                    "Fix .camel-kit/config.properties and re-run camel-kit doctor."));
+            return;
+        }
+
+        Path commandsDir = root.resolve(agent.folder());
+        if (!Files.isDirectory(commandsDir)) {
+            findings.add(Finding.fail("workspace", relativize(root, commandsDir),
+                    "Generated command directory is missing",
+                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate commands."));
+        } else {
+            checkCommandFiles(root, commandsDir, agent, findings);
+        }
+
+        Path skillsDir = root.resolve(agent.folder()).getParent().resolve("skills");
+        if (!Files.isDirectory(skillsDir)) {
+            findings.add(Finding.fail("skills", relativize(root, skillsDir),
+                    "Generated skills directory is missing",
+                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate skills."));
+            return;
+        }
+
+        List<String> missingSkills = expectations.requiredSkills().stream()
+                .filter(skill -> !Files.isRegularFile(skillsDir.resolve(skill).resolve("SKILL.md")))
+                .toList();
+        if (missingSkills.isEmpty()) {
+            findings.add(Finding.pass("skills", relativize(root, skillsDir),
+                    "All expected skill directories contain SKILL.md",
+                    "No action required."));
+        } else {
+            findings.add(Finding.fail("skills", relativize(root, skillsDir),
+                    "Missing SKILL.md for: " + String.join(", ", missingSkills),
+                    "Restore the missing skill folders or re-run camel-kit init --here --force."));
+        }
+    }
+
+    private void checkCommandFiles(
+            Path root, Path commandsDir, AgentConfig agent, List<Finding> findings) {
+        String extension = "." + agent.fileFormat();
+        List<String> missing = expectations.userCommands().stream()
+                .filter(command -> !Files.isRegularFile(commandsDir.resolve(command + extension)))
+                .toList();
+
+        Set<String> unexpected = new LinkedHashSet<>();
+        try (Stream<Path> stream = Files.list(commandsDir)) {
+            stream.filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .filter(name -> name.startsWith("camel-"))
+                    .map(this::commandName)
+                    .filter(command -> !expectations.userCommands().contains(command))
+                    .forEach(unexpected::add);
+        } catch (IOException e) {
+            findings.add(Finding.fail("workspace", relativize(root, commandsDir),
+                    "Could not list generated command directory: " + e.getMessage(),
+                    "Check filesystem permissions and re-run camel-kit doctor."));
+            return;
+        }
+
+        if (missing.isEmpty() && unexpected.isEmpty()) {
+            findings.add(Finding.pass("workspace", relativize(root, commandsDir),
+                    "Generated user-invocable commands match the expected skill router set",
+                    "No action required."));
+            return;
+        }
+
+        List<String> problems = new ArrayList<>();
+        if (!missing.isEmpty()) {
+            problems.add("missing " + String.join(", ", missing));
+        }
+        if (!unexpected.isEmpty()) {
+            problems.add("unexpected " + String.join(", ", unexpected));
+        }
+        findings.add(Finding.fail("workspace", relativize(root, commandsDir),
+                "Generated command directory has " + String.join("; ", problems),
+                "Remove unexpected command stubs and re-run camel-kit init --here --force if required files are missing."));
+    }
+
+    private void checkMcp(Path root, Properties config, List<Finding> findings) {
+        String agentName = config.getProperty("agent.name", "").trim();
+        Path mcpFile = mcpConfigPath(root, agentName);
+        if (mcpFile == null) {
+            findings.add(Finding.fail("mcp", null,
+                    "Cannot determine MCP config path for agent '" + agentName + "'",
+                    "Fix agent.name in .camel-kit/config.properties."));
+            return;
+        }
+        if (!Files.isRegularFile(mcpFile)) {
+            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
+                    "MCP config is missing for agent '" + agentName + "'",
+                    "Run camel-kit init --here --ai " + agentName + " --force to regenerate MCP configuration."));
+            return;
+        }
+
+        JsonNode rootNode;
+        try {
+            rootNode = MAPPER.readTree(mcpFile.toFile());
+        } catch (IOException e) {
+            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
+                    "MCP config is not valid JSON: " + e.getMessage(),
+                    "Fix the JSON syntax or regenerate the MCP config with camel-kit init --here --force."));
+            return;
+        }
+
+        JsonNode servers = rootNode.has("mcp") ? rootNode.path("mcp") : rootNode.path("mcpServers");
+        if (!servers.isObject()) {
+            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
+                    "MCP config does not contain an mcp or mcpServers object",
+                    "Regenerate the MCP config with camel-kit init --here --force."));
+            return;
+        }
+
+        boolean camelOk = checkMcpServer(root, mcpFile, servers, "camel", expectations.camelMcpTools(), findings);
+        boolean knowledgeOk = checkMcpServer(
+                root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), findings);
+        if (camelOk && knowledgeOk) {
+            findings.add(Finding.pass("mcp", relativize(root, mcpFile),
+                    "MCP config exists and tool allowlists match Camel-Kit expectations",
+                    "No action required."));
+        }
+    }
+
+    private boolean checkMcpServer(
+            Path root, Path mcpFile, JsonNode servers, String serverName, Set<String> expected,
+            List<Finding> findings) {
+        JsonNode server = servers.path(serverName);
+        if (!server.isObject()) {
+            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' is missing",
+                    "Regenerate the MCP config with camel-kit init --here --force."));
+            return false;
+        }
+
+        boolean autoApproveOk = checkAllowlist(root, mcpFile, serverName, "autoApprove", server, expected, findings);
+        boolean alwaysAllowOk = checkAllowlist(root, mcpFile, serverName, "alwaysAllow", server, expected, findings);
+        return autoApproveOk && alwaysAllowOk;
+    }
+
+    private boolean checkAllowlist(
+            Path root, Path mcpFile, String serverName, String field, JsonNode server, Set<String> expected,
+            List<Finding> findings) {
+        JsonNode node = server.path(field);
+        if (!node.isArray()) {
+            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' is missing " + field + " array",
+                    "Regenerate the MCP config with camel-kit init --here --force."));
+            return false;
+        }
+
+        Set<String> actual = new LinkedHashSet<>();
+        node.forEach(value -> actual.add(value.asText()));
+        Set<String> missing = new LinkedHashSet<>(expected);
+        missing.removeAll(actual);
+        Set<String> extra = new LinkedHashSet<>(actual);
+        extra.removeAll(expected);
+        if (missing.isEmpty() && extra.isEmpty()) {
+            return true;
+        }
+
+        List<String> problems = new ArrayList<>();
+        if (!missing.isEmpty()) {
+            problems.add("missing " + String.join(", ", missing));
+        }
+        if (!extra.isEmpty()) {
+            problems.add("extra " + String.join(", ", extra));
+        }
+        findings.add(Finding.fail("mcp", relativize(root, mcpFile),
+                "MCP server '" + serverName + "' " + field + " has " + String.join("; ", problems),
+                "Regenerate the MCP config or update the allowlist to match the generated Camel-Kit tools."));
+        return false;
+    }
+
+    private void checkGraph(Path root, List<Finding> findings) {
+        Path graphFile = root.resolve(".camel-kit/project-graph.json");
+        if (Files.isRegularFile(graphFile)) {
+            try {
+                MAPPER.readTree(graphFile.toFile());
+                findings.add(Finding.pass("graph", relativize(root, graphFile),
+                        ".camel-kit/project-graph.json exists and is valid JSON",
+                        "No action required."));
+            } catch (IOException e) {
+                findings.add(Finding.fail("graph", relativize(root, graphFile),
+                        ".camel-kit/project-graph.json is not valid JSON: " + e.getMessage(),
+                        "Run camel-kit graph generate --project-dir " + root + " to regenerate it."));
+            }
+            return;
+        }
+
+        try {
+            new GraphBuilder().build(root);
+            findings.add(Finding.warn("graph", relativize(root, graphFile),
+                    ".camel-kit/project-graph.json is missing, but graph generation can run",
+                    "Run camel-kit graph generate --project-dir " + root + " to persist the graph."));
+        } catch (Exception e) {
+            findings.add(Finding.fail("graph", relativize(root, graphFile),
+                    ".camel-kit/project-graph.json is missing and graph generation failed: " + e.getMessage(),
+                    "Fix the project files reported by graph generation, then run camel-kit graph generate."));
+        }
+    }
+
+    private void checkCommandPrefix(Properties config, List<Finding> findings) {
+        String prefix = config.getProperty("project.command-prefix", "").trim();
+        if ("camel-kit".equals(prefix) || "camel kit".equals(prefix)) {
+            findings.add(Finding.pass("config", ".camel-kit/config.properties",
+                    "project.command-prefix uses a supported invocation style: " + prefix,
+                    "No action required."));
+        } else {
+            findings.add(Finding.warn("config", ".camel-kit/config.properties",
+                    "project.command-prefix is not a known invocation style: " + prefix,
+                    "Set project.command-prefix to camel-kit or camel kit, matching how this CLI is installed."));
+        }
+    }
+
+    private void checkPrerequisites(Path root, List<Finding> findings) {
+        ToolResult java = runTool(null, "java", "-version");
+        if (java.available() && javaMajorVersion(java.output()) >= 17) {
+            findings.add(Finding.pass("prerequisites", null,
+                    "Java 17+ is available",
+                    "No action required."));
+        } else if (java.available()) {
+            findings.add(Finding.warn("prerequisites", null,
+                    "Java is available but the version could not be confirmed as 17+",
+                    "Install or select JDK 17+ before running generated Camel projects."));
+        } else {
+            findings.add(Finding.warn("prerequisites", null,
+                    "Java 17+ was not found on PATH",
+                    "Install JDK 17+ before running generated Camel projects."));
+        }
+
+        Path mvnw = root.resolve(isWindows() ? "mvnw.cmd" : "mvnw");
+        if (Files.isRegularFile(mvnw)) {
+            findings.add(Finding.pass("prerequisites", relativize(root, mvnw),
+                    "Maven Wrapper is present",
+                    "No action required."));
+        } else if (runTool(root, "mvn", "-version").available()) {
+            findings.add(Finding.warn("prerequisites", null,
+                    "Maven is available, but the generated Maven Wrapper is missing",
+                    "Run camel-kit init --here --force to restore mvnw and .mvn/wrapper."));
+        } else {
+            findings.add(Finding.warn("prerequisites", null,
+                    "Neither Maven Wrapper nor mvn was found",
+                    "Install Maven or restore the generated Maven Wrapper with camel-kit init --here --force."));
+        }
+
+        if (runTool(null, "jbang", "version").available()) {
+            findings.add(Finding.pass("prerequisites", null,
+                    "JBang is available for MCP server launch commands",
+                    "No action required."));
+        } else {
+            findings.add(Finding.warn("prerequisites", null,
+                    "JBang was not found on PATH",
+                    "Install JBang so generated MCP server commands can run."));
+        }
+
+        if (runTool(null, "camel", "--version").available()) {
+            findings.add(Finding.pass("prerequisites", null,
+                    "Camel JBang is available",
+                    "No action required."));
+        } else {
+            findings.add(Finding.warn("prerequisites", null,
+                    "Camel JBang was not found on PATH",
+                    "Install Camel JBang for local graph, validation, and verification workflows."));
+        }
+    }
+
+    private void checkStaleReferences(Path root, AgentConfig agent, List<Finding> findings) {
+        List<Path> activeFiles = new ArrayList<>();
+        addIfExists(activeFiles, root.resolve("AGENTS.md"));
+        addIfExists(activeFiles, root.resolve("CLAUDE.md"));
+        addIfExists(activeFiles, root.resolve("GEMINI.md"));
+        addIfExists(activeFiles, root.resolve("QWEN.md"));
+        addIfExists(activeFiles, root.resolve("opencode.json"));
+        if (agent != null) {
+            Path commandsDir = root.resolve(agent.folder());
+            if (Files.isDirectory(commandsDir)) {
+                try (Stream<Path> stream = Files.list(commandsDir)) {
+                    stream.filter(Files::isRegularFile).forEach(activeFiles::add);
+                } catch (IOException e) {
+                    findings.add(Finding.warn("workspace", relativize(root, commandsDir),
+                            "Could not scan generated command files for stale references: " + e.getMessage(),
+                            "Check filesystem permissions and re-run camel-kit doctor."));
+                }
+            }
+            addIfExists(activeFiles, mcpConfigPath(root, agentKey(agent)));
+        }
+
+        Map<Path, List<String>> matches = new LinkedHashMap<>();
+        for (Path file : activeFiles) {
+            try {
+                String content = Files.readString(file, StandardCharsets.UTF_8);
+                List<String> found = STALE_REFERENCES.stream()
+                        .filter(content::contains)
+                        .toList();
+                if (!found.isEmpty()) {
+                    matches.put(file, found);
+                }
+            } catch (IOException e) {
+                findings.add(Finding.warn("workspace", relativize(root, file),
+                        "Could not scan active generated file for stale references: " + e.getMessage(),
+                        "Check filesystem permissions and re-run camel-kit doctor."));
+            }
+        }
+
+        if (matches.isEmpty()) {
+            findings.add(Finding.pass("workspace", null,
+                    "Active generated files do not contain common stale resource references",
+                    "No action required."));
+            return;
+        }
+
+        List<String> details = matches.entrySet().stream()
+                .map(entry -> relativize(root, entry.getKey()) + " -> " + String.join(", ", entry.getValue()))
+                .toList();
+        findings.add(Finding.fail("workspace", null,
+                "Active generated files contain stale references: " + String.join("; ", details),
+                "Regenerate the workspace or update the listed files to current Camel-Kit paths and commands."));
+    }
+
+    private void printText(Path root, List<Finding> findings) {
+        printer().println(bold("Camel-Kit Doctor"));
+        printer().println("Workspace: " + root);
+        printer().println();
+        for (Finding finding : findings) {
+            printer().println(statusLabel(finding.status()) + " " + finding.category() + " - " + finding.message());
+            if (finding.path() != null) {
+                printer().println("  Path: " + finding.path());
+            }
+            printer().println("  Fix:  " + finding.remediation());
+        }
+        printer().println();
+        printer().println(summary(findings));
+    }
+
+    private String toJson(Path root, List<Finding> findings) throws IOException {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("projectDir", root.toString());
+        node.put("status", findings.stream().anyMatch(f -> f.status() == Status.FAIL) ? "FAIL" : "PASS");
+        ObjectNode summary = node.putObject("summary");
+        summary.put("pass", findings.stream().filter(f -> f.status() == Status.PASS).count());
+        summary.put("warn", findings.stream().filter(f -> f.status() == Status.WARN).count());
+        summary.put("fail", findings.stream().filter(f -> f.status() == Status.FAIL).count());
+        ArrayNode array = node.putArray("findings");
+        for (Finding finding : findings) {
+            ObjectNode findingNode = array.addObject();
+            findingNode.put("status", finding.status().name());
+            findingNode.put("category", finding.category());
+            if (finding.path() == null) {
+                findingNode.putNull("path");
+            } else {
+                findingNode.put("path", finding.path());
+            }
+            findingNode.put("message", finding.message());
+            findingNode.put("remediation", finding.remediation());
+        }
+        return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
+    }
+
+    private String summary(List<Finding> findings) {
+        long pass = findings.stream().filter(f -> f.status() == Status.PASS).count();
+        long warn = findings.stream().filter(f -> f.status() == Status.WARN).count();
+        long fail = findings.stream().filter(f -> f.status() == Status.FAIL).count();
+        return "Summary: " + pass + " PASS, " + warn + " WARN, " + fail + " FAIL";
+    }
+
+    private String statusLabel(Status status) {
+        return switch (status) {
+            case PASS -> green("PASS");
+            case WARN -> yellow("WARN");
+            case FAIL -> red("FAIL");
+        };
+    }
+
+    private ToolResult runTool(Path directory, String... command) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            if (directory != null) {
+                pb.directory(directory.toFile());
+            }
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            boolean finished = process.waitFor(PREREQUISITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                return new ToolResult(false, "");
+            }
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return new ToolResult(process.exitValue() == 0, output);
+        } catch (Exception e) {
+            return new ToolResult(false, "");
+        }
+    }
+
+    private int javaMajorVersion(String output) {
+        Matcher matcher = Pattern.compile("version\\s+\"([^\"]+)\"").matcher(output);
+        if (!matcher.find()) {
+            return 0;
+        }
+        String version = matcher.group(1);
+        if (version.startsWith("1.")) {
+            String[] parts = version.split("\\.");
+            return parts.length > 1 ? parseInt(parts[1]) : 0;
+        }
+        return parseInt(version.split("[.+\\-]")[0]);
+    }
+
+    private int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private Path mcpConfigPath(Path root, String agentName) {
+        return switch (agentName.toLowerCase(Locale.ROOT)) {
+            case "claude" -> root.resolve(".mcp.json");
+            case "bob" -> root.resolve(".bob/mcp.json");
+            case "gemini" -> root.resolve(".gemini/settings.json");
+            case "qwen" -> root.resolve(".qwen/settings.json");
+            case "opencode" -> root.resolve("opencode.json");
+            default -> null;
+        };
+    }
+
+    private String commandName(String filename) {
+        int dot = filename.indexOf('.');
+        return dot == -1 ? filename : filename.substring(0, dot);
+    }
+
+    private String agentKey(AgentConfig agent) {
+        return AgentRegistry.all().entrySet().stream()
+                .filter(entry -> entry.getValue().equals(agent))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(agent.name());
+    }
+
+    private String relativize(Path root, Path path) {
+        if (path == null) {
+            return null;
+        }
+        try {
+            return root.relativize(path.toAbsolutePath().normalize()).toString();
+        } catch (IllegalArgumentException e) {
+            return path.toString();
+        }
+    }
+
+    private void addIfExists(List<Path> paths, Path path) {
+        if (path != null && Files.isRegularFile(path)) {
+            paths.add(path);
+        }
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    enum Status {
+        PASS,
+        WARN,
+        FAIL
+    }
+
+    record Finding(Status status, String category, String path, String message, String remediation) {
+        static Finding pass(String category, String path, String message, String remediation) {
+            return new Finding(Status.PASS, category, path, message, remediation);
+        }
+
+        static Finding warn(String category, String path, String message, String remediation) {
+            return new Finding(Status.WARN, category, path, message, remediation);
+        }
+
+        static Finding fail(String category, String path, String message, String remediation) {
+            return new Finding(Status.FAIL, category, path, message, remediation);
+        }
+    }
+
+    record ToolResult(boolean available, String output) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/DoctorExpectations.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/DoctorExpectations.java
@@ -1,0 +1,73 @@
+package io.github.luigidemasi.camelkit.command;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
+
+/**
+ * Expected generated workspace contract used by {@link DoctorCommand}.
+ */
+final class DoctorExpectations {
+
+    private final List<String> userCommands;
+    private final List<String> requiredSkills;
+    private final Set<String> camelMcpTools;
+    private final Set<String> knowledgeMcpTools;
+
+    private DoctorExpectations(
+                               List<String> userCommands,
+                               List<String> requiredSkills,
+                               Set<String> camelMcpTools,
+                               Set<String> knowledgeMcpTools) {
+        this.userCommands = List.copyOf(userCommands);
+        this.requiredSkills = List.copyOf(requiredSkills);
+        this.camelMcpTools = Collections.unmodifiableSet(new LinkedHashSet<>(camelMcpTools));
+        this.knowledgeMcpTools = Collections.unmodifiableSet(new LinkedHashSet<>(knowledgeMcpTools));
+    }
+
+    static DoctorExpectations loadDefault() {
+        try {
+            return from(WorkflowManifestLoader.loadDefault());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not load workflow manifest for doctor expectations", e);
+        }
+    }
+
+    static DoctorExpectations from(WorkflowManifest workflow) {
+        return new DoctorExpectations(
+                workflow.generatedCommandStubs().stream()
+                        .map(WorkflowManifest.WorkflowCommand::name)
+                        .toList(),
+                workflow.skills().stream()
+                        .map(WorkflowManifest.WorkflowSkill::name)
+                        .toList(),
+                orderedSet(workflow.mcpServer("camel").allowedTools()),
+                orderedSet(workflow.mcpServer("camel-knowledge").allowedTools()));
+    }
+
+    List<String> userCommands() {
+        return userCommands;
+    }
+
+    List<String> requiredSkills() {
+        return requiredSkills;
+    }
+
+    Set<String> camelMcpTools() {
+        return camelMcpTools;
+    }
+
+    Set<String> knowledgeMcpTools() {
+        return knowledgeMcpTools;
+    }
+
+    private static Set<String> orderedSet(List<String> values) {
+        return new LinkedHashSet<>(values);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -51,7 +51,7 @@ public class DistributionConfig {
         this.camelMainSupported = props.getProperty("camel.main.supported", "4.20.0");
         this.camelSpringbootSupported = props.getProperty("camel.springboot.supported", "4.20.0");
         this.camelQuarkusSupported = props.getProperty("camel.quarkus.supported", "4.18.0");
-        this.camelMcpVersion = props.getProperty("camel.mcp.version", "4.20.0");
+        this.camelMcpVersion = props.getProperty("camel.mcp.version", "4.21.0-SNAPSHOT");
         this.knowledgeMcpVersion = props.getProperty("knowledge.mcp.version", "0.0.1-SNAPSHOT");
         this.camelMcpRepos = props.getProperty("camel.mcp.repos", "maven");
         this.knowledgeMcpRepos = props.getProperty("knowledge.mcp.repos", "maven");
@@ -114,9 +114,19 @@ public class DistributionConfig {
     public static DistributionConfig load(InputStream in) {
         Properties props = new Properties();
         try {
-            props.load(in);
+            if (in != null) {
+                props.load(in);
+            }
         } catch (Exception e) {
             // Fall through with empty properties — defaults will apply
+        }
+        return new DistributionConfig(props, 0);
+    }
+
+    public static DistributionConfig load(Properties properties) {
+        Properties props = new Properties();
+        if (properties != null) {
+            props.putAll(properties);
         }
         return new DistributionConfig(props, 0);
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -324,6 +324,8 @@ public class DefaultGenerator implements AgentGenerator {
                             "CAMEL_MCP_REPOS", camelMcpRepos,
                             "KNOWLEDGE_MCP_REPOS", knowledgeMcpRepos,
                             "CAMEL_CATALOG_REPOS", CamelKitMain.CAMEL_CATALOG_REPOS));
+            WorkflowManifest.WorkflowMcpServer camelServer = workflow.mcpServer("camel");
+            templateData.put("CAMEL_TOOLS_JSON", toJsonArray(camelServer.allowedTools()));
             templateData.put("CAMEL_VERSION", dist.camelMainVersion());
             templateData.put("CAMEL_MAIN_VERSION", dist.camelMainVersion());
             templateData.put("CAMEL_SPRINGBOOT_VERSION", dist.camelSpringbootVersion());

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/GeminiGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/GeminiGenerator.java
@@ -27,18 +27,10 @@ public class GeminiGenerator extends DefaultGenerator {
             new String[]{
                     "Create implementation plan",
                     "Delegate this task to the camel-planner subagent.\nRead .gemini/skills/camel-plan/SKILL.md and follow those instructions."},
-            "camel-implement",
-            new String[]{
-                    "Implement Camel routes",
-                    "Delegate this task to the camel-implementer subagent.\nRead .gemini/skills/camel-implement/SKILL.md and follow those instructions."},
             "camel-validate",
             new String[]{
                     "Validate Camel routes against quality rules",
                     "Delegate this task to the camel-validator subagent.\nRead .gemini/skills/camel-validate/SKILL.md and follow those instructions."},
-            "camel-test",
-            new String[]{
-                    "Write and run tests for Camel routes",
-                    "Delegate this task to the camel-tester subagent.\nRead .gemini/skills/camel-test/SKILL.md and follow those instructions."},
             "camel-migrate",
             new String[]{
                     "Migrate integrations to Apache Camel",

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/OpenCodeGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/OpenCodeGenerator.java
@@ -18,9 +18,7 @@ public class OpenCodeGenerator extends DefaultGenerator {
             "camel-brainstorm",
             "@brainstormer discover integration requirements and design Camel routes for this project",
             "camel-plan", "@planner create an implementation plan with TDD task decomposition for this project",
-            "camel-implement", "@implementer implement the Camel routes in this project",
             "camel-validate", "@validator validate the Camel routes in this project",
-            "camel-test", "@tester write and run tests for the Camel routes in this project",
             "camel-migrate", "@migrator migrate the integrations to Apache Camel",
             "camel-execute", "@executor execute the implementation plan for this project");
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/QwenGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/QwenGenerator.java
@@ -19,11 +19,7 @@ public class QwenGenerator extends DefaultGenerator {
             "Delegate to the camel-brainstormer sub-agent: discover integration requirements and design Camel routes for this project",
             "camel-plan",
             "Delegate to the camel-planner sub-agent: create an implementation plan with TDD task decomposition for this project",
-            "camel-implement",
-            "Delegate to the camel-implementer sub-agent: implement the Camel routes in this project",
             "camel-validate", "Delegate to the camel-validator sub-agent: validate the Camel routes in this project",
-            "camel-test",
-            "Delegate to the camel-tester sub-agent: write and run tests for the Camel routes in this project",
             "camel-migrate", "Delegate to the camel-migrator sub-agent: migrate the integrations to Apache Camel",
             "camel-execute",
             "Delegate to the camel-executor sub-agent: execute the implementation plan for this project");

--- a/camel-kit-core/src/main/resources/agents/catalog-researcher.md
+++ b/camel-kit-core/src/main/resources/agents/catalog-researcher.md
@@ -19,10 +19,10 @@ This pattern keeps MCP response traces (often 500+ tokens each) out of the orche
 
 1. Receive a list of artifacts to verify (components, EIPs, dataformats, languages)
 2. For EACH artifact, call the appropriate MCP tool:
-   - `camel_catalog_component_doc(name, runtime, platformBom)` for components
-   - `camel_catalog_eip(name, runtime, platformBom)` for EIPs
-   - `camel_catalog_dataformat(name, runtime, platformBom)` for dataformats
-   - `camel_catalog_language(name, runtime, platformBom)` for languages
+   - `camel_catalog_component_doc(component, runtime, platformBom)` for components
+   - `camel_catalog_eip_doc(eip, runtime, platformBom)` for EIPs
+   - `camel_catalog_dataformat_doc(dataformat, runtime, platformBom)` for dataformats
+   - `camel_catalog_language_doc(language, runtime, platformBom)` for languages
 3. Record verification results: exists (with exact option names) or not found
 4. Return a structured summary
 

--- a/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/code-quality-reviewer.md
@@ -60,7 +60,7 @@ Check all 7 rules for every route:
 ## MCP Tools You Use
 
 - `camel_catalog_component_doc` — spot-check endpoint URIs and options
-- `camel_catalog_eip` — verify EIP configuration
+- `camel_catalog_eip_doc` — verify EIP configuration
 
 ## Guides You Reference
 

--- a/camel-kit-core/src/main/resources/agents/critic-route-architecture.md
+++ b/camel-kit-core/src/main/resources/agents/critic-route-architecture.md
@@ -52,7 +52,7 @@ You produce **PASS** or a list of **spec violations**. You never generate altern
 ## MCP Tools You Use
 
 - `camel_catalog_component_doc` — verify component option names and URI syntax
-- `camel_catalog_eip` — verify EIP configuration options
+- `camel_catalog_eip_doc` — verify EIP configuration options
 
 ## Output Format
 

--- a/camel-kit-core/src/main/resources/agents/implementation-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/implementation-engineer.md
@@ -35,9 +35,9 @@ You are dispatched during the **Execute phase** as the implementer subagent for 
 ## MCP Tools You Use
 
 - `camel_catalog_component_doc` — verify component options before generating YAML
-- `camel_catalog_eip` — verify EIP configuration options
-- `camel_catalog_dataformat` — verify dataformat options
-- `camel_catalog_language` — verify expression language syntax
+- `camel_catalog_eip_doc` — verify EIP configuration options
+- `camel_catalog_dataformat_doc` — verify dataformat options
+- `camel_catalog_language_doc` — verify expression language syntax
 
 ## Guides You Reference
 

--- a/camel-kit-core/src/main/resources/agents/integration-architect.md
+++ b/camel-kit-core/src/main/resources/agents/integration-architect.md
@@ -35,9 +35,9 @@ You are dispatched during the **Brainstorm phase** to:
 ## MCP Tools You Use
 
 - `camel_catalog_component_doc` — verify component exists, get exact option names
-- `camel_catalog_eip` — verify EIP exists, get configuration options
-- `camel_catalog_dataformat` — verify dataformat exists
-- `camel_catalog_language` — verify expression language exists
+- `camel_catalog_eip_doc` — verify EIP exists, get configuration options
+- `camel_catalog_dataformat_doc` — verify dataformat exists
+- `camel_catalog_language_doc` — verify expression language exists
 
 ## Output Format
 

--- a/camel-kit-core/src/main/resources/agents/migration-specialist.md
+++ b/camel-kit-core/src/main/resources/agents/migration-specialist.md
@@ -43,8 +43,8 @@ You are dispatched for migration-specific tasks:
 
 ## MCP Tools You Use
 
-- `camel_catalog_component` — verify target component exists and get exact options
-- `camel_catalog_eip` — verify EIP availability in target version
+- `camel_catalog_component_doc` — verify target component exists and get exact options
+- `camel_catalog_eip_doc` — verify EIP availability in target version
 - `camel_graph_analyze` — analyze project structure for large-scale migrations
 
 ## Guides You Reference

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -235,10 +235,10 @@ You MUST complete these items in order:
 
 ## MCP Tools Used in This Phase
 
-- `camel_catalog_component` — verify component exists, get options
-- `camel_catalog_eip` — verify EIP exists, get configuration
-- `camel_catalog_dataformat` — verify dataformat exists
-- `camel_catalog_language` — verify expression language exists
+- `camel_catalog_component_doc` — verify component exists, get options
+- `camel_catalog_eip_doc` — verify EIP exists, get configuration
+- `camel_catalog_dataformat_doc` — verify dataformat exists
+- `camel_catalog_language_doc` — verify expression language exists
 → For MCP setup, version mapping, and fallback policy: see `shared/mcp-setup.md`
 → For graph analysis: use `{COMMAND_PREFIX} graph` CLI commands (see `shared/graph-availability.md`)
 

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/greenfield-interview.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/greenfield-interview.md
@@ -297,7 +297,7 @@ Record: `project.constraints`
 
 After the interview, for EACH flow, verify all source and sink components via MCP catalog:
 
-1. Call `camel_catalog_component` for each source/sink technology
+1. Call `camel_catalog_component_doc` for each source/sink technology
 2. Confirm the component exists and note exact option names
 
 This verification happens BEFORE assembling the design spec. Failed verification = the design spec is wrong.

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-discovery.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/migration-discovery.md
@@ -366,7 +366,7 @@ For EACH route to be migrated, design the Camel 4.x equivalent:
    - Load the appropriate mapping guide from `camel-migrate/guides/`:
      - MuleSoft: `mule-component-mapping.md`
      - Camel 2.x: `camel2-component-mapping.md`, `camel2-eip-mapping.md`, `camel2-dataformat-mapping.md`, `camel2-language-mapping.md`
-   - For each mapped component, verify via MCP catalog (`camel_catalog_component`)
+   - For each mapped component, verify via MCP catalog (`camel_catalog_component_doc`)
 
 2. **Handle transformations:**
    - DataWeave → XSLT: load `mule-dataweave-conversion.md`

--- a/camel-kit-core/src/main/resources/skills/camel-debug/guides/debug-workflow.md
+++ b/camel-kit-core/src/main/resources/skills/camel-debug/guides/debug-workflow.md
@@ -100,7 +100,7 @@ For errors related to components, endpoints, or data formats:
 1. Identify all components referenced in the affected route files
 2. For each component, call the MCP catalog tool:
    ```
-   camel_catalog_component(name="{component}", runtime="{runtime}", platformBom="{bom}")
+   camel_catalog_component_doc(component="{component}", runtime="{runtime}", platformBom="{bom}")
    ```
 3. Check:
    - Does the component exist for this runtime and version?

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/environment-probe.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/environment-probe.md
@@ -186,7 +186,7 @@ All probe errors start classified as **MECHANICAL**. Only promote to **ARCHITECT
 
 | Error | Default Class | MCP Check | Promotion to Architectural |
 |---|---|---|---|
-| `Could not find artifact` | Mechanical | `camel_catalog_component(name, runtime, platformBom)` — exists? fix the name. Does not exist? promote. | If MCP says the component does not exist |
+| `Could not find artifact` | Mechanical | `camel_catalog_component_doc(component, runtime, platformBom)` — exists? fix the name. Does not exist? promote. | If MCP says the component does not exist |
 | `Could not resolve dependencies` (transitive conflict) | Mechanical | Check if both dependencies exist individually | If conflict persists after fix attempt |
 | Docker `manifest unknown` | Mechanical | N/A | If the same image fails after 2 attempts |
 | Docker `pull access denied` | Architectural | N/A | Immediately — private or licensed image |
@@ -199,7 +199,7 @@ All probe errors start classified as **MECHANICAL**. Only promote to **ARCHITECT
 For dependency and runtime errors, verify against the MCP catalog before attempting a fix:
 
 ```text
-camel_catalog_component(name="{component}", runtime="{runtime}", platformBom="{bom-gav}")
+camel_catalog_component_doc(component="{component}", runtime="{runtime}", platformBom="{bom-gav}")
 ```
 
 - If the component exists → the error is mechanical (wrong artifact name, wrong groupId, typo)

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
@@ -73,7 +73,7 @@ For all MCP catalog calls, use these parameters:
 - platformBom: [full GAV]
 
 Example call:
-camel_catalog_component_doc(name="kafka", runtime="spring-boot", platformBom="org.apache.camel.springboot:camel-catalog-provider-springboot:4.14.0")
+camel_catalog_component_doc(component="kafka", runtime="spring-boot", platformBom="org.apache.camel.springboot:camel-catalog-provider-springboot:4.14.0")
 ```
 
 #### 7. Pre-Verified Catalog Summary

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/quality-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/quality-reviewer-criteria.md
@@ -30,5 +30,5 @@ If the quality reviewer reports Critical issues:
 ## MCP Tools for Quality Review
 
 The quality reviewer should use:
-- `camel_catalog_component_doc(name, runtime, platformBom)` — verify endpoint option names
-- `camel_catalog_eip(name, runtime, platformBom)` — verify EIP configuration
+- `camel_catalog_component_doc(component, runtime, platformBom)` — verify endpoint option names
+- `camel_catalog_eip_doc(eip, runtime, platformBom)` — verify EIP configuration

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/re-plan-loop.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/re-plan-loop.md
@@ -40,7 +40,7 @@ Triggered when the MCP catalog CONFIRMS the failure is structural. Skip further 
 
 | Failure | MCP Verification | Action |
 |---|---|---|
-| Component does not exist in the catalog for this runtime/version | `camel_catalog_component` returns no result | Enter re-plan |
+| Component does not exist in the catalog for this runtime/version | `camel_catalog_component_doc` returns no result | Enter re-plan |
 | Required EIP pattern not available in this Camel version | `camel_catalog_model` returns no result | Enter re-plan |
 | Component combination is invalid (incompatible transitive dependencies confirmed) | Both components exist individually but dependency analysis shows conflict | Enter re-plan |
 
@@ -82,12 +82,13 @@ Determine which TDD file(s) and which sections within those TDDs need modificati
 
 Query the MCP catalog for alternative components that fulfill the same role.
 
-1. Call `camel_catalog_component` with the target `runtime` and `platformBom` to list available components in the same category
+1. Call `camel_catalog_components` with the target `runtime`, `platformBom`, and a category/name/label filter
+   to list available components in the same category
 2. Identify an alternative component that:
    - Fulfills the same integration role (same protocol family or equivalent)
    - Has required options that can satisfy the TDD requirements
    - Does not conflict with other planned components in the project
-3. Verify the alternative's required and optional options via `camel_catalog_component(name="{alternative}")`
+3. Verify the alternative's required and optional options via `camel_catalog_component_doc(component="{alternative}")`
 4. If no viable alternative exists in the catalog — skip to escalation (do not guess)
 
 ### Step 3: Modify TDD

--- a/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
@@ -207,7 +207,7 @@ generated:
 - [other guides specific to this task]
 
 **MCP Tools:**
-- `camel_catalog_component(name="X", runtime="Y", platformBom="Z")`
+- `camel_catalog_component_doc(component="X", runtime="Y", platformBom="Z")`
 - [other MCP calls]
 
 **Design Spec Section:** Section 3, Flow: [flow-name]

--- a/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-greenfield.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-greenfield.md
@@ -73,10 +73,10 @@ Do NOT generate the POM from scratch. COPY the template file and replace ONLY th
 - `camel-implement/guides/sequential-http-calls.md` (if HTTP→HTTP)
 
 **MCP Tools:**
-- `camel_catalog_component(name="[source-component]", runtime="[runtime]", platformBom="[bom]")`
-- `camel_catalog_component(name="[sink-component]", runtime="[runtime]", platformBom="[bom]")`
-- `camel_catalog_eip(name="[eip]")` for each EIP used
-- `camel_catalog_dataformat(name="[format]")` for each data format
+- `camel_catalog_component_doc(component="[source-component]", runtime="[runtime]", platformBom="[bom]")`
+- `camel_catalog_component_doc(component="[sink-component]", runtime="[runtime]", platformBom="[bom]")`
+- `camel_catalog_eip_doc(eip="[eip]")` for each EIP used
+- `camel_catalog_dataformat_doc(dataformat="[format]")` for each data format
 
 **Design Spec Section:** Section 3, Flow: [flow-name]
 
@@ -165,7 +165,7 @@ Do NOT generate the POM from scratch. COPY the template file and replace ONLY th
 - `camel-validate/guides/anti-patterns.md`
 
 **MCP Tools:**
-- `camel_catalog_component` for each endpoint URI
+- `camel_catalog_component_doc` for each endpoint URI
 
 - [ ] Run schema validation on each route YAML
 - [ ] Verify each endpoint URI via MCP catalog

--- a/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-migration.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-migration.md
@@ -59,10 +59,10 @@ These tasks are added to the standard greenfield sequence:
 - `camel-migrate/guides/camel2-dataformat-mapping.md` (Camel 2.x)
 
 **MCP Tools:**
-- `camel_catalog_component(name="[target-component]", runtime="[runtime]", platformBom="[bom]")`
+- `camel_catalog_component_doc(component="[target-component]", runtime="[runtime]", platformBom="[bom]")`
 
 - [ ] For each component in the mapping table:
-  - [ ] Verify target component exists via `camel_catalog_component`
+  - [ ] Verify target component exists via `camel_catalog_component_doc`
   - [ ] Note exact option names from catalog (may differ from source)
 - [ ] If any mapping fails, flag and suggest alternative
 

--- a/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
@@ -29,8 +29,8 @@ Test tasks come after all implementation and validation tasks. Generate one test
 - `camel-test/guides/test-runner.md` — execution and verification
 
 **MCP Tools:**
-- `camel_catalog_component(name="[source-component]")` — understand trigger behavior
-- `camel_catalog_component(name="[sink-component]")` — understand assertion points
+- `camel_catalog_component_doc(component="[source-component]")` — understand trigger behavior
+- `camel_catalog_component_doc(component="[sink-component]")` — understand assertion points
 
 **Design Spec Section:** Section 3, Flow: [flow-name]
 

--- a/camel-kit-core/src/main/resources/skills/camel-validate/guides/quality-checks.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/guides/quality-checks.md
@@ -62,7 +62,7 @@ SQL Component:
 
 ### 5.2 Component Catalog Verification (optional, if catalog MCP is available)
 
-For each component, call `camel_catalog_component` to collect catalog availability. If the tool call fails (tool not found, network error), skip this section with a note: `"Skipping catalog verification — MCP not available."`
+For each component, call `camel_catalog_component_doc` to collect catalog availability. If the tool call fails (tool not found, network error), skip this section with a note: `"Skipping catalog verification — MCP not available."`
 
 **This step is data collection only.** Store the results (availability per component) for use in Stage 6 Constitution Rule 7, which evaluates and reports warnings.
 
@@ -108,7 +108,7 @@ Validate against the 7 rules in `docs/constitution.md`. Each gate maps 1:1 to a 
 | 4 | Naming Conventions | Route ID convention | If PROJECT_NORMS.NAMING_PATTERN is available, validate route ID against the project's dominant pattern (examples: PROJECT_NORMS.NAMING_EXAMPLES). Otherwise, route ID matches `{domain}-{action}` lowercase kebab-case. Valid: `order-process`, `user-notify`. Invalid: `route1`, `myRoute`, `OrderProcess`. Regex: `^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)+$` | WARNING |
 | 5 | Observability | routeId + description | Every route declares both a `routeId` and a `description` (≥10 chars describing the flow's business purpose). These are essential for monitoring, logging, and tracing. | FAIL |
 | 6 | External Configuration | No hardcoded values | No hostnames, ports, IPs, database URLs, queue names, credentials, API keys, tokens, or secrets in route YAML. Detect patterns: `password=`, `apiKey=`, `secret=`, `token=`, Base64 strings >20 chars, `jdbc:` URLs with inline credentials. All must use `{{placeholder}}` syntax. | FAIL |
-| 7 | Component Support | Catalog verified | Every component verified to exist in the Apache Camel catalog for the target version. **Primary:** Uses Stage 5.2 collected data (from `camel_catalog_component`). **Fallback (Stage 5.2 was skipped):** Consult the Apache Camel component catalog for the target version. Two warning levels: (1) **Not found** — component not in catalog; (2) **Deprecated** — component is deprecated in the target version. "Available" passes without warning. | WARNING |
+| 7 | Component Support | Catalog verified | Every component verified to exist in the Apache Camel catalog for the target version. **Primary:** Uses Stage 5.2 collected data (from `camel_catalog_component_doc`). **Fallback (Stage 5.2 was skipped):** Consult the Apache Camel component catalog for the target version. Two warning levels: (1) **Not found** — component not in catalog; (2) **Deprecated** — component is deprecated in the target version. "Available" passes without warning. | WARNING |
 
 Show results:
 

--- a/camel-kit-core/src/main/resources/skills/camel-verify/guides/error-taxonomy.md
+++ b/camel-kit-core/src/main/resources/skills/camel-verify/guides/error-taxonomy.md
@@ -106,7 +106,7 @@ Re-check TDD Section 2/4 for the correct component name. Verify against MCP cata
 **Phase:** Startup
 **Category:** Component/endpoint
 **Fix target:** camel-validate
-**Fix action:** The component endpoint options are invalid for this Camel version. Load `camel-validate` and re-validate the component options against the MCP catalog (`camel_catalog_component`). Common cause: option names changed between Camel versions.
+**Fix action:** The component endpoint options are invalid for this Camel version. Load `camel-validate` and re-validate the component options against the MCP catalog (`camel_catalog_component_doc`). Common cause: option names changed between Camel versions.
 
 ### Missing Bean
 
@@ -254,7 +254,7 @@ After 1 failed fix attempt, query the MCP catalog to check if the failure is str
 - Required EIP pattern not available in this Camel version → `re-plan`
 - Incompatible component combination confirmed → `re-plan`
 
-**Detection:** After the first fix attempt fails, call `camel_catalog_component(name={component}, runtime={runtime}, platformBom={bom})`. If MCP returns no result, the failure is structural. Route to `re-plan` immediately — do not consume additional fix attempts.
+**Detection:** After the first fix attempt fails, call `camel_catalog_component_doc(component={component}, runtime={runtime}, platformBom={bom})`. If MCP returns no result, the failure is structural. Route to `re-plan` immediately — do not consume additional fix attempts.
 
 ### Tier 2: Progressive Promotion
 

--- a/camel-kit-core/src/main/resources/skills/shared/iron-laws.md
+++ b/camel-kit-core/src/main/resources/skills/shared/iron-laws.md
@@ -17,7 +17,7 @@ You do NOT know what components exist. You do NOT know their options. The MCP ca
 
 **Gate function:**
 1. IDENTIFY the component/EIP/dataformat/language name
-2. CALL the appropriate MCP tool (`camel_catalog_component`, `camel_catalog_eip`, `camel_catalog_dataformat`, `camel_catalog_language`)
+2. CALL the appropriate MCP tool (`camel_catalog_component_doc`, `camel_catalog_eip_doc`, `camel_catalog_dataformat_doc`, `camel_catalog_language_doc`)
 3. READ the response — confirm the artifact exists and note exact option names
 4. USE only verified names and options in your output
 5. If the artifact does NOT exist, STOP and find an alternative

--- a/camel-kit-core/src/main/resources/skills/shared/mcp-setup.md
+++ b/camel-kit-core/src/main/resources/skills/shared/mcp-setup.md
@@ -55,7 +55,7 @@ The runtime affects which components are returned (e.g., Quarkus extensions vs S
 
 ### Rule 3: Omitting `platformBom` and `camelVersion`
 
-When both are omitted, the MCP server uses its built-in catalog (4.20.0). This is a superset of all versions — component schemas are backwards-compatible. Use this as a fallback when the exact version doesn't matter.
+When both are omitted, the MCP server uses its built-in catalog (4.21.0-SNAPSHOT). Use this as a fallback when the exact version doesn't matter.
 
 **Examples:**
 - Project has `camelVersion: 4.14.4`, `runtime: quarkus` → `runtime=quarkus`, `platformBom=io.quarkus.platform:quarkus-camel-bom:3.17.7`

--- a/camel-kit-core/src/main/resources/templates/bob/custom_modes.yaml
+++ b/camel-kit-core/src/main/resources/templates/bob/custom_modes.yaml
@@ -54,7 +54,7 @@ customModes:
       Use this mode when implementing Camel routes from an approved plan.
       Activated during the implementation phase of the camel-kit pipeline.
     customInstructions: >
-      Every component MUST be verified via camel_catalog_component before use.
+      Every component MUST be verified via camel_catalog_component_doc before use.
       Follow the plan step by step. Do not skip steps or add unrequested features.
     groups:
       - read

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
@@ -146,7 +146,7 @@ For each flow, design the integration using relevant guides from `camel-design/`
 - Resilience: `guides/resilience.md`
 
 **CRITICAL:** Verify EVERY component via MCP:
-1. `camel_catalog_component` — verify component exists
+1. `camel_catalog_component_doc` — verify component exists
 
 Do NOT guess component names. MCP catalog is truth.
 </Step>
@@ -374,10 +374,10 @@ Read `shared/iron-laws.md` for the full Iron Laws. This skill enforces:
 
 ## MCP Tools Used
 
-- `camel_catalog_component` — verify component exists, get options
-- `camel_catalog_eip` — verify EIP exists, get configuration
-- `camel_catalog_dataformat` — verify dataformat exists
-- `camel_catalog_language` — verify expression language exists
+- `camel_catalog_component_doc` — verify component exists, get options
+- `camel_catalog_eip_doc` — verify EIP exists, get configuration
+- `camel_catalog_dataformat_doc` — verify dataformat exists
+- `camel_catalog_language_doc` — verify expression language exists
 - `camel_docs_search` — search docs for guidance
 
 For MCP setup, version mapping, and fallback policy: see `shared/mcp-setup.md`

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
@@ -80,10 +80,10 @@ For EACH task in the queue:
 Follow the task's step-by-step instructions. For implementation tasks:
 
 1. **Verify components via MCP:**
-   - For EVERY component: `camel_catalog_component`
-   - For EVERY EIP: `camel_catalog_eip`
-   - For EVERY dataformat: `camel_catalog_dataformat`
-   - For EVERY language: `camel_catalog_language`
+   - For EVERY component: `camel_catalog_component_doc`
+   - For EVERY EIP: `camel_catalog_eip_doc`
+   - For EVERY dataformat: `camel_catalog_dataformat_doc`
+   - For EVERY language: `camel_catalog_language_doc`
 
 2. **Generate artifacts:**
    - YAML routes: follow `guides/yaml-structure.md` + `guides/yaml-catalog-rules.md`

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-implement.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-implement.md
@@ -61,10 +61,10 @@ For EACH route in the plan:
 
 1. **Read the TDD** at `docs/flows/<flow-name>/<flow-name>.tdd.md`
 2. **Verify components via MCP:**
-   - For EVERY component: `camel_catalog_component(name="X", runtime="Y", platformBom="Z")`
-   - For EVERY EIP: `camel_catalog_eip(name="X")`
-   - For EVERY dataformat: `camel_catalog_dataformat(name="X")`
-   - For EVERY language: `camel_catalog_language(name="X")`
+   - For EVERY component: `camel_catalog_component_doc(component="X", runtime="Y", platformBom="Z")`
+   - For EVERY EIP: `camel_catalog_eip_doc(eip="X")`
+   - For EVERY dataformat: `camel_catalog_dataformat_doc(dataformat="X")`
+   - For EVERY language: `camel_catalog_language_doc(language="X")`
 3. **Write the failing test FIRST:**
    - Load `guides/test-generation.md`
    - Write a Citrus test that expects the behavior from the TDD
@@ -168,10 +168,10 @@ All implementation enforces:
 
 ## MCP Tools Used
 
-- `camel_catalog_component` — verify component exists, get options schema
-- `camel_catalog_eip` — verify EIP exists, get configuration schema
-- `camel_catalog_dataformat` — verify dataformat exists
-- `camel_catalog_language` — verify expression language exists
+- `camel_catalog_component_doc` — verify component exists, get options schema
+- `camel_catalog_eip_doc` — verify EIP exists, get configuration schema
+- `camel_catalog_dataformat_doc` — verify dataformat exists
+- `camel_catalog_language_doc` — verify expression language exists
 
 For MCP setup, version mapping, and fallback policy: see `shared/mcp-setup.md`
 

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-migrate.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-migrate.md
@@ -111,7 +111,7 @@ For migration-specific mappings, read the appropriate guide:
 - MuleSoft: `.bob/skills/camel-migrate/guides/mule-component-mapping.md`
 - Camel 2.x: `.bob/skills/camel-migrate/guides/camel2-component-mapping.md`, `.bob/skills/camel-migrate/guides/camel2-eip-mapping.md`, `.bob/skills/camel-migrate/guides/camel2-dataformat-mapping.md`, `.bob/skills/camel-migrate/guides/camel2-language-mapping.md`
 
-Verify EVERY component via MCP: `camel_catalog_component`.
+Verify EVERY component via MCP: `camel_catalog_component_doc`.
 </Step>
 
 <Step>

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-plan.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-plan.md
@@ -108,7 +108,7 @@ Use this format:
 - [other guides specific to this task]
 
 **MCP Tools:**
-- `camel_catalog_component(name="X", runtime="Y", platformBom="Z")`
+- `camel_catalog_component_doc(component="X", runtime="Y", platformBom="Z")`
 - [other MCP calls]
 
 **Design Spec Section:** Section 3, Flow: [flow-name]

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-validate.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-validate.md
@@ -78,7 +78,7 @@ Load `guides/endpoint-validation.md`.
 
 For EVERY endpoint URI:
 1. Extract scheme (component name)
-2. Call `camel_catalog_component(name="<scheme>", runtime="...", platformBom="...")`
+2. Call `camel_catalog_component_doc(component="<scheme>", runtime="...", platformBom="...")`
 3. Parse URI options
 4. Validate each option against catalog schema
 5. Check for typos in option names
@@ -124,7 +124,7 @@ Check all 7 constitution rules:
 - Report insecure endpoints
 
 **Rule 7: Component Verification**
-- Call `camel_catalog_component` for every component
+- Call `camel_catalog_component_doc` for every component
 - Report unrecognized components
 
 Report constitution violations per route.
@@ -296,8 +296,8 @@ Validation enforces:
 
 ## MCP Tools Used
 
-- `camel_catalog_component` — verify component exists, validate options
-- `camel_catalog_eip` — verify EIP schema
+- `camel_catalog_component_doc` — verify component exists, validate options
+- `camel_catalog_eip_doc` — verify EIP schema
 
 For MCP setup: see `shared/mcp-setup.md`
 

--- a/camel-kit-core/src/main/resources/templates/bob/rules-camel-implement/implementation.md
+++ b/camel-kit-core/src/main/resources/templates/bob/rules-camel-implement/implementation.md
@@ -5,7 +5,7 @@
 For EVERY component, EIP, dataformat, or language used in implementation:
 
 1. Look up in the mapping guide (if migration)
-2. Call `camel_catalog_component` / `camel_catalog_eip` / etc. to verify it exists
+2. Call `camel_catalog_component_doc` / `camel_catalog_eip_doc` / etc. to verify it exists
 3. Only then use it in code
 
 ## YAML DSL

--- a/camel-kit-core/src/main/resources/templates/bob/rules/iron-laws.md
+++ b/camel-kit-core/src/main/resources/templates/bob/rules/iron-laws.md
@@ -2,7 +2,7 @@
 
 These rules apply across ALL camel-kit pipeline modes. They are non-negotiable.
 
-1. **MCP Catalog Verification** — Every component, EIP, dataformat, and language MUST be verified via the MCP catalog (`camel_catalog_component`, `camel_catalog_eip`, etc.) before inclusion in any design, plan, or implementation. You do NOT guess component names from training data.
+1. **MCP Catalog Verification** — Every component, EIP, dataformat, and language MUST be verified via the MCP catalog (`camel_catalog_component_doc`, `camel_catalog_eip_doc`, etc.) before inclusion in any design, plan, or implementation. You do NOT guess component names from training data.
 
 2. **Constitution Enforcement** — Read and follow `docs/constitution.md` in every pipeline phase. The constitution defines project-specific rules that override general best practices.
 

--- a/camel-kit-core/src/main/resources/templates/constitution.md
+++ b/camel-kit-core/src/main/resources/templates/constitution.md
@@ -88,10 +88,10 @@ Never hardcode connection strings, credentials, or environment-specific values.
 
 Every component used in a route MUST be verified to **exist in the Apache Camel catalog** for the target version.
 
-- **Primary check:** Call `camel_catalog_component` to verify that the component exists in the Apache Camel catalog for the target Camel version.
+- **Primary check:** Call `camel_catalog_component_doc` to verify that the component exists in the Apache Camel catalog for the target Camel version.
 - **If a component does NOT exist in the catalog:**
   1. Raise a WARNING to the user explaining that the component was not found.
-  2. Search for an alternative that provides equivalent functionality (query `camel_catalog_component` for related components).
+  2. Search for an alternative that provides equivalent functionality (query `camel_catalog_component_doc` for related components).
   3. Present the warning and the suggested alternative to the user before proceeding. Let the user decide whether to switch to the alternative.
 - **Violation:** WARNING — this is not a validation blocker, but users must be clearly informed.
 

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/bob-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/bob-mcp.json
@@ -10,20 +10,8 @@
         "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
       ],
       "description": "Apache Camel MCP Server - Component catalog, validation, and security analysis",
-      "autoApprove": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ],
-      "alwaysAllow": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ]
+      "autoApprove": {CAMEL_TOOLS_JSON},
+      "alwaysAllow": {CAMEL_TOOLS_JSON}
     },
     "camel-knowledge": {
       "command": "jbang",

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/claude-code-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/claude-code-mcp.json
@@ -10,20 +10,8 @@
         "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
       ],
       "description": "Apache Camel MCP Server - Component catalog, validation, and security analysis",
-      "autoApprove": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ],
-      "alwaysAllow": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ]
+      "autoApprove": {CAMEL_TOOLS_JSON},
+      "alwaysAllow": {CAMEL_TOOLS_JSON}
     },
     "camel-knowledge": {
       "command": "jbang",

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/gemini-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/gemini-mcp.json
@@ -10,20 +10,8 @@
         "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
       ],
       "description": "Apache Camel MCP Server - Component catalog, validation, and security analysis",
-      "autoApprove": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ],
-      "alwaysAllow": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ]
+      "autoApprove": {CAMEL_TOOLS_JSON},
+      "alwaysAllow": {CAMEL_TOOLS_JSON}
     },
     "camel-knowledge": {
       "command": "jbang",

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/opencode-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/opencode-mcp.json
@@ -12,20 +12,8 @@
         "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
       ],
       "enabled": true,
-      "autoApprove": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ],
-      "alwaysAllow": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ]
+      "autoApprove": {CAMEL_TOOLS_JSON},
+      "alwaysAllow": {CAMEL_TOOLS_JSON}
     },
     "camel-knowledge": {
       "type": "local",

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/qwen-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/qwen-mcp.json
@@ -10,20 +10,8 @@
         "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
       ],
       "description": "Apache Camel MCP Server - Component catalog, validation, and security analysis",
-      "autoApprove": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ],
-      "alwaysAllow": [
-        "camel_catalog_component", "camel_catalog_components", "camel_catalog_component_doc",
-        "camel_catalog_eip", "camel_catalog_eips", "camel_catalog_eip_doc",
-        "camel_catalog_dataformat", "camel_catalog_dataformats", "camel_catalog_dataformat_doc",
-        "camel_catalog_language", "camel_catalog_languages", "camel_catalog_language_doc",
-        "camel_validate_route", "camel_route_context", "camel_route_harden_context"
-      ]
+      "autoApprove": {CAMEL_TOOLS_JSON},
+      "alwaysAllow": {CAMEL_TOOLS_JSON}
     },
     "camel-knowledge": {
       "command": "jbang",

--- a/camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml
+++ b/camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml
@@ -248,21 +248,39 @@ mcp_servers:
     display_name: "Camel Catalog MCP"
     description: "Apache Camel MCP Server - Component catalog, validation, and security analysis"
     allowed_tools:
-      - camel_catalog_component
       - camel_catalog_components
       - camel_catalog_component_doc
-      - camel_catalog_eip
-      - camel_catalog_eips
-      - camel_catalog_eip_doc
-      - camel_catalog_dataformat
+      - camel_catalog_component_maven
       - camel_catalog_dataformats
       - camel_catalog_dataformat_doc
-      - camel_catalog_language
       - camel_catalog_languages
       - camel_catalog_language_doc
+      - camel_catalog_eips
+      - camel_catalog_eip_doc
+      - camel_catalog_kamelets
+      - camel_catalog_kamelet_doc
+      - camel_catalog_examples
+      - camel_catalog_example_file
       - camel_validate_route
+      - camel_validate_yaml_dsl
+      - camel_transform_route
       - camel_route_context
       - camel_route_harden_context
+      - camel_route_test_scaffold
+      - camel_component_properties
+      - camel_configuration_validate
+      - camel_dependency_check
+      - camel_error_diagnose
+      - camel_properties_translate
+      - camel_version_list
+      - camel_migration_analyze
+      - camel_migration_compatibility
+      - camel_migration_recipes
+      - camel_migration_guide_search
+      - camel_migration_wildfly_karaf
+      - camel_openapi_validate
+      - camel_openapi_scaffold
+      - camel_openapi_mock_guidance
   - id: camel-knowledge
     display_name: "Camel-Kit Knowledge MCP"
     description: "camel-kit Knowledge Server - documentation search for Apache Camel"

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
@@ -1,0 +1,332 @@
+package io.github.luigidemasi.camelkit.command;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.CamelKitMain;
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
+import io.github.luigidemasi.camelkit.generator.InitContext;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DoctorCommandTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final DoctorExpectations EXPECTATIONS = DoctorExpectations.loadDefault();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void healthyWorkspaceReturnsSuccessAndJsonFindings() throws Exception {
+        createHealthyWorkspace(tempDir);
+
+        RunResult result = runDoctor("--project-dir", tempDir.toString(), "--json");
+
+        assertEquals(0, result.exitCode());
+        JsonNode json = MAPPER.readTree(result.output());
+        assertEquals("PASS", json.get("status").asText());
+        assertEquals(0, json.get("summary").get("fail").asInt());
+        assertTrue(json.get("summary").get("pass").asInt() > 0);
+        assertTrue(hasFinding(json, "PASS", "config"));
+        assertTrue(hasFinding(json, "PASS", "mcp"));
+        assertTrue(hasFinding(json, "PASS", "skills"));
+        assertTrue(hasFinding(json, "PASS", "workspace"));
+        assertTrue(hasFinding(json, "PASS", "graph"));
+    }
+
+    @Test
+    void brokenWorkspaceReportsActionableFailures() throws Exception {
+        createHealthyWorkspace(tempDir);
+        Files.writeString(tempDir.resolve("AGENTS.md"), "Use /camel-design for old generated workflows.\n");
+        Files.writeString(tempDir.resolve(".bob/commands/camel-implement.md"), "internal command should not exist");
+        Files.writeString(tempDir.resolve(".bob/commands/camel-verify.md"), "internal command should not exist");
+        Files.delete(tempDir.resolve(".bob/skills/camel-start/SKILL.md"));
+        Files.writeString(tempDir.resolve(".bob/mcp.json"), mcpJson(List.of("camel_catalog_components", "extra_tool"),
+                EXPECTATIONS.knowledgeMcpTools()));
+
+        RunResult result = runDoctor("--project-dir", tempDir.toString());
+
+        assertEquals(1, result.exitCode());
+        assertTrue(result.output().contains("FAIL"));
+        assertTrue(result.output().contains("unexpected"));
+        assertTrue(result.output().contains("camel-implement"));
+        assertTrue(result.output().contains("camel-verify"));
+        assertTrue(result.output().contains("Missing SKILL.md for: camel-start"));
+        assertTrue(result.output().contains("extra extra_tool"));
+        assertTrue(result.output().contains("stale references"));
+        assertTrue(result.output().contains("Fix:"));
+    }
+
+    @Test
+    void missingConfigFileProducesConfigFailFinding() throws Exception {
+        RunResult result = runDoctor("--project-dir", tempDir.toString(), "--json");
+
+        assertNotEquals(0, result.exitCode());
+        JsonNode json = MAPPER.readTree(result.output());
+        assertEquals("FAIL", json.get("status").asText());
+        assertTrue(json.get("summary").get("fail").asInt() > 0);
+        assertTrue(hasFinding(json, "FAIL", "config",
+                ".camel-kit/config.properties is missing",
+                "Run camel-kit init --here --ai <agent>"), result.output());
+
+        RunResult textResult = runDoctor("--project-dir", tempDir.toString());
+        assertNotEquals(0, textResult.exitCode());
+        assertTrue(textResult.output().contains(".camel-kit/config.properties is missing"));
+        assertTrue(textResult.output().contains("Run camel-kit init --here --ai <agent>"));
+    }
+
+    @Test
+    void missingAgentNameInConfigProducesSpecificFailure() throws Exception {
+        writeConfig("""
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.folder=.bob/commands
+                """);
+
+        RunResult result = runDoctor("--project-dir", tempDir.toString(), "--json");
+
+        assertNotEquals(0, result.exitCode());
+        JsonNode json = MAPPER.readTree(result.output());
+        assertEquals("FAIL", json.get("status").asText());
+        assertTrue(hasFinding(json, "FAIL", "config", "agent.name is not configured"), result.output());
+    }
+
+    @Test
+    void missingAgentFolderInConfigProducesSpecificFailure() throws Exception {
+        writeConfig("""
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.name=bob
+                """);
+
+        RunResult result = runDoctor("--project-dir", tempDir.toString(), "--json");
+
+        assertNotEquals(0, result.exitCode());
+        JsonNode json = MAPPER.readTree(result.output());
+        assertEquals("FAIL", json.get("status").asText());
+        assertTrue(hasFinding(json, "FAIL", "config",
+                ".camel-kit/config.properties is missing keys: agent.folder"), result.output());
+        assertTrue(hasFinding(json, "FAIL", "config",
+                "agent.folder is '' but bob expects '.bob/commands'"), result.output());
+    }
+
+    @Test
+    void agentFolderMismatchProducesFailure() throws Exception {
+        writeConfig("""
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.name=bob
+                agent.folder=.claude/commands
+                """);
+
+        RunResult result = runDoctor("--project-dir", tempDir.toString(), "--json");
+
+        assertNotEquals(0, result.exitCode());
+        JsonNode json = MAPPER.readTree(result.output());
+        assertEquals("FAIL", json.get("status").asText());
+        assertTrue(hasFinding(json, "FAIL", "config",
+                "agent.folder is '.claude/commands' but bob expects '.bob/commands'"), result.output());
+    }
+
+    @Test
+    void unknownAgentNameProducesFailureWithValidOptions() throws Exception {
+        writeConfig("""
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.name=unknown-agent
+                agent.folder=.unknown/commands
+                """);
+
+        RunResult result = runDoctor("--project-dir", tempDir.toString(), "--json");
+
+        assertNotEquals(0, result.exitCode());
+        JsonNode json = MAPPER.readTree(result.output());
+        assertEquals("FAIL", json.get("status").asText());
+        assertTrue(hasFinding(json, "FAIL", "config",
+                "Unknown agent.name 'unknown-agent'",
+                "Set agent.name to one of:"), result.output());
+    }
+
+    @Test
+    void generatedWorkspacesMatchDoctorExpectations() throws Exception {
+        for (String agentName : List.of("bob", "claude", "gemini", "qwen", "opencode")) {
+            Path root = tempDir.resolve(agentName);
+            createGeneratedWorkspace(root, agentName);
+
+            RunResult result = runDoctor("--project-dir", root.toString(), "--json");
+
+            assertEquals(0, result.exitCode(), agentName + System.lineSeparator() + result.output());
+            AgentConfig agent = AgentRegistry.get(agentName);
+            String extension = "." + agent.fileFormat();
+            Path commandsDir = root.resolve(agent.folder());
+            for (String internalCommand : List.of("camel-design", "camel-implement", "camel-test", "camel-verify")) {
+                assertFalse(Files.exists(commandsDir.resolve(internalCommand + extension)),
+                        agentName + " should not expose " + internalCommand + " as a command");
+            }
+
+            Path skillsDir = commandsDir.getParent().resolve("skills");
+            for (String internalSkill : List.of("camel-design", "camel-implement", "camel-test", "camel-verify")) {
+                assertTrue(Files.isRegularFile(skillsDir.resolve(internalSkill).resolve("SKILL.md")),
+                        agentName + " should keep " + internalSkill + " as a skill");
+            }
+        }
+    }
+
+    private RunResult runDoctor(String... args) {
+        CapturingPrinter printer = new CapturingPrinter();
+        CamelKitMain main = new CamelKitMain();
+        main.setOut(printer);
+        DoctorCommand command = new DoctorCommand(main);
+        int exitCode = new CommandLine(command).execute(args);
+        return new RunResult(exitCode, printer.output());
+    }
+
+    private void createHealthyWorkspace(Path root) throws Exception {
+        Files.createDirectories(root.resolve(".camel-kit"));
+        Files.writeString(root.resolve(".camel-kit/config.properties"), """
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.name=bob
+                agent.folder=.bob/commands
+                """);
+        Files.writeString(root.resolve(".camel-kit/project-graph.json"), "{}");
+        Files.writeString(root.resolve("AGENTS.md"), "Integration work -> /camel-start\n");
+        Files.writeString(root.resolve("mvnw"), "#!/bin/sh\n");
+
+        Path commands = root.resolve(".bob/commands");
+        Files.createDirectories(commands);
+        for (String command : EXPECTATIONS.userCommands()) {
+            Files.writeString(commands.resolve(command + ".md"),
+                    "Read .bob/skills/" + command + "/SKILL.md and follow those instructions\n");
+        }
+
+        Path skills = root.resolve(".bob/skills");
+        for (String skill : EXPECTATIONS.requiredSkills()) {
+            Path skillDir = skills.resolve(skill);
+            Files.createDirectories(skillDir);
+            Files.writeString(skillDir.resolve("SKILL.md"), "# " + skill + "\n");
+        }
+
+        Files.createDirectories(root.resolve(".bob"));
+        Files.writeString(root.resolve(".bob/mcp.json"),
+                mcpJson(EXPECTATIONS.camelMcpTools(), EXPECTATIONS.knowledgeMcpTools()));
+    }
+
+    private void writeConfig(String config) throws Exception {
+        Path camelKitDir = Files.createDirectories(tempDir.resolve(".camel-kit"));
+        Files.writeString(camelKitDir.resolve("config.properties"), config);
+    }
+
+    private void createGeneratedWorkspace(Path root, String agentName) throws Exception {
+        AgentConfig agent = AgentRegistry.get(agentName);
+        Files.createDirectories(root.resolve(".camel-kit"));
+        Files.writeString(root.resolve(".camel-kit/config.properties"), String.format(Locale.ROOT, """
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.name=%s
+                agent.folder=%s
+                """, agentName, agent.folder()));
+        Files.writeString(root.resolve(".camel-kit/project-graph.json"), "{}");
+        Files.writeString(root.resolve("mvnw"), "#!/bin/sh\n");
+
+        Path commandsDir = root.resolve(agent.folder());
+        Path skillsDir = commandsDir.getParent().resolve("skills");
+        InitContext ctx = new InitContext(
+                agent, agentName, commandsDir, skillsDir, root, "camel-kit", Printer.noop());
+        AgentGeneratorFactory.create(agentName).generate(ctx);
+    }
+
+    private String mcpJson(Collection<String> camelTools, Collection<String> knowledgeTools) {
+        return String.format(Locale.ROOT, """
+                {
+                  "mcpServers": {
+                    "camel": {
+                      "command": "jbang",
+                      "autoApprove": [%s],
+                      "alwaysAllow": [%s]
+                    },
+                    "camel-knowledge": {
+                      "command": "jbang",
+                      "autoApprove": [%s],
+                      "alwaysAllow": [%s]
+                    }
+                  }
+                }
+                """, jsonArray(camelTools), jsonArray(camelTools),
+                jsonArray(knowledgeTools), jsonArray(knowledgeTools));
+    }
+
+    private String jsonArray(Collection<String> values) {
+        return values.stream()
+                .map(value -> "\"" + value + "\"")
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("");
+    }
+
+    private boolean hasFinding(JsonNode root, String status, String category) {
+        for (JsonNode finding : root.get("findings")) {
+            if (status.equals(finding.get("status").asText())
+                    && category.equals(finding.get("category").asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasFinding(JsonNode root, String status, String category, String messageContains) {
+        return hasFinding(root, status, category, messageContains, null);
+    }
+
+    private boolean hasFinding(
+            JsonNode root, String status, String category, String messageContains, String remediationContains) {
+        for (JsonNode finding : root.get("findings")) {
+            boolean matches = status.equals(finding.get("status").asText())
+                    && category.equals(finding.get("category").asText())
+                    && finding.path("message").asText().contains(messageContains);
+            if (matches && (remediationContains == null
+                    || finding.path("remediation").asText().contains(remediationContains))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final class CapturingPrinter implements Printer {
+        private final StringBuilder output = new StringBuilder();
+
+        @Override
+        public void println() {
+            output.append(System.lineSeparator());
+        }
+
+        @Override
+        public void println(String line) {
+            output.append(line).append(System.lineSeparator());
+        }
+
+        @Override
+        public void print(String value) {
+            output.append(value);
+        }
+
+        String output() {
+            return output.toString();
+        }
+    }
+
+    record RunResult(int exitCode, String output) {
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -1,6 +1,7 @@
 package io.github.luigidemasi.camelkit.config;
 
 import java.io.InputStream;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,11 +60,24 @@ class DistributionConfigTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig config = DistributionConfig.load(in);
 
-        assertEquals("4.20.0", config.camelMcpVersion());
+        assertEquals("4.21.0-SNAPSHOT", config.camelMcpVersion());
         assertEquals("0.0.1-SNAPSHOT", config.knowledgeMcpVersion());
         assertEquals("maven", config.camelMcpRepos());
         assertEquals("maven", config.knowledgeMcpRepos());
         assertEquals("maven", config.camelCatalogRepos());
+    }
+
+    @Test
+    void camelMcpVersionCanBeOverriddenViaProperties() {
+        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
+        DistributionConfig baselineConfig = DistributionConfig.load(in);
+        assertEquals("4.21.0-SNAPSHOT", baselineConfig.camelMcpVersion());
+
+        Properties properties = new Properties();
+        properties.setProperty("camel.mcp.version", "9.9.9-TEST");
+
+        DistributionConfig overriddenConfig = DistributionConfig.load(properties);
+        assertEquals("9.9.9-TEST", overriddenConfig.camelMcpVersion());
     }
 
     @Test

--- a/camel-kit-core/src/test/resources/distribution.properties
+++ b/camel-kit-core/src/test/resources/distribution.properties
@@ -15,7 +15,7 @@ quarkus.platform.4.14.4=3.27.2
 quarkus.platform.4.13.0=3.20.0
 
 # MCP server versions
-camel.mcp.version=4.20.0
+camel.mcp.version=4.21.0-SNAPSHOT
 knowledge.mcp.version=0.0.1-SNAPSHOT
 
 # MCP repos

--- a/distribution.properties
+++ b/distribution.properties
@@ -35,7 +35,7 @@ quarkus.platform.4.18.2=3.33.1
 quarkus.platform.4.14.7=3.27.3
 
 # ─── MCP Server Versions ───────────────────────────────────────────────────
-camel.mcp.version=4.20.0
+camel.mcp.version=4.21.0-SNAPSHOT
 knowledge.mcp.version=0.0.1-SNAPSHOT
 
 # ─── MCP Repos ─────────────────────────────────────────────────────────────

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,77 +458,87 @@ The `DefaultGenerator` provides shared logic (skill file copying, MCP config gen
 
 ## 6. MCP Integration
 
-### Camel Catalog MCP
+### Camel JBang MCP
 
-The Camel MCP server (`camel-jbang-mcp`) provides **15 tools** organized into 6 categories:
+The Camel MCP server (`camel-jbang-mcp`, `4.21.0-SNAPSHOT`) exposes the Camel catalog, route validation,
+diagnostics, migration, and scaffolding tools. Camel-Kit auto-allows the read-only and generation helpers used by
+the skills, and leaves runtime mutation/control tools out of the generated allowlist.
 
-#### 1. Catalog Exploration (8 tools)
+#### 1. Catalog Exploration
 
 | Tool Name | Purpose |
 |-----------|---------|
 | `camel_catalog_components` | List Camel components with filtering by name, label, runtime |
 | `camel_catalog_component_doc` | Get comprehensive component documentation |
+| `camel_catalog_component_maven` | Get Maven coordinates for a component |
 | `camel_catalog_dataformats` | List data formats (JSON, XML, CSV, etc.) |
 | `camel_catalog_dataformat_doc` | Get data format configuration options |
 | `camel_catalog_languages` | List expression languages (Simple, JsonPath, XPath, JQ) |
 | `camel_catalog_language_doc` | Get expression language documentation |
 | `camel_catalog_eips` | List Enterprise Integration Patterns |
 | `camel_catalog_eip_doc` | Get EIP documentation and configuration |
-
-#### 2. Kamelet Catalog (2 tools)
-
-| Tool Name | Purpose |
-|-----------|---------|
 | `camel_catalog_kamelets` | List available Kamelets with filtering |
 | `camel_catalog_kamelet_doc` | Get Kamelet documentation and dependencies |
+| `camel_catalog_examples` | List Camel examples |
+| `camel_catalog_example_file` | Read a file from a Camel example |
 
-#### 3. Route Understanding (1 tool)
-
-| Tool Name | Purpose |
-|-----------|---------|
-| `camel_route_context` | Extract components and EIPs from route (YAML/XML/Java) |
-
-#### 4. Security Analysis (1 tool)
+#### 2. Route Validation, Security, And Tests
 
 | Tool Name | Purpose |
 |-----------|---------|
-| `camel_route_harden_context` | Analyze routes for security concerns (47 checks) |
-
-#### 5. Validation and Transformation (2 tools)
-
-| Tool Name | Purpose |
-|-----------|---------|
-| `camel_validate_route` | Validate endpoint URIs against catalog schema |
+| `camel_validate_route` | Validate endpoint URIs and route definitions against catalog schema |
+| `camel_validate_yaml_dsl` | Validate Camel YAML DSL syntax |
 | `camel_transform_route` | Convert routes between YAML and XML formats |
+| `camel_route_context` | Extract components and EIPs from route (YAML/XML/Java) |
+| `camel_route_harden_context` | Analyze routes for security concerns (47 checks) |
+| `camel_route_test_scaffold` | Generate a JUnit 5 test skeleton for a route |
 
-#### 6. Version Management (1 tool)
+#### 3. Diagnostics And Configuration
 
 | Tool Name | Purpose |
 |-----------|---------|
+| `camel_component_properties` | Inspect component property metadata |
+| `camel_configuration_validate` | Validate Camel configuration properties |
+| `camel_dependency_check` | Check dependencies for common Camel issues |
+| `camel_error_diagnose` | Diagnose Camel errors |
+| `camel_properties_translate` | Translate properties between Camel runtimes |
 | `camel_version_list` | List Camel versions with LTS status and JDK requirements |
+
+#### 4. Migration And OpenAPI
+
+| Tool Name | Purpose |
+|-----------|---------|
+| `camel_migration_analyze` | Analyze a project for migration concerns |
+| `camel_migration_compatibility` | Check migration compatibility |
+| `camel_migration_recipes` | Find migration recipes |
+| `camel_migration_guide_search` | Search Camel migration guidance |
+| `camel_migration_wildfly_karaf` | Analyze WildFly/Karaf migration concerns |
+| `camel_openapi_validate` | Validate OpenAPI input for Camel use |
+| `camel_openapi_scaffold` | Generate Camel OpenAPI route scaffolding |
+| `camel_openapi_mock_guidance` | Provide OpenAPI mock guidance |
 
 ### Knowledge Layer MCP
 
-Separate from the Camel Catalog MCP, the knowledge layer runs from the `camel-kit-knowledge` repository (a separate project with its own version line).
+Separate from Camel JBang MCP, the knowledge layer runs from the `camel-kit-knowledge` repository and exposes
+`camel_docs_*` documentation search tools.
 
 | Tool Name | Purpose |
 |-----------|---------|
-| `camel_docs_search` | General documentation search |
-| `camel_docs_component_info` | Component documentation and CVE lookup |
-| `camel_docs_cve_search` | CVE security advisory search |
-| `camel_docs_release_info` | Release notes for a version |
-| `camel_docs_jira_lookup` | JIRA issue lookup by ID |
+| `camel_docs_search` | General hybrid search across Apache Camel documentation |
+| `camel_docs_component_info` | Component documentation lookup with usage, options, and related CVEs |
+| `camel_docs_cve_search` | CVE search by ID, component, severity, or version |
+| `camel_docs_release_info` | Release notes by version |
+| `camel_docs_jira_lookup` | CAMEL-* JIRA issue details and fix version |
 
 ### Tool Usage by Skill
 
 | Skill | Tools Used | Count |
 |-------|------------|-------|
-| `camel-brainstorm` | `camel_version_list`, `camel_catalog_*` (all 8) | 9 |
-| `camel-brainstorm` | `camel_catalog_components`, `camel_catalog_component_doc`, `camel_catalog_eips`, `camel_catalog_eip_doc`, `camel_catalog_dataformats`, `camel_catalog_dataformat_doc`, `camel_catalog_languages`, `camel_catalog_language_doc` | 8 |
-| `camel-migrate` | Same as `camel-brainstorm` (Phase 2) | 8 |
-| `camel-implement` | `camel_catalog_component_doc`, `camel_catalog_dataformat_doc`, `camel_catalog_eip_doc`, `camel_catalog_language_doc`, `camel_route_context`, `camel_validate_route` | 6 |
-| `camel-validate` | `camel_validate_route`, `camel_route_harden_context` | 2 |
-| `camel-test` | `camel_route_context`, `camel_catalog_component_doc` | 2 |
+| `camel-brainstorm` | Catalog discovery/detail tools, `camel_version_list`, `camel_docs_search` | varies |
+| `camel-migrate` | Catalog, migration, and knowledge tools | varies |
+| `camel-implement` | Catalog detail tools, route context, validation, transformation, test scaffold | varies |
+| `camel-validate` | Route validation, hardening, diagnostics, dependency/config checks | varies |
+| `camel-test` | Route context, catalog details, test scaffold | varies |
 | `camel-knowledge` | `camel_docs_search`, `camel_docs_component_info`, `camel_docs_cve_search`, `camel_docs_release_info`, `camel_docs_jira_lookup` | 5 |
 
 ### Token Savings

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,7 @@ This document is the reference for all Camel-Kit commands: the `camel-kit` CLI a
 
 - [CLI Commands](#cli-commands)
   - [camel-kit init](#camel-kit-init)
+  - [camel-kit doctor](#camel-kit-doctor)
   - [camel-kit graph](#camel-kit-graph)
   - [camel-kit doc](#camel-kit-doc)
   - [camel-kit nextId](#camel-kit-nextid)
@@ -157,7 +158,7 @@ Any property from `distribution.properties` can be overridden at layers 2 or 3. 
 | `springboot.bom.version` | `4.20.0` | Spring Boot BOM version |
 | `camel.quarkus.version` | `4.18.2` | Apache Camel version for Quarkus projects |
 | `quarkus.platform.version` | `3.33.1` | Quarkus platform BOM version |
-| `camel.mcp.version` | `4.20.0` | Camel MCP server version |
+| `camel.mcp.version` | `4.21.0-SNAPSHOT` | Camel MCP server version |
 
 **Output:**
 
@@ -190,6 +191,42 @@ my-integration/
 ```
 
 The MCP configuration file created depends on the `--ai` option chosen.
+
+### camel-kit doctor
+
+Validate a generated Camel-Kit workspace and report actionable findings.
+
+**Usage:**
+
+```bash
+camel-kit doctor [options]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--project-dir` | `.` | Workspace directory to validate |
+| `--json` | `false` | Print machine-readable JSON output for automation |
+
+**Examples:**
+
+```bash
+# Check the current workspace
+camel-kit doctor
+
+# Check another workspace
+camel-kit doctor --project-dir /path/to/order-processing
+
+# Produce JSON for automation
+camel-kit doctor --json
+```
+
+**Checks:**
+
+`doctor` validates `.camel-kit/config.properties`, selected agent command stubs, skill directories and `SKILL.md` files, user-invocable command exposure, agent MCP config, MCP tool allowlists, graph availability, command prefix configuration, Java/Maven/JBang prerequisites, and common stale references in active generated files. Internal skills such as `camel-verify` must exist as skills, but must not be exposed as user command stubs.
+
+Findings are printed as `PASS`, `WARN`, or `FAIL`. Missing external prerequisites are warnings so automated checks do not depend on the local machine having every optional tool installed. Broken generated workspace artifacts are failures and produce a non-zero exit code.
 
 ### camel-kit graph
 
@@ -504,10 +541,10 @@ When invoked with a `<PIPELINE_ID>` argument:
 
 **MCP tools used:**
 
-- `camel_catalog_component` -- verify component exists
-- `camel_catalog_eip` -- verify EIP exists
-- `camel_catalog_dataformat` -- verify data format exists
-- `camel_catalog_language` -- verify expression language exists
+- `camel_catalog_component_doc` -- verify component exists
+- `camel_catalog_eip_doc` -- verify EIP exists
+- `camel_catalog_dataformat_doc` -- verify data format exists
+- `camel_catalog_language_doc` -- verify expression language exists
 
 ---
 

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -89,7 +89,7 @@ Never hardcode connection strings, credentials, or environment-specific values.
 
 Every component used in a route MUST be verified as **available** in the target Camel version.
 
-- **Primary check:** Call `camel_catalog_component` (via Camel MCP) to check whether the component exists in the Apache Camel catalog for the target version.
+- **Primary check:** Call `camel_catalog_component_doc` (via Camel MCP) to check whether the component exists in the Apache Camel catalog for the target version.
 - **If a component is NOT found:**
   1. Raise a WARNING to the user explaining the availability status.
   2. Search for an alternative that provides equivalent functionality.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,7 +30,7 @@ Camel-Kit is an AI-powered toolkit that guides you through designing, planning, 
 | **TDD** (Technical Design Document) | Per-flow specification. Describes the source, processing steps, sink, error handling, data transformation, configuration, and dependencies for a single Camel route. |
 | **MCP** (Model Context Protocol) | Real-time catalog queries. The AI assistant queries the Camel MCP server to verify components, EIPs, data formats, and expression languages exist in your exact Camel version -- never relying on training data. |
 | **Constitution** | Seven route quality rules enforced on every generated route: route structure, single responsibility, separation of concerns, naming conventions, observability, external configuration, and component support verification. |
-| **Iron Laws** | Four non-negotiable pipeline rules that govern the entire workflow: (1) MCP catalog verification for every component, (2) constitution compliance on every route, (3) no code without design approval (planning and execution flow continuously after design is approved), (4) spec compliance review before quality review. |
+| **Iron Laws** | Non-negotiable pipeline rules that govern the entire workflow: MCP catalog verification for every component, constitution compliance on every route, no code without design approval, and spec compliance review before quality review. |
 
 ---
 
@@ -195,6 +195,22 @@ order-processing/
 ```
 
 The init command checks prerequisites (Java, JBang, Camel JBang, test plugin), copies skill files, configures MCP, and sets up the Maven wrapper so you can start designing immediately. If the target directory already contains a camel-kit project (`AGENTS.md` or `.camel-kit/`), init warns and exits — use `--force` to overwrite.
+
+### Validating the Workspace
+
+After initialization, run `doctor` from the workspace root:
+
+```bash
+camel-kit doctor
+```
+
+`doctor` checks the generated configuration, command stubs, skill files, MCP config and allowlists, project graph, command prefix, prerequisites, and common stale generated references. It also verifies that internal skills such as `camel-verify` are present as skills but not exposed as user command stubs. It prints `PASS`, `WARN`, and `FAIL` findings with remediation text. External tools such as JBang and Camel JBang are reported as warnings when unavailable; broken generated workspace files are failures.
+
+For automation:
+
+```bash
+camel-kit doctor --json
+```
 
 ---
 
@@ -800,6 +816,14 @@ If the MCP server is unavailable, the AI assistant falls back to bundled compone
 ---
 
 ## 11. Troubleshooting
+
+Start with the workspace diagnostic:
+
+```bash
+camel-kit doctor
+```
+
+Use `camel-kit doctor --json` in scripts or CI to detect broken generated files. A `FAIL` means the generated workspace needs repair; a `WARN` usually means an optional prerequisite or persisted graph file is missing.
 
 ### Catalog Not Found
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- Also in distribution.properties (runtime source of truth).
              Duplicated here because maven-dependency-plugin resolves
              artifact versions at POM parse time, before any lifecycle phase. -->
-        <camel.mcp.version>${camel.version}</camel.mcp.version>
+        <camel.mcp.version>4.21.0-SNAPSHOT</camel.mcp.version>
 
         <!-- Code quality -->
         <impsort-maven-plugin.version>1.13.0</impsort-maven-plugin.version>


### PR DESCRIPTION
## Summary

  - Add `camel-kit doctor` to validate generated Camel-Kit workspaces.
  - Report actionable diagnostics for config, generated commands, skills, MCP setup, graph state, prerequisites, and stale references.
  - Align generated MCP config with:
    - Camel JBang MCP `4.21.0-SNAPSHOT`
    - `camel-kit-knowledge` using the real `camel_docs_*` tool set
  - Keep internal workflow steps as skills instead of exposed command stubs.

  ## Validation

  - `mvnd clean install`
  - `./mvnw -pl camel-kit-core
  -Dtest=DoctorCommandTest,DefaultGeneratorTest,BobGeneratorTest,GeminiGeneratorTest,QwenGeneratorTest,OpenCodeGeneratorTest,DistributionConfigTest,ResourceConsistencyTest test`

## Summary by Sourcery

Add a workspace diagnostic CLI command and align MCP integration with the latest Camel JBang and knowledge server tooling.

New Features:
- Introduce the `camel-kit doctor` command to validate generated workspaces and emit human- and machine-readable diagnostics.

Enhancements:
- Align MCP tool allowlists and documentation with the current Camel JBang MCP toolset and the `camel_docs_*` knowledge tools.
- Ensure internal workflow skills remain internal by removing their user-facing command stubs in generated agents.
- Clarify user documentation around Iron Laws, workspace validation, troubleshooting, and MCP usage details.

Build:
- Update distribution properties and Maven configuration to target Camel MCP server version `4.21.0-SNAPSHOT`.

Documentation:
- Document the new `camel-kit doctor` command, its options, and its checks in the command reference and user guide.
- Update architecture and constitution docs to reflect the expanded Camel MCP toolset and revised MCP usage patterns.

Tests:
- Add unit tests for the new doctor command and update distribution and MCP-related tests to cover the new configuration defaults.