### PR TITLE
Fix #107: Extract command services

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/DoctorCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/DoctorCommand.java
@@ -1,30 +1,14 @@
 package io.github.luigidemasi.camelkit.command;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import io.github.luigidemasi.camelkit.CamelKitMain;
-import io.github.luigidemasi.camelkit.config.AgentConfig;
-import io.github.luigidemasi.camelkit.config.AgentRegistry;
-import io.github.luigidemasi.camelkit.graph.GraphBuilder;
+import io.github.luigidemasi.camelkit.service.DoctorFinding;
+import io.github.luigidemasi.camelkit.service.DoctorRequest;
+import io.github.luigidemasi.camelkit.service.DoctorResult;
+import io.github.luigidemasi.camelkit.service.DoctorService;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,15 +22,8 @@ import picocli.CommandLine.Option;
 public class DoctorCommand extends CamelKitCommand {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final Duration PREREQUISITE_TIMEOUT = Duration.ofSeconds(3);
 
-    private static final List<String> REQUIRED_CONFIG_KEYS = List.of(
-            "project.name", "project.command-prefix", "agent.name", "agent.folder");
-
-    private static final List<String> STALE_REFERENCES = List.of(
-            "/camel-design", ".camel-kit/business-requirements.md", ".camel-kit/flows/");
-
-    private final DoctorExpectations expectations;
+    private final DoctorService doctorService;
 
     @Option(names = {"--project-dir"}, description = "Workspace directory to validate", defaultValue = ".")
     Path projectDir;
@@ -55,421 +32,30 @@ public class DoctorCommand extends CamelKitCommand {
     boolean json;
 
     public DoctorCommand(CamelKitMain main) {
+        this(main, new DoctorService());
+    }
+
+    DoctorCommand(CamelKitMain main, DoctorService doctorService) {
         super(main);
-        this.expectations = DoctorExpectations.loadDefault();
+        this.doctorService = doctorService;
     }
 
     @Override
     public Integer doCall() throws Exception {
-        Path root = projectDir.toAbsolutePath().normalize();
-        List<Finding> findings = new ArrayList<>();
-
-        Properties config = checkConfig(root, findings);
-        AgentConfig agent = checkAgentConfig(config, findings);
-        checkGeneratedWorkspace(root, agent, findings);
-        checkMcp(root, config, findings);
-        checkGraph(root, findings);
-        checkCommandPrefix(config, findings);
-        checkPrerequisites(root, findings);
-        checkStaleReferences(root, agent, findings);
-
+        DoctorResult result = doctorService.inspect(new DoctorRequest(projectDir));
         if (json) {
-            printer().println(toJson(root, findings));
+            printer().println(toJson(result));
         } else {
-            printText(root, findings);
+            printText(result);
         }
-
-        return findings.stream().anyMatch(f -> f.status() == Status.FAIL) ? 1 : 0;
+        return result.hasFailures() ? 1 : 0;
     }
 
-    private Properties checkConfig(Path root, List<Finding> findings) {
-        Path configFile = root.resolve(".camel-kit/config.properties");
-        if (!Files.isRegularFile(configFile)) {
-            findings.add(Finding.fail("config", relativize(root, configFile),
-                    ".camel-kit/config.properties is missing",
-                    "Run camel-kit init --here --ai <agent> from the workspace root."));
-            return new Properties();
-        }
-
-        Properties config = new Properties();
-        try (InputStream in = Files.newInputStream(configFile)) {
-            config.load(in);
-        } catch (IOException e) {
-            findings.add(Finding.fail("config", relativize(root, configFile),
-                    "Could not read .camel-kit/config.properties: " + e.getMessage(),
-                    "Recreate the file with camel-kit init --here --force or restore it from source control."));
-            return config;
-        }
-
-        List<String> missing = REQUIRED_CONFIG_KEYS.stream()
-                .filter(key -> config.getProperty(key, "").isBlank())
-                .toList();
-        if (missing.isEmpty()) {
-            findings.add(Finding.pass("config", relativize(root, configFile),
-                    ".camel-kit/config.properties contains the required keys",
-                    "No action required."));
-        } else {
-            findings.add(Finding.fail("config", relativize(root, configFile),
-                    ".camel-kit/config.properties is missing keys: " + String.join(", ", missing),
-                    "Restore the missing keys or re-run camel-kit init --here --ai <agent> --force."));
-        }
-        return config;
-    }
-
-    private AgentConfig checkAgentConfig(Properties config, List<Finding> findings) {
-        String agentName = config.getProperty("agent.name", "").trim();
-        if (agentName.isEmpty()) {
-            findings.add(Finding.fail("config", ".camel-kit/config.properties",
-                    "agent.name is not configured",
-                    "Set agent.name to one of: " + String.join(", ", AgentRegistry.names()) + "."));
-            return null;
-        }
-        if (!AgentRegistry.contains(agentName)) {
-            findings.add(Finding.fail("config", ".camel-kit/config.properties",
-                    "Unknown agent.name '" + agentName + "'",
-                    "Set agent.name to one of: " + String.join(", ", AgentRegistry.names()) + "."));
-            return null;
-        }
-
-        AgentConfig agent = AgentRegistry.get(agentName);
-        String folder = config.getProperty("agent.folder", "").trim();
-        if (agent.folder().equals(folder)) {
-            findings.add(Finding.pass("config", ".camel-kit/config.properties",
-                    "Agent configuration selects " + agent.name(),
-                    "No action required."));
-        } else {
-            findings.add(Finding.fail("config", ".camel-kit/config.properties",
-                    "agent.folder is '" + folder + "' but " + agentName + " expects '" + agent.folder() + "'",
-                    "Set agent.folder=" + agent.folder() + " or re-run camel-kit init for " + agentName + "."));
-        }
-        return agent;
-    }
-
-    private void checkGeneratedWorkspace(Path root, AgentConfig agent, List<Finding> findings) {
-        if (agent == null) {
-            findings.add(Finding.fail("workspace", null,
-                    "Cannot validate generated commands and skills without a valid agent",
-                    "Fix .camel-kit/config.properties and re-run camel-kit doctor."));
-            return;
-        }
-
-        Path commandsDir = root.resolve(agent.folder());
-        if (!Files.isDirectory(commandsDir)) {
-            findings.add(Finding.fail("workspace", relativize(root, commandsDir),
-                    "Generated command directory is missing",
-                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate commands."));
-        } else {
-            checkCommandFiles(root, commandsDir, agent, findings);
-        }
-
-        Path skillsDir = root.resolve(agent.folder()).getParent().resolve("skills");
-        if (!Files.isDirectory(skillsDir)) {
-            findings.add(Finding.fail("skills", relativize(root, skillsDir),
-                    "Generated skills directory is missing",
-                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate skills."));
-            return;
-        }
-
-        List<String> missingSkills = expectations.requiredSkills().stream()
-                .filter(skill -> !Files.isRegularFile(skillsDir.resolve(skill).resolve("SKILL.md")))
-                .toList();
-        if (missingSkills.isEmpty()) {
-            findings.add(Finding.pass("skills", relativize(root, skillsDir),
-                    "All expected skill directories contain SKILL.md",
-                    "No action required."));
-        } else {
-            findings.add(Finding.fail("skills", relativize(root, skillsDir),
-                    "Missing SKILL.md for: " + String.join(", ", missingSkills),
-                    "Restore the missing skill folders or re-run camel-kit init --here --force."));
-        }
-    }
-
-    private void checkCommandFiles(
-            Path root, Path commandsDir, AgentConfig agent, List<Finding> findings) {
-        String extension = "." + agent.fileFormat();
-        List<String> missing = expectations.userCommands().stream()
-                .filter(command -> !Files.isRegularFile(commandsDir.resolve(command + extension)))
-                .toList();
-
-        Set<String> unexpected = new LinkedHashSet<>();
-        try (Stream<Path> stream = Files.list(commandsDir)) {
-            stream.filter(Files::isRegularFile)
-                    .map(path -> path.getFileName().toString())
-                    .filter(name -> name.startsWith("camel-"))
-                    .map(this::commandName)
-                    .filter(command -> !expectations.userCommands().contains(command))
-                    .forEach(unexpected::add);
-        } catch (IOException e) {
-            findings.add(Finding.fail("workspace", relativize(root, commandsDir),
-                    "Could not list generated command directory: " + e.getMessage(),
-                    "Check filesystem permissions and re-run camel-kit doctor."));
-            return;
-        }
-
-        if (missing.isEmpty() && unexpected.isEmpty()) {
-            findings.add(Finding.pass("workspace", relativize(root, commandsDir),
-                    "Generated user-invocable commands match the expected skill router set",
-                    "No action required."));
-            return;
-        }
-
-        List<String> problems = new ArrayList<>();
-        if (!missing.isEmpty()) {
-            problems.add("missing " + String.join(", ", missing));
-        }
-        if (!unexpected.isEmpty()) {
-            problems.add("unexpected " + String.join(", ", unexpected));
-        }
-        findings.add(Finding.fail("workspace", relativize(root, commandsDir),
-                "Generated command directory has " + String.join("; ", problems),
-                "Remove unexpected command stubs and re-run camel-kit init --here --force if required files are missing."));
-    }
-
-    private void checkMcp(Path root, Properties config, List<Finding> findings) {
-        String agentName = config.getProperty("agent.name", "").trim();
-        Path mcpFile = mcpConfigPath(root, agentName);
-        if (mcpFile == null) {
-            findings.add(Finding.fail("mcp", null,
-                    "Cannot determine MCP config path for agent '" + agentName + "'",
-                    "Fix agent.name in .camel-kit/config.properties."));
-            return;
-        }
-        if (!Files.isRegularFile(mcpFile)) {
-            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
-                    "MCP config is missing for agent '" + agentName + "'",
-                    "Run camel-kit init --here --ai " + agentName + " --force to regenerate MCP configuration."));
-            return;
-        }
-
-        JsonNode rootNode;
-        try {
-            rootNode = MAPPER.readTree(mcpFile.toFile());
-        } catch (IOException e) {
-            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
-                    "MCP config is not valid JSON: " + e.getMessage(),
-                    "Fix the JSON syntax or regenerate the MCP config with camel-kit init --here --force."));
-            return;
-        }
-
-        JsonNode servers = rootNode.has("mcp") ? rootNode.path("mcp") : rootNode.path("mcpServers");
-        if (!servers.isObject()) {
-            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
-                    "MCP config does not contain an mcp or mcpServers object",
-                    "Regenerate the MCP config with camel-kit init --here --force."));
-            return;
-        }
-
-        boolean camelOk = checkMcpServer(root, mcpFile, servers, "camel", expectations.camelMcpTools(), findings);
-        boolean knowledgeOk = checkMcpServer(
-                root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), findings);
-        if (camelOk && knowledgeOk) {
-            findings.add(Finding.pass("mcp", relativize(root, mcpFile),
-                    "MCP config exists and tool allowlists match Camel-Kit expectations",
-                    "No action required."));
-        }
-    }
-
-    private boolean checkMcpServer(
-            Path root, Path mcpFile, JsonNode servers, String serverName, Set<String> expected,
-            List<Finding> findings) {
-        JsonNode server = servers.path(serverName);
-        if (!server.isObject()) {
-            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
-                    "MCP server '" + serverName + "' is missing",
-                    "Regenerate the MCP config with camel-kit init --here --force."));
-            return false;
-        }
-
-        boolean autoApproveOk = checkAllowlist(root, mcpFile, serverName, "autoApprove", server, expected, findings);
-        boolean alwaysAllowOk = checkAllowlist(root, mcpFile, serverName, "alwaysAllow", server, expected, findings);
-        return autoApproveOk && alwaysAllowOk;
-    }
-
-    private boolean checkAllowlist(
-            Path root, Path mcpFile, String serverName, String field, JsonNode server, Set<String> expected,
-            List<Finding> findings) {
-        JsonNode node = server.path(field);
-        if (!node.isArray()) {
-            findings.add(Finding.fail("mcp", relativize(root, mcpFile),
-                    "MCP server '" + serverName + "' is missing " + field + " array",
-                    "Regenerate the MCP config with camel-kit init --here --force."));
-            return false;
-        }
-
-        Set<String> actual = new LinkedHashSet<>();
-        node.forEach(value -> actual.add(value.asText()));
-        Set<String> missing = new LinkedHashSet<>(expected);
-        missing.removeAll(actual);
-        Set<String> extra = new LinkedHashSet<>(actual);
-        extra.removeAll(expected);
-        if (missing.isEmpty() && extra.isEmpty()) {
-            return true;
-        }
-
-        List<String> problems = new ArrayList<>();
-        if (!missing.isEmpty()) {
-            problems.add("missing " + String.join(", ", missing));
-        }
-        if (!extra.isEmpty()) {
-            problems.add("extra " + String.join(", ", extra));
-        }
-        findings.add(Finding.fail("mcp", relativize(root, mcpFile),
-                "MCP server '" + serverName + "' " + field + " has " + String.join("; ", problems),
-                "Regenerate the MCP config or update the allowlist to match the generated Camel-Kit tools."));
-        return false;
-    }
-
-    private void checkGraph(Path root, List<Finding> findings) {
-        Path graphFile = root.resolve(".camel-kit/project-graph.json");
-        if (Files.isRegularFile(graphFile)) {
-            try {
-                MAPPER.readTree(graphFile.toFile());
-                findings.add(Finding.pass("graph", relativize(root, graphFile),
-                        ".camel-kit/project-graph.json exists and is valid JSON",
-                        "No action required."));
-            } catch (IOException e) {
-                findings.add(Finding.fail("graph", relativize(root, graphFile),
-                        ".camel-kit/project-graph.json is not valid JSON: " + e.getMessage(),
-                        "Run camel-kit graph generate --project-dir " + root + " to regenerate it."));
-            }
-            return;
-        }
-
-        try {
-            new GraphBuilder().build(root);
-            findings.add(Finding.warn("graph", relativize(root, graphFile),
-                    ".camel-kit/project-graph.json is missing, but graph generation can run",
-                    "Run camel-kit graph generate --project-dir " + root + " to persist the graph."));
-        } catch (Exception e) {
-            findings.add(Finding.fail("graph", relativize(root, graphFile),
-                    ".camel-kit/project-graph.json is missing and graph generation failed: " + e.getMessage(),
-                    "Fix the project files reported by graph generation, then run camel-kit graph generate."));
-        }
-    }
-
-    private void checkCommandPrefix(Properties config, List<Finding> findings) {
-        String prefix = config.getProperty("project.command-prefix", "").trim();
-        if ("camel-kit".equals(prefix) || "camel kit".equals(prefix)) {
-            findings.add(Finding.pass("config", ".camel-kit/config.properties",
-                    "project.command-prefix uses a supported invocation style: " + prefix,
-                    "No action required."));
-        } else {
-            findings.add(Finding.warn("config", ".camel-kit/config.properties",
-                    "project.command-prefix is not a known invocation style: " + prefix,
-                    "Set project.command-prefix to camel-kit or camel kit, matching how this CLI is installed."));
-        }
-    }
-
-    private void checkPrerequisites(Path root, List<Finding> findings) {
-        ToolResult java = runTool(null, "java", "-version");
-        if (java.available() && javaMajorVersion(java.output()) >= 17) {
-            findings.add(Finding.pass("prerequisites", null,
-                    "Java 17+ is available",
-                    "No action required."));
-        } else if (java.available()) {
-            findings.add(Finding.warn("prerequisites", null,
-                    "Java is available but the version could not be confirmed as 17+",
-                    "Install or select JDK 17+ before running generated Camel projects."));
-        } else {
-            findings.add(Finding.warn("prerequisites", null,
-                    "Java 17+ was not found on PATH",
-                    "Install JDK 17+ before running generated Camel projects."));
-        }
-
-        Path mvnw = root.resolve(isWindows() ? "mvnw.cmd" : "mvnw");
-        if (Files.isRegularFile(mvnw)) {
-            findings.add(Finding.pass("prerequisites", relativize(root, mvnw),
-                    "Maven Wrapper is present",
-                    "No action required."));
-        } else if (runTool(root, "mvn", "-version").available()) {
-            findings.add(Finding.warn("prerequisites", null,
-                    "Maven is available, but the generated Maven Wrapper is missing",
-                    "Run camel-kit init --here --force to restore mvnw and .mvn/wrapper."));
-        } else {
-            findings.add(Finding.warn("prerequisites", null,
-                    "Neither Maven Wrapper nor mvn was found",
-                    "Install Maven or restore the generated Maven Wrapper with camel-kit init --here --force."));
-        }
-
-        if (runTool(null, "jbang", "version").available()) {
-            findings.add(Finding.pass("prerequisites", null,
-                    "JBang is available for MCP server launch commands",
-                    "No action required."));
-        } else {
-            findings.add(Finding.warn("prerequisites", null,
-                    "JBang was not found on PATH",
-                    "Install JBang so generated MCP server commands can run."));
-        }
-
-        if (runTool(null, "camel", "--version").available()) {
-            findings.add(Finding.pass("prerequisites", null,
-                    "Camel JBang is available",
-                    "No action required."));
-        } else {
-            findings.add(Finding.warn("prerequisites", null,
-                    "Camel JBang was not found on PATH",
-                    "Install Camel JBang for local graph, validation, and verification workflows."));
-        }
-    }
-
-    private void checkStaleReferences(Path root, AgentConfig agent, List<Finding> findings) {
-        List<Path> activeFiles = new ArrayList<>();
-        addIfExists(activeFiles, root.resolve("AGENTS.md"));
-        addIfExists(activeFiles, root.resolve("CLAUDE.md"));
-        addIfExists(activeFiles, root.resolve("GEMINI.md"));
-        addIfExists(activeFiles, root.resolve("QWEN.md"));
-        addIfExists(activeFiles, root.resolve("opencode.json"));
-        if (agent != null) {
-            Path commandsDir = root.resolve(agent.folder());
-            if (Files.isDirectory(commandsDir)) {
-                try (Stream<Path> stream = Files.list(commandsDir)) {
-                    stream.filter(Files::isRegularFile).forEach(activeFiles::add);
-                } catch (IOException e) {
-                    findings.add(Finding.warn("workspace", relativize(root, commandsDir),
-                            "Could not scan generated command files for stale references: " + e.getMessage(),
-                            "Check filesystem permissions and re-run camel-kit doctor."));
-                }
-            }
-            addIfExists(activeFiles, mcpConfigPath(root, agentKey(agent)));
-        }
-
-        Map<Path, List<String>> matches = new LinkedHashMap<>();
-        for (Path file : activeFiles) {
-            try {
-                String content = Files.readString(file, StandardCharsets.UTF_8);
-                List<String> found = STALE_REFERENCES.stream()
-                        .filter(content::contains)
-                        .toList();
-                if (!found.isEmpty()) {
-                    matches.put(file, found);
-                }
-            } catch (IOException e) {
-                findings.add(Finding.warn("workspace", relativize(root, file),
-                        "Could not scan active generated file for stale references: " + e.getMessage(),
-                        "Check filesystem permissions and re-run camel-kit doctor."));
-            }
-        }
-
-        if (matches.isEmpty()) {
-            findings.add(Finding.pass("workspace", null,
-                    "Active generated files do not contain common stale resource references",
-                    "No action required."));
-            return;
-        }
-
-        List<String> details = matches.entrySet().stream()
-                .map(entry -> relativize(root, entry.getKey()) + " -> " + String.join(", ", entry.getValue()))
-                .toList();
-        findings.add(Finding.fail("workspace", null,
-                "Active generated files contain stale references: " + String.join("; ", details),
-                "Regenerate the workspace or update the listed files to current Camel-Kit paths and commands."));
-    }
-
-    private void printText(Path root, List<Finding> findings) {
+    private void printText(DoctorResult result) {
         printer().println(bold("Camel-Kit Doctor"));
-        printer().println("Workspace: " + root);
+        printer().println("Workspace: " + result.projectDir());
         printer().println();
-        for (Finding finding : findings) {
+        for (DoctorFinding finding : result.findings()) {
             printer().println(statusLabel(finding.status()) + " " + finding.category() + " - " + finding.message());
             if (finding.path() != null) {
                 printer().println("  Path: " + finding.path());
@@ -477,19 +63,19 @@ public class DoctorCommand extends CamelKitCommand {
             printer().println("  Fix:  " + finding.remediation());
         }
         printer().println();
-        printer().println(summary(findings));
+        printer().println(summary(result));
     }
 
-    private String toJson(Path root, List<Finding> findings) throws IOException {
+    private String toJson(DoctorResult result) throws IOException {
         ObjectNode node = MAPPER.createObjectNode();
-        node.put("projectDir", root.toString());
-        node.put("status", findings.stream().anyMatch(f -> f.status() == Status.FAIL) ? "FAIL" : "PASS");
+        node.put("projectDir", result.projectDir().toString());
+        node.put("status", result.hasFailures() ? "FAIL" : "PASS");
         ObjectNode summary = node.putObject("summary");
-        summary.put("pass", findings.stream().filter(f -> f.status() == Status.PASS).count());
-        summary.put("warn", findings.stream().filter(f -> f.status() == Status.WARN).count());
-        summary.put("fail", findings.stream().filter(f -> f.status() == Status.FAIL).count());
+        summary.put("pass", result.count(DoctorFinding.Status.PASS));
+        summary.put("warn", result.count(DoctorFinding.Status.WARN));
+        summary.put("fail", result.count(DoctorFinding.Status.FAIL));
         ArrayNode array = node.putArray("findings");
-        for (Finding finding : findings) {
+        for (DoctorFinding finding : result.findings()) {
             ObjectNode findingNode = array.addObject();
             findingNode.put("status", finding.status().name());
             findingNode.put("category", finding.category());
@@ -504,127 +90,17 @@ public class DoctorCommand extends CamelKitCommand {
         return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
     }
 
-    private String summary(List<Finding> findings) {
-        long pass = findings.stream().filter(f -> f.status() == Status.PASS).count();
-        long warn = findings.stream().filter(f -> f.status() == Status.WARN).count();
-        long fail = findings.stream().filter(f -> f.status() == Status.FAIL).count();
-        return "Summary: " + pass + " PASS, " + warn + " WARN, " + fail + " FAIL";
+    private String summary(DoctorResult result) {
+        return "Summary: " + result.count(DoctorFinding.Status.PASS)
+               + " PASS, " + result.count(DoctorFinding.Status.WARN)
+               + " WARN, " + result.count(DoctorFinding.Status.FAIL) + " FAIL";
     }
 
-    private String statusLabel(Status status) {
+    private String statusLabel(DoctorFinding.Status status) {
         return switch (status) {
             case PASS -> green("PASS");
             case WARN -> yellow("WARN");
             case FAIL -> red("FAIL");
         };
-    }
-
-    private ToolResult runTool(Path directory, String... command) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder(command);
-            if (directory != null) {
-                pb.directory(directory.toFile());
-            }
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-            boolean finished = process.waitFor(PREREQUISITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-            if (!finished) {
-                process.destroyForcibly();
-                return new ToolResult(false, "");
-            }
-            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            return new ToolResult(process.exitValue() == 0, output);
-        } catch (Exception e) {
-            return new ToolResult(false, "");
-        }
-    }
-
-    private int javaMajorVersion(String output) {
-        Matcher matcher = Pattern.compile("version\\s+\"([^\"]+)\"").matcher(output);
-        if (!matcher.find()) {
-            return 0;
-        }
-        String version = matcher.group(1);
-        if (version.startsWith("1.")) {
-            String[] parts = version.split("\\.");
-            return parts.length > 1 ? parseInt(parts[1]) : 0;
-        }
-        return parseInt(version.split("[.+\\-]")[0]);
-    }
-
-    private int parseInt(String value) {
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
-    private Path mcpConfigPath(Path root, String agentName) {
-        return switch (agentName.toLowerCase(Locale.ROOT)) {
-            case "claude" -> root.resolve(".mcp.json");
-            case "bob" -> root.resolve(".bob/mcp.json");
-            case "gemini" -> root.resolve(".gemini/settings.json");
-            case "qwen" -> root.resolve(".qwen/settings.json");
-            case "opencode" -> root.resolve("opencode.json");
-            default -> null;
-        };
-    }
-
-    private String commandName(String filename) {
-        int dot = filename.indexOf('.');
-        return dot == -1 ? filename : filename.substring(0, dot);
-    }
-
-    private String agentKey(AgentConfig agent) {
-        return AgentRegistry.all().entrySet().stream()
-                .filter(entry -> entry.getValue().equals(agent))
-                .map(Map.Entry::getKey)
-                .findFirst()
-                .orElse(agent.name());
-    }
-
-    private String relativize(Path root, Path path) {
-        if (path == null) {
-            return null;
-        }
-        try {
-            return root.relativize(path.toAbsolutePath().normalize()).toString();
-        } catch (IllegalArgumentException e) {
-            return path.toString();
-        }
-    }
-
-    private void addIfExists(List<Path> paths, Path path) {
-        if (path != null && Files.isRegularFile(path)) {
-            paths.add(path);
-        }
-    }
-
-    private boolean isWindows() {
-        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
-    }
-
-    enum Status {
-        PASS,
-        WARN,
-        FAIL
-    }
-
-    record Finding(Status status, String category, String path, String message, String remediation) {
-        static Finding pass(String category, String path, String message, String remediation) {
-            return new Finding(Status.PASS, category, path, message, remediation);
-        }
-
-        static Finding warn(String category, String path, String message, String remediation) {
-            return new Finding(Status.WARN, category, path, message, remediation);
-        }
-
-        static Finding fail(String category, String path, String message, String remediation) {
-            return new Finding(Status.FAIL, category, path, message, remediation);
-        }
-    }
-
-    record ToolResult(boolean available, String output) {
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -2,27 +2,20 @@ package io.github.luigidemasi.camelkit.command;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.ZoneId;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 import io.github.luigidemasi.camelkit.CamelKitMain;
-import io.github.luigidemasi.camelkit.catalog.CitrusSchemaDownloader;
-import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
-import io.github.luigidemasi.camelkit.config.DistributionConfig;
-import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
-import io.github.luigidemasi.camelkit.generator.InitContext;
-import io.github.luigidemasi.camelkit.generator.QuteTemplateEngine;
-import io.github.luigidemasi.camelkit.graph.GraphBuilder;
-import io.github.luigidemasi.camelkit.graph.ProjectGraph;
-import io.github.luigidemasi.camelkit.graph.RuntimeDetector;
 import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.service.InitGraphSummary;
+import io.github.luigidemasi.camelkit.service.InitProgress;
+import io.github.luigidemasi.camelkit.service.InitReporter;
+import io.github.luigidemasi.camelkit.service.InitRequest;
+import io.github.luigidemasi.camelkit.service.InitService;
+import io.github.luigidemasi.camelkit.service.InitWarning;
 import io.github.luigidemasi.camelkit.tui.InitTuiView;
 import io.github.luigidemasi.camelkit.tui.TaskTracker;
 import io.github.luigidemasi.camelkit.util.PrerequisiteChecker;
-import io.github.luigidemasi.camelkit.util.TemplateUtils;
 
 import dev.tamboui.image.capability.TerminalImageCapabilities;
 import picocli.CommandLine.Command;
@@ -71,10 +64,16 @@ public class InitCommand extends CamelKitCommand {
             description = "Source platform for migration graph analysis: mulesoft, camel, biztalk, auto (default: auto)")
     public String sourcePlatform;
 
+    private final InitService initService;
     private Path resolvedTargetDir;
 
     public InitCommand(CamelKitMain main) {
+        this(main, new InitService());
+    }
+
+    InitCommand(CamelKitMain main, InitService initService) {
         super(main);
+        this.initService = initService;
     }
 
     @Override
@@ -83,12 +82,10 @@ public class InitCommand extends CamelKitCommand {
             main.setOut(Printer.noop());
         }
 
-        // Reload config with cascading overrides: JAR defaults → -c file → -p properties
         if (configFile != null || properties != null) {
             CamelKitMain.reloadDistribution(configFile, properties);
         }
 
-        // Validate agent and resolve arguments upfront (fast, non-blocking)
         if (!AgentRegistry.contains(ai)) {
             if (!silent)
                 main.printBanner();
@@ -104,7 +101,6 @@ public class InitCommand extends CamelKitCommand {
             return 1;
         }
 
-        // Resolve target directory once — reused in doInitWork()
         if (here) {
             resolvedTargetDir = Path.of("").toAbsolutePath();
             projectName = resolvedTargetDir.getFileName().toString();
@@ -112,14 +108,13 @@ public class InitCommand extends CamelKitCommand {
             resolvedTargetDir = Path.of(projectName).toAbsolutePath();
         }
 
-        // Overwrite detection (runs before TUI so colors work on error)
         Path agentsMd = resolvedTargetDir.resolve("AGENTS.md");
         Path camelKitDir = resolvedTargetDir.resolve(".camel-kit");
         if (!force && (Files.exists(agentsMd) || Files.isDirectory(camelKitDir))) {
             if (!silent)
                 main.printBanner();
             printer().println();
-            printer().println(yellow("⚠") + bold(" Project already initialized"));
+            printer().println(yellow("\u26A0") + bold(" Project already initialized"));
             printer().println(dim("  Directory: ") + cyan(resolvedTargetDir.toString()));
             if (Files.exists(agentsMd)) {
                 printer().println(dim("  Found:     ") + "AGENTS.md");
@@ -135,26 +130,20 @@ public class InitCommand extends CamelKitCommand {
         }
 
         if (!silent) {
-            // If native image protocol is available and TUI is enabled, run the full
-            // split-screen experience. Falls back to normal mode on any failure
-            // (missing backend JAR, dumb terminal, JBang plugin context, etc.).
             if (main.isTuiEnabled() && TerminalImageCapabilities.detect().supportsNativeImages()) {
                 InitTuiView tui = new InitTuiView();
                 Printer original = main.getOut();
                 main.setOut(tui.createPrinter());
                 main.setTaskTracker(tui.createTaskTracker());
-                // Release our JLine terminal so TamboUI can acquire the device cleanly.
                 main.closeTerminal();
                 try {
                     return tui.run(this::doInitWork);
                 } catch (Throwable e) {
-                    // TUI not available — restore and continue in normal mode
                     main.setOut(original);
                     main.setTaskTracker(TaskTracker.noop());
                 }
             }
 
-            // Normal mode: print banner then run init inline
             main.printBanner();
         }
 
@@ -162,118 +151,27 @@ public class InitCommand extends CamelKitCommand {
     }
 
     private Integer doInitWork() throws Exception {
-        // Prerequisite check (non-blocking, informational)
         if (!silent) {
             PrerequisiteChecker.check(printer());
         }
 
-        AgentConfig agent = AgentRegistry.get(ai);
-        Path targetDir = resolvedTargetDir;
-        Path camelKitDir = targetDir.resolve(".camel-kit");
+        InitRequest request = new InitRequest(
+                projectName,
+                ai,
+                resolvedTargetDir,
+                citrusVersion,
+                noFetch,
+                sourcePlatform,
+                detectCommandPrefix(),
+                CamelKitMain.DEFAULT_CITRUS_VERSION,
+                CamelKitMain.distribution(),
+                printer(),
+                initProgress(),
+                initReporter());
 
-        // Get Citrus version
-        String citrusVer = "default".equals(citrusVersion)
-                ? CamelKitMain.DEFAULT_CITRUS_VERSION
-                : citrusVersion;
-
-        TaskTracker tracker = main.getTaskTracker();
-
-        // 1 — project structure
-        tracker.startTask("📁", "Creating project structure");
-        Files.createDirectories(targetDir);
-        Path commandsDir = targetDir.resolve(agent.folder());
-        Files.createDirectories(commandsDir);
-        Files.createDirectories(camelKitDir);
-        Path docsDir = targetDir.resolve("docs");
-        Files.createDirectories(docsDir.resolve("flows"));
-        Files.createDirectories(camelKitDir.resolve("templates"));
-        Files.createDirectories(camelKitDir.resolve(".cache"));
-        Files.createDirectories(targetDir.resolve("test/data"));
-        Files.createDirectories(targetDir.resolve("schemas"));
-        tracker.finishTask();
-
-        // 2 — configuration files
-        tracker.startTask("\uD83D\uDCDD", "Writing configuration");
-        createConfigFile(camelKitDir, projectName, ai, agent);
-        createConstitution(docsDir);
-        copyAdditionalTemplates(camelKitDir.resolve("templates"));
-        tracker.finishTask();
-
-        // 3+4+4b+5 — AI agent generation (commands, skills, MCP)
-        tracker.startTask("🤖", "Generating " + agent.name() + " workspace");
-        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
-        Path agentBaseDir = targetDir.resolve(agent.folder()).getParent();
-        InitContext genCtx = new InitContext(
-                agent, ai, commandsDir,
-                agentBaseDir.resolve("skills"), targetDir,
-                detectCommandPrefix(), printer());
-        AgentGeneratorFactory.create(ai).generate(genCtx);
-        tracker.finishTask();
-
-        // Maven Wrapper
-        tracker.startTask("🔌", "Configuring Maven wrapper");
-        createMavenWrapper(targetDir);
-        tracker.finishTask();
-
-        // 6 — Project graph
-        tracker.startTask("\uD83D\uDD0D", "Building project graph");
-        try {
-            GraphBuilder graphBuilder = new GraphBuilder();
-            ProjectGraph projectGraph = graphBuilder.build(targetDir);
-            if (projectGraph.nodeCount() > 0) {
-                Path graphFile = camelKitDir.resolve("project-graph.json");
-                io.github.luigidemasi.camelkit.graph.GraphSerializer.write(
-                        projectGraph, graphFile, targetDir.toAbsolutePath().toString());
-                printer().println(green("✓") + " Project graph: " + projectGraph.nodeCount()
-                                  + " nodes, " + projectGraph.edgeCount() + " edges");
-
-                String detected = detectProjectType(projectGraph);
-                if (!detected.isEmpty()) {
-                    printer().println("     Detected: " + cyan(detected));
-                }
-
-                // Update config file with detected runtime
-                updateConfigWithRuntime(camelKitDir, projectGraph);
-            } else {
-                printer().println(yellow("  No source files found — graph skipped"));
-            }
-        } catch (Exception e) {
-            printer().println(yellow("  Warning: Could not build project graph: " + e.getMessage()));
-        }
-        tracker.finishTask();
-
-        // 7 — Citrus schemas
-        int citrusSchemaCount = 0;
-        if (!noFetch) {
-            tracker.startTask("⬇️", "Downloading Citrus schemas");
-            try {
-                CitrusSchemaDownloader citrusDownloader = new CitrusSchemaDownloader(camelKitDir.resolve(".cache"));
-                citrusDownloader.fetchCitrusSchemas(citrusVer, false, printer()::println);
-                Path citrusSchemasDir = citrusDownloader.getCitrusSchemasDir(citrusVer);
-                if (Files.exists(citrusSchemasDir)) {
-                    try (var paths = Files.walk(citrusSchemasDir)) {
-                        citrusSchemaCount = (int) paths
-                                .filter(p -> p.toString().endsWith(".json"))
-                                .count();
-                    }
-                }
-            } catch (Exception e) {
-                printer().println(yellow("  Warning: Could not fetch Citrus schemas: " + e.getMessage()));
-            }
-            tracker.finishTask();
-        }
-
-        // Summary line
-        printer().println();
-        printer().print("  " + green("✓") + "  ");
-        printer().println(bold(projectName));
-        String meta = "     " + agent.name()
-                      + (citrusSchemaCount > 0 ? "  \u00b7  " + citrusSchemaCount + " schemas" : "");
-        printer().println(meta);
-        printer().println();
-
-        printNextSteps(projectName, agent.name());
-
+        var result = initService.initialize(request);
+        printSummary(result.projectName(), result.agent().name(), result.citrusSchemaCount());
+        printNextSteps(result.projectName(), result.agent().name());
         return 0;
     }
 
@@ -289,164 +187,56 @@ public class InitCommand extends CamelKitCommand {
         printer().println();
     }
 
-    private String detectProjectType(ProjectGraph graph) {
-        var types = new java.util.ArrayList<String>();
+    private InitProgress initProgress() {
+        return new InitProgress() {
+            @Override
+            public void startTask(String icon, String label) {
+                main.getTaskTracker().startTask(icon, label);
+            }
 
-        if (!graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MULE_FLOW).isEmpty()) {
-            int flows = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MULE_FLOW).size();
-            int subFlows = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MULE_SUB_FLOW).size();
-            int dwl = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.DATAWEAVE_SCRIPT).size();
-            String muleVersion = findMavenProperty(graph, "mule.version");
-            if (muleVersion == null)
-                muleVersion = findMavenProperty(graph, "app.runtime");
-            if (muleVersion == null)
-                muleVersion = findArtifactVersion(graph, "org.mule.runtime", "mule-core");
-            if (muleVersion == null)
-                muleVersion = findArtifactVersion(graph, "org.mule", "mule-core");
-            types.add("MuleSoft Mule" + (muleVersion != null ? " " + muleVersion : "")
-                      + " (" + flows + " flows, " + subFlows + " sub-flows"
-                      + (dwl > 0 ? ", " + dwl + " DataWeave scripts" : "") + ")");
-        }
-
-        int orchs = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.BIZTALK_ORCHESTRATION).size();
-        int maps = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.BIZTALK_MAP).size();
-        int pipelines = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.BIZTALK_PIPELINE).size();
-        if (orchs > 0 || maps > 0 || pipelines > 0) {
-            types.add("Microsoft BizTalk (" + orchs + " orchestrations"
-                      + (maps > 0 ? ", " + maps + " maps" : "")
-                      + (pipelines > 0 ? ", " + pipelines + " pipelines" : "") + ")");
-        }
-
-        if (!graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.CAMEL_ROUTE).isEmpty()) {
-            int routes = graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.CAMEL_ROUTE).size();
-            String camelVersion = detectCamelVersion(graph);
-            String platform = detectCamelPlatform(graph);
-            types.add(platform + (camelVersion != null ? " " + camelVersion : "")
-                      + " (" + routes + " routes)");
-        }
-
-        if (!graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MAVEN_ARTIFACT).isEmpty()
-                && types.isEmpty()) {
-            types.add("Maven project");
-        }
-
-        return String.join(", ", types);
+            @Override
+            public void finishTask() {
+                main.getTaskTracker().finishTask();
+            }
+        };
     }
 
-    private String detectCamelVersion(ProjectGraph graph) {
-        // Try Maven property first (most reliable — declared in POM <properties>)
-        String version = findMavenProperty(graph, "camel.version");
-        if (version != null)
-            return version;
+    private InitReporter initReporter() {
+        return new InitReporter() {
+            @Override
+            public void mavenWrapperCreated(String mavenVersion) {
+                printer().println(green("\u2713") + " Maven Wrapper created (portable Maven " + mavenVersion + ")");
+            }
 
-        // Try explicit dependency version
-        version = findArtifactVersion(graph, "org.apache.camel", "camel-core");
-        if (version != null)
-            return version;
-
-        version = findArtifactVersion(graph, "org.apache.camel", "camel-bom");
-        if (version != null)
-            return version;
-
-        // Camel dependencies are "managed" — scan all camel artifacts for any with a real version
-        for (var node : graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MAVEN_ARTIFACT)) {
-            if ("org.apache.camel".equals(node.properties().get("groupId"))) {
-                String v = node.properties().get("version");
-                if (v != null && !"managed".equals(v) && !"unknown".equals(v) && !v.contains("${")) {
-                    return v;
+            @Override
+            public void graphBuilt(InitGraphSummary graph) {
+                printer().println(green("\u2713") + " Project graph: " + graph.nodeCount()
+                                  + " nodes, " + graph.edgeCount() + " edges");
+                if (graph.detectedProjectType() != null && !graph.detectedProjectType().isEmpty()) {
+                    printer().println("     Detected: " + cyan(graph.detectedProjectType()));
                 }
             }
-        }
 
-        return null;
+            @Override
+            public void graphSkipped() {
+                printer().println(yellow("  No source files found \u2014 graph skipped"));
+            }
+
+            @Override
+            public void warning(InitWarning warning) {
+                printer().println(yellow("  Warning: " + warning.message()));
+            }
+        };
     }
 
-    private String detectCamelPlatform(ProjectGraph graph) {
-        // Check project groupId for Fuse indicators
-        for (var node : graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MAVEN_ARTIFACT)) {
-            String file = node.properties().get("file");
-            if (file != null && file.contains("pom.xml")) {
-                String groupId = node.properties().getOrDefault("groupId", "");
-                if (groupId.contains("jboss.fuse") || groupId.contains("fusesource")) {
-                    return "JBoss Fuse";
-                }
-            }
-        }
-
-        // Check dependency versions for .redhat- or .fuse- qualifiers
-        for (var node : graph.findByType(io.github.luigidemasi.camelkit.graph.model.NodeType.MAVEN_ARTIFACT)) {
-            String v = node.properties().getOrDefault("version", "");
-            if (v.contains(".fuse-") || v.contains(".redhat-")) {
-                return "JBoss Fuse";
-            }
-        }
-
-        return "Apache Camel";
-    }
-
-    private String findMavenProperty(ProjectGraph graph, String propertyName) {
-        var node = graph.getNode("maven-property:" + propertyName);
-        if (node != null) {
-            String value = node.properties().get("value");
-            if (value != null && !value.isEmpty() && !value.contains("${")) {
-                return value;
-            }
-        }
-        return null;
-    }
-
-    private String findArtifactVersion(ProjectGraph graph, String groupId, String artifactId) {
-        String nodeId = "maven:" + groupId + ":" + artifactId;
-        var node = graph.getNode(nodeId);
-        if (node != null) {
-            String version = node.properties().get("version");
-            if (version != null && !"managed".equals(version) && !"unknown".equals(version)
-                    && !version.contains("${")) {
-                return version;
-            }
-        }
-        return null;
-    }
-
-    private void createConfigFile(
-            Path dir, String name,
-            String ai, AgentConfig agent)
-            throws Exception {
-        String cmdPrefix = detectCommandPrefix();
-        java.util.Properties config = new java.util.Properties();
-        config.setProperty("project.name", name);
-        config.setProperty("project.command-prefix", cmdPrefix);
-        config.setProperty("agent.name", ai);
-        config.setProperty("agent.folder", agent.folder());
-        if (sourcePlatform != null && !"auto".equals(sourcePlatform)) {
-            config.setProperty("project.sourcePlatform", sourcePlatform);
-        }
-
-        Path configFile = dir.resolve("config.properties");
-        try (var out = Files.newOutputStream(configFile)) {
-            config.store(out, "Camel-Kit Project Configuration");
-        }
-    }
-
-    private void updateConfigWithRuntime(Path dir, ProjectGraph graph) throws Exception {
-        Path configFile = dir.resolve("config.properties");
-        java.util.Properties config = new java.util.Properties();
-
-        // Load existing properties
-        if (Files.exists(configFile)) {
-            try (var in = Files.newInputStream(configFile)) {
-                config.load(in);
-            }
-        }
-
-        // Detect and set runtime
-        String runtime = RuntimeDetector.detect(graph);
-        config.setProperty("project.runtime", runtime);
-
-        // Write back
-        try (var out = Files.newOutputStream(configFile)) {
-            config.store(out, "Camel-Kit Project Configuration");
-        }
+    private void printSummary(String projectName, String agentName, int citrusSchemaCount) {
+        printer().println();
+        printer().print("  " + green("\u2713") + "  ");
+        printer().println(bold(projectName));
+        String meta = "     " + agentName
+                      + (citrusSchemaCount > 0 ? "  \u00b7  " + citrusSchemaCount + " schemas" : "");
+        printer().println(meta);
+        printer().println();
     }
 
     private String detectCommandPrefix() {
@@ -455,65 +245,4 @@ public class InitCommand extends CamelKitCommand {
             return "camel-kit";
         return "camel kit";
     }
-
-    private void createConstitution(Path dir) throws Exception {
-        QuteTemplateEngine qute = new QuteTemplateEngine();
-
-        String template = TemplateUtils.readTemplate("templates/constitution.md");
-
-        DistributionConfig dist = CamelKitMain.distribution();
-        String content = qute.renderString(template, Map.of(
-                "DATE", java.time.LocalDate.now(ZoneId.systemDefault()).toString(),
-                "CAMEL_VERSION", dist.camelMainVersion()));
-        Files.writeString(dir.resolve("constitution.md"), content);
-    }
-
-    private void copyAdditionalTemplates(Path templatesDir) throws Exception {
-        String[] additionalTemplates = {
-                "patterns-foundational.md",
-                "patterns-error-handling.md",
-                "patterns-deployment.md",
-                "yaml-structure.md",
-                "yaml-components.md",
-                "yaml-examples.md",
-                "validation-completeness.md",
-                "validation-constitution.md",
-                "validation-testing.md",
-                "flow.md"
-        };
-        for (String template : additionalTemplates) {
-            String content = TemplateUtils.readTemplate("templates/" + template);
-            Files.writeString(templatesDir.resolve(template), content);
-        }
-    }
-
-    private void createMavenWrapper(Path projectDir) throws Exception {
-        // Create .mvn/wrapper directory
-        Path wrapperDir = projectDir.resolve(".mvn/wrapper");
-        Files.createDirectories(wrapperDir);
-
-        // Create maven-wrapper.properties
-        String mavenVersion = "3.9.9";
-        String wrapperProps
-                = String.format(Locale.ROOT,
-                        """
-                                distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip
-                                wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
-                                """,
-                        mavenVersion, mavenVersion);
-        Files.writeString(wrapperDir.resolve("maven-wrapper.properties"), wrapperProps);
-
-        // Create mvnw (Unix script)
-        String mvnwScript = TemplateUtils.readTemplate("maven/mvnw");
-        Path mvnwPath = projectDir.resolve("mvnw");
-        Files.writeString(mvnwPath, mvnwScript);
-        mvnwPath.toFile().setExecutable(true);
-
-        // Create mvnw.cmd (Windows script)
-        String mvnwCmdScript = TemplateUtils.readTemplate("maven/mvnw.cmd");
-        Files.writeString(projectDir.resolve("mvnw.cmd"), mvnwCmdScript);
-
-        printer().println(green("✓") + " Maven Wrapper created (portable Maven " + mavenVersion + ")");
-    }
-
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorExpectations.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorExpectations.java
@@ -1,4 +1,4 @@
-package io.github.luigidemasi.camelkit.command;
+package io.github.luigidemasi.camelkit.service;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -11,9 +11,9 @@ import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
 import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
 
 /**
- * Expected generated workspace contract used by {@link DoctorCommand}.
+ * Expected generated workspace contract used by {@link DoctorService}.
  */
-final class DoctorExpectations {
+public final class DoctorExpectations {
 
     private final List<String> userCommands;
     private final List<String> requiredSkills;
@@ -31,7 +31,7 @@ final class DoctorExpectations {
         this.knowledgeMcpTools = Collections.unmodifiableSet(new LinkedHashSet<>(knowledgeMcpTools));
     }
 
-    static DoctorExpectations loadDefault() {
+    public static DoctorExpectations loadDefault() {
         try {
             return from(WorkflowManifestLoader.loadDefault());
         } catch (IOException e) {
@@ -39,7 +39,7 @@ final class DoctorExpectations {
         }
     }
 
-    static DoctorExpectations from(WorkflowManifest workflow) {
+    public static DoctorExpectations from(WorkflowManifest workflow) {
         return new DoctorExpectations(
                 workflow.generatedCommandStubs().stream()
                         .map(WorkflowManifest.WorkflowCommand::name)
@@ -51,19 +51,19 @@ final class DoctorExpectations {
                 orderedSet(workflow.mcpServer("camel-knowledge").allowedTools()));
     }
 
-    List<String> userCommands() {
+    public List<String> userCommands() {
         return userCommands;
     }
 
-    List<String> requiredSkills() {
+    public List<String> requiredSkills() {
         return requiredSkills;
     }
 
-    Set<String> camelMcpTools() {
+    public Set<String> camelMcpTools() {
         return camelMcpTools;
     }
 
-    Set<String> knowledgeMcpTools() {
+    public Set<String> knowledgeMcpTools() {
         return knowledgeMcpTools;
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorFinding.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorFinding.java
@@ -1,0 +1,39 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.util.Objects;
+
+/**
+ * Structured diagnostic produced by {@link DoctorService}.
+ */
+public record DoctorFinding(
+        Status status,
+        String category,
+        String path,
+        String message,
+        String remediation) {
+
+    public DoctorFinding {
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(category, "category");
+        Objects.requireNonNull(message, "message");
+        Objects.requireNonNull(remediation, "remediation");
+    }
+
+    public static DoctorFinding pass(String category, String path, String message, String remediation) {
+        return new DoctorFinding(Status.PASS, category, path, message, remediation);
+    }
+
+    public static DoctorFinding warn(String category, String path, String message, String remediation) {
+        return new DoctorFinding(Status.WARN, category, path, message, remediation);
+    }
+
+    public static DoctorFinding fail(String category, String path, String message, String remediation) {
+        return new DoctorFinding(Status.FAIL, category, path, message, remediation);
+    }
+
+    public enum Status {
+        PASS,
+        WARN,
+        FAIL
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorRequest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorRequest.java
@@ -1,0 +1,14 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Request for validating a generated Camel-Kit workspace.
+ */
+public record DoctorRequest(Path projectDir) {
+
+    public DoctorRequest {
+        Objects.requireNonNull(projectDir, "projectDir");
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorResult.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorResult.java
@@ -1,0 +1,24 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Result of validating a generated Camel-Kit workspace.
+ */
+public record DoctorResult(Path projectDir, List<DoctorFinding> findings) {
+
+    public DoctorResult {
+        Objects.requireNonNull(projectDir, "projectDir");
+        findings = List.copyOf(Objects.requireNonNull(findings, "findings"));
+    }
+
+    public boolean hasFailures() {
+        return findings.stream().anyMatch(finding -> finding.status() == DoctorFinding.Status.FAIL);
+    }
+
+    public long count(DoctorFinding.Status status) {
+        return findings.stream().filter(finding -> finding.status() == status).count();
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -1,0 +1,540 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.graph.GraphBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Validates generated Camel-Kit workspaces.
+ */
+public class DoctorService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration PREREQUISITE_TIMEOUT = Duration.ofSeconds(3);
+
+    private static final List<String> REQUIRED_CONFIG_KEYS = List.of(
+            "project.name", "project.command-prefix", "agent.name", "agent.folder");
+
+    private static final List<String> STALE_REFERENCES = List.of(
+            "/camel-design", ".camel-kit/business-requirements.md", ".camel-kit/flows/");
+
+    private final DoctorExpectations expectations;
+
+    public DoctorService() {
+        this(DoctorExpectations.loadDefault());
+    }
+
+    DoctorService(DoctorExpectations expectations) {
+        this.expectations = expectations;
+    }
+
+    public DoctorResult inspect(DoctorRequest request) {
+        Path root = request.projectDir().toAbsolutePath().normalize();
+        List<DoctorFinding> findings = new ArrayList<>();
+
+        Properties config = checkConfig(root, findings);
+        AgentConfig agent = checkAgentConfig(config, findings);
+        checkGeneratedWorkspace(root, agent, findings);
+        checkMcp(root, config, findings);
+        checkGraph(root, findings);
+        checkCommandPrefix(config, findings);
+        checkPrerequisites(root, findings);
+        checkStaleReferences(root, agent, findings);
+
+        return new DoctorResult(root, findings);
+    }
+
+    private Properties checkConfig(Path root, List<DoctorFinding> findings) {
+        Path configFile = root.resolve(".camel-kit/config.properties");
+        if (!Files.isRegularFile(configFile)) {
+            findings.add(DoctorFinding.fail("config", relativize(root, configFile),
+                    ".camel-kit/config.properties is missing",
+                    "Run camel-kit init --here --ai <agent> from the workspace root."));
+            return new Properties();
+        }
+
+        Properties config = new Properties();
+        try (InputStream in = Files.newInputStream(configFile)) {
+            config.load(in);
+        } catch (IOException e) {
+            findings.add(DoctorFinding.fail("config", relativize(root, configFile),
+                    "Could not read .camel-kit/config.properties: " + e.getMessage(),
+                    "Recreate the file with camel-kit init --here --force or restore it from source control."));
+            return config;
+        }
+
+        List<String> missing = REQUIRED_CONFIG_KEYS.stream()
+                .filter(key -> config.getProperty(key, "").isBlank())
+                .toList();
+        if (missing.isEmpty()) {
+            findings.add(DoctorFinding.pass("config", relativize(root, configFile),
+                    ".camel-kit/config.properties contains the required keys",
+                    "No action required."));
+        } else {
+            findings.add(DoctorFinding.fail("config", relativize(root, configFile),
+                    ".camel-kit/config.properties is missing keys: " + String.join(", ", missing),
+                    "Restore the missing keys or re-run camel-kit init --here --ai <agent> --force."));
+        }
+        return config;
+    }
+
+    private AgentConfig checkAgentConfig(Properties config, List<DoctorFinding> findings) {
+        String agentName = config.getProperty("agent.name", "").trim();
+        if (agentName.isEmpty()) {
+            findings.add(DoctorFinding.fail("config", ".camel-kit/config.properties",
+                    "agent.name is not configured",
+                    "Set agent.name to one of: " + String.join(", ", AgentRegistry.names()) + "."));
+            return null;
+        }
+        if (!AgentRegistry.contains(agentName)) {
+            findings.add(DoctorFinding.fail("config", ".camel-kit/config.properties",
+                    "Unknown agent.name '" + agentName + "'",
+                    "Set agent.name to one of: " + String.join(", ", AgentRegistry.names()) + "."));
+            return null;
+        }
+
+        AgentConfig agent = AgentRegistry.get(agentName);
+        String folder = config.getProperty("agent.folder", "").trim();
+        if (agent.folder().equals(folder)) {
+            findings.add(DoctorFinding.pass("config", ".camel-kit/config.properties",
+                    "Agent configuration selects " + agent.name(),
+                    "No action required."));
+        } else {
+            findings.add(DoctorFinding.fail("config", ".camel-kit/config.properties",
+                    "agent.folder is '" + folder + "' but " + agentName + " expects '" + agent.folder() + "'",
+                    "Set agent.folder=" + agent.folder() + " or re-run camel-kit init for " + agentName + "."));
+        }
+        return agent;
+    }
+
+    private void checkGeneratedWorkspace(Path root, AgentConfig agent, List<DoctorFinding> findings) {
+        if (agent == null) {
+            findings.add(DoctorFinding.fail("workspace", null,
+                    "Cannot validate generated commands and skills without a valid agent",
+                    "Fix .camel-kit/config.properties and re-run camel-kit doctor."));
+            return;
+        }
+
+        Path commandsDir = root.resolve(agent.folder());
+        if (!Files.isDirectory(commandsDir)) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, commandsDir),
+                    "Generated command directory is missing",
+                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate commands."));
+        } else {
+            checkCommandFiles(root, commandsDir, agent, findings);
+        }
+
+        Path skillsDir = root.resolve(agent.folder()).getParent().resolve("skills");
+        if (!Files.isDirectory(skillsDir)) {
+            findings.add(DoctorFinding.fail("skills", relativize(root, skillsDir),
+                    "Generated skills directory is missing",
+                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate skills."));
+            return;
+        }
+
+        List<String> missingSkills = expectations.requiredSkills().stream()
+                .filter(skill -> !Files.isRegularFile(skillsDir.resolve(skill).resolve("SKILL.md")))
+                .toList();
+        if (missingSkills.isEmpty()) {
+            findings.add(DoctorFinding.pass("skills", relativize(root, skillsDir),
+                    "All expected skill directories contain SKILL.md",
+                    "No action required."));
+        } else {
+            findings.add(DoctorFinding.fail("skills", relativize(root, skillsDir),
+                    "Missing SKILL.md for: " + String.join(", ", missingSkills),
+                    "Restore the missing skill folders or re-run camel-kit init --here --force."));
+        }
+    }
+
+    private void checkCommandFiles(
+            Path root, Path commandsDir, AgentConfig agent, List<DoctorFinding> findings) {
+        String extension = "." + agent.fileFormat();
+        List<String> missing = expectations.userCommands().stream()
+                .filter(command -> !Files.isRegularFile(commandsDir.resolve(command + extension)))
+                .toList();
+
+        Set<String> unexpected = new LinkedHashSet<>();
+        try (Stream<Path> stream = Files.list(commandsDir)) {
+            stream.filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .filter(name -> name.startsWith("camel-"))
+                    .map(this::commandName)
+                    .filter(command -> !expectations.userCommands().contains(command))
+                    .forEach(unexpected::add);
+        } catch (IOException e) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, commandsDir),
+                    "Could not list generated command directory: " + e.getMessage(),
+                    "Check filesystem permissions and re-run camel-kit doctor."));
+            return;
+        }
+
+        if (missing.isEmpty() && unexpected.isEmpty()) {
+            findings.add(DoctorFinding.pass("workspace", relativize(root, commandsDir),
+                    "Generated user-invocable commands match the expected skill router set",
+                    "No action required."));
+            return;
+        }
+
+        List<String> problems = new ArrayList<>();
+        if (!missing.isEmpty()) {
+            problems.add("missing " + String.join(", ", missing));
+        }
+        if (!unexpected.isEmpty()) {
+            problems.add("unexpected " + String.join(", ", unexpected));
+        }
+        findings.add(DoctorFinding.fail("workspace", relativize(root, commandsDir),
+                "Generated command directory has " + String.join("; ", problems),
+                "Remove unexpected command stubs and re-run camel-kit init --here --force if required files are missing."));
+    }
+
+    private void checkMcp(Path root, Properties config, List<DoctorFinding> findings) {
+        String agentName = config.getProperty("agent.name", "").trim();
+        Path mcpFile = mcpConfigPath(root, agentName);
+        if (mcpFile == null) {
+            findings.add(DoctorFinding.fail("mcp", null,
+                    "Cannot determine MCP config path for agent '" + agentName + "'",
+                    "Fix agent.name in .camel-kit/config.properties."));
+            return;
+        }
+        if (!Files.isRegularFile(mcpFile)) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP config is missing for agent '" + agentName + "'",
+                    "Run camel-kit init --here --ai " + agentName + " --force to regenerate MCP configuration."));
+            return;
+        }
+
+        JsonNode rootNode;
+        try {
+            rootNode = MAPPER.readTree(mcpFile.toFile());
+        } catch (IOException e) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP config is not valid JSON: " + e.getMessage(),
+                    "Fix the JSON syntax or regenerate the MCP config with camel-kit init --here --force."));
+            return;
+        }
+
+        JsonNode servers = rootNode.has("mcp") ? rootNode.path("mcp") : rootNode.path("mcpServers");
+        if (!servers.isObject()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP config does not contain an mcp or mcpServers object",
+                    "Regenerate the MCP config with camel-kit init --here --force."));
+            return;
+        }
+
+        boolean camelOk = checkMcpServer(root, mcpFile, servers, "camel", expectations.camelMcpTools(), findings);
+        boolean knowledgeOk = checkMcpServer(
+                root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), findings);
+        if (camelOk && knowledgeOk) {
+            findings.add(DoctorFinding.pass("mcp", relativize(root, mcpFile),
+                    "MCP config exists and tool allowlists match Camel-Kit expectations",
+                    "No action required."));
+        }
+    }
+
+    private boolean checkMcpServer(
+            Path root, Path mcpFile, JsonNode servers, String serverName, Set<String> expected,
+            List<DoctorFinding> findings) {
+        JsonNode server = servers.path(serverName);
+        if (!server.isObject()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' is missing",
+                    "Regenerate the MCP config with camel-kit init --here --force."));
+            return false;
+        }
+
+        boolean autoApproveOk = checkAllowlist(root, mcpFile, serverName, "autoApprove", server, expected, findings);
+        boolean alwaysAllowOk = checkAllowlist(root, mcpFile, serverName, "alwaysAllow", server, expected, findings);
+        return autoApproveOk && alwaysAllowOk;
+    }
+
+    private boolean checkAllowlist(
+            Path root, Path mcpFile, String serverName, String field, JsonNode server, Set<String> expected,
+            List<DoctorFinding> findings) {
+        JsonNode node = server.path(field);
+        if (!node.isArray()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' is missing " + field + " array",
+                    "Regenerate the MCP config with camel-kit init --here --force."));
+            return false;
+        }
+
+        Set<String> actual = new LinkedHashSet<>();
+        node.forEach(value -> actual.add(value.asText()));
+        Set<String> missing = new LinkedHashSet<>(expected);
+        missing.removeAll(actual);
+        Set<String> extra = new LinkedHashSet<>(actual);
+        extra.removeAll(expected);
+        if (missing.isEmpty() && extra.isEmpty()) {
+            return true;
+        }
+
+        List<String> problems = new ArrayList<>();
+        if (!missing.isEmpty()) {
+            problems.add("missing " + String.join(", ", missing));
+        }
+        if (!extra.isEmpty()) {
+            problems.add("extra " + String.join(", ", extra));
+        }
+        findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                "MCP server '" + serverName + "' " + field + " has " + String.join("; ", problems),
+                "Regenerate the MCP config or update the allowlist to match the generated Camel-Kit tools."));
+        return false;
+    }
+
+    private void checkGraph(Path root, List<DoctorFinding> findings) {
+        Path graphFile = root.resolve(".camel-kit/project-graph.json");
+        if (Files.isRegularFile(graphFile)) {
+            try {
+                MAPPER.readTree(graphFile.toFile());
+                findings.add(DoctorFinding.pass("graph", relativize(root, graphFile),
+                        ".camel-kit/project-graph.json exists and is valid JSON",
+                        "No action required."));
+            } catch (IOException e) {
+                findings.add(DoctorFinding.fail("graph", relativize(root, graphFile),
+                        ".camel-kit/project-graph.json is not valid JSON: " + e.getMessage(),
+                        "Run camel-kit graph generate --project-dir " + root + " to regenerate it."));
+            }
+            return;
+        }
+
+        try {
+            new GraphBuilder().build(root);
+            findings.add(DoctorFinding.warn("graph", relativize(root, graphFile),
+                    ".camel-kit/project-graph.json is missing, but graph generation can run",
+                    "Run camel-kit graph generate --project-dir " + root + " to persist the graph."));
+        } catch (Exception e) {
+            findings.add(DoctorFinding.fail("graph", relativize(root, graphFile),
+                    ".camel-kit/project-graph.json is missing and graph generation failed: " + e.getMessage(),
+                    "Fix the project files reported by graph generation, then run camel-kit graph generate."));
+        }
+    }
+
+    private void checkCommandPrefix(Properties config, List<DoctorFinding> findings) {
+        String prefix = config.getProperty("project.command-prefix", "").trim();
+        if ("camel-kit".equals(prefix) || "camel kit".equals(prefix)) {
+            findings.add(DoctorFinding.pass("config", ".camel-kit/config.properties",
+                    "project.command-prefix uses a supported invocation style: " + prefix,
+                    "No action required."));
+        } else {
+            findings.add(DoctorFinding.warn("config", ".camel-kit/config.properties",
+                    "project.command-prefix is not a known invocation style: " + prefix,
+                    "Set project.command-prefix to camel-kit or camel kit, matching how this CLI is installed."));
+        }
+    }
+
+    private void checkPrerequisites(Path root, List<DoctorFinding> findings) {
+        ToolResult java = runTool(null, "java", "-version");
+        if (java.available() && javaMajorVersion(java.output()) >= 17) {
+            findings.add(DoctorFinding.pass("prerequisites", null,
+                    "Java 17+ is available",
+                    "No action required."));
+        } else if (java.available()) {
+            findings.add(DoctorFinding.warn("prerequisites", null,
+                    "Java is available but the version could not be confirmed as 17+",
+                    "Install or select JDK 17+ before running generated Camel projects."));
+        } else {
+            findings.add(DoctorFinding.warn("prerequisites", null,
+                    "Java 17+ was not found on PATH",
+                    "Install JDK 17+ before running generated Camel projects."));
+        }
+
+        Path mvnw = root.resolve(isWindows() ? "mvnw.cmd" : "mvnw");
+        if (Files.isRegularFile(mvnw)) {
+            findings.add(DoctorFinding.pass("prerequisites", relativize(root, mvnw),
+                    "Maven Wrapper is present",
+                    "No action required."));
+        } else if (runTool(root, "mvn", "-version").available()) {
+            findings.add(DoctorFinding.warn("prerequisites", null,
+                    "Maven is available, but the generated Maven Wrapper is missing",
+                    "Run camel-kit init --here --force to restore mvnw and .mvn/wrapper."));
+        } else {
+            findings.add(DoctorFinding.warn("prerequisites", null,
+                    "Neither Maven Wrapper nor mvn was found",
+                    "Install Maven or restore the generated Maven Wrapper with camel-kit init --here --force."));
+        }
+
+        if (runTool(null, "jbang", "version").available()) {
+            findings.add(DoctorFinding.pass("prerequisites", null,
+                    "JBang is available for MCP server launch commands",
+                    "No action required."));
+        } else {
+            findings.add(DoctorFinding.warn("prerequisites", null,
+                    "JBang was not found on PATH",
+                    "Install JBang so generated MCP server commands can run."));
+        }
+
+        if (runTool(null, "camel", "--version").available()) {
+            findings.add(DoctorFinding.pass("prerequisites", null,
+                    "Camel JBang is available",
+                    "No action required."));
+        } else {
+            findings.add(DoctorFinding.warn("prerequisites", null,
+                    "Camel JBang was not found on PATH",
+                    "Install Camel JBang for local graph, validation, and verification workflows."));
+        }
+    }
+
+    private void checkStaleReferences(Path root, AgentConfig agent, List<DoctorFinding> findings) {
+        List<Path> activeFiles = new ArrayList<>();
+        addIfExists(activeFiles, root.resolve("AGENTS.md"));
+        addIfExists(activeFiles, root.resolve("CLAUDE.md"));
+        addIfExists(activeFiles, root.resolve("GEMINI.md"));
+        addIfExists(activeFiles, root.resolve("QWEN.md"));
+        addIfExists(activeFiles, root.resolve("opencode.json"));
+        if (agent != null) {
+            Path commandsDir = root.resolve(agent.folder());
+            if (Files.isDirectory(commandsDir)) {
+                try (Stream<Path> stream = Files.list(commandsDir)) {
+                    stream.filter(Files::isRegularFile).forEach(activeFiles::add);
+                } catch (IOException e) {
+                    findings.add(DoctorFinding.warn("workspace", relativize(root, commandsDir),
+                            "Could not scan generated command files for stale references: " + e.getMessage(),
+                            "Check filesystem permissions and re-run camel-kit doctor."));
+                }
+            }
+            addIfExists(activeFiles, mcpConfigPath(root, agentKey(agent)));
+        }
+
+        Map<Path, List<String>> matches = new LinkedHashMap<>();
+        for (Path file : activeFiles) {
+            try {
+                String content = Files.readString(file, StandardCharsets.UTF_8);
+                List<String> found = STALE_REFERENCES.stream()
+                        .filter(content::contains)
+                        .toList();
+                if (!found.isEmpty()) {
+                    matches.put(file, found);
+                }
+            } catch (IOException e) {
+                findings.add(DoctorFinding.warn("workspace", relativize(root, file),
+                        "Could not scan active generated file for stale references: " + e.getMessage(),
+                        "Check filesystem permissions and re-run camel-kit doctor."));
+            }
+        }
+
+        if (matches.isEmpty()) {
+            findings.add(DoctorFinding.pass("workspace", null,
+                    "Active generated files do not contain common stale resource references",
+                    "No action required."));
+            return;
+        }
+
+        List<String> details = matches.entrySet().stream()
+                .map(entry -> relativize(root, entry.getKey()) + " -> " + String.join(", ", entry.getValue()))
+                .toList();
+        findings.add(DoctorFinding.fail("workspace", null,
+                "Active generated files contain stale references: " + String.join("; ", details),
+                "Regenerate the workspace or update the listed files to current Camel-Kit paths and commands."));
+    }
+
+    private ToolResult runTool(Path directory, String... command) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            if (directory != null) {
+                pb.directory(directory.toFile());
+            }
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            boolean finished = process.waitFor(PREREQUISITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                return new ToolResult(false, "");
+            }
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return new ToolResult(process.exitValue() == 0, output);
+        } catch (Exception e) {
+            return new ToolResult(false, "");
+        }
+    }
+
+    private int javaMajorVersion(String output) {
+        Matcher matcher = Pattern.compile("version\\s+\"([^\"]+)\"").matcher(output);
+        if (!matcher.find()) {
+            return 0;
+        }
+        String version = matcher.group(1);
+        if (version.startsWith("1.")) {
+            String[] parts = version.split("\\.");
+            return parts.length > 1 ? parseInt(parts[1]) : 0;
+        }
+        return parseInt(version.split("[.+\\-]")[0]);
+    }
+
+    private int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private Path mcpConfigPath(Path root, String agentName) {
+        return switch (agentName.toLowerCase(Locale.ROOT)) {
+            case "claude" -> root.resolve(".mcp.json");
+            case "bob" -> root.resolve(".bob/mcp.json");
+            case "gemini" -> root.resolve(".gemini/settings.json");
+            case "qwen" -> root.resolve(".qwen/settings.json");
+            case "opencode" -> root.resolve("opencode.json");
+            default -> null;
+        };
+    }
+
+    private String commandName(String filename) {
+        int dot = filename.indexOf('.');
+        return dot == -1 ? filename : filename.substring(0, dot);
+    }
+
+    private String agentKey(AgentConfig agent) {
+        return AgentRegistry.all().entrySet().stream()
+                .filter(entry -> entry.getValue().equals(agent))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(agent.name());
+    }
+
+    private String relativize(Path root, Path path) {
+        if (path == null) {
+            return null;
+        }
+        try {
+            return root.relativize(path.toAbsolutePath().normalize()).toString();
+        } catch (IllegalArgumentException e) {
+            return path.toString();
+        }
+    }
+
+    private void addIfExists(List<Path> paths, Path path) {
+        if (path != null && Files.isRegularFile(path)) {
+            paths.add(path);
+        }
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    record ToolResult(boolean available, String output) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -14,14 +14,13 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.graph.GraphBuilder;
+import io.github.luigidemasi.camelkit.util.PrerequisiteChecker;
+import io.github.luigidemasi.camelkit.util.ProcessRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -450,44 +449,13 @@ public class DoctorService {
     }
 
     private ToolResult runTool(Path directory, String... command) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder(command);
-            if (directory != null) {
-                pb.directory(directory.toFile());
-            }
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-            boolean finished = process.waitFor(PREREQUISITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-            if (!finished) {
-                process.destroyForcibly();
-                return new ToolResult(false, "");
-            }
-            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            return new ToolResult(process.exitValue() == 0, output);
-        } catch (Exception e) {
-            return new ToolResult(false, "");
-        }
+        ProcessRunner.Result result = ProcessRunner.run(directory, PREREQUISITE_TIMEOUT, command);
+        return new ToolResult(result.succeeded(), result.output());
     }
 
     private int javaMajorVersion(String output) {
-        Matcher matcher = Pattern.compile("version\\s+\"([^\"]+)\"").matcher(output);
-        if (!matcher.find()) {
-            return 0;
-        }
-        String version = matcher.group(1);
-        if (version.startsWith("1.")) {
-            String[] parts = version.split("\\.");
-            return parts.length > 1 ? parseInt(parts[1]) : 0;
-        }
-        return parseInt(version.split("[.+\\-]")[0]);
-    }
-
-    private int parseInt(String value) {
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
+        String version = PrerequisiteChecker.parseJavaVersion(output);
+        return version == null ? 0 : PrerequisiteChecker.parseMajorVersion(version);
     }
 
     private Path mcpConfigPath(Path root, String agentName) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitGraphSummary.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitGraphSummary.java
@@ -1,0 +1,19 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Project graph generated during initialization.
+ */
+public record InitGraphSummary(
+        Path graphFile,
+        int nodeCount,
+        int edgeCount,
+        String detectedProjectType,
+        String detectedRuntime) {
+
+    public InitGraphSummary {
+        Objects.requireNonNull(graphFile, "graphFile");
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitProgress.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitProgress.java
@@ -1,0 +1,23 @@
+package io.github.luigidemasi.camelkit.service;
+
+/**
+ * Receives initialization task lifecycle events without coupling services to a specific UI.
+ */
+public interface InitProgress {
+
+    void startTask(String icon, String label);
+
+    void finishTask();
+
+    static InitProgress noop() {
+        return new InitProgress() {
+            @Override
+            public void startTask(String icon, String label) {
+            }
+
+            @Override
+            public void finishTask() {
+            }
+        };
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitReporter.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitReporter.java
@@ -1,0 +1,35 @@
+package io.github.luigidemasi.camelkit.service;
+
+/**
+ * Receives user-facing initialization events for command-layer rendering.
+ */
+public interface InitReporter {
+
+    void mavenWrapperCreated(String mavenVersion);
+
+    void graphBuilt(InitGraphSummary graph);
+
+    void graphSkipped();
+
+    void warning(InitWarning warning);
+
+    static InitReporter noop() {
+        return new InitReporter() {
+            @Override
+            public void mavenWrapperCreated(String mavenVersion) {
+            }
+
+            @Override
+            public void graphBuilt(InitGraphSummary graph) {
+            }
+
+            @Override
+            public void graphSkipped() {
+            }
+
+            @Override
+            public void warning(InitWarning warning) {
+            }
+        };
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitRequest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitRequest.java
@@ -1,0 +1,42 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+/**
+ * Request for initializing a Camel-Kit workspace.
+ */
+public record InitRequest(
+        String projectName,
+        String agentName,
+        Path targetDir,
+        String citrusVersion,
+        boolean noFetch,
+        String sourcePlatform,
+        String commandPrefix,
+        String defaultCitrusVersion,
+        DistributionConfig distribution,
+        Printer printer,
+        InitProgress progress,
+        InitReporter reporter) {
+
+    public InitRequest {
+        Objects.requireNonNull(projectName, "projectName");
+        Objects.requireNonNull(agentName, "agentName");
+        Objects.requireNonNull(targetDir, "targetDir");
+        Objects.requireNonNull(citrusVersion, "citrusVersion");
+        Objects.requireNonNull(commandPrefix, "commandPrefix");
+        Objects.requireNonNull(defaultCitrusVersion, "defaultCitrusVersion");
+        Objects.requireNonNull(distribution, "distribution");
+        Objects.requireNonNull(printer, "printer");
+        progress = progress == null ? InitProgress.noop() : progress;
+        reporter = reporter == null ? InitReporter.noop() : reporter;
+    }
+
+    String resolvedCitrusVersion() {
+        return "default".equals(citrusVersion) ? defaultCitrusVersion : citrusVersion;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitResult.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitResult.java
@@ -1,0 +1,40 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+
+/**
+ * Result of initializing a Camel-Kit workspace.
+ */
+public record InitResult(
+        String projectName,
+        String agentName,
+        AgentConfig agent,
+        Path targetDir,
+        Path camelKitDir,
+        Path commandsDir,
+        Path skillsDir,
+        String citrusVersion,
+        int citrusSchemaCount,
+        String mavenWrapperVersion,
+        InitGraphSummary graph,
+        List<Path> createdPaths,
+        List<InitWarning> warnings) {
+
+    public InitResult {
+        Objects.requireNonNull(projectName, "projectName");
+        Objects.requireNonNull(agentName, "agentName");
+        Objects.requireNonNull(agent, "agent");
+        Objects.requireNonNull(targetDir, "targetDir");
+        Objects.requireNonNull(camelKitDir, "camelKitDir");
+        Objects.requireNonNull(commandsDir, "commandsDir");
+        Objects.requireNonNull(skillsDir, "skillsDir");
+        Objects.requireNonNull(citrusVersion, "citrusVersion");
+        Objects.requireNonNull(mavenWrapperVersion, "mavenWrapperVersion");
+        createdPaths = List.copyOf(Objects.requireNonNull(createdPaths, "createdPaths"));
+        warnings = List.copyOf(Objects.requireNonNull(warnings, "warnings"));
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
@@ -1,0 +1,381 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import io.github.luigidemasi.camelkit.catalog.CitrusSchemaDownloader;
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
+import io.github.luigidemasi.camelkit.generator.InitContext;
+import io.github.luigidemasi.camelkit.generator.QuteTemplateEngine;
+import io.github.luigidemasi.camelkit.graph.GraphBuilder;
+import io.github.luigidemasi.camelkit.graph.GraphSerializer;
+import io.github.luigidemasi.camelkit.graph.ProjectGraph;
+import io.github.luigidemasi.camelkit.graph.RuntimeDetector;
+import io.github.luigidemasi.camelkit.graph.model.NodeType;
+import io.github.luigidemasi.camelkit.util.TemplateUtils;
+
+/**
+ * Initializes Camel-Kit workspaces.
+ */
+public class InitService {
+
+    private static final String MAVEN_WRAPPER_VERSION = "3.9.9";
+
+    public InitResult initialize(InitRequest request) throws Exception {
+        AgentConfig agent = AgentRegistry.get(request.agentName());
+        if (agent == null) {
+            throw new IllegalArgumentException("Unknown agent: " + request.agentName());
+        }
+
+        Path targetDir = request.targetDir();
+        Path camelKitDir = targetDir.resolve(".camel-kit");
+        Path commandsDir = targetDir.resolve(agent.folder());
+        Path docsDir = targetDir.resolve("docs");
+        Path skillsDir = commandsDir.getParent().resolve("skills");
+        String citrusVersion = request.resolvedCitrusVersion();
+
+        List<Path> createdPaths = new ArrayList<>();
+        List<InitWarning> warnings = new ArrayList<>();
+        InitProgress progress = request.progress();
+
+        progress.startTask("\uD83D\uDCC1", "Creating project structure");
+        createProjectStructure(targetDir, commandsDir, camelKitDir, docsDir, createdPaths);
+        progress.finishTask();
+
+        progress.startTask("\uD83D\uDCDD", "Writing configuration");
+        createConfigFile(camelKitDir, request.projectName(), request.agentName(), agent, request, createdPaths);
+        createConstitution(docsDir, request, createdPaths);
+        copyAdditionalTemplates(camelKitDir.resolve("templates"), createdPaths);
+        progress.finishTask();
+
+        progress.startTask("\uD83E\uDD16", "Generating " + agent.name() + " workspace");
+        Path agentBaseDir = targetDir.resolve(agent.folder()).getParent();
+        InitContext genCtx = new InitContext(
+                agent, request.agentName(), commandsDir,
+                agentBaseDir.resolve("skills"), targetDir,
+                request.commandPrefix(), request.printer());
+        AgentGeneratorFactory.create(request.agentName()).generate(genCtx);
+        progress.finishTask();
+
+        progress.startTask("\uD83D\uDD0C", "Configuring Maven wrapper");
+        createMavenWrapper(targetDir, createdPaths);
+        request.reporter().mavenWrapperCreated(MAVEN_WRAPPER_VERSION);
+        progress.finishTask();
+
+        progress.startTask("\uD83D\uDD0D", "Building project graph");
+        InitGraphSummary graph = buildProjectGraph(targetDir, camelKitDir, request, warnings, createdPaths);
+        progress.finishTask();
+
+        int citrusSchemaCount = 0;
+        if (!request.noFetch()) {
+            progress.startTask("\u2B07\uFE0F", "Downloading Citrus schemas");
+            citrusSchemaCount = fetchCitrusSchemas(camelKitDir, citrusVersion, request, warnings);
+            progress.finishTask();
+        }
+
+        return new InitResult(
+                request.projectName(), request.agentName(), agent, targetDir, camelKitDir, commandsDir, skillsDir,
+                citrusVersion, citrusSchemaCount, MAVEN_WRAPPER_VERSION, graph, createdPaths, warnings);
+    }
+
+    private void createProjectStructure(
+            Path targetDir, Path commandsDir, Path camelKitDir, Path docsDir, List<Path> createdPaths)
+            throws Exception {
+        createDirectory(targetDir, createdPaths);
+        createDirectory(commandsDir, createdPaths);
+        createDirectory(camelKitDir, createdPaths);
+        createDirectory(docsDir.resolve("flows"), createdPaths);
+        createDirectory(camelKitDir.resolve("templates"), createdPaths);
+        createDirectory(camelKitDir.resolve(".cache"), createdPaths);
+        createDirectory(targetDir.resolve("test/data"), createdPaths);
+        createDirectory(targetDir.resolve("schemas"), createdPaths);
+    }
+
+    private void createDirectory(Path path, List<Path> createdPaths) throws Exception {
+        Files.createDirectories(path);
+        createdPaths.add(path);
+    }
+
+    private void createConfigFile(
+            Path dir,
+            String name,
+            String agentName,
+            AgentConfig agent,
+            InitRequest request,
+            List<Path> createdPaths)
+            throws Exception {
+        Properties config = new Properties();
+        config.setProperty("project.name", name);
+        config.setProperty("project.command-prefix", request.commandPrefix());
+        config.setProperty("agent.name", agentName);
+        config.setProperty("agent.folder", agent.folder());
+        if (request.sourcePlatform() != null && !"auto".equals(request.sourcePlatform())) {
+            config.setProperty("project.sourcePlatform", request.sourcePlatform());
+        }
+
+        Path configFile = dir.resolve("config.properties");
+        try (var out = Files.newOutputStream(configFile)) {
+            config.store(out, "Camel-Kit Project Configuration");
+        }
+        createdPaths.add(configFile);
+    }
+
+    private void createConstitution(Path dir, InitRequest request, List<Path> createdPaths) throws Exception {
+        QuteTemplateEngine qute = new QuteTemplateEngine();
+        String template = TemplateUtils.readTemplate("templates/constitution.md");
+
+        String content = qute.renderString(template, Map.of(
+                "DATE", LocalDate.now(ZoneId.systemDefault()).toString(),
+                "CAMEL_VERSION", request.distribution().camelMainVersion()));
+        Path constitution = dir.resolve("constitution.md");
+        Files.writeString(constitution, content);
+        createdPaths.add(constitution);
+    }
+
+    private void copyAdditionalTemplates(Path templatesDir, List<Path> createdPaths) throws Exception {
+        String[] additionalTemplates = {
+                "patterns-foundational.md",
+                "patterns-error-handling.md",
+                "patterns-deployment.md",
+                "yaml-structure.md",
+                "yaml-components.md",
+                "yaml-examples.md",
+                "validation-completeness.md",
+                "validation-constitution.md",
+                "validation-testing.md",
+                "flow.md"
+        };
+        for (String template : additionalTemplates) {
+            String content = TemplateUtils.readTemplate("templates/" + template);
+            Path target = templatesDir.resolve(template);
+            Files.writeString(target, content);
+            createdPaths.add(target);
+        }
+    }
+
+    private void createMavenWrapper(Path projectDir, List<Path> createdPaths) throws Exception {
+        Path wrapperDir = projectDir.resolve(".mvn/wrapper");
+        createDirectory(wrapperDir, createdPaths);
+
+        String wrapperProps
+                = String.format(Locale.ROOT,
+                        """
+                                distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip
+                                wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
+                                """,
+                        MAVEN_WRAPPER_VERSION, MAVEN_WRAPPER_VERSION);
+        Path wrapperProperties = wrapperDir.resolve("maven-wrapper.properties");
+        Files.writeString(wrapperProperties, wrapperProps);
+        createdPaths.add(wrapperProperties);
+
+        String mvnwScript = TemplateUtils.readTemplate("maven/mvnw");
+        Path mvnwPath = projectDir.resolve("mvnw");
+        Files.writeString(mvnwPath, mvnwScript);
+        mvnwPath.toFile().setExecutable(true);
+        createdPaths.add(mvnwPath);
+
+        String mvnwCmdScript = TemplateUtils.readTemplate("maven/mvnw.cmd");
+        Path mvnwCmd = projectDir.resolve("mvnw.cmd");
+        Files.writeString(mvnwCmd, mvnwCmdScript);
+        createdPaths.add(mvnwCmd);
+    }
+
+    private InitGraphSummary buildProjectGraph(
+            Path targetDir,
+            Path camelKitDir,
+            InitRequest request,
+            List<InitWarning> warnings,
+            List<Path> createdPaths)
+            throws Exception {
+        Path graphFile = camelKitDir.resolve("project-graph.json");
+        try {
+            ProjectGraph projectGraph = new GraphBuilder().build(targetDir);
+            if (projectGraph.nodeCount() > 0) {
+                GraphSerializer.write(projectGraph, graphFile, targetDir.toAbsolutePath().toString());
+                createdPaths.add(graphFile);
+                String detectedProjectType = detectProjectType(projectGraph);
+                String detectedRuntime = updateConfigWithRuntime(camelKitDir, projectGraph);
+                InitGraphSummary graph = new InitGraphSummary(
+                        graphFile,
+                        projectGraph.nodeCount(),
+                        projectGraph.edgeCount(),
+                        detectedProjectType,
+                        detectedRuntime);
+                request.reporter().graphBuilt(graph);
+                return graph;
+            }
+            InitGraphSummary graph = new InitGraphSummary(graphFile, 0, 0, "", "");
+            request.reporter().graphSkipped();
+            return graph;
+        } catch (Exception e) {
+            reportWarning(request, warnings, "Could not build project graph: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private int fetchCitrusSchemas(
+            Path camelKitDir, String citrusVersion, InitRequest request, List<InitWarning> warnings) {
+        try {
+            CitrusSchemaDownloader citrusDownloader = new CitrusSchemaDownloader(camelKitDir.resolve(".cache"));
+            citrusDownloader.fetchCitrusSchemas(citrusVersion, false, request.printer()::println);
+            Path citrusSchemasDir = citrusDownloader.getCitrusSchemasDir(citrusVersion);
+            if (Files.exists(citrusSchemasDir)) {
+                try (var paths = Files.walk(citrusSchemasDir)) {
+                    return (int) paths
+                            .filter(p -> p.toString().endsWith(".json"))
+                            .count();
+                }
+            }
+        } catch (Exception e) {
+            reportWarning(request, warnings, "Could not fetch Citrus schemas: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private void reportWarning(InitRequest request, List<InitWarning> warnings, String message) {
+        InitWarning warning = new InitWarning(message);
+        warnings.add(warning);
+        request.reporter().warning(warning);
+    }
+
+    private String updateConfigWithRuntime(Path dir, ProjectGraph graph) throws Exception {
+        Path configFile = dir.resolve("config.properties");
+        Properties config = new Properties();
+
+        if (Files.exists(configFile)) {
+            try (var in = Files.newInputStream(configFile)) {
+                config.load(in);
+            }
+        }
+
+        String runtime = RuntimeDetector.detect(graph);
+        config.setProperty("project.runtime", runtime);
+
+        try (var out = Files.newOutputStream(configFile)) {
+            config.store(out, "Camel-Kit Project Configuration");
+        }
+        return runtime;
+    }
+
+    private String detectProjectType(ProjectGraph graph) {
+        var types = new ArrayList<String>();
+
+        if (!graph.findByType(NodeType.MULE_FLOW).isEmpty()) {
+            int flows = graph.findByType(NodeType.MULE_FLOW).size();
+            int subFlows = graph.findByType(NodeType.MULE_SUB_FLOW).size();
+            int dwl = graph.findByType(NodeType.DATAWEAVE_SCRIPT).size();
+            String muleVersion = findMavenProperty(graph, "mule.version");
+            if (muleVersion == null)
+                muleVersion = findMavenProperty(graph, "app.runtime");
+            if (muleVersion == null)
+                muleVersion = findArtifactVersion(graph, "org.mule.runtime", "mule-core");
+            if (muleVersion == null)
+                muleVersion = findArtifactVersion(graph, "org.mule", "mule-core");
+            types.add("MuleSoft Mule" + (muleVersion != null ? " " + muleVersion : "")
+                      + " (" + flows + " flows, " + subFlows + " sub-flows"
+                      + (dwl > 0 ? ", " + dwl + " DataWeave scripts" : "") + ")");
+        }
+
+        int orchs = graph.findByType(NodeType.BIZTALK_ORCHESTRATION).size();
+        int maps = graph.findByType(NodeType.BIZTALK_MAP).size();
+        int pipelines = graph.findByType(NodeType.BIZTALK_PIPELINE).size();
+        if (orchs > 0 || maps > 0 || pipelines > 0) {
+            types.add("Microsoft BizTalk (" + orchs + " orchestrations"
+                      + (maps > 0 ? ", " + maps + " maps" : "")
+                      + (pipelines > 0 ? ", " + pipelines + " pipelines" : "") + ")");
+        }
+
+        if (!graph.findByType(NodeType.CAMEL_ROUTE).isEmpty()) {
+            int routes = graph.findByType(NodeType.CAMEL_ROUTE).size();
+            String camelVersion = detectCamelVersion(graph);
+            String platform = detectCamelPlatform(graph);
+            types.add(platform + (camelVersion != null ? " " + camelVersion : "")
+                      + " (" + routes + " routes)");
+        }
+
+        if (!graph.findByType(NodeType.MAVEN_ARTIFACT).isEmpty() && types.isEmpty()) {
+            types.add("Maven project");
+        }
+
+        return String.join(", ", types);
+    }
+
+    private String detectCamelVersion(ProjectGraph graph) {
+        String version = findMavenProperty(graph, "camel.version");
+        if (version != null)
+            return version;
+
+        version = findArtifactVersion(graph, "org.apache.camel", "camel-core");
+        if (version != null)
+            return version;
+
+        version = findArtifactVersion(graph, "org.apache.camel", "camel-bom");
+        if (version != null)
+            return version;
+
+        for (var node : graph.findByType(NodeType.MAVEN_ARTIFACT)) {
+            if ("org.apache.camel".equals(node.properties().get("groupId"))) {
+                String v = node.properties().get("version");
+                if (v != null && !"managed".equals(v) && !"unknown".equals(v) && !v.contains("${")) {
+                    return v;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private String detectCamelPlatform(ProjectGraph graph) {
+        for (var node : graph.findByType(NodeType.MAVEN_ARTIFACT)) {
+            String file = node.properties().get("file");
+            if (file != null && file.contains("pom.xml")) {
+                String groupId = node.properties().getOrDefault("groupId", "");
+                if (groupId.contains("jboss.fuse") || groupId.contains("fusesource")) {
+                    return "JBoss Fuse";
+                }
+            }
+        }
+
+        for (var node : graph.findByType(NodeType.MAVEN_ARTIFACT)) {
+            String v = node.properties().getOrDefault("version", "");
+            if (v.contains(".fuse-") || v.contains(".redhat-")) {
+                return "JBoss Fuse";
+            }
+        }
+
+        return "Apache Camel";
+    }
+
+    private String findMavenProperty(ProjectGraph graph, String propertyName) {
+        var node = graph.getNode("maven-property:" + propertyName);
+        if (node != null) {
+            String value = node.properties().get("value");
+            if (value != null && !value.isEmpty() && !value.contains("${")) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String findArtifactVersion(ProjectGraph graph, String groupId, String artifactId) {
+        String nodeId = "maven:" + groupId + ":" + artifactId;
+        var node = graph.getNode(nodeId);
+        if (node != null) {
+            String version = node.properties().get("version");
+            if (version != null && !"managed".equals(version) && !"unknown".equals(version)
+                    && !version.contains("${")) {
+                return version;
+            }
+        }
+        return null;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitWarning.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitWarning.java
@@ -1,0 +1,13 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.util.Objects;
+
+/**
+ * Non-fatal problem encountered while initializing a workspace.
+ */
+public record InitWarning(String message) {
+
+    public InitWarning {
+        Objects.requireNonNull(message, "message");
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/PrerequisiteChecker.java
@@ -1,12 +1,9 @@
 package io.github.luigidemasi.camelkit.util;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,7 +15,7 @@ import io.github.luigidemasi.camelkit.output.Printer;
  */
 public final class PrerequisiteChecker {
 
-    private static final int TIMEOUT_SECONDS = 5;
+    private static final Duration PREREQUISITE_TIMEOUT = Duration.ofSeconds(5);
     private static final int MIN_JAVA_VERSION = 17;
 
     private PrerequisiteChecker() {
@@ -59,28 +56,20 @@ public final class PrerequisiteChecker {
     // ------------------------------------------------------------------
 
     private static CheckResult checkJava() {
-        try {
-            ProcessBuilder pb = new ProcessBuilder("java", "-version");
-            pb.redirectErrorStream(true);
-            Process proc = pb.start();
-
-            String output = drainWithTimeout(proc);
-            if (output == null) {
-                return new CheckResult("Java 17+", false, null, null);
-            }
-
-            String version = parseJavaVersion(output);
-            if (version != null) {
-                int major = parseMajorVersion(version);
-                if (major >= MIN_JAVA_VERSION) {
-                    return new CheckResult("Java 17+", true, version, null);
-                }
-                return new CheckResult("Java 17+", false, null, "found " + version + ", need 17+");
-            }
-            return new CheckResult("Java 17+", false, null, null);
-        } catch (Exception e) {
+        ProcessRunner.Result result = ProcessRunner.run(PREREQUISITE_TIMEOUT, "java", "-version");
+        if (!result.completed()) {
             return new CheckResult("Java 17+", false, null, null);
         }
+
+        String version = parseJavaVersion(result.output());
+        if (version != null) {
+            int major = parseMajorVersion(version);
+            if (major >= MIN_JAVA_VERSION) {
+                return new CheckResult("Java 17+", true, version, null);
+            }
+            return new CheckResult("Java 17+", false, null, "found " + version + ", need 17+");
+        }
+        return new CheckResult("Java 17+", false, null, null);
     }
 
     private static CheckResult checkJBang() {
@@ -108,58 +97,23 @@ public final class PrerequisiteChecker {
     // ------------------------------------------------------------------
 
     private static CheckResult runSimpleCheck(String name, String[] command, boolean ignoreOutput) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder(command);
-            pb.redirectErrorStream(true);
-            Process proc = pb.start();
-
-            String output = drainWithTimeout(proc);
-            if (output == null) {
-                return new CheckResult(name, false, null, null);
-            }
-
-            if (proc.exitValue() == 0) {
-                String version = ignoreOutput ? "installed" : extractFirstLine(output);
-                return new CheckResult(name, true, version, null);
-            }
-            return new CheckResult(name, false, null, null);
-        } catch (Exception e) {
+        ProcessRunner.Result result = ProcessRunner.run(PREREQUISITE_TIMEOUT, command);
+        if (!result.completed()) {
             return new CheckResult(name, false, null, null);
         }
-    }
 
-    /**
-     * Drain process output in a daemon thread while the main thread holds the timed wait. Returns the output string, or
-     * null if the process timed out.
-     */
-    private static String drainWithTimeout(Process proc) throws InterruptedException {
-        StringBuilder sb = new StringBuilder();
-        Thread drainer = new Thread(() -> {
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
-                reader.lines().forEach(line -> sb.append(line).append('\n'));
-            } catch (java.io.IOException ignored) {
-            }
-        });
-        drainer.setDaemon(true);
-        drainer.start();
-
-        if (!proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            proc.destroyForcibly();
-            return null;
+        if (result.succeeded()) {
+            String version = ignoreOutput ? "installed" : extractFirstLine(result.output());
+            return new CheckResult(name, true, version, null);
         }
-        try {
-            drainer.join(500);
-        } catch (InterruptedException ignored) {
-        }
-        return sb.toString().trim();
+        return new CheckResult(name, false, null, null);
     }
 
     /**
      * Parse the Java version from {@code java -version} output. Handles both the old format
      * ({@code java version "1.8.0_xxx"}) and the modern format ({@code openjdk version "17.0.1"}).
      */
-    static String parseJavaVersion(String output) {
+    public static String parseJavaVersion(String output) {
         Pattern pattern = Pattern.compile("version\\s+\"([^\"]+)\"");
         Matcher matcher = pattern.matcher(output);
         if (matcher.find()) {
@@ -171,7 +125,7 @@ public final class PrerequisiteChecker {
     /**
      * Extract the major version number. Handles {@code 1.8.0_xxx} (returns 8) and {@code 17.0.1} (returns 17).
      */
-    static int parseMajorVersion(String version) {
+    public static int parseMajorVersion(String version) {
         if (version.startsWith("1.")) {
             // Old-style: 1.8.0_xxx → 8
             String[] parts = version.split("\\.");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/ProcessRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/ProcessRunner.java
@@ -1,0 +1,71 @@
+package io.github.luigidemasi.camelkit.util;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Runs short-lived external commands with timeout-bound output capture.
+ */
+public final class ProcessRunner {
+
+    private ProcessRunner() {
+        // Utility class
+    }
+
+    public static Result run(Duration timeout, String... command) {
+        return run(null, timeout, command);
+    }
+
+    public static Result run(Path directory, Duration timeout, String... command) {
+        Objects.requireNonNull(timeout, "timeout");
+        Objects.requireNonNull(command, "command");
+
+        Process process = null;
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            if (directory != null) {
+                pb.directory(directory.toFile());
+            }
+            pb.redirectErrorStream(true);
+
+            process = pb.start();
+            Process runningProcess = process;
+            StringBuffer output = new StringBuffer();
+            Thread drainer = new Thread(() -> drain(runningProcess, output));
+            drainer.setDaemon(true);
+            drainer.start();
+
+            if (!process.waitFor(timeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                process.destroyForcibly();
+                return new Result(false, -1, output.toString().trim());
+            }
+
+            drainer.join(500);
+            return new Result(true, process.exitValue(), output.toString().trim());
+        } catch (Exception e) {
+            if (process != null) {
+                process.destroyForcibly();
+            }
+            return new Result(false, -1, "");
+        }
+    }
+
+    private static void drain(Process process, StringBuffer output) {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            reader.lines().forEach(line -> output.append(line).append('\n'));
+        } catch (java.io.IOException ignored) {
+        }
+    }
+
+    public record Result(boolean completed, int exitCode, String output) {
+
+        public boolean succeeded() {
+            return completed && exitCode == 0;
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
@@ -12,6 +12,7 @@ import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
 import io.github.luigidemasi.camelkit.generator.InitContext;
 import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.service.DoctorExpectations;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -1,0 +1,124 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DoctorServiceTest {
+
+    private static final DoctorExpectations EXPECTATIONS = DoctorExpectations.loadDefault();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void healthyWorkspaceReturnsStructuredFindings() throws Exception {
+        createHealthyWorkspace(tempDir);
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertFalse(result.hasFailures());
+        assertEquals(tempDir.toAbsolutePath().normalize(), result.projectDir());
+        assertTrue(result.count(DoctorFinding.Status.PASS) > 0);
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "config"));
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "mcp"));
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "workspace"));
+    }
+
+    @Test
+    void missingConfigReturnsActionableFailure() {
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "config",
+                ".camel-kit/config.properties is missing",
+                "Run camel-kit init --here --ai <agent>"));
+    }
+
+    private void createHealthyWorkspace(Path root) throws Exception {
+        Files.createDirectories(root.resolve(".camel-kit"));
+        Files.writeString(root.resolve(".camel-kit/config.properties"), """
+                project.name=orders
+                project.command-prefix=camel-kit
+                agent.name=bob
+                agent.folder=.bob/commands
+                """);
+        Files.writeString(root.resolve(".camel-kit/project-graph.json"), "{}");
+        Files.writeString(root.resolve("AGENTS.md"), "Integration work -> /camel-start\n");
+        Files.writeString(root.resolve("mvnw"), "#!/bin/sh\n");
+
+        Path commands = root.resolve(".bob/commands");
+        Files.createDirectories(commands);
+        for (String command : EXPECTATIONS.userCommands()) {
+            Files.writeString(commands.resolve(command + ".md"),
+                    "Read .bob/skills/" + command + "/SKILL.md and follow those instructions\n");
+        }
+
+        Path skills = root.resolve(".bob/skills");
+        for (String skill : EXPECTATIONS.requiredSkills()) {
+            Path skillDir = skills.resolve(skill);
+            Files.createDirectories(skillDir);
+            Files.writeString(skillDir.resolve("SKILL.md"), "# " + skill + "\n");
+        }
+
+        Files.createDirectories(root.resolve(".bob"));
+        Files.writeString(root.resolve(".bob/mcp.json"),
+                mcpJson(EXPECTATIONS.camelMcpTools(), EXPECTATIONS.knowledgeMcpTools()));
+    }
+
+    private String mcpJson(Collection<String> camelTools, Collection<String> knowledgeTools) {
+        return String.format(Locale.ROOT, """
+                {
+                  "mcpServers": {
+                    "camel": {
+                      "command": "jbang",
+                      "autoApprove": [%s],
+                      "alwaysAllow": [%s]
+                    },
+                    "camel-knowledge": {
+                      "command": "jbang",
+                      "autoApprove": [%s],
+                      "alwaysAllow": [%s]
+                    }
+                  }
+                }
+                """, jsonArray(camelTools), jsonArray(camelTools),
+                jsonArray(knowledgeTools), jsonArray(knowledgeTools));
+    }
+
+    private String jsonArray(Collection<String> values) {
+        return values.stream()
+                .map(value -> "\"" + value + "\"")
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("");
+    }
+
+    private boolean hasFinding(DoctorResult result, DoctorFinding.Status status, String category) {
+        return hasFinding(result, status, category, null, null);
+    }
+
+    private boolean hasFinding(
+            DoctorResult result,
+            DoctorFinding.Status status,
+            String category,
+            String messageContains,
+            String remediationContains) {
+        List<DoctorFinding> findings = result.findings();
+        for (DoctorFinding finding : findings) {
+            boolean matches = status == finding.status()
+                    && category.equals(finding.category())
+                    && (messageContains == null || finding.message().contains(messageContains));
+            if (matches && (remediationContains == null || finding.remediation().contains(remediationContains))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -1,0 +1,146 @@
+package io.github.luigidemasi.camelkit.service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InitServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void initializesWorkspaceAndReturnsStructuredResult() throws Exception {
+        RecordingProgress progress = new RecordingProgress();
+        RecordingReporter reporter = new RecordingReporter();
+        Path targetDir = tempDir.resolve("orders");
+
+        InitResult result = new InitService().initialize(request(targetDir, "bob", progress, reporter));
+
+        assertEquals("orders", result.projectName());
+        assertEquals("bob", result.agentName());
+        assertEquals(targetDir, result.targetDir());
+        assertEquals("4.9.2", result.citrusVersion());
+        assertEquals(0, result.citrusSchemaCount());
+        assertEquals("3.9.9", result.mavenWrapperVersion());
+        assertFalse(result.createdPaths().isEmpty());
+
+        assertTrue(Files.isRegularFile(targetDir.resolve(".camel-kit/config.properties")));
+        assertTrue(Files.isRegularFile(targetDir.resolve("AGENTS.md")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".bob/mcp.json")));
+        assertTrue(Files.isRegularFile(targetDir.resolve("mvnw")));
+
+        String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
+        assertTrue(config.contains("project.name=orders"));
+        assertTrue(config.contains("agent.name=bob"));
+        assertTrue(config.contains("project.sourcePlatform=mulesoft"));
+
+        assertTrue(progress.events().contains("start:Creating project structure"));
+        assertTrue(progress.events().contains("start:Generating IBM Project Bob workspace"));
+        assertEquals("3.9.9", reporter.mavenVersion());
+        assertTrue(reporter.wasGraphSkipped() || reporter.graph() != null || !reporter.warnings().isEmpty());
+    }
+
+    @Test
+    void unknownAgentFailsBeforeWritingWorkspace() {
+        Path targetDir = tempDir.resolve("orders");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> new InitService().initialize(
+                        request(targetDir, "unknown-agent", InitProgress.noop(), InitReporter.noop())));
+
+        assertEquals("Unknown agent: unknown-agent", error.getMessage());
+        assertFalse(Files.exists(targetDir));
+    }
+
+    private InitRequest request(
+            Path targetDir,
+            String agentName,
+            InitProgress progress,
+            InitReporter reporter) {
+        return new InitRequest(
+                "orders",
+                agentName,
+                targetDir,
+                "default",
+                true,
+                "mulesoft",
+                "camel-kit",
+                "4.9.2",
+                DistributionConfig.load(new Properties()),
+                Printer.noop(),
+                progress,
+                reporter);
+    }
+
+    private static final class RecordingProgress implements InitProgress {
+        private final List<String> events = new ArrayList<>();
+
+        @Override
+        public void startTask(String icon, String label) {
+            events.add("start:" + label);
+        }
+
+        @Override
+        public void finishTask() {
+            events.add("finish");
+        }
+
+        List<String> events() {
+            return events;
+        }
+    }
+
+    private static final class RecordingReporter implements InitReporter {
+        private final List<InitWarning> warnings = new ArrayList<>();
+        private String mavenVersion;
+        private InitGraphSummary graph;
+        private boolean graphSkipped;
+
+        @Override
+        public void mavenWrapperCreated(String mavenVersion) {
+            this.mavenVersion = mavenVersion;
+        }
+
+        @Override
+        public void graphBuilt(InitGraphSummary graph) {
+            this.graph = graph;
+        }
+
+        @Override
+        public void graphSkipped() {
+            graphSkipped = true;
+        }
+
+        @Override
+        public void warning(InitWarning warning) {
+            warnings.add(warning);
+        }
+
+        String mavenVersion() {
+            return mavenVersion;
+        }
+
+        InitGraphSummary graph() {
+            return graph;
+        }
+
+        boolean wasGraphSkipped() {
+            return graphSkipped;
+        }
+
+        List<InitWarning> warnings() {
+            return warnings;
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/util/ProcessRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/util/ProcessRunnerTest.java
@@ -1,0 +1,30 @@
+package io.github.luigidemasi.camelkit.util;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProcessRunnerTest {
+
+    @Test
+    void capturesSuccessfulCommandOutput() {
+        ProcessRunner.Result result = ProcessRunner.run(
+                Duration.ofSeconds(5),
+                javaExecutable().toString(),
+                "-version");
+
+        assertTrue(result.succeeded());
+        assertTrue(result.output().contains("version"));
+    }
+
+    private Path javaExecutable() {
+        String binary = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win")
+                ? "java.exe"
+                : "java";
+        return Path.of(System.getProperty("java.home"), "bin", binary);
+    }
+}


### PR DESCRIPTION
## Summary

- Extracted doctor workspace validation into `DoctorService` with structured request/result/finding types.
- Extracted init workspace creation into `InitService` with structured request/result, graph summary, warnings, and progress/reporting adapters.
- Kept CLI classes responsible for Picocli options, banners, TUI wiring, text/JSON rendering, and existing command output behavior.
- Addressed review feedback by sharing timeout-bound process execution through `ProcessRunner` and reusing `PrerequisiteChecker` Java version parsing.
- Added focused service tests and direct `ProcessRunner` coverage.

Fixes #107

## Tests

- `./mvnw -pl camel-kit-core,camel-jbang-plugin-kit test -Dformat.skip=true`
- `./mvnw clean install -DskipTests`
