### PR TITLE
Fix #105: add shipped asset structure checks

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentConfig.java
@@ -9,6 +9,7 @@ public record AgentConfig(
         String fileFormat,
         String argPlaceholder,
         String mcpConfigPath,
+        String mcpConfigTemplatePath,
         String mcpServerContainerKey,
         String description) {
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentRegistry.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentRegistry.java
@@ -15,6 +15,7 @@ public final class AgentRegistry {
                     "md",
                     "$ARGUMENTS",
                     ".bob/mcp.json",
+                    "templates/mcp-configs/bob-mcp.json",
                     "mcpServers",
                     "IBM's AI-powered development assistant"),
             "gemini", new AgentConfig(
@@ -23,6 +24,7 @@ public final class AgentRegistry {
                     "toml",
                     "{{args}}",
                     ".gemini/settings.json",
+                    "templates/mcp-configs/gemini-mcp.json",
                     "mcpServers",
                     "Google's Gemini CLI"),
             "claude", new AgentConfig(
@@ -31,6 +33,7 @@ public final class AgentRegistry {
                     "md",
                     "$ARGUMENTS",
                     ".mcp.json",
+                    "templates/mcp-configs/claude-code-mcp.json",
                     "mcpServers",
                     "Anthropic's Claude Code CLI"),
             "qwen", new AgentConfig(
@@ -39,6 +42,7 @@ public final class AgentRegistry {
                     "md",
                     "$ARGUMENTS",
                     ".qwen/settings.json",
+                    "templates/mcp-configs/qwen-mcp.json",
                     "mcpServers",
                     "Alibaba's Qwen Code CLI"),
             "opencode", new AgentConfig(
@@ -47,6 +51,7 @@ public final class AgentRegistry {
                     "md",
                     "$ARGUMENTS",
                     "opencode.json",
+                    "templates/mcp-configs/opencode-mcp.json",
                     "mcp",
                     "AI coding agent for the terminal"));
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -272,50 +272,18 @@ public class DefaultGenerator implements AgentGenerator {
     }
 
     private void createMcpConfigs(InitContext ctx, WorkflowManifest workflow) throws Exception {
-        String agentName = "";
-
         // Knowledge server repos (still uses JBang for now)
         String knowledgeMcpRepos = CamelKitMain.KNOWLEDGE_MCP_REPOS;
         String camelMcpRepos = CamelKitMain.CAMEL_MCP_REPOS;
 
         try {
-            String templatePath;
-
-            switch (ctx.agentName().toLowerCase(Locale.ROOT)) {
-                case "claude" -> {
-                    templatePath = "templates/mcp-configs/claude-code-mcp.json";
-                    agentName = "Claude Code";
-                }
-                case "bob" -> {
-                    templatePath = "templates/mcp-configs/bob-mcp.json";
-                    agentName = "IBM Bob";
-                }
-                case "gemini" -> {
-                    templatePath = "templates/mcp-configs/gemini-mcp.json";
-                    agentName = "Gemini CLI";
-                }
-                case "qwen" -> {
-                    templatePath = "templates/mcp-configs/qwen-mcp.json";
-                    agentName = "Qwen Code";
-                }
-                case "opencode" -> {
-                    templatePath = "templates/mcp-configs/opencode-mcp.json";
-                    agentName = "OpenCode";
-                }
-                default -> {
-                    ctx.printer().println(AnsiColors
-                            .yellow("  Warning: Unknown agent '" + ctx.agentName() + "', skipping MCP config"));
-                    return;
-                }
-            }
-
             Path configFile = ctx.projectDir().resolve(ctx.agent().mcpConfigPath());
             if (configFile.getParent() != null) {
                 Files.createDirectories(configFile.getParent());
             }
 
             QuteTemplateEngine qute = new QuteTemplateEngine();
-            String template = TemplateUtils.readTemplate(templatePath);
+            String template = TemplateUtils.readTemplate(ctx.agent().mcpConfigTemplatePath());
             DistributionConfig dist = CamelKitMain.distribution();
             Map<String, Object> templateData = new java.util.HashMap<>(
                     Map.of(
@@ -343,7 +311,7 @@ public class DefaultGenerator implements AgentGenerator {
             String processed = qute.renderString(template, templateData);
             Files.writeString(configFile, processed);
 
-            ctx.printer().println(AnsiColors.green("✓") + " MCP config created for " + agentName);
+            ctx.printer().println(AnsiColors.green("✓") + " MCP config created for " + ctx.agent().name());
         } catch (Exception e) {
             ctx.printer().println(AnsiColors.yellow("  Warning: Could not create MCP config: " + e.getMessage()));
         }

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
@@ -17,9 +17,9 @@
 
 **Conditionally load:**
 - `skills/camel-migrate/guides/datamapper-migrate.md` — load once per orchestration that contains a BizTalk map (see Step 2.2)
-- `skills/camel-flow/guides/performance.md` — if SLA requirements are strict
-- `skills/camel-flow/guides/security.md` — if compliance requirements exist
-- `skills/camel-flow/guides/monitoring.md` — if observability requirements exist
+- `skills/camel-design/guides/performance.md` — if SLA requirements are strict
+- `skills/camel-design/guides/security.md` — if compliance requirements exist
+- `skills/camel-design/guides/monitoring.md` — if observability requirements exist
 
 **MCP catalog tools — MANDATORY when MCP is configured (same rules as `/camel-flow`):**
 

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
@@ -138,12 +138,12 @@ Store selections in `.camel-kit/config.properties`.
 ## Design Flows
 
 For each flow, design the integration using relevant guides from `camel-design/`:
-- Component selection: `guides/component-selection.md`
-- EIP patterns: `guides/eip-patterns.md`
-- Data formats: `guides/data-formats.md`
-- Error handling: `guides/error-handling.md`
-- Security: `guides/security.md`
-- Resilience: `guides/resilience.md`
+- Component selection: `.bob/skills/camel-design/guides/component-selection.md`
+- EIP catalog: `.bob/skills/camel-design/guides/eip-catalog.md`
+- Integration patterns: `.bob/skills/camel-design/guides/integration-patterns.md`
+- Data formats: `.bob/skills/camel-design/guides/data-formats.md`
+- Error handling and resilience: `.bob/skills/camel-design/guides/resilience-interview.md`
+- Security: `.bob/skills/camel-design/guides/security.md`
 
 **CRITICAL:** Verify EVERY component via MCP:
 1. `camel_catalog_component_doc` — verify component exists

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -68,6 +68,28 @@ class ResourceConsistencyTest {
     }
 
     @Test
+    void activeResourceScanIncludesTopLevelDocsOnly() throws IOException {
+        Path root = repositoryRoot();
+
+        Set<String> activeResources = activeResourceFiles(root).stream()
+                .map(path -> root.relativize(path).toString())
+                .collect(Collectors.toSet());
+        Set<String> topLevelDocs;
+        try (Stream<Path> paths = Files.list(root.resolve("docs"))) {
+            topLevelDocs = paths.filter(Files::isRegularFile)
+                    .filter(ResourceConsistencyTest::isScannedTextFile)
+                    .map(path -> root.relativize(path).toString())
+                    .collect(Collectors.toSet());
+        }
+
+        assertTrue(activeResources.containsAll(topLevelDocs));
+        assertFalse(activeResources.stream().anyMatch(path -> path.startsWith("docs/plans/")));
+        assertFalse(activeResources.stream().anyMatch(path -> path.startsWith("docs/superpowers/")));
+        assertFalse(activeResources.stream().anyMatch(path -> path.startsWith("docs/flows/")));
+        assertFalse(activeResources.stream().anyMatch(path -> path.startsWith("docs/img/")));
+    }
+
+    @Test
     void generatedCommandStubsMatchIntendedExposedSkills() throws Exception {
         for (String agentName : sortedAgentNames()) {
             Path projectDir = tempDir.resolve(agentName);
@@ -140,11 +162,11 @@ class ResourceConsistencyTest {
         List<Path> scanRoots = List.of(
                 root.resolve("camel-kit-core/src/main/resources/skills"),
                 root.resolve("camel-kit-core/src/main/resources/templates"),
-                root.resolve("docs"),
                 root.resolve("README.md"),
                 root.resolve("CONTRIBUTING.md"));
 
         List<Path> files = new ArrayList<>();
+        addTopLevelDocs(root, files);
         for (Path scanRoot : scanRoots) {
             if (Files.isRegularFile(scanRoot)) {
                 if (isScannedTextFile(scanRoot)) {
@@ -160,6 +182,18 @@ class ResourceConsistencyTest {
         }
         files.sort(Comparator.comparing(path -> root.relativize(path).toString()));
         return files;
+    }
+
+    private static void addTopLevelDocs(Path root, List<Path> files) throws IOException {
+        Path docsDir = root.resolve("docs");
+        if (!Files.isDirectory(docsDir)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.list(docsDir)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(ResourceConsistencyTest::isScannedTextFile)
+                    .forEach(files::add);
+        }
     }
 
     private static boolean isScannedTextFile(Path path) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
@@ -1,0 +1,381 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShippedAssetStructureTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final Pattern CODE_SPAN = Pattern.compile("`([^`\\n]+\\.md)`");
+    private static final Pattern GENERATED_SKILL_REFERENCE
+            = Pattern.compile("(?<path>\\.[A-Za-z0-9_-]+/skills/[A-Za-z0-9_./-]+/SKILL\\.md)");
+
+    private static final Map<String, String> MCP_CONFIG_TEMPLATES = Map.of(
+            "bob", "bob-mcp.json",
+            "claude", "claude-code-mcp.json",
+            "gemini", "gemini-mcp.json",
+            "opencode", "opencode-mcp.json",
+            "qwen", "qwen-mcp.json");
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void workflowManifestSkillsHaveShippedSkillAssets() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+        Path skillsDir = resourcePath("skills");
+
+        Set<String> shippedSkills;
+        try (Stream<Path> paths = Files.list(skillsDir)) {
+            shippedSkills = paths.filter(Files::isDirectory)
+                    .filter(path -> Files.isRegularFile(path.resolve("SKILL.md")))
+                    .map(path -> path.getFileName().toString())
+                    .collect(Collectors.toCollection(java.util.TreeSet::new));
+        }
+
+        Set<String> manifestSkills = manifest.skills().stream()
+                .map(WorkflowManifest.WorkflowSkill::name)
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+
+        assertEquals(manifestSkills, shippedSkills,
+                "Every workflow manifest skill must have a shipped skills/<name>/SKILL.md file");
+    }
+
+    @Test
+    void skillGuideManifestReferencesResolveToExistingAssets() throws Exception {
+        Path resourcesDir = resourceRoot();
+        Path skillsDir = resourcesDir.resolve("skills");
+
+        List<String> missingReferences = new ArrayList<>();
+        try (Stream<Path> paths = Files.list(skillsDir)) {
+            paths.filter(Files::isDirectory)
+                    .map(path -> path.resolve("SKILL.md"))
+                    .filter(Files::isRegularFile)
+                    .sorted()
+                    .forEach(path -> validateSkillGuideManifestReferences(resourcesDir, skillsDir, path,
+                            missingReferences));
+        }
+
+        assertTrue(missingReferences.isEmpty(),
+                "Skill guide manifest tables reference missing assets:\n"
+                                                + String.join("\n", missingReferences));
+    }
+
+    @Test
+    void sharedGuideReferencesResolveToExistingAssets() throws Exception {
+        Path resourcesDir = resourceRoot();
+        Path skillsDir = resourcesDir.resolve("skills");
+        Path templatesDir = resourcesDir.resolve("templates");
+
+        List<String> missingReferences = new ArrayList<>();
+        for (Path source : shippedMarkdownFiles(skillsDir, templatesDir)) {
+            String content = Files.readString(source);
+            Matcher matcher = CODE_SPAN.matcher(content);
+            while (matcher.find()) {
+                String reference = matcher.group(1).strip();
+                resolveSharedGuideReference(resourcesDir, reference).ifPresent(target -> {
+                    if (!Files.isRegularFile(target)) {
+                        missingReferences.add(resourcesDir.relativize(source) + " references missing asset `"
+                                              + reference + "` -> " + resourcesDir.relativize(target));
+                    }
+                });
+            }
+        }
+
+        assertTrue(missingReferences.isEmpty(),
+                "Shipped skill/template shared guide references point to missing assets:\n"
+                                                + String.join("\n", missingReferences));
+    }
+
+    @Test
+    void dispatchAndMcpTemplatesExistForEverySupportedAgent() throws Exception {
+        Path templatesDir = resourcePath("templates");
+
+        List<String> missingAssets = new ArrayList<>();
+        for (String agentName : sortedAgentNames()) {
+            if (!Files.isRegularFile(templatesDir.resolve("dispatch/" + agentName + ".md"))) {
+                missingAssets.add("templates/dispatch/" + agentName + ".md");
+            }
+            String mcpTemplate = MCP_CONFIG_TEMPLATES.get(agentName);
+            if (mcpTemplate == null) {
+                missingAssets.add("MCP template mapping for agent '" + agentName + "'");
+            } else if (!Files.isRegularFile(templatesDir.resolve("mcp-configs/" + mcpTemplate))) {
+                missingAssets.add("templates/mcp-configs/" + mcpTemplate);
+            }
+        }
+
+        assertTrue(missingAssets.isEmpty(),
+                "Supported agents are missing dispatch or MCP config templates:\n"
+                                            + String.join("\n", missingAssets));
+    }
+
+    @Test
+    void traitFilesTargetExistingSkillAssets() throws Exception {
+        Path resourcesDir = resourceRoot();
+        Path traitsDir = resourcesDir.resolve("templates/traits");
+
+        List<String> invalidTraits = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(traitsDir)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".append.md"))
+                    .sorted()
+                    .forEach(path -> validateTraitTarget(resourcesDir, traitsDir, path, invalidTraits));
+        }
+
+        assertTrue(invalidTraits.isEmpty(),
+                "Agent trait files target missing skills or guides:\n"
+                                            + String.join("\n", invalidTraits));
+    }
+
+    @Test
+    void generatedAgentAssetsAreStructurallyCoherent() throws Exception {
+        WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
+        Map<String, WorkflowManifest.WorkflowCommand> generatedCommands = manifest.generatedCommandStubs().stream()
+                .collect(Collectors.toMap(
+                        WorkflowManifest.WorkflowCommand::name,
+                        command -> command,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+
+        for (String agentName : sortedAgentNames()) {
+            InitContext ctx = createContext(agentName, tempDir.resolve(agentName));
+            AgentGeneratorFactory.create(agentName).generate(ctx);
+
+            assertGeneratedCommandFiles(agentName, ctx, generatedCommands);
+            assertGeneratedSkillReferencesResolve(agentName, ctx, generatedCommands);
+            assertGeneratedMcpConfigIsValid(agentName, ctx);
+        }
+    }
+
+    private static List<Path> shippedMarkdownFiles(Path skillsDir, Path templatesDir) throws IOException {
+        List<Path> files = new ArrayList<>();
+        for (Path root : List.of(skillsDir, templatesDir)) {
+            try (Stream<Path> paths = Files.walk(root)) {
+                paths.filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().endsWith(".md"))
+                        .forEach(files::add);
+            }
+        }
+        files.sort(Comparator.comparing(Path::toString));
+        return files;
+    }
+
+    private static void validateSkillGuideManifestReferences(
+            Path resourcesDir, Path skillsDir, Path skillFile, List<String> missingReferences) {
+        try {
+            boolean inGuideSection = false;
+            for (String line : Files.readAllLines(skillFile)) {
+                if (line.startsWith("## ")) {
+                    inGuideSection = line.toLowerCase(Locale.ROOT).contains("guide");
+                    continue;
+                }
+                if (!inGuideSection || !line.startsWith("|") || !line.contains(".md")) {
+                    continue;
+                }
+
+                Matcher matcher = CODE_SPAN.matcher(line);
+                while (matcher.find()) {
+                    String reference = matcher.group(1).strip();
+                    resolveGuideManifestReference(resourcesDir, skillsDir, skillFile, reference).ifPresent(target -> {
+                        if (!Files.isRegularFile(target)) {
+                            missingReferences.add(resourcesDir.relativize(skillFile)
+                                                  + " guide table references missing asset `" + reference + "` -> "
+                                                  + resourcesDir.relativize(target));
+                        }
+                    });
+                }
+            }
+        } catch (IOException e) {
+            missingReferences.add(resourcesDir.relativize(skillFile) + " could not be read: " + e.getMessage());
+        }
+    }
+
+    private static Optional<Path> resolveGuideManifestReference(
+            Path resourcesDir, Path skillsDir, Path skillFile, String reference) {
+        String normalized = normalizeReference(reference);
+        if (normalized.startsWith("guides/")) {
+            return owningSkill(skillFile, skillsDir).map(skill -> skillsDir.resolve(skill).resolve(normalized));
+        }
+        if (normalized.startsWith("camel-")) {
+            return Optional.of(skillsDir.resolve(normalized));
+        }
+        if (normalized.startsWith("shared/")) {
+            return Optional.of(skillsDir.resolve(normalized));
+        }
+        if (normalized.startsWith("agents/")) {
+            return Optional.of(resourcesDir.resolve(normalized));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Path> resolveSharedGuideReference(Path resourcesDir, String reference) {
+        String normalized = normalizeReference(reference);
+
+        Path skillsDir = resourcesDir.resolve("skills");
+        if (normalized.startsWith("shared/")) {
+            return Optional.of(skillsDir.resolve(normalized));
+        }
+        return Optional.empty();
+    }
+
+    private static String normalizeReference(String reference) {
+        String normalized = reference.strip()
+                .replace("\\", "/");
+        while (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        }
+        int skillsIndex = normalized.indexOf("/skills/");
+        if (skillsIndex >= 0) {
+            normalized = normalized.substring(skillsIndex + "/skills/".length());
+        }
+        return normalized;
+    }
+
+    private static Optional<String> owningSkill(Path source, Path skillsDir) {
+        if (!source.startsWith(skillsDir)) {
+            return Optional.empty();
+        }
+        Path relative = skillsDir.relativize(source);
+        if (relative.getNameCount() < 2) {
+            return Optional.empty();
+        }
+        String skillName = relative.getName(0).toString();
+        if ("shared".equals(skillName)) {
+            return Optional.empty();
+        }
+        return Optional.of(skillName);
+    }
+
+    private static void validateTraitTarget(
+            Path resourcesDir, Path traitsDir, Path traitFile, List<String> invalidTraits) {
+        Path relative = traitsDir.relativize(traitFile);
+        if (relative.getNameCount() < 2) {
+            invalidTraits.add(resourcesDir.relativize(traitFile) + " is not under traits/<agent>/");
+            return;
+        }
+
+        String agentName = relative.getName(0).toString();
+        if (!AgentRegistry.contains(agentName)) {
+            invalidTraits.add(resourcesDir.relativize(traitFile) + " uses unsupported agent '" + agentName + "'");
+        }
+
+        String skillName = stripAppendSuffix(relative.getName(1).toString());
+        Path target;
+        if (relative.getNameCount() == 2) {
+            target = resourcesDir.resolve("skills").resolve(skillName).resolve("SKILL.md");
+        } else {
+            String guideName = stripAppendSuffix(relative.getFileName().toString());
+            target = resourcesDir.resolve("skills").resolve(skillName).resolve("guides").resolve(guideName + ".md");
+        }
+        if (!Files.isRegularFile(target)) {
+            invalidTraits.add(resourcesDir.relativize(traitFile) + " targets missing "
+                              + resourcesDir.relativize(target));
+        }
+    }
+
+    private static String stripAppendSuffix(String fileName) {
+        return fileName.endsWith(".append.md")
+                ? fileName.substring(0, fileName.length() - ".append.md".length())
+                : fileName;
+    }
+
+    private static void assertGeneratedCommandFiles(
+            String agentName, InitContext ctx, Map<String, WorkflowManifest.WorkflowCommand> generatedCommands)
+            throws IOException {
+        Set<String> expected = generatedCommands.keySet().stream()
+                .map(command -> command + "." + ctx.agent().fileFormat())
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+        Set<String> actual;
+        try (Stream<Path> files = Files.list(ctx.commandsDir())) {
+            actual = files.filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .collect(Collectors.toCollection(java.util.TreeSet::new));
+        }
+        assertEquals(expected, actual, agentName + " command files must match manifest generated commands");
+    }
+
+    private static void assertGeneratedSkillReferencesResolve(
+            String agentName, InitContext ctx, Map<String, WorkflowManifest.WorkflowCommand> generatedCommands)
+            throws IOException {
+        for (WorkflowManifest.WorkflowCommand command : generatedCommands.values()) {
+            Path commandFile = ctx.commandsDir().resolve(command.name() + "." + ctx.agent().fileFormat());
+            assertTrue(Files.isRegularFile(commandFile), agentName + " missing command file " + commandFile);
+            assertTrue(Files.isRegularFile(ctx.skillsDir().resolve(command.skill() + "/SKILL.md")),
+                    agentName + " command " + command.name() + " points to missing copied skill " + command.skill());
+
+            String content = Files.readString(commandFile);
+            Matcher matcher = GENERATED_SKILL_REFERENCE.matcher(content);
+            while (matcher.find()) {
+                Path referenced = ctx.projectDir().resolve(matcher.group("path"));
+                assertTrue(Files.isRegularFile(referenced),
+                        agentName + " command " + command.name() + " references missing " + matcher.group("path"));
+            }
+        }
+    }
+
+    private static void assertGeneratedMcpConfigIsValid(String agentName, InitContext ctx) throws IOException {
+        Path configPath = ctx.projectDir().resolve(ctx.agent().mcpConfigPath());
+        assertTrue(Files.isRegularFile(configPath), agentName + " MCP config must be generated at " + configPath);
+
+        JsonNode root = MAPPER.readTree(configPath.toFile());
+        JsonNode servers = root.get(ctx.agent().mcpServerContainerKey());
+        assertNotNull(servers, agentName + " MCP config missing " + ctx.agent().mcpServerContainerKey());
+        assertTrue(servers.has("camel"), agentName + " MCP config missing camel server");
+        assertTrue(servers.has("camel-knowledge"), agentName + " MCP config missing camel-knowledge server");
+    }
+
+    private static InitContext createContext(String agentName, Path projectDir) {
+        AgentConfig agent = AgentRegistry.get(agentName);
+        assertNotNull(agent, "Unexpected agent: " + agentName);
+        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
+        Path commandsDir = projectDir.resolve(agent.folder());
+        Path skillsDir = projectDir.resolve(agentBaseFolder + "/skills");
+        return new InitContext(
+                agent, agentName, commandsDir, skillsDir, projectDir,
+                "camel-kit", Printer.noop());
+    }
+
+    private static List<String> sortedAgentNames() {
+        return AgentRegistry.names().stream()
+                .sorted()
+                .toList();
+    }
+
+    private static Path resourcePath(String resource) throws Exception {
+        String normalized = resource.startsWith("/") ? resource.substring(1) : resource;
+        URI uri = ShippedAssetStructureTest.class.getClassLoader().getResource(normalized).toURI();
+        return Path.of(uri);
+    }
+
+    private static Path resourceRoot() throws Exception {
+        return resourcePath("skills").getParent();
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -37,13 +38,6 @@ class ShippedAssetStructureTest {
     private static final Pattern CODE_SPAN = Pattern.compile("`([^`\\n]+\\.md)`");
     private static final Pattern GENERATED_SKILL_REFERENCE
             = Pattern.compile("(?<path>\\.[A-Za-z0-9_-]+/skills/[A-Za-z0-9_./-]+/SKILL\\.md)");
-
-    private static final Map<String, String> MCP_CONFIG_TEMPLATES = Map.of(
-            "bob", "bob-mcp.json",
-            "claude", "claude-code-mcp.json",
-            "gemini", "gemini-mcp.json",
-            "opencode", "opencode-mcp.json",
-            "qwen", "qwen-mcp.json");
 
     @TempDir
     Path tempDir;
@@ -117,18 +111,19 @@ class ShippedAssetStructureTest {
 
     @Test
     void dispatchAndMcpTemplatesExistForEverySupportedAgent() throws Exception {
-        Path templatesDir = resourcePath("templates");
+        Path resourcesDir = resourceRoot();
+        Path templatesDir = resourcesDir.resolve("templates");
 
         List<String> missingAssets = new ArrayList<>();
         for (String agentName : sortedAgentNames()) {
             if (!Files.isRegularFile(templatesDir.resolve("dispatch/" + agentName + ".md"))) {
                 missingAssets.add("templates/dispatch/" + agentName + ".md");
             }
-            String mcpTemplate = MCP_CONFIG_TEMPLATES.get(agentName);
-            if (mcpTemplate == null) {
-                missingAssets.add("MCP template mapping for agent '" + agentName + "'");
-            } else if (!Files.isRegularFile(templatesDir.resolve("mcp-configs/" + mcpTemplate))) {
-                missingAssets.add("templates/mcp-configs/" + mcpTemplate);
+
+            AgentConfig agent = AgentRegistry.get(agentName);
+            assertNotNull(agent, "AgentRegistry listed unknown agent '" + agentName + "'");
+            if (!Files.isRegularFile(resourcesDir.resolve(agent.mcpConfigTemplatePath()))) {
+                missingAssets.add(agent.mcpConfigTemplatePath());
             }
         }
 
@@ -220,47 +215,92 @@ class ShippedAssetStructureTest {
 
     private static Optional<Path> resolveGuideManifestReference(
             Path resourcesDir, Path skillsDir, Path skillFile, String reference) {
-        String normalized = normalizeReference(reference);
-        if (normalized.startsWith("guides/")) {
-            return owningSkill(skillFile, skillsDir).map(skill -> skillsDir.resolve(skill).resolve(normalized));
-        }
-        if (normalized.startsWith("camel-")) {
-            return Optional.of(skillsDir.resolve(normalized));
-        }
-        if (normalized.startsWith("shared/")) {
-            return Optional.of(skillsDir.resolve(normalized));
-        }
-        if (normalized.startsWith("agents/")) {
-            return Optional.of(resourcesDir.resolve(normalized));
-        }
-        return Optional.empty();
+        return ShippedReference.parse(reference)
+                .resolve(EnumSet.allOf(ShippedReferenceKind.class),
+                        new ReferenceContext(resourcesDir, skillsDir, skillFile));
     }
 
     private static Optional<Path> resolveSharedGuideReference(Path resourcesDir, String reference) {
-        String normalized = normalizeReference(reference);
-
         Path skillsDir = resourcesDir.resolve("skills");
-        if (normalized.startsWith("shared/")) {
-            return Optional.of(skillsDir.resolve(normalized));
-        }
-        return Optional.empty();
+        return ShippedReference.parse(reference)
+                .resolve(EnumSet.of(ShippedReferenceKind.SHARED_GUIDE),
+                        new ReferenceContext(resourcesDir, skillsDir, null));
     }
 
-    private static String normalizeReference(String reference) {
-        String normalized = reference.strip()
-                .replace("\\", "/");
-        while (normalized.startsWith("./")) {
-            normalized = normalized.substring(2);
+    private record ReferenceContext(Path resourcesDir, Path skillsDir, Path source) {
+    }
+
+    private record ShippedReference(String path) {
+
+        private static ShippedReference parse(String reference) {
+            String normalized = reference.strip()
+                    .replace("\\", "/");
+            while (normalized.startsWith("./")) {
+                normalized = normalized.substring(2);
+            }
+            int skillsIndex = normalized.indexOf("/skills/");
+            if (skillsIndex >= 0) {
+                normalized = normalized.substring(skillsIndex + "/skills/".length());
+            }
+            return new ShippedReference(normalized);
         }
-        int skillsIndex = normalized.indexOf("/skills/");
-        if (skillsIndex >= 0) {
-            normalized = normalized.substring(skillsIndex + "/skills/".length());
+
+        private Optional<Path> resolve(EnumSet<ShippedReferenceKind> allowedKinds, ReferenceContext context) {
+            for (ShippedReferenceKind kind : allowedKinds) {
+                if (kind.matches(this)) {
+                    return kind.resolve(this, context);
+                }
+            }
+            return Optional.empty();
         }
-        return normalized;
+    }
+
+    /**
+     * Structural references intentionally support only shipped asset paths, not generated project artifacts such as
+     * design-spec.md. Add new reference forms here so their resolution stays explicit.
+     */
+    private enum ShippedReferenceKind {
+        LOCAL_GUIDE("guides/") {
+            @Override
+            Optional<Path> resolve(ShippedReference reference, ReferenceContext context) {
+                return owningSkill(context.source(), context.skillsDir())
+                        .map(skill -> context.skillsDir().resolve(skill).resolve(reference.path()));
+            }
+        },
+        SKILL("camel-") {
+            @Override
+            Optional<Path> resolve(ShippedReference reference, ReferenceContext context) {
+                return Optional.of(context.skillsDir().resolve(reference.path()));
+            }
+        },
+        SHARED_GUIDE("shared/") {
+            @Override
+            Optional<Path> resolve(ShippedReference reference, ReferenceContext context) {
+                return Optional.of(context.skillsDir().resolve(reference.path()));
+            }
+        },
+        AGENT("agents/") {
+            @Override
+            Optional<Path> resolve(ShippedReference reference, ReferenceContext context) {
+                return Optional.of(context.resourcesDir().resolve(reference.path()));
+            }
+        };
+
+        private final String prefix;
+
+        ShippedReferenceKind(String prefix) {
+            this.prefix = prefix;
+        }
+
+        private boolean matches(ShippedReference reference) {
+            return reference.path().startsWith(prefix);
+        }
+
+        abstract Optional<Path> resolve(ShippedReference reference, ReferenceContext context);
     }
 
     private static Optional<String> owningSkill(Path source, Path skillsDir) {
-        if (!source.startsWith(skillsDir)) {
+        if (source == null || !source.startsWith(skillsDir)) {
             return Optional.empty();
         }
         Path relative = skillsDir.relativize(source);
@@ -371,7 +411,9 @@ class ShippedAssetStructureTest {
 
     private static Path resourcePath(String resource) throws Exception {
         String normalized = resource.startsWith("/") ? resource.substring(1) : resource;
-        URI uri = ShippedAssetStructureTest.class.getClassLoader().getResource(normalized).toURI();
+        var resourceUrl = ShippedAssetStructureTest.class.getClassLoader().getResource(normalized);
+        assertNotNull(resourceUrl, "Missing test resource on classpath: " + normalized);
+        URI uri = resourceUrl.toURI();
         return Path.of(uri);
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -341,7 +341,11 @@ The validation guide (`datamapper-validation.md`) reads the `Transformation Engi
 
 Skills, generated instruction files, MCP config templates, and active docs are runtime contract surfaces. They are tested by `ResourceConsistencyTest` in `camel-kit-core` so stale contract tokens fail the build before they ship.
 
-The active scan covers `camel-kit-core/src/main/resources/skills`, `camel-kit-core/src/main/resources/templates`, `docs/`, `README.md`, and `CONTRIBUTING.md`. These files must reference current command names, current config files, current graph access patterns, current Knowledge MCP tool names, and current Iron Law counts.
+The active scan covers `camel-kit-core/src/main/resources/skills`, `camel-kit-core/src/main/resources/templates`, top-level Markdown files under `docs/`, `README.md`, and `CONTRIBUTING.md`. These files must reference current command names, current config files, current graph access patterns, current Knowledge MCP tool names, and current Iron Law counts.
+
+Docs subdirectories are intentionally out of scope; this keeps ignored archives such as `docs/plans/` and `docs/superpowers/`, image assets, and generated planning material out of the contract check.
+
+`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent has dispatch and MCP config templates, trait files target existing skills or guides, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as JSON with the expected server containers.
 
 Historical release notes, old planning material, and archived ADR-style documents are outside the active contract unless they are copied into generated projects or used as live instructions. Keep historical context in those files as history; do not exclude an active shipped instruction just because it is inconvenient to update.
 


### PR DESCRIPTION
Fixes #105.

Summary:
- Add ShippedAssetStructureTest to validate shipped skill assets, SKILL.md guide tables, shared guide references, supported-agent dispatch/MCP templates, trait targets, generated command stubs, generated skill references, and generated MCP JSON structure.
- Keep ResourceConsistencyTest focused on active runtime contract surfaces while scanning top-level docs and excluding archived/generated docs subdirectories.
- Fix stale shipped guide references in the BizTalk migration guide and Bob brainstorm gate.
- Document the shipped asset structural contract in docs/architecture.md.

Review feedback addressed:
- Centralize MCP config template paths in AgentConfig and use that metadata from DefaultGenerator and ShippedAssetStructureTest.
- Make missing classpath resources fail with a clear assertion message in ShippedAssetStructureTest.
- Replace ad-hoc shipped-reference string resolution with a small typed ShippedReferenceKind resolver.

Validation:
- ./mvnw -q -pl camel-kit-core -Dtest='ShippedAssetStructureTest,DefaultGeneratorTest,ResourceConsistencyTest,WorkflowManifestTest' test -Dformat.skip=true
- ./mvnw -q -pl camel-kit-core process-sources
- mvnd clean install

Generated by Codex via /oss-address-review