### PR TITLE
Fix #109: Load agent registry from resource descriptors

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptor.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptor.java
@@ -24,9 +24,6 @@ public record AgentDescriptor(
         Boolean supportsTraits,
         List<String> capabilities) {
 
-    private static final List<String> SUPPORTED_GENERATOR_STRATEGIES = List.of(
-            "default", "bob", "claude", "gemini", "opencode", "qwen");
-
     public AgentDescriptor {
         templates = immutableList(templates);
         capabilities = immutableList(capabilities);
@@ -50,12 +47,7 @@ public record AgentDescriptor(
         if (!id.matches("[a-z][a-z0-9-]*")) {
             throw new IllegalStateException(source + " has invalid agent id '" + id + "'");
         }
-        if (!SUPPORTED_GENERATOR_STRATEGIES.contains(generatorStrategy)) {
-            throw new IllegalStateException(
-                    source + " has unsupported generatorStrategy '" + generatorStrategy
-                                            + "'. Supported values: "
-                                            + String.join(", ", SUPPORTED_GENERATOR_STRATEGIES));
-        }
+        generatorStrategyType(source);
         for (int i = 0; i < templates.size(); i++) {
             TemplateInstall template = templates.get(i);
             if (template == null) {
@@ -67,6 +59,14 @@ public record AgentDescriptor(
             requireText(capabilities.get(i), "capabilities[" + i + "]", source);
         }
         return this;
+    }
+
+    public AgentGeneratorStrategy generatorStrategyType() {
+        return generatorStrategyType("agent descriptor '" + id + "'");
+    }
+
+    private AgentGeneratorStrategy generatorStrategyType(String source) {
+        return AgentGeneratorStrategy.fromDescriptorValue(generatorStrategy, source);
     }
 
     AgentConfig toAgentConfig() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptor.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptor.java
@@ -1,0 +1,110 @@
+package io.github.luigidemasi.camelkit.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Resource-backed description of a supported AI coding agent.
+ */
+public record AgentDescriptor(
+        String id,
+        String displayName,
+        String commandDirectory,
+        String commandFileFormat,
+        String argumentPlaceholder,
+        String mcpConfigPath,
+        String mcpConfigTemplatePath,
+        String mcpServerContainerKey,
+        String description,
+        String generatorStrategy,
+        String dispatchTemplatePath,
+        List<TemplateInstall> templates,
+        Boolean supportsSubagents,
+        Boolean supportsTraits,
+        List<String> capabilities) {
+
+    private static final List<String> SUPPORTED_GENERATOR_STRATEGIES = List.of(
+            "default", "bob", "claude", "gemini", "opencode", "qwen");
+
+    public AgentDescriptor {
+        templates = immutableList(templates);
+        capabilities = immutableList(capabilities);
+    }
+
+    AgentDescriptor validate(String source) {
+        requireText(id, "id", source);
+        requireText(displayName, "displayName", source);
+        requireText(commandDirectory, "commandDirectory", source);
+        requireText(commandFileFormat, "commandFileFormat", source);
+        requireText(argumentPlaceholder, "argumentPlaceholder", source);
+        requireText(mcpConfigPath, "mcpConfigPath", source);
+        requireText(mcpConfigTemplatePath, "mcpConfigTemplatePath", source);
+        requireText(mcpServerContainerKey, "mcpServerContainerKey", source);
+        requireText(description, "description", source);
+        requireText(generatorStrategy, "generatorStrategy", source);
+        requireText(dispatchTemplatePath, "dispatchTemplatePath", source);
+        requireBoolean(supportsSubagents, "supportsSubagents", source);
+        requireBoolean(supportsTraits, "supportsTraits", source);
+
+        if (!id.matches("[a-z][a-z0-9-]*")) {
+            throw new IllegalStateException(source + " has invalid agent id '" + id + "'");
+        }
+        if (!SUPPORTED_GENERATOR_STRATEGIES.contains(generatorStrategy)) {
+            throw new IllegalStateException(
+                    source + " has unsupported generatorStrategy '" + generatorStrategy
+                                            + "'. Supported values: "
+                                            + String.join(", ", SUPPORTED_GENERATOR_STRATEGIES));
+        }
+        for (int i = 0; i < templates.size(); i++) {
+            TemplateInstall template = templates.get(i);
+            if (template == null) {
+                throw new IllegalStateException(source + " has null templates[" + i + "]");
+            }
+            template.validate(source + " templates[" + i + "]");
+        }
+        for (int i = 0; i < capabilities.size(); i++) {
+            requireText(capabilities.get(i), "capabilities[" + i + "]", source);
+        }
+        return this;
+    }
+
+    AgentConfig toAgentConfig() {
+        return new AgentConfig(
+                displayName,
+                commandDirectory,
+                commandFileFormat,
+                argumentPlaceholder,
+                mcpConfigPath,
+                mcpConfigTemplatePath,
+                mcpServerContainerKey,
+                description);
+    }
+
+    private static <T> List<T> immutableList(List<T> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    private static void requireText(String value, String field, String source) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(source + " is missing required field '" + field + "'");
+        }
+    }
+
+    private static void requireBoolean(Boolean value, String field, String source) {
+        if (value == null) {
+            throw new IllegalStateException(source + " is missing required field '" + field + "'");
+        }
+    }
+
+    public record TemplateInstall(String source, String target) {
+
+        private void validate(String location) {
+            requireText(source, "source", location);
+            requireText(target, "target", location);
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptorLoader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptorLoader.java
@@ -1,0 +1,138 @@
+package io.github.luigidemasi.camelkit.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+final class AgentDescriptorLoader {
+
+    private static final String DEFAULT_REGISTRY_PATH = "agents/registry";
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private AgentDescriptorLoader() {
+    }
+
+    static Map<String, AgentDescriptor> loadDefault() {
+        var registryUrl = AgentDescriptorLoader.class.getClassLoader().getResource(DEFAULT_REGISTRY_PATH);
+        if (registryUrl == null) {
+            throw new IllegalStateException(
+                    "Agent descriptor registry not found on classpath: "
+                                            + DEFAULT_REGISTRY_PATH);
+        }
+
+        FileSystem fileSystem = null;
+        boolean closeFileSystem = false;
+        try {
+            URI uri = registryUrl.toURI();
+            Path registryPath;
+            if ("jar".equals(uri.getScheme())) {
+                try {
+                    fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                    closeFileSystem = true;
+                } catch (FileSystemAlreadyExistsException e) {
+                    fileSystem = FileSystems.getFileSystem(uri);
+                }
+                registryPath = fileSystem.getPath("/" + DEFAULT_REGISTRY_PATH);
+            } else {
+                registryPath = Path.of(uri);
+            }
+            return load(registryPath);
+        } catch (IOException | URISyntaxException e) {
+            throw new IllegalStateException(
+                    "Could not load agent descriptor registry from " + registryUrl
+                                            + ": " + e.getMessage(),
+                    e);
+        } finally {
+            if (closeFileSystem && fileSystem != null) {
+                try {
+                    fileSystem.close();
+                } catch (IOException e) {
+                    // Ignore close errors.
+                }
+            }
+        }
+    }
+
+    static Map<String, AgentDescriptor> load(Path registryDir) {
+        if (!Files.isDirectory(registryDir)) {
+            throw new IllegalStateException("Agent descriptor registry not found: " + registryDir);
+        }
+
+        List<Path> descriptorFiles;
+        try (Stream<Path> paths = Files.list(registryDir)) {
+            descriptorFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(AgentDescriptorLoader::isDescriptorFile)
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .toList();
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Could not list agent descriptor registry " + registryDir
+                                            + ": " + e.getMessage(),
+                    e);
+        }
+
+        if (descriptorFiles.isEmpty()) {
+            throw new IllegalStateException("No agent descriptors found in " + registryDir);
+        }
+
+        Map<String, AgentDescriptor> descriptors = new LinkedHashMap<>();
+        for (Path descriptorFile : descriptorFiles) {
+            AgentDescriptor descriptor = readDescriptor(descriptorFile);
+            validateFileName(descriptorFile, descriptor);
+            AgentDescriptor previous = descriptors.putIfAbsent(descriptor.id(), descriptor);
+            if (previous != null) {
+                throw new IllegalStateException(
+                        "Duplicate agent descriptor id '" + descriptor.id()
+                                                + "' in " + descriptorFile);
+            }
+        }
+        return Collections.unmodifiableMap(descriptors);
+    }
+
+    private static AgentDescriptor readDescriptor(Path descriptorFile) {
+        try (InputStream input = Files.newInputStream(descriptorFile)) {
+            AgentDescriptor descriptor = YAML_MAPPER.readValue(input, AgentDescriptor.class);
+            if (descriptor == null) {
+                throw new IllegalStateException(descriptorFile + " is empty");
+            }
+            return descriptor.validate(descriptorFile.toString());
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Could not read agent descriptor " + descriptorFile
+                                            + ": " + e.getMessage(),
+                    e);
+        }
+    }
+
+    private static void validateFileName(Path descriptorFile, AgentDescriptor descriptor) {
+        String fileName = descriptorFile.getFileName().toString();
+        String expectedYaml = descriptor.id() + ".yaml";
+        String expectedYml = descriptor.id() + ".yml";
+        if (!fileName.equals(expectedYaml) && !fileName.equals(expectedYml)) {
+            throw new IllegalStateException(
+                    descriptorFile + " id '" + descriptor.id()
+                                            + "' must match descriptor filename");
+        }
+    }
+
+    private static boolean isDescriptorFile(Path path) {
+        String fileName = path.getFileName().toString();
+        return fileName.endsWith(".yaml") || fileName.endsWith(".yml");
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptorLoader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptorLoader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
@@ -35,19 +36,24 @@ final class AgentDescriptorLoader {
                                             + DEFAULT_REGISTRY_PATH);
         }
 
+        return load(registryUrl);
+    }
+
+    static Map<String, AgentDescriptor> load(URL registryUrl) {
         FileSystem fileSystem = null;
         boolean closeFileSystem = false;
         try {
             URI uri = registryUrl.toURI();
             Path registryPath;
             if ("jar".equals(uri.getScheme())) {
+                URI jarUri = jarFileSystemUri(uri);
                 try {
-                    fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                    fileSystem = FileSystems.newFileSystem(jarUri, Collections.emptyMap());
                     closeFileSystem = true;
                 } catch (FileSystemAlreadyExistsException e) {
-                    fileSystem = FileSystems.getFileSystem(uri);
+                    fileSystem = FileSystems.getFileSystem(jarUri);
                 }
-                registryPath = fileSystem.getPath("/" + DEFAULT_REGISTRY_PATH);
+                registryPath = fileSystem.getPath(jarEntryPath(uri));
             } else {
                 registryPath = Path.of(uri);
             }
@@ -66,6 +72,24 @@ final class AgentDescriptorLoader {
                 }
             }
         }
+    }
+
+    private static URI jarFileSystemUri(URI resourceUri) {
+        String value = resourceUri.toString();
+        int separator = value.indexOf("!/");
+        if (separator < 0) {
+            throw new IllegalStateException("Invalid jar resource URI: " + resourceUri);
+        }
+        return URI.create(value.substring(0, separator));
+    }
+
+    private static String jarEntryPath(URI resourceUri) {
+        String value = resourceUri.toString();
+        int separator = value.indexOf("!/");
+        if (separator < 0) {
+            throw new IllegalStateException("Invalid jar resource URI: " + resourceUri);
+        }
+        return "/" + value.substring(separator + 2);
     }
 
     static Map<String, AgentDescriptor> load(Path registryDir) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
@@ -1,0 +1,43 @@
+package io.github.luigidemasi.camelkit.config;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Generator strategies supported by agent descriptors.
+ */
+public enum AgentGeneratorStrategy {
+    DEFAULT("default"),
+    BOB("bob"),
+    CLAUDE("claude"),
+    GEMINI("gemini"),
+    OPENCODE("opencode"),
+    QWEN("qwen");
+
+    private final String descriptorValue;
+
+    AgentGeneratorStrategy(String descriptorValue) {
+        this.descriptorValue = descriptorValue;
+    }
+
+    public String descriptorValue() {
+        return descriptorValue;
+    }
+
+    static AgentGeneratorStrategy fromDescriptorValue(String value, String source) {
+        for (AgentGeneratorStrategy strategy : values()) {
+            if (strategy.descriptorValue.equals(value)) {
+                return strategy;
+            }
+        }
+        throw new IllegalStateException(
+                source + " has unsupported generatorStrategy '" + value
+                                        + "'. Supported values: " + supportedValues());
+    }
+
+    private static String supportedValues() {
+        return Arrays.stream(values())
+                .map(AgentGeneratorStrategy::descriptorValue)
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentRegistry.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentRegistry.java
@@ -1,5 +1,7 @@
 package io.github.luigidemasi.camelkit.config;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -8,52 +10,8 @@ import java.util.Set;
  */
 public final class AgentRegistry {
 
-    private static final Map<String, AgentConfig> AGENTS = Map.of(
-            "bob", new AgentConfig(
-                    "IBM Project Bob",
-                    ".bob/commands",
-                    "md",
-                    "$ARGUMENTS",
-                    ".bob/mcp.json",
-                    "templates/mcp-configs/bob-mcp.json",
-                    "mcpServers",
-                    "IBM's AI-powered development assistant"),
-            "gemini", new AgentConfig(
-                    "Gemini CLI",
-                    ".gemini/commands",
-                    "toml",
-                    "{{args}}",
-                    ".gemini/settings.json",
-                    "templates/mcp-configs/gemini-mcp.json",
-                    "mcpServers",
-                    "Google's Gemini CLI"),
-            "claude", new AgentConfig(
-                    "Claude Code",
-                    ".claude/commands",
-                    "md",
-                    "$ARGUMENTS",
-                    ".mcp.json",
-                    "templates/mcp-configs/claude-code-mcp.json",
-                    "mcpServers",
-                    "Anthropic's Claude Code CLI"),
-            "qwen", new AgentConfig(
-                    "Qwen Code",
-                    ".qwen/commands",
-                    "md",
-                    "$ARGUMENTS",
-                    ".qwen/settings.json",
-                    "templates/mcp-configs/qwen-mcp.json",
-                    "mcpServers",
-                    "Alibaba's Qwen Code CLI"),
-            "opencode", new AgentConfig(
-                    "OpenCode",
-                    ".opencode/commands",
-                    "md",
-                    "$ARGUMENTS",
-                    "opencode.json",
-                    "templates/mcp-configs/opencode-mcp.json",
-                    "mcp",
-                    "AI coding agent for the terminal"));
+    private static final Map<String, AgentDescriptor> DESCRIPTORS = AgentDescriptorLoader.loadDefault();
+    private static final Map<String, AgentConfig> AGENTS = configsFrom(DESCRIPTORS);
 
     private AgentRegistry() {
         // Utility class
@@ -73,5 +31,19 @@ public final class AgentRegistry {
 
     public static Map<String, AgentConfig> all() {
         return AGENTS;
+    }
+
+    public static AgentDescriptor descriptor(String name) {
+        return DESCRIPTORS.get(name);
+    }
+
+    public static Map<String, AgentDescriptor> descriptors() {
+        return DESCRIPTORS;
+    }
+
+    private static Map<String, AgentConfig> configsFrom(Map<String, AgentDescriptor> descriptors) {
+        Map<String, AgentConfig> configs = new LinkedHashMap<>();
+        descriptors.forEach((name, descriptor) -> configs.put(name, descriptor.toAgentConfig()));
+        return Collections.unmodifiableMap(configs);
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
@@ -1,6 +1,7 @@
 package io.github.luigidemasi.camelkit.generator;
 
 import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentGeneratorStrategy;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 
 public final class AgentGeneratorFactory {
@@ -10,17 +11,20 @@ public final class AgentGeneratorFactory {
 
     public static AgentGenerator create(String agentName) {
         return switch (generatorStrategy(agentName)) {
-            case "bob" -> new BobGenerator();
-            case "claude" -> new ClaudeGenerator();
-            case "qwen" -> new QwenGenerator();
-            case "opencode" -> new OpenCodeGenerator();
-            case "gemini" -> new GeminiGenerator();
-            default -> new DefaultGenerator();
+            case BOB -> new BobGenerator();
+            case CLAUDE -> new ClaudeGenerator();
+            case GEMINI -> new GeminiGenerator();
+            case OPENCODE -> new OpenCodeGenerator();
+            case QWEN -> new QwenGenerator();
+            case DEFAULT -> new DefaultGenerator();
         };
     }
 
-    private static String generatorStrategy(String agentName) {
+    private static AgentGeneratorStrategy generatorStrategy(String agentName) {
         AgentDescriptor descriptor = AgentRegistry.descriptor(agentName);
-        return descriptor == null ? "default" : descriptor.generatorStrategy();
+        if (descriptor == null) {
+            throw new IllegalArgumentException("Unsupported agent: " + agentName);
+        }
+        return descriptor.generatorStrategyType();
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
@@ -1,12 +1,15 @@
 package io.github.luigidemasi.camelkit.generator;
 
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+
 public final class AgentGeneratorFactory {
 
     private AgentGeneratorFactory() {
     }
 
     public static AgentGenerator create(String agentName) {
-        return switch (agentName) {
+        return switch (generatorStrategy(agentName)) {
             case "bob" -> new BobGenerator();
             case "claude" -> new ClaudeGenerator();
             case "qwen" -> new QwenGenerator();
@@ -14,5 +17,10 @@ public final class AgentGeneratorFactory {
             case "gemini" -> new GeminiGenerator();
             default -> new DefaultGenerator();
         };
+    }
+
+    private static String generatorStrategy(String agentName) {
+        AgentDescriptor descriptor = AgentRegistry.descriptor(agentName);
+        return descriptor == null ? "default" : descriptor.generatorStrategy();
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DispatchBlockAppender.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DispatchBlockAppender.java
@@ -4,12 +4,18 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.util.TemplateUtils;
 
 class DispatchBlockAppender {
 
     void append(Path skillMdFile, String agentName) throws IOException {
-        String dispatchTemplatePath = "templates/dispatch/" + agentName + ".md";
+        AgentDescriptor descriptor = AgentRegistry.descriptor(agentName);
+        if (descriptor == null) {
+            return;
+        }
+        String dispatchTemplatePath = descriptor.dispatchTemplatePath();
         try {
             String dispatchBlock = TemplateUtils.readTemplate(dispatchTemplatePath);
             String existing = Files.readString(skillMdFile);

--- a/camel-kit-core/src/main/resources/agents/registry/bob.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/bob.yaml
@@ -1,0 +1,47 @@
+id: bob
+displayName: IBM Project Bob
+commandDirectory: .bob/commands
+commandFileFormat: md
+argumentPlaceholder: $ARGUMENTS
+mcpConfigPath: .bob/mcp.json
+mcpConfigTemplatePath: templates/mcp-configs/bob-mcp.json
+mcpServerContainerKey: mcpServers
+description: IBM's AI-powered development assistant
+generatorStrategy: bob
+dispatchTemplatePath: templates/dispatch/bob.md
+templates:
+  - source: templates/bob/custom_modes.yaml
+    target: .bob/custom_modes.yaml
+  - source: templates/bob/rules/iron-laws.md
+    target: .bob/rules/iron-laws.md
+  - source: templates/bob/rules-camel-brainstorm/interview-gates.md
+    target: .bob/rules-camel-brainstorm/interview-gates.md
+  - source: templates/bob/rules-camel-plan/plan-structure.md
+    target: .bob/rules-camel-plan/plan-structure.md
+  - source: templates/bob/rules-camel-implement/implementation.md
+    target: .bob/rules-camel-implement/implementation.md
+  - source: templates/bob/rules-camel-validate/validation.md
+    target: .bob/rules-camel-validate/validation.md
+  - source: templates/bob/rules-camel-test/testing.md
+    target: .bob/rules-camel-test/testing.md
+  - source: templates/bob/gates/camel-brainstorm.md
+    target: .bob/skills/camel-brainstorm/SKILL.md
+  - source: templates/bob/gates/camel-execute.md
+    target: .bob/skills/camel-execute/SKILL.md
+  - source: templates/bob/gates/camel-implement.md
+    target: .bob/skills/camel-implement/SKILL.md
+  - source: templates/bob/gates/camel-migrate.md
+    target: .bob/skills/camel-migrate/SKILL.md
+  - source: templates/bob/gates/camel-plan.md
+    target: .bob/skills/camel-plan/SKILL.md
+  - source: templates/bob/gates/camel-test.md
+    target: .bob/skills/camel-test/SKILL.md
+  - source: templates/bob/gates/camel-validate.md
+    target: .bob/skills/camel-validate/SKILL.md
+supportsSubagents: false
+supportsTraits: true
+capabilities:
+  - custom-modes
+  - mode-rules
+  - monolithic-gates
+  - mcp

--- a/camel-kit-core/src/main/resources/agents/registry/claude.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/claude.yaml
@@ -1,0 +1,23 @@
+id: claude
+displayName: Claude Code
+commandDirectory: .claude/commands
+commandFileFormat: md
+argumentPlaceholder: $ARGUMENTS
+mcpConfigPath: .mcp.json
+mcpConfigTemplatePath: templates/mcp-configs/claude-code-mcp.json
+mcpServerContainerKey: mcpServers
+description: Anthropic's Claude Code CLI
+generatorStrategy: claude
+dispatchTemplatePath: templates/dispatch/claude.md
+templates:
+  - source: templates/claude/claude-md.md
+    target: CLAUDE.md
+  - source: templates/claude/settings.json
+    target: .claude/settings.json
+supportsSubagents: true
+supportsTraits: true
+capabilities:
+  - parallel-subagent-dispatch
+  - agent-tool
+  - settings
+  - mcp

--- a/camel-kit-core/src/main/resources/agents/registry/gemini.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/gemini.yaml
@@ -1,0 +1,43 @@
+id: gemini
+displayName: Gemini CLI
+commandDirectory: .gemini/commands
+commandFileFormat: toml
+argumentPlaceholder: "{{args}}"
+mcpConfigPath: .gemini/settings.json
+mcpConfigTemplatePath: templates/mcp-configs/gemini-mcp.json
+mcpServerContainerKey: mcpServers
+description: Google's Gemini CLI
+generatorStrategy: gemini
+dispatchTemplatePath: templates/dispatch/gemini.md
+templates:
+  - source: templates/gemini/gemini-md.md
+    target: GEMINI.md
+  - source: templates/gemini/geminiignore
+    target: .geminiignore
+  - source: templates/gemini/instructions/iron-laws.md
+    target: .gemini/instructions/iron-laws.md
+  - source: templates/gemini/instructions/mcp-usage.md
+    target: .gemini/instructions/mcp-usage.md
+  - source: templates/gemini/instructions/pipeline-overview.md
+    target: .gemini/instructions/pipeline-overview.md
+  - source: templates/gemini/policies/camel-kit.toml
+    target: .gemini/policies/camel-kit.toml
+  - source: templates/gemini/agents/camel-brainstormer.md
+    target: .gemini/agents/camel-brainstormer.md
+  - source: templates/gemini/agents/camel-implementer.md
+    target: .gemini/agents/camel-implementer.md
+  - source: templates/gemini/agents/camel-migrator.md
+    target: .gemini/agents/camel-migrator.md
+  - source: templates/gemini/agents/camel-planner.md
+    target: .gemini/agents/camel-planner.md
+  - source: templates/gemini/agents/camel-tester.md
+    target: .gemini/agents/camel-tester.md
+  - source: templates/gemini/agents/camel-validator.md
+    target: .gemini/agents/camel-validator.md
+supportsSubagents: true
+supportsTraits: true
+capabilities:
+  - named-subagents
+  - toml-commands
+  - policy
+  - mcp

--- a/camel-kit-core/src/main/resources/agents/registry/opencode.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/opencode.yaml
@@ -1,0 +1,32 @@
+id: opencode
+displayName: OpenCode
+commandDirectory: .opencode/commands
+commandFileFormat: md
+argumentPlaceholder: $ARGUMENTS
+mcpConfigPath: opencode.json
+mcpConfigTemplatePath: templates/mcp-configs/opencode-mcp.json
+mcpServerContainerKey: mcp
+description: AI coding agent for the terminal
+generatorStrategy: opencode
+dispatchTemplatePath: templates/dispatch/opencode.md
+templates:
+  - source: templates/opencode/agents/brainstormer.md
+    target: .opencode/agents/brainstormer.md
+  - source: templates/opencode/agents/executor.md
+    target: .opencode/agents/executor.md
+  - source: templates/opencode/agents/implementer.md
+    target: .opencode/agents/implementer.md
+  - source: templates/opencode/agents/migrator.md
+    target: .opencode/agents/migrator.md
+  - source: templates/opencode/agents/planner.md
+    target: .opencode/agents/planner.md
+  - source: templates/opencode/agents/tester.md
+    target: .opencode/agents/tester.md
+  - source: templates/opencode/agents/validator.md
+    target: .opencode/agents/validator.md
+supportsSubagents: true
+supportsTraits: true
+capabilities:
+  - task-tool-agents
+  - permissions
+  - mcp

--- a/camel-kit-core/src/main/resources/agents/registry/qwen.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/qwen.yaml
@@ -1,0 +1,36 @@
+id: qwen
+displayName: Qwen Code
+commandDirectory: .qwen/commands
+commandFileFormat: md
+argumentPlaceholder: $ARGUMENTS
+mcpConfigPath: .qwen/settings.json
+mcpConfigTemplatePath: templates/mcp-configs/qwen-mcp.json
+mcpServerContainerKey: mcpServers
+description: Alibaba's Qwen Code CLI
+generatorStrategy: qwen
+dispatchTemplatePath: templates/dispatch/qwen.md
+templates:
+  - source: templates/qwen/qwen-md.md
+    target: QWEN.md
+  - source: templates/qwen/qwenignore
+    target: .qwenignore
+  - source: templates/qwen/agents/camel-brainstormer.md
+    target: .qwen/agents/camel-brainstormer.md
+  - source: templates/qwen/agents/camel-executor.md
+    target: .qwen/agents/camel-executor.md
+  - source: templates/qwen/agents/camel-implementer.md
+    target: .qwen/agents/camel-implementer.md
+  - source: templates/qwen/agents/camel-migrator.md
+    target: .qwen/agents/camel-migrator.md
+  - source: templates/qwen/agents/camel-planner.md
+    target: .qwen/agents/camel-planner.md
+  - source: templates/qwen/agents/camel-tester.md
+    target: .qwen/agents/camel-tester.md
+  - source: templates/qwen/agents/camel-validator.md
+    target: .qwen/agents/camel-validator.md
+supportsSubagents: true
+supportsTraits: true
+capabilities:
+  - named-subagents
+  - fork-dispatch
+  - mcp

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
@@ -1,0 +1,143 @@
+package io.github.luigidemasi.camelkit.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AgentRegistryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void builtInAgentsAreLoadedFromResourceDescriptors() {
+        assertEquals(Set.of("bob", "claude", "gemini", "opencode", "qwen"), AgentRegistry.names());
+
+        AgentConfig claude = AgentRegistry.get("claude");
+        assertNotNull(claude);
+        assertEquals("Claude Code", claude.name());
+        assertEquals(".claude/commands", claude.folder());
+        assertEquals("md", claude.fileFormat());
+        assertEquals("$ARGUMENTS", claude.argPlaceholder());
+        assertEquals(".mcp.json", claude.mcpConfigPath());
+        assertEquals("templates/mcp-configs/claude-code-mcp.json", claude.mcpConfigTemplatePath());
+        assertEquals("mcpServers", claude.mcpServerContainerKey());
+        assertEquals("Anthropic's Claude Code CLI", claude.description());
+
+        AgentDescriptor descriptor = AgentRegistry.descriptor("claude");
+        assertNotNull(descriptor);
+        assertEquals("claude", descriptor.id());
+        assertEquals("claude", descriptor.generatorStrategy());
+        assertEquals("templates/dispatch/claude.md", descriptor.dispatchTemplatePath());
+        assertTrue(descriptor.supportsSubagents());
+        assertTrue(descriptor.supportsTraits());
+        assertTrue(descriptor.capabilities().contains("parallel-subagent-dispatch"));
+    }
+
+    @Test
+    void descriptorRegistryIsImmutable() {
+        assertThrows(UnsupportedOperationException.class, () -> AgentRegistry.descriptors().clear());
+        assertThrows(UnsupportedOperationException.class, () -> AgentRegistry.all().clear());
+    }
+
+    @Test
+    void missingRegistryDirectoryFailsClearly() {
+        IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> AgentDescriptorLoader.load(tempDir.resolve("missing")));
+
+        assertTrue(thrown.getMessage().contains("Agent descriptor registry not found"));
+        assertTrue(thrown.getMessage().contains("missing"));
+    }
+
+    @Test
+    void missingRequiredDescriptorFieldFailsClearly() throws IOException {
+        Files.writeString(tempDir.resolve("broken.yaml"), """
+                id: broken
+                commandDirectory: .broken/commands
+                commandFileFormat: md
+                argumentPlaceholder: $ARGUMENTS
+                mcpConfigPath: .broken/mcp.json
+                mcpConfigTemplatePath: templates/mcp-configs/broken-mcp.json
+                mcpServerContainerKey: mcpServers
+                description: Broken test agent
+                generatorStrategy: default
+                dispatchTemplatePath: templates/dispatch/broken.md
+                supportsSubagents: false
+                supportsTraits: false
+                """);
+
+        IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> AgentDescriptorLoader.load(tempDir));
+
+        assertTrue(thrown.getMessage().contains("broken.yaml"));
+        assertTrue(thrown.getMessage().contains("displayName"));
+    }
+
+    @Test
+    void malformedDescriptorYamlFailsClearly() throws IOException {
+        Files.writeString(tempDir.resolve("broken.yaml"), "id: [\n");
+
+        IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> AgentDescriptorLoader.load(tempDir));
+
+        assertTrue(thrown.getMessage().contains("Could not read agent descriptor"));
+        assertTrue(thrown.getMessage().contains("broken.yaml"));
+    }
+
+    @Test
+    void unsupportedGeneratorStrategyFailsClearly() throws IOException {
+        Files.writeString(tempDir.resolve("broken.yaml"), validDescriptor("broken")
+                .replace("generatorStrategy: default", "generatorStrategy: custom"));
+
+        IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> AgentDescriptorLoader.load(tempDir));
+
+        assertTrue(thrown.getMessage().contains("unsupported generatorStrategy 'custom'"));
+    }
+
+    @Test
+    void duplicateDescriptorIdsFailClearly() throws IOException {
+        Files.writeString(tempDir.resolve("broken.yaml"), validDescriptor("broken"));
+        Files.writeString(tempDir.resolve("broken.yml"), validDescriptor("broken"));
+
+        IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> AgentDescriptorLoader.load(tempDir));
+
+        assertTrue(thrown.getMessage().contains("Duplicate agent descriptor id 'broken'"));
+    }
+
+    private static String validDescriptor(String id) {
+        return String.format(Locale.ROOT, """
+                id: %1$s
+                displayName: Test Agent
+                commandDirectory: .%1$s/commands
+                commandFileFormat: md
+                argumentPlaceholder: $ARGUMENTS
+                mcpConfigPath: .%1$s/mcp.json
+                mcpConfigTemplatePath: templates/mcp-configs/%1$s-mcp.json
+                mcpServerContainerKey: mcpServers
+                description: Test agent
+                generatorStrategy: default
+                dispatchTemplatePath: templates/dispatch/%1$s.md
+                templates:
+                  - source: templates/%1$s/settings.json
+                    target: .%1$s/settings.json
+                supportsSubagents: false
+                supportsTraits: false
+                capabilities:
+                  - test
+                """, id);
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
@@ -1,10 +1,15 @@
 package io.github.luigidemasi.camelkit.config;
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,6 +40,7 @@ class AgentRegistryTest {
         assertNotNull(descriptor);
         assertEquals("claude", descriptor.id());
         assertEquals("claude", descriptor.generatorStrategy());
+        assertEquals(AgentGeneratorStrategy.CLAUDE, descriptor.generatorStrategyType());
         assertEquals("templates/dispatch/claude.md", descriptor.dispatchTemplatePath());
         assertTrue(descriptor.supportsSubagents());
         assertTrue(descriptor.supportsTraits());
@@ -104,6 +110,24 @@ class AgentRegistryTest {
                 () -> AgentDescriptorLoader.load(tempDir));
 
         assertTrue(thrown.getMessage().contains("unsupported generatorStrategy 'custom'"));
+    }
+
+    @Test
+    void jarBackedRegistryLoadsDescriptors() throws Exception {
+        Path jarFile = tempDir.resolve("agents.jar");
+        try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarFile))) {
+            jar.putNextEntry(new JarEntry("agents/registry/"));
+            jar.closeEntry();
+            jar.putNextEntry(new JarEntry("agents/registry/broken.yaml"));
+            jar.write(validDescriptor("broken").getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
+
+        URI jarResourceUri = URI.create("jar:" + jarFile.toUri() + "!/agents/registry");
+        Map<String, AgentDescriptor> descriptors = AgentDescriptorLoader.load(jarResourceUri.toURL());
+
+        assertEquals(Set.of("broken"), descriptors.keySet());
+        assertEquals("Test Agent", descriptors.get("broken").displayName());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
@@ -32,13 +32,11 @@ class AgentGeneratorFactoryTest {
     }
 
     @Test
-    void unknownAgentReturnsDefaultGenerator() {
-        AgentGenerator gen = AgentGeneratorFactory.create("unknown-agent");
-        assertInstanceOf(DefaultGenerator.class, gen);
-        assertFalse(gen instanceof BobGenerator);
-        assertFalse(gen instanceof ClaudeGenerator);
-        assertFalse(gen instanceof QwenGenerator);
-        assertFalse(gen instanceof OpenCodeGenerator);
-        assertFalse(gen instanceof GeminiGenerator);
+    void unknownAgentFailsFast() {
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> AgentGeneratorFactory.create("unknown-agent"));
+
+        assertEquals("Unsupported agent: unknown-agent", thrown.getMessage());
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.output.Printer;
 import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
@@ -112,12 +113,13 @@ class ShippedAssetStructureTest {
     @Test
     void dispatchAndMcpTemplatesExistForEverySupportedAgent() throws Exception {
         Path resourcesDir = resourceRoot();
-        Path templatesDir = resourcesDir.resolve("templates");
 
         List<String> missingAssets = new ArrayList<>();
         for (String agentName : sortedAgentNames()) {
-            if (!Files.isRegularFile(templatesDir.resolve("dispatch/" + agentName + ".md"))) {
-                missingAssets.add("templates/dispatch/" + agentName + ".md");
+            AgentDescriptor descriptor = AgentRegistry.descriptor(agentName);
+            assertNotNull(descriptor, "AgentRegistry listed unknown descriptor '" + agentName + "'");
+            if (!Files.isRegularFile(resourcesDir.resolve(descriptor.dispatchTemplatePath()))) {
+                missingAssets.add(descriptor.dispatchTemplatePath());
             }
 
             AgentConfig agent = AgentRegistry.get(agentName);
@@ -129,6 +131,24 @@ class ShippedAssetStructureTest {
 
         assertTrue(missingAssets.isEmpty(),
                 "Supported agents are missing dispatch or MCP config templates:\n"
+                                            + String.join("\n", missingAssets));
+    }
+
+    @Test
+    void agentDescriptorTemplateSourcesExist() throws Exception {
+        Path resourcesDir = resourceRoot();
+
+        List<String> missingAssets = new ArrayList<>();
+        for (AgentDescriptor descriptor : AgentRegistry.descriptors().values()) {
+            for (AgentDescriptor.TemplateInstall template : descriptor.templates()) {
+                if (!Files.isRegularFile(resourcesDir.resolve(template.source()))) {
+                    missingAssets.add(descriptor.id() + " -> " + template.source());
+                }
+            }
+        }
+
+        assertTrue(missingAssets.isEmpty(),
+                "Agent descriptors reference missing template sources:\n"
                                             + String.join("\n", missingAssets));
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,9 @@ The frontmatter fields:
 | `camel-start` | Yes | -- | Meta-router and primary entry point: detects intent, loads appropriate pipeline |
 | `camel-brainstorm` | No | `camel-start` (greenfield) | Orchestrate design phase: interview user, produce BRD + TDDs |
 | `camel-plan` | No | `camel-brainstorm` (after design approval) | Produce detailed implementation plan from approved design spec |
-| `camel-execute` | No | `camel-plan` (auto-invoked after planning) | Environment probe, dispatch subagents per task with two-stage review |
+| `camel-execute` | No | `camel-plan` (auto-invoked after planning) | Environment probe, dispatch sub-agents per task with two-stage review |
 | `camel-migrate` | No | `camel-start` (migration) | Migration entry point: shortcut into `camel-brainstorm` with project type pre-set |
-| `camel-verify` | No | `camel-execute` (internal subagent) | 3-phase runtime verification loop (build, Citrus tests, report) — runs inside execute, not as a standalone pipeline stage |
+| `camel-verify` | No | `camel-execute` (internal sub-agent) | 3-phase runtime verification loop (build, Citrus tests, report) — runs inside execute, not as a standalone pipeline stage |
 | `camel-ship` | No | -- (standalone orchestrator) | Autonomous pipeline — chains brainstorm → plan → execute → validate with configurable oversight |
 | `camel-design` | No | `camel-brainstorm` | Guides for component selection, EIP catalog, TDD assembly |
 | `camel-implement` | No | `camel-execute` | Guides for YAML generation, properties, Docker Compose, DataMapper |
@@ -226,27 +226,27 @@ Entry points diverge (`camel-brainstorm` for greenfield, `camel-migrate` for mig
 
 1. Read the approved implementation plan, prefer the `yaml plan-metadata` task graph, and fall back to Markdown task
    parsing for older plans
-2. **Catalog research** (Step 1.5): dispatch a `catalog-researcher` subagent to batch-verify all MCP catalog artifacts for the wave. Only the structured summary flows back -- MCP response traces stay in the research subagent's context.
+2. **Catalog research** (Step 1.5): dispatch a `catalog-researcher` sub-agent to batch-verify all MCP catalog artifacts for the wave. Only the structured summary flows back -- MCP response traces stay in the research sub-agent's context.
 3. For each task:
-   - Dispatch an implementer subagent with full task text, design spec section, pre-verified catalog summary, and MCP parameters
-   - **Adversarial Code Review** (Step 2b.5): dispatch parallel Critic Lanes via a Moderator subagent to adversarially review the implementation against the TDD. Hard cap: 3 cycles.
-   - Dispatch a **spec compliance reviewer** (subagent) -- does the output match the design spec?
-   - If spec review passes, dispatch a **code quality reviewer** (subagent) -- constitution compliance, security, anti-patterns
+   - Dispatch an implementer sub-agent with full task text, design spec section, pre-verified catalog summary, and MCP parameters
+   - **Adversarial Code Review** (Step 2b.5): dispatch parallel Critic Lanes via a Moderator sub-agent to adversarially review the implementation against the TDD. Hard cap: 3 cycles.
+   - Dispatch a **spec compliance reviewer** (sub-agent) -- does the output match the design spec?
+   - If spec review passes, dispatch a **code quality reviewer** (sub-agent) -- constitution compliance, security, anti-patterns
    - If either reviewer finds critical issues, return to the implementer for fixes, then re-review
    - Mark task complete and immediately start the next task (no pause, no user confirmation)
-4. After all tasks: dispatch a **cross-cutting review** as a subagent across all generated routes
-5. Dispatch the **verification phase** (`camel-verify`) as an internal subagent within execute (build, Citrus tests, report)
+4. After all tasks: dispatch a **cross-cutting review** as a sub-agent across all generated routes
+5. Dispatch the **verification phase** (`camel-verify`) as an internal sub-agent within execute (build, Citrus tests, report)
 6. Print the completion summary
 
 After execute completes, the pipeline continues to **validation** (`camel-validate`) as Stage 3 — the final quality gate.
 
-All reviews, verification, and catalog lookups run as subagents with isolated context windows. Only structured reports flow back to the orchestrator -- preventing ~60-70% of pipeline tokens from accumulating in the main conversation.
+All reviews, verification, and catalog lookups run as sub-agents with isolated context windows. Only structured reports flow back to the orchestrator -- preventing ~60-70% of pipeline tokens from accumulating in the main conversation.
 
 ### Agent-Specific Execution
 
 The dispatch model varies by AI agent:
 
-- **Claude Code** -- dispatches fresh subagents per task. Each subagent runs in isolated context with no cross-contamination between tasks.
+- **Claude Code** -- dispatches fresh sub-agents per task. Each sub-agent runs in isolated context with no cross-contamination between tasks.
 - **IBM Project Bob** -- switches between custom modes (`brainstorm`, `plan`, `implement`, `validate`, `test`) with scoped tool permissions per mode.
 - **Gemini CLI, Qwen, OpenCode** -- inline execution within the same session. Skills are loaded as instruction context rather than dispatched as separate agents.
 
@@ -335,7 +335,7 @@ commands and generators.
 
 Each descriptor defines the agent id, display name, command directory, command file format, argument placeholder,
 MCP config path, MCP config template path, MCP server container key, description, generator strategy, dispatch
-template path, templates installed by the agent-specific generator, and whether the agent supports subagents or
+template path, templates installed by the agent-specific generator, and whether the agent supports sub-agents or
 traits. Missing required fields, duplicate ids, unsupported generator strategies, or malformed YAML fail during
 registry loading with a descriptor-specific error.
 
@@ -373,10 +373,10 @@ All five agents receive the same skills (markdown instruction files). The templa
 - Output formats (same YAML routes, properties, test files)
 
 **What equalization does NOT cover:**
-- Dispatch mechanism (subagents vs. modes vs. inline)
+- Dispatch mechanism (sub-agents vs. modes vs. inline)
 - Tool restriction model (each agent's permission system is different)
 - File reading patterns (context isolation varies)
-- Parallelization strategy (only Claude supports parallel subagent dispatch)
+- Parallelization strategy (only Claude supports parallel sub-agent dispatch)
 - Configuration format (YAML modes, TOML policies, markdown frontmatter)
 
 ### Agent Traits
@@ -394,7 +394,7 @@ Traits are agent-specific instruction fragments that are appended to shared skil
 | SKILL.md-level (strategy) | `traits/{agent}/{skill-name}.append.md` | `{skills-dir}/{skill-name}/SKILL.md` |
 | Guide-level (tactics) | `traits/{agent}/{skill-name}/{guide-name}.append.md` | `{skills-dir}/{skill-name}/guides/{guide-name}.md` |
 
-**Example:** `traits/claude/camel-execute.append.md` appends Claude-specific instructions to `camel-execute/SKILL.md` -- parallel subagent dispatch via the `Agent` tool, worktree isolation via `EnterWorktree`, build health monitoring via `CronCreate`. The same skill on Gemini gets different trait content: named agent delegation, TOML policy guidance, batch context loading via `read_many_files`.
+**Example:** `traits/claude/camel-execute.append.md` appends Claude-specific instructions to `camel-execute/SKILL.md` -- parallel sub-agent dispatch via the `Agent` tool, worktree isolation via `EnterWorktree`, build health monitoring via `CronCreate`. The same skill on Gemini gets different trait content: named agent delegation, TOML policy guidance, batch context loading via `read_many_files`.
 
 **What traits contain:** Agent-specific tool usage, dispatch strategies, state persistence mechanisms, and execution optimizations. Each trait is written for the specific agent's capabilities -- Claude traits reference `Agent`, `ScheduleWakeup`, `TaskCreate`; Gemini traits reference `save_memory`, `read_many_files`; Bob traits reference `switch_mode`, `insert_content`.
 
@@ -409,21 +409,21 @@ The six shared Iron Laws from `skills/shared/iron-laws.md` are embedded in or re
 5. **Adversarial Code Review** -- generated code must pass the adversarial review gate before spec compliance and quality review
 6. **Surgical Changes** -- implementation tasks must touch only what they were asked to touch
 
-### Subagent-Driven Execution
+### Sub-agent-Driven Execution
 
 The `/camel-execute` pipeline relies on dispatching discrete units of work to isolated agents. The design principle: the agent that writes the code should never be the same agent that reviews it, and each task should start from a clean context with no residual assumptions from previous tasks.
 
-Four of the five agents support this natively through **subagent dispatch**:
+Four of the five agents support this natively through **sub-agent dispatch**:
 
-- **Claude Code** -- uses the `Agent` tool to spawn fresh subagents per task. Each subagent receives the task text, relevant TDD section, guide file paths, and MCP parameters. Before implementation, a `catalog-researcher` subagent batch-verifies all MCP catalog artifacts (research isolation). After implementation, an Adversarial Code Review dispatches parallel Critic Lanes (Route Architecture, Security, Performance, Boundary Compliance, Behavioral Equivalence) via a Moderator subagent, then a spec-compliance reviewer subagent checks the design spec, then a code-quality reviewer subagent checks constitution compliance. At the Stamp Gate, three reviewers run in parallel (spec, quality, security). Claude uniquely supports **parallel dispatch**: `camel-kit plan analyze` groups tasks into waves using structured plan metadata (`dependsOn`, file overlap, and logical `provides`/`consumes` resources such as endpoints, routes, properties, schemas, test data, beans, external services, and route contracts), then independent tasks are dispatched simultaneously to multiple subagents.
+- **Claude Code** -- uses the `Agent` tool to spawn fresh sub-agents per task. Each sub-agent receives the task text, relevant TDD section, guide file paths, and MCP parameters. Before implementation, a `catalog-researcher` sub-agent batch-verifies all MCP catalog artifacts (research isolation). After implementation, an Adversarial Code Review dispatches parallel Critic Lanes (Route Architecture, Security, Performance, Boundary Compliance, Behavioral Equivalence) via a Moderator sub-agent, then a spec-compliance reviewer sub-agent checks the design spec, then a code-quality reviewer sub-agent checks constitution compliance. At the Stamp Gate, three reviewers run in parallel (spec, quality, security). Claude uniquely supports **parallel dispatch**: `camel-kit plan analyze` groups tasks into waves using structured plan metadata (`dependsOn`, file overlap, and logical `provides`/`consumes` resources such as endpoints, routes, properties, schemas, test data, beans, external services, and route contracts), then independent tasks are dispatched simultaneously to multiple sub-agents.
 
-- **Gemini CLI** -- dispatches via a unified `invoke_subagent` tool to 6 specialized subagents. The scheduler natively supports **parallel tool execution** via `Promise.all()` (default-parallel). However, subagents cannot invoke other subagents (hardcoded `Kind.Agent` filter), so `/camel-execute` runs in the **main agent context** where it can dispatch to all subagents. Within-wave parallelism is achieved through the scheduler batching multiple `invoke_subagent` calls.
+- **Gemini CLI** -- dispatches via a unified `invoke_subagent` tool to 6 specialized sub-agents. The scheduler natively supports **parallel tool execution** via `Promise.all()` (default-parallel). However, sub-agents cannot invoke other sub-agents (hardcoded `Kind.Agent` filter), so `/camel-execute` runs in the **main agent context** where it can dispatch to all sub-agents. Within-wave parallelism is achieved through the scheduler batching multiple `invoke_subagent` calls.
 
-- **Qwen** -- dual dispatch model: **named subagents** (clean context, parent blocks) and **forks** (inherit parent context, run in background). The fork model enables parallel review and research tasks. Read-only tools (Read, Search, Fetch) are concurrent with a configurable cap (max 10). The `"MUST BE USED for..."` phrasing in description fields forces automatic delegation.
+- **Qwen** -- dual dispatch model: **named sub-agents** (clean context, parent blocks) and **forks** (inherit parent context, run in background). The fork model enables parallel review and research tasks. Read-only tools (Read, Search, Fetch) are concurrent with a configurable cap (max 10). The `"MUST BE USED for..."` phrasing in description fields forces automatic delegation.
 
-- **OpenCode** -- 7 agents with granular, per-type glob permissions. The executor agent has `task: {"*": allow}` permission. Subagent-to-subagent delegation is now opt-in (PR #7756) with configurable depth limits and call budgets. LLM-level parallel tool calls are supported. Each agent has a `steps` limit (implementer: 50, executor: 100) that triggers graceful summarization rather than hard failure.
+- **OpenCode** -- 7 agents with granular, per-type glob permissions. The executor agent has `task: {"*": allow}` permission. Sub-agent-to-sub-agent delegation is now opt-in (PR #7756) with configurable depth limits and call budgets. LLM-level parallel tool calls are supported. Each agent has a `steps` limit (implementer: 50, executor: 100) that triggers graceful summarization rather than hard failure.
 
-**IBM Project Bob does not support subagents.** It uses a fundamentally different architecture -- the **B+A (Behavior + Advanced) hybrid with mode switching**:
+**IBM Project Bob does not support sub-agents.** It uses a fundamentally different architecture -- the **B+A (Behavior + Advanced) hybrid with mode switching**:
 
 1. Each pipeline phase starts in **Advanced mode** (unrestricted), allowing the agent to read all skill files and project context
 2. The first instruction in the gate file switches to a **restricted custom mode** (e.g., `camel-brainstorm`, `camel-implement`) with scoped tool permissions
@@ -431,25 +431,25 @@ Four of the five agents support this natively through **subagent dispatch**:
 
 This means Bob cannot isolate tasks into separate context windows or use independent reviewer agents. The compensation is that Bob's tool restrictions are **platform-enforced**, not instruction-based. During design, Bob's `camel-brainstorm` mode grants only `read`, `edit` (`.md` files only via `fileRegex`), `mcp`, and `browser` -- the AI physically cannot edit code files because the mode excludes the edit tool for non-markdown files. This is stricter than any instruction-based constraint, which the AI could rationalize away.
 
-Bob also requires **monolithic gate files** (one per pipeline phase, 6-10 KB each) that inline complete orchestration logic, because it cannot chain skill references across mode switches the way subagent-based agents load skills into fresh contexts.
+Bob also requires **monolithic gate files** (one per pipeline phase, 6-10 KB each) that inline complete orchestration logic, because it cannot chain skill references across mode switches the way sub-agent-based agents load skills into fresh contexts.
 
 The trade-off table:
 
-| Design Dimension | Subagent Dispatch | Mode Switching (Bob) |
+| Design Dimension | Sub-agent Dispatch | Mode Switching (Bob) |
 |-----------------|-------------------|---------------------|
-| Context isolation | Per-task (fresh subagent) | Per-session (accumulated) |
-| Reviewer independence | Separate subagent | Same session self-reviews |
+| Context isolation | Per-task (fresh sub-agent) | Per-session (accumulated) |
+| Reviewer independence | Separate sub-agent | Same session self-reviews |
 | Tool restriction mechanism | Instruction-based / tool whitelists / policies | Platform-enforced mode tool groups |
 | Parallel execution | Claude (graph topology), Gemini (scheduler `Promise.all()`), Qwen (fork), OpenCode (LLM-level) | Not possible |
-| Skill loading | Loaded into subagent context on dispatch | Inlined in monolithic gate files |
+| Skill loading | Loaded into sub-agent context on dispatch | Inlined in monolithic gate files |
 | Template complexity | 3-12 files per agent | 17+ files (gates + rules + modes) |
-| Failure isolation | Subagent failure doesn't affect other tasks | Phase failure affects entire session |
+| Failure isolation | Sub-agent failure doesn't affect other tasks | Phase failure affects entire session |
 
 ### Per-Agent Summary
 
 | Agent | Dispatch Model | Key Differentiator |
 |-------|---------------|-------------------|
-| Claude Code | Parallel subagent dispatch | Route graph topology, research isolation, parallel fan-out, adversarial code review |
+| Claude Code | Parallel sub-agent dispatch | Route graph topology, research isolation, parallel fan-out, adversarial code review |
 | IBM Project Bob | B+A hybrid with 5 custom modes | Monolithic gate files, 3 checkpoint types |
 | Gemini CLI | `invoke_subagent` + parallel scheduler | Default-parallel `Promise.all()`, TOML policy, MCP wildcards, A2A remote agents |
 | Qwen | Dual dispatch (named + fork) | Fork background tasks, DashScope cache sharing, auto-delegation |
@@ -465,7 +465,7 @@ To add support for a new AI coding assistant:
 2. Implement `{Agent}Generator extends DefaultGenerator` in `io.github.luigidemasi.camelkit.generator`
 3. Register in `AgentGeneratorFactory` (`{agent-name}` → `{Agent}Generator`)
 4. Generate the agent's instruction file with embedded iron laws and skill references
-5. Map pipeline phases to the agent's native dispatch mechanism (modes, subagents, permissions, etc.)
+5. Map pipeline phases to the agent's native dispatch mechanism (modes, sub-agents, permissions, etc.)
 6. Add MCP configuration for the agent's MCP config format
 7. Write tests following existing patterns (verify structure + key content markers)
 
@@ -575,7 +575,7 @@ If the MCP server is not available, skills fall back to local component data and
 
 ## 7. Verification Pipeline
 
-The verification pipeline (`camel-verify`) is a 3-phase feedback loop that builds and tests the generated application using Citrus integration tests. It runs as an internal subagent within `camel-execute`, not as a standalone pipeline stage. After verification completes inside execute, `camel-validate` runs as the final pipeline stage.
+The verification pipeline (`camel-verify`) is a 3-phase feedback loop that builds and tests the generated application using Citrus integration tests. It runs as an internal sub-agent within `camel-execute`, not as a standalone pipeline stage. After verification completes inside execute, `camel-validate` runs as the final pipeline stage.
 
 ### Phases
 
@@ -714,7 +714,7 @@ Camel-Kit defaults to the latest Apache Camel version, configured in `distributi
 
 ### Multi-Agent Parity
 
-Skills are markdown instruction files -- the same skill works across all five supported agents. Agent-specific differences (subagent dispatch vs. custom modes vs. inline execution) are handled by the template layer, not the skill layer. A bug fix or improvement to a guide file benefits every agent.
+Skills are markdown instruction files -- the same skill works across all five supported agents. Agent-specific differences (sub-agent dispatch vs. custom modes vs. inline execution) are handled by the template layer, not the skill layer. A bug fix or improvement to a guide file benefits every agent.
 
 ### Constitution vs Iron Laws
 
@@ -758,7 +758,7 @@ user_invocable: false
 
 4. **Update the workflow manifest first:** add or modify the entry in `camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml`. Set `generated_stub: true` only for commands that should be emitted into each agent's commands directory. Add or update the corresponding skill entry, stage/artifact metadata, transitions, and MCP tool allowlists if the workflow contract changes.
 
-5. **If registering slash commands:** update agent-specific guidance only where the command needs custom behavior beyond the generated stub. The default generator creates command stubs from the manifest. Agent templates still need updates when they contain human-readable command tables, custom modes, policies, or subagent dispatch:
+5. **If registering slash commands:** update agent-specific guidance only where the command needs custom behavior beyond the generated stub. The default generator creates command stubs from the manifest. Agent templates still need updates when they contain human-readable command tables, custom modes, policies, or sub-agent dispatch:
    - Claude Code: update `templates/claude/claude-md.md`
    - IBM Project Bob: update `templates/bob/custom_modes.yaml` and add rules directory
    - Gemini CLI: update `templates/gemini/gemini-md.md`
@@ -766,7 +766,7 @@ user_invocable: false
    - OpenCode: update `templates/opencode/agents-md.md`
 
 6. **If changing an agent capability:** update `agents/registry/{agent}.yaml` when command directories,
-   file formats, MCP config paths, generator strategy, dispatch templates, installed templates, subagent support,
+   file formats, MCP config paths, generator strategy, dispatch templates, installed templates, sub-agent support,
    trait support, or capability labels change.
 
 7. **If internal:** update the loading skill's `SKILL.md` to reference the new guides (e.g., add a guide reference to `camel-execute`'s guide manifest).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,15 +327,27 @@ The validation guide (`datamapper-validation.md`) reads the `Transformation Engi
 
 `camel-kit-core/src/main/resources/templates/{agent}/`
 
+### Agent Capability Registry
+
+Built-in agent metadata lives in `camel-kit-core/src/main/resources/agents/registry/{agent}.yaml`.
+`AgentRegistry` loads these descriptors at startup and maps them into the public `AgentConfig` model used by
+commands and generators.
+
+Each descriptor defines the agent id, display name, command directory, command file format, argument placeholder,
+MCP config path, MCP config template path, MCP server container key, description, generator strategy, dispatch
+template path, templates installed by the agent-specific generator, and whether the agent supports subagents or
+traits. Missing required fields, duplicate ids, unsupported generator strategies, or malformed YAML fail during
+registry loading with a descriptor-specific error.
+
 ### What `camel-kit init` Generates
 
 | Agent | Template Dir | Instruction File | MCP Config | Skills Location |
 |-------|-------------|-----------------|------------|-----------------|
 | Claude Code | `templates/claude/` | `CLAUDE.md` | `.mcp.json` | `.claude/skills/` |
 | IBM Project Bob | `templates/bob/` | `custom_modes.yaml` + rules + gates | `.bob/mcp.json` | `.bob/skills/` |
-| Gemini CLI | `templates/gemini/` | `GEMINI.md` + `@file.md` imports + policies | `.gemini/mcp.json` | `.gemini/skills/` |
-| Qwen | `templates/qwen/` | `QWEN.md` + sub-agent definitions | `.qwen/mcp.json` | `.qwen/skills/` |
-| OpenCode | `templates/opencode/` | `AGENTS.md` + permission-based agents | `.opencode/mcp.json` | `.opencode/skills/` |
+| Gemini CLI | `templates/gemini/` | `GEMINI.md` + `@file.md` imports + policies | `.gemini/settings.json` | `.gemini/skills/` |
+| Qwen | `templates/qwen/` | `QWEN.md` + sub-agent definitions | `.qwen/settings.json` | `.qwen/skills/` |
+| OpenCode | `templates/opencode/` | `AGENTS.md` + permission-based agents | `opencode.json` | `.opencode/skills/` |
 
 ### Resource Consistency Contract
 
@@ -345,7 +357,7 @@ The active scan covers `camel-kit-core/src/main/resources/skills`, `camel-kit-co
 
 Docs subdirectories are intentionally out of scope; this keeps ignored archives such as `docs/plans/` and `docs/superpowers/`, image assets, and generated planning material out of the contract check.
 
-`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent has dispatch and MCP config templates, trait files target existing skills or guides, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as JSON with the expected server containers.
+`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent descriptor has dispatch and MCP config templates, descriptor template sources exist, trait files target existing skills or guides, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as JSON with the expected server containers.
 
 Historical release notes, old planning material, and archived ADR-style documents are outside the active contract unless they are copied into generated projects or used as live instructions. Keep historical context in those files as history; do not exclude an active shipped instruction just because it is inconvenient to update.
 
@@ -753,8 +765,12 @@ user_invocable: false
    - Qwen: update `templates/qwen/qwen-md.md`
    - OpenCode: update `templates/opencode/agents-md.md`
 
-6. **If internal:** update the loading skill's `SKILL.md` to reference the new guides (e.g., add a guide reference to `camel-execute`'s guide manifest).
+6. **If changing an agent capability:** update `agents/registry/{agent}.yaml` when command directories,
+   file formats, MCP config paths, generator strategy, dispatch templates, installed templates, subagent support,
+   trait support, or capability labels change.
 
-7. **Update `docs/commands.md`** if the skill is user-facing.
+7. **If internal:** update the loading skill's `SKILL.md` to reference the new guides (e.g., add a guide reference to `camel-execute`'s guide manifest).
 
-8. **Run manifest consistency tests** in `camel-kit-core` to verify generated stubs, skill metadata, and MCP allowlists still match the manifest.
+8. **Update `docs/commands.md`** if the skill is user-facing.
+
+9. **Run manifest consistency tests** in `camel-kit-core` to verify generated stubs, skill metadata, and MCP allowlists still match the manifest.


### PR DESCRIPTION
Fixes #109.

Summary:
- Move built-in agent metadata into YAML descriptors under `agents/registry`.
- Load descriptors into `AgentRegistry` and use descriptor metadata for generator strategy and dispatch templates.
- Add descriptor validation tests, shipped asset checks, and architecture documentation.

Review feedback addressed:
- Centralized generator strategy validation in `AgentGeneratorStrategy` and switched the factory on that enum.
- Made `AgentGeneratorFactory` fail fast for unknown agents instead of silently using the default generator.
- Fixed jar-backed descriptor registry loading by opening the jar file system with the jar URI and resolving the registry path inside it.
- Standardized `docs/architecture.md` on the `sub-agent` spelling while preserving literal tool names such as `invoke_subagent`.

Tests:
- `./mvnw -pl camel-kit-core process-sources`
- `./mvnw -pl camel-kit-core -Dtest='AgentGeneratorFactoryTest,*GeneratorTest,AgentRegistryTest,ShippedAssetStructureTest' test -Dformat.skip=true`
- `./mvnw clean install -DskipTests`

Generated by Codex via /oss-address-review
