### PR TITLE
Fix #106: enforce workflow manifest validation

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/ManifestValidationException.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/ManifestValidationException.java
@@ -1,0 +1,21 @@
+package io.github.luigidemasi.camelkit.workflow;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Thrown when the workflow manifest parses successfully but violates semantic constraints.
+ */
+public final class ManifestValidationException extends IOException {
+
+    private final List<String> errors;
+
+    ManifestValidationException(List<String> errors) {
+        super("Invalid workflow manifest:\n" + String.join("\n", errors));
+        this.errors = List.copyOf(errors);
+    }
+
+    public List<String> errors() {
+        return errors;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestLoader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestLoader.java
@@ -3,7 +3,6 @@ package io.github.luigidemasi.camelkit.workflow;
 import java.io.IOException;
 import java.io.InputStream;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -16,8 +15,7 @@ public final class WorkflowManifestLoader {
     public static final String DEFAULT_RESOURCE = "workflow/camel-kit-workflow.yaml";
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory())
-            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
     private WorkflowManifestLoader() {
         // Utility class
@@ -32,7 +30,16 @@ public final class WorkflowManifestLoader {
             if (input == null) {
                 throw new IOException("Workflow manifest not found on classpath: " + resourcePath);
             }
-            return OBJECT_MAPPER.readValue(input, WorkflowManifest.class);
+            return load(input);
         }
+    }
+
+    public static WorkflowManifest load(InputStream input) throws IOException {
+        if (input == null) {
+            throw new IOException("Workflow manifest input stream must not be null");
+        }
+        WorkflowManifest manifest = OBJECT_MAPPER.readValue(input, WorkflowManifest.class);
+        WorkflowManifestValidator.validateOrThrow(manifest);
+        return manifest;
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestValidator.java
@@ -1,6 +1,5 @@
 package io.github.luigidemasi.camelkit.workflow;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -20,10 +19,10 @@ final class WorkflowManifestValidator {
     private WorkflowManifestValidator() {
     }
 
-    static void validateOrThrow(WorkflowManifest manifest) throws IOException {
+    static void validateOrThrow(WorkflowManifest manifest) throws ManifestValidationException {
         List<String> errors = validate(manifest);
         if (!errors.isEmpty()) {
-            throw new IOException("Invalid workflow manifest:\n" + String.join("\n", errors));
+            throw new ManifestValidationException(errors);
         }
     }
 
@@ -59,8 +58,12 @@ final class WorkflowManifestValidator {
             Map<String, WorkflowManifest.WorkflowCommand> commandsByName,
             Map<String, WorkflowManifest.WorkflowSkill> skillsByName,
             List<String> errors) {
+        commands = nullToEmpty(commands);
         for (int i = 0; i < commands.size(); i++) {
             WorkflowManifest.WorkflowCommand command = commands.get(i);
+            if (command == null) {
+                continue;
+            }
             String commandName = label(command.name(), i);
             validateRequired("commands[" + commandName + "].skill", command.skill(), errors);
 
@@ -85,8 +88,12 @@ final class WorkflowManifestValidator {
             List<WorkflowManifest.WorkflowSkill> skills,
             Map<String, WorkflowManifest.WorkflowCommand> commandsByName,
             List<String> errors) {
+        skills = nullToEmpty(skills);
         for (int i = 0; i < skills.size(); i++) {
             WorkflowManifest.WorkflowSkill skill = skills.get(i);
+            if (skill == null) {
+                continue;
+            }
             String skillName = label(skill.name(), i);
             if (isBlank(skill.generatedCommand())) {
                 continue;
@@ -114,14 +121,18 @@ final class WorkflowManifestValidator {
             Set<String> stageIds,
             Set<String> skillNames,
             List<String> errors) {
+        stages = nullToEmpty(stages);
         for (int i = 0; i < stages.size(); i++) {
             WorkflowManifest.WorkflowStage stage = stages.get(i);
+            if (stage == null) {
+                continue;
+            }
             String stageId = label(stage.id(), i);
             validateRequired("stages[" + stageId + "].skill", stage.skill(), errors);
             if (!isBlank(stage.skill()) && !skillNames.contains(stage.skill())) {
                 errors.add("stages[" + stageId + "].skill references unknown skill '" + stage.skill() + "'");
             }
-            for (String transition : stage.transitions()) {
+            for (String transition : nullToEmpty(stage.transitions())) {
                 if (isBlank(transition)) {
                     errors.add("stages[" + stageId + "].transitions contains a blank stage id");
                 } else if (!stageIds.contains(transition)) {
@@ -135,8 +146,12 @@ final class WorkflowManifestValidator {
             List<WorkflowManifest.WorkflowArtifact> artifacts,
             Set<String> skillNames,
             List<String> errors) {
+        artifacts = nullToEmpty(artifacts);
         for (int i = 0; i < artifacts.size(); i++) {
             WorkflowManifest.WorkflowArtifact artifact = artifacts.get(i);
+            if (artifact == null) {
+                continue;
+            }
             String artifactId = label(artifact.id(), i);
             validateRequired("artifacts[" + artifactId + "].path", artifact.path(), errors);
             validateSkillReferences(
@@ -156,6 +171,7 @@ final class WorkflowManifestValidator {
 
     private static void validateSkillReferences(
             String path, List<String> referencedSkills, Set<String> skillNames, List<String> errors) {
+        referencedSkills = nullToEmpty(referencedSkills);
         for (String skill : referencedSkills) {
             if (isBlank(skill)) {
                 errors.add(path + " contains a blank skill name");
@@ -171,10 +187,16 @@ final class WorkflowManifestValidator {
             List<T> items,
             Function<T, String> idExtractor,
             List<String> errors) {
+        items = nullToEmpty(items);
         Map<String, T> values = new LinkedHashMap<>();
         Set<String> duplicates = new LinkedHashSet<>();
         for (int i = 0; i < items.size(); i++) {
-            String id = idExtractor.apply(items.get(i));
+            T item = items.get(i);
+            if (item == null) {
+                errors.add(section + "[" + i + "] must not be null");
+                continue;
+            }
+            String id = idExtractor.apply(item);
             String path = section + "[" + i + "]." + idField;
             if (isBlank(id)) {
                 errors.add(path + " must not be blank");
@@ -191,6 +213,10 @@ final class WorkflowManifestValidator {
             errors.add(section + " must not be empty");
         }
         return values;
+    }
+
+    private static <T> List<T> nullToEmpty(List<T> items) {
+        return items == null ? List.of() : items;
     }
 
     private static void validateRequired(String path, String value, List<String> errors) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestValidator.java
@@ -1,0 +1,209 @@
+package io.github.luigidemasi.camelkit.workflow;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Validates cross-references in the workflow manifest.
+ */
+final class WorkflowManifestValidator {
+
+    private static final Set<String> REQUIRED_MCP_SERVERS = Set.of("camel", "camel-knowledge");
+
+    private WorkflowManifestValidator() {
+    }
+
+    static void validateOrThrow(WorkflowManifest manifest) throws IOException {
+        List<String> errors = validate(manifest);
+        if (!errors.isEmpty()) {
+            throw new IOException("Invalid workflow manifest:\n" + String.join("\n", errors));
+        }
+    }
+
+    static List<String> validate(WorkflowManifest manifest) {
+        List<String> errors = new ArrayList<>();
+        if (manifest == null) {
+            errors.add("manifest must not be null");
+            return errors;
+        }
+
+        Map<String, WorkflowManifest.WorkflowCommand> commands = indexBy(
+                "commands", "name", manifest.commands(), WorkflowManifest.WorkflowCommand::name, errors);
+        Map<String, WorkflowManifest.WorkflowSkill> skills = indexBy(
+                "skills", "name", manifest.skills(), WorkflowManifest.WorkflowSkill::name, errors);
+        Map<String, WorkflowManifest.WorkflowStage> stages = indexBy(
+                "stages", "id", manifest.stages(), WorkflowManifest.WorkflowStage::id, errors);
+        Map<String, WorkflowManifest.WorkflowArtifact> artifacts = indexBy(
+                "artifacts", "id", manifest.artifacts(), WorkflowManifest.WorkflowArtifact::id, errors);
+        Map<String, WorkflowManifest.WorkflowMcpServer> mcpServers = indexBy(
+                "mcp_servers", "id", manifest.mcpServers(), WorkflowManifest.WorkflowMcpServer::id, errors);
+
+        validateCommands(manifest.commands(), commands, skills, errors);
+        validateSkills(manifest.skills(), commands, errors);
+        validateStages(manifest.stages(), stages.keySet(), skills.keySet(), errors);
+        validateArtifacts(manifest.artifacts(), skills.keySet(), errors);
+        validateMcpServers(mcpServers.keySet(), errors);
+
+        return errors;
+    }
+
+    private static void validateCommands(
+            List<WorkflowManifest.WorkflowCommand> commands,
+            Map<String, WorkflowManifest.WorkflowCommand> commandsByName,
+            Map<String, WorkflowManifest.WorkflowSkill> skillsByName,
+            List<String> errors) {
+        for (int i = 0; i < commands.size(); i++) {
+            WorkflowManifest.WorkflowCommand command = commands.get(i);
+            String commandName = label(command.name(), i);
+            validateRequired("commands[" + commandName + "].skill", command.skill(), errors);
+
+            WorkflowManifest.WorkflowSkill skill = skillsByName.get(command.skill());
+            if (!isBlank(command.skill()) && skill == null) {
+                errors.add("commands[" + commandName + "].skill references unknown skill '" + command.skill() + "'");
+            }
+            if (skill != null && command.generatedStub()
+                    && !Objects.equals(command.name(), skill.generatedCommand())) {
+                errors.add("commands[" + commandName + "].generated_stub is true but skills["
+                           + skill.name() + "].generated_command is '" + skill.generatedCommand() + "'");
+            }
+            if (skill != null && command.generatedStub()
+                    && commandsByName.get(skill.generatedCommand()) != command) {
+                errors.add("skills[" + skill.name() + "].generated_command does not point back to command '"
+                           + command.name() + "'");
+            }
+        }
+    }
+
+    private static void validateSkills(
+            List<WorkflowManifest.WorkflowSkill> skills,
+            Map<String, WorkflowManifest.WorkflowCommand> commandsByName,
+            List<String> errors) {
+        for (int i = 0; i < skills.size(); i++) {
+            WorkflowManifest.WorkflowSkill skill = skills.get(i);
+            String skillName = label(skill.name(), i);
+            if (isBlank(skill.generatedCommand())) {
+                continue;
+            }
+
+            WorkflowManifest.WorkflowCommand command = commandsByName.get(skill.generatedCommand());
+            if (command == null) {
+                errors.add("skills[" + skillName + "].generated_command references unknown command '"
+                           + skill.generatedCommand() + "'");
+                continue;
+            }
+            if (!command.generatedStub()) {
+                errors.add("skills[" + skillName + "].generated_command references non-generated command '"
+                           + command.name() + "'");
+            }
+            if (!Objects.equals(skill.name(), command.skill())) {
+                errors.add("skills[" + skillName + "].generated_command references command '" + command.name()
+                           + "' but that command points to skill '" + command.skill() + "'");
+            }
+        }
+    }
+
+    private static void validateStages(
+            List<WorkflowManifest.WorkflowStage> stages,
+            Set<String> stageIds,
+            Set<String> skillNames,
+            List<String> errors) {
+        for (int i = 0; i < stages.size(); i++) {
+            WorkflowManifest.WorkflowStage stage = stages.get(i);
+            String stageId = label(stage.id(), i);
+            validateRequired("stages[" + stageId + "].skill", stage.skill(), errors);
+            if (!isBlank(stage.skill()) && !skillNames.contains(stage.skill())) {
+                errors.add("stages[" + stageId + "].skill references unknown skill '" + stage.skill() + "'");
+            }
+            for (String transition : stage.transitions()) {
+                if (isBlank(transition)) {
+                    errors.add("stages[" + stageId + "].transitions contains a blank stage id");
+                } else if (!stageIds.contains(transition)) {
+                    errors.add("stages[" + stageId + "].transitions references unknown stage '" + transition + "'");
+                }
+            }
+        }
+    }
+
+    private static void validateArtifacts(
+            List<WorkflowManifest.WorkflowArtifact> artifacts,
+            Set<String> skillNames,
+            List<String> errors) {
+        for (int i = 0; i < artifacts.size(); i++) {
+            WorkflowManifest.WorkflowArtifact artifact = artifacts.get(i);
+            String artifactId = label(artifact.id(), i);
+            validateRequired("artifacts[" + artifactId + "].path", artifact.path(), errors);
+            validateSkillReferences(
+                    "artifacts[" + artifactId + "].produced_by", artifact.producedBy(), skillNames, errors);
+            validateSkillReferences(
+                    "artifacts[" + artifactId + "].consumed_by", artifact.consumedBy(), skillNames, errors);
+        }
+    }
+
+    private static void validateMcpServers(Set<String> mcpServerIds, List<String> errors) {
+        for (String required : REQUIRED_MCP_SERVERS) {
+            if (!mcpServerIds.contains(required)) {
+                errors.add("mcp_servers missing required server '" + required + "'");
+            }
+        }
+    }
+
+    private static void validateSkillReferences(
+            String path, List<String> referencedSkills, Set<String> skillNames, List<String> errors) {
+        for (String skill : referencedSkills) {
+            if (isBlank(skill)) {
+                errors.add(path + " contains a blank skill name");
+            } else if (!skillNames.contains(skill)) {
+                errors.add(path + " references unknown skill '" + skill + "'");
+            }
+        }
+    }
+
+    private static <T> Map<String, T> indexBy(
+            String section,
+            String idField,
+            List<T> items,
+            Function<T, String> idExtractor,
+            List<String> errors) {
+        Map<String, T> values = new LinkedHashMap<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (int i = 0; i < items.size(); i++) {
+            String id = idExtractor.apply(items.get(i));
+            String path = section + "[" + i + "]." + idField;
+            if (isBlank(id)) {
+                errors.add(path + " must not be blank");
+                continue;
+            }
+            if (values.putIfAbsent(id, items.get(i)) != null) {
+                duplicates.add(id);
+            }
+        }
+        for (String duplicate : duplicates) {
+            errors.add(section + " contains duplicate " + idField + " '" + duplicate + "'");
+        }
+        if (items.isEmpty()) {
+            errors.add(section + " must not be empty");
+        }
+        return values;
+    }
+
+    private static void validateRequired(String path, String value, List<String> errors) {
+        if (isBlank(value)) {
+            errors.add(path + " must not be blank");
+        }
+    }
+
+    private static String label(String value, int index) {
+        return isBlank(value) ? String.valueOf(index) : value;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
@@ -1,6 +1,9 @@
 package io.github.luigidemasi.camelkit.workflow;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -11,6 +14,7 @@ import java.util.stream.Collectors;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
 import io.github.luigidemasi.camelkit.generator.DefaultGenerator;
 import io.github.luigidemasi.camelkit.generator.InitContext;
 import io.github.luigidemasi.camelkit.output.Printer;
@@ -25,6 +29,49 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.*;
 
 class WorkflowManifestTest {
+
+    private static final String MINIMAL_VALID_MANIFEST = """
+            version: "1.0"
+            description: "Test manifest"
+            commands:
+              - name: camel-start
+                aliases: []
+                skill: camel-start
+                generated_stub: true
+                user_facing: true
+                tier: entry
+                description: "Start"
+                standalone: true
+                chained: false
+            skills:
+              - name: camel-start
+                user_invocable: true
+                status: router
+                generated_command: camel-start
+            stages:
+              - id: route
+                skill: camel-start
+                kind: entry
+                standalone: true
+                chained: false
+                inputs: []
+                outputs: []
+                transitions: []
+            artifacts:
+              - id: design-spec
+                path: docs/camel-kit/<pipeline-id>/design-spec.md
+                produced_by: [camel-start]
+                consumed_by: [camel-start]
+            mcp_servers:
+              - id: camel
+                display_name: "Camel Catalog MCP"
+                description: "Camel"
+                allowed_tools: []
+              - id: camel-knowledge
+                display_name: "Camel-Kit Knowledge MCP"
+                description: "Knowledge"
+                allowed_tools: []
+            """;
 
     @TempDir
     Path tempDir;
@@ -43,22 +90,84 @@ class WorkflowManifestTest {
     @Test
     void generatedCommandStubsMatchManifest() throws Exception {
         WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
-        InitContext ctx = createContext("bob");
 
-        new DefaultGenerator().generate(ctx);
+        for (String agentName : AgentRegistry.names()) {
+            InitContext ctx = createContext(agentName);
+            AgentGeneratorFactory.create(agentName).generate(ctx);
 
-        Set<String> expected = manifest.generatedCommandStubs().stream()
-                .map(command -> command.name() + "." + ctx.agent().fileFormat())
-                .collect(Collectors.toCollection(java.util.TreeSet::new));
-        Set<String> actual;
-        try (var stream = Files.list(ctx.commandsDir())) {
-            actual = stream
-                    .filter(Files::isRegularFile)
-                    .map(path -> path.getFileName().toString())
+            Set<String> expected = manifest.generatedCommandStubs().stream()
+                    .map(command -> command.name() + "." + ctx.agent().fileFormat())
                     .collect(Collectors.toCollection(java.util.TreeSet::new));
-        }
+            Set<String> actual;
+            try (var stream = Files.list(ctx.commandsDir())) {
+                actual = stream
+                        .filter(Files::isRegularFile)
+                        .map(path -> path.getFileName().toString())
+                        .collect(Collectors.toCollection(java.util.TreeSet::new));
+            }
 
-        assertEquals(expected, actual);
+            assertEquals(expected, actual, agentName + " generated command stubs must match manifest");
+        }
+    }
+
+    @Test
+    void rejectsUnknownManifestFields() {
+        IOException ex = assertThrows(IOException.class,
+                () -> loadManifest(MINIMAL_VALID_MANIFEST + "unexpected_root: true\n"));
+        assertTrue(ex.getMessage().contains("Unrecognized field \"unexpected_root\""), ex.getMessage());
+    }
+
+    @Test
+    void rejectsCommandsReferencingUnknownSkills() {
+        assertInvalidManifest(
+                MINIMAL_VALID_MANIFEST.replace("skill: camel-start", "skill: missing-skill"),
+                "commands[camel-start].skill references unknown skill 'missing-skill'");
+    }
+
+    @Test
+    void rejectsGeneratedCommandDrift() {
+        assertInvalidManifest(
+                MINIMAL_VALID_MANIFEST.replace("generated_command: camel-start", "generated_command: camel-plan"),
+                "skills[camel-start].generated_command references unknown command 'camel-plan'");
+    }
+
+    @Test
+    void rejectsStagesReferencingUnknownSkills() {
+        assertInvalidManifest(
+                MINIMAL_VALID_MANIFEST.replace("""
+                          - id: route
+                            skill: camel-start
+                        """, """
+                          - id: route
+                            skill: missing-skill
+                        """),
+                "stages[route].skill references unknown skill 'missing-skill'");
+    }
+
+    @Test
+    void rejectsStagesReferencingUnknownTransitions() {
+        assertInvalidManifest(
+                MINIMAL_VALID_MANIFEST.replace("transitions: []", "transitions: [missing-stage]"),
+                "stages[route].transitions references unknown stage 'missing-stage'");
+    }
+
+    @Test
+    void rejectsArtifactsReferencingUnknownSkills() {
+        assertInvalidManifest(
+                MINIMAL_VALID_MANIFEST.replace("produced_by: [camel-start]", "produced_by: [missing-skill]"),
+                "artifacts[design-spec].produced_by references unknown skill 'missing-skill'");
+    }
+
+    @Test
+    void rejectsMissingRequiredMcpServers() {
+        assertInvalidManifest(
+                MINIMAL_VALID_MANIFEST.replace("""
+                          - id: camel-knowledge
+                            display_name: "Camel-Kit Knowledge MCP"
+                            description: "Knowledge"
+                            allowed_tools: []
+                        """, ""),
+                "mcp_servers missing required server 'camel-knowledge'");
     }
 
     @Test
@@ -160,6 +269,15 @@ class WorkflowManifestTest {
     private static Path resourcePath(String resource) throws Exception {
         URI uri = WorkflowManifestTest.class.getClassLoader().getResource(resource).toURI();
         return Path.of(uri);
+    }
+
+    private static void assertInvalidManifest(String yaml, String expectedMessage) {
+        IOException ex = assertThrows(IOException.class, () -> loadManifest(yaml));
+        assertTrue(ex.getMessage().contains(expectedMessage), ex.getMessage());
+    }
+
+    private static WorkflowManifest loadManifest(String yaml) throws IOException {
+        return WorkflowManifestLoader.load(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
     }
 
     private static Map<String, Object> readFrontmatter(Path skillFile) throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
@@ -20,6 +20,7 @@ import io.github.luigidemasi.camelkit.generator.InitContext;
 import io.github.luigidemasi.camelkit.output.Printer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -88,6 +89,39 @@ class WorkflowManifestTest {
     }
 
     @Test
+    void loadsMinimalValidManifest() {
+        WorkflowManifest manifest = assertDoesNotThrow(() -> loadManifest(MINIMAL_VALID_MANIFEST));
+
+        assertNotNull(manifest);
+        assertEquals(List.of("camel-start"), manifest.commands().stream()
+                .map(WorkflowManifest.WorkflowCommand::name)
+                .toList());
+    }
+
+    @Test
+    void loadsManifestWithOmittedOptionalCollections() {
+        String yaml = MINIMAL_VALID_MANIFEST
+                .replace("    aliases: []\n", "")
+                .replace("""
+                            inputs: []
+                            outputs: []
+                            transitions: []
+                        """, "")
+                .replace("""
+                            produced_by: [camel-start]
+                            consumed_by: [camel-start]
+                        """, "")
+                .replace("    allowed_tools: []\n", "");
+
+        WorkflowManifest manifest = assertDoesNotThrow(() -> loadManifest(yaml));
+
+        assertTrue(manifest.commands().get(0).aliases().isEmpty());
+        assertTrue(manifest.stages().get(0).transitions().isEmpty());
+        assertTrue(manifest.artifacts().get(0).producedBy().isEmpty());
+        assertTrue(manifest.mcpServer("camel").allowedTools().isEmpty());
+    }
+
+    @Test
     void generatedCommandStubsMatchManifest() throws Exception {
         WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
 
@@ -112,9 +146,23 @@ class WorkflowManifestTest {
 
     @Test
     void rejectsUnknownManifestFields() {
-        IOException ex = assertThrows(IOException.class,
+        JsonMappingException ex = assertThrows(JsonMappingException.class,
                 () -> loadManifest(MINIMAL_VALID_MANIFEST + "unexpected_root: true\n"));
-        assertTrue(ex.getMessage().contains("Unrecognized field \"unexpected_root\""), ex.getMessage());
+        assertTrue(ex.getMessage().contains("unexpected_root"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsMissingCollectionSectionsAsValidationErrors() {
+        ManifestValidationException ex = assertThrows(ManifestValidationException.class, () -> loadManifest("""
+                version: "1.0"
+                description: "Missing sections"
+                """));
+
+        assertTrue(ex.errors().contains("commands must not be empty"), ex.getMessage());
+        assertTrue(ex.errors().contains("skills must not be empty"), ex.getMessage());
+        assertTrue(ex.errors().contains("stages must not be empty"), ex.getMessage());
+        assertTrue(ex.errors().contains("artifacts must not be empty"), ex.getMessage());
+        assertTrue(ex.errors().contains("mcp_servers must not be empty"), ex.getMessage());
     }
 
     @Test
@@ -272,7 +320,7 @@ class WorkflowManifestTest {
     }
 
     private static void assertInvalidManifest(String yaml, String expectedMessage) {
-        IOException ex = assertThrows(IOException.class, () -> loadManifest(yaml));
+        ManifestValidationException ex = assertThrows(ManifestValidationException.class, () -> loadManifest(yaml));
         assertTrue(ex.getMessage().contains(expectedMessage), ex.getMessage());
     }
 


### PR DESCRIPTION
## Summary

- Enable strict workflow manifest YAML binding so unknown fields fail instead of being silently ignored.
- Add `WorkflowManifestValidator` to enforce cross-references between commands, skills, stages, artifacts, and required MCP servers.
- Expand workflow manifest tests with negative cases for unknown fields, bad references, missing MCP servers, and all-agent generated command stub consistency.

Fixes #106

## Verification

- `./mvnw -pl camel-kit-core process-sources`
- `./mvnw -pl camel-kit-core -Dtest=WorkflowManifestTest test -Dformat.skip=true`
- `./mvnw test -B -Dformat.skip=true`
- `./mvnw clean install -DskipTests -Dformat.skip=true`

Generated by Codex via /oss-fix-issue

## Summary by Sourcery

Enforce strict validation of workflow manifests and expand tests to cover invalid configurations and generated command stub consistency across agents.

Bug Fixes:
- Fail workflow manifest loading on unknown YAML fields instead of ignoring them.
- Validate cross-references between commands, skills, stages, artifacts, and required MCP servers when loading manifests.
- Ensure generated command stubs remain consistent with the workflow manifest for all registered agents.

Tests:
- Add a minimal valid manifest fixture and negative tests for unknown fields, bad references, missing required MCP servers, and generated command drift.