### PR TITLE
Fix #104: Refactor graph builder diagnostics

### DIFF
--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuildResult.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuildResult.java
@@ -1,0 +1,14 @@
+package io.github.luigidemasi.camelkit.graph;
+
+import java.util.List;
+import java.util.Objects;
+
+public record GraphBuildResult(
+        ProjectGraph graph,
+        List<ParserDiagnostic> diagnostics) {
+
+    public GraphBuildResult {
+        Objects.requireNonNull(graph, "graph");
+        diagnostics = List.copyOf(Objects.requireNonNull(diagnostics, "diagnostics"));
+    }
+}

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuilder.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuilder.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,10 +58,12 @@ public class GraphBuilder {
     public GraphBuildResult buildWithDiagnostics(Path projectRoot) {
         ProjectGraph graph = new ProjectGraph();
         List<ParserDiagnostic> diagnostics = new ArrayList<>();
+        List<Path> projectFiles = projectFiles(projectRoot);
 
         // Run PomParser first so MAVEN_ARTIFACT nodes are available for all other parsers
         ParserRun pomRun
-                = runParser(pomParser, projectRoot, new ProjectGraph(), collectScannedFiles(pomParser, projectRoot));
+                = runParser(pomParser, projectRoot, new ProjectGraph(),
+                        parserTask(pomParser, projectRoot, projectFiles));
         diagnostics.add(pomRun.diagnostic());
         if (pomRun.diagnostic().successful()) {
             mergeDeterministically(graph, pomRun.graph());
@@ -75,7 +76,7 @@ public class GraphBuilder {
             baseGraph.merge(graph);
 
             List<ParserTask> tasks = remainingParsers.stream()
-                    .map(parser -> new ParserTask(parser, collectScannedFiles(parser, projectRoot)))
+                    .map(parser -> parserTask(parser, projectRoot, projectFiles))
                     .toList();
 
             List<ParserFuture> futures = tasks.stream()
@@ -84,7 +85,7 @@ public class GraphBuilder {
                         return new ParserFuture(
                                 task,
                                 executor.submit(
-                                        () -> runParser(task.parser(), projectRoot, baseGraph, task.scannedFiles())),
+                                        () -> runParser(task.parser(), projectRoot, baseGraph, task)),
                                 submittedAt);
                     })
                     .toList();
@@ -145,15 +146,15 @@ public class GraphBuilder {
 
     private ParserRun runParser(
             GraphParser parser, Path projectRoot, ProjectGraph baseGraph,
-            List<String> scannedFiles) {
+            ParserTask task) {
         long startedAt = System.nanoTime();
         ProjectGraph delta = new ProjectGraph();
         try {
-            ProjectGraph fragment = parser.parseFragment(projectRoot, baseGraph);
+            ProjectGraph fragment = parser.parseFragment(projectRoot, baseGraph, task.scannedFilePaths());
             delta = deltaFrom(fragment, baseGraph);
-            ParserDiagnostic diagnostic = new ParserDiagnostic(
-                    parserName(parser),
-                    scannedFiles,
+            ParserDiagnostic diagnostic = diagnostic(
+                    parser,
+                    task.scannedFiles(),
                     List.of(),
                     collectWarnings(parser),
                     List.of(),
@@ -163,16 +164,28 @@ public class GraphBuilder {
                     elapsedMillis(startedAt));
             return new ParserRun(delta, diagnostic);
         } catch (RuntimeException e) {
-            ParserDiagnostic diagnostic = failureDiagnostic(parser, scannedFiles, e, elapsedMillis(startedAt));
+            ParserDiagnostic diagnostic = failureDiagnostic(parser, task.scannedFiles(), e, elapsedMillis(startedAt));
             return new ParserRun(delta, diagnostic);
         }
     }
 
-    private List<String> collectScannedFiles(GraphParser parser, Path projectRoot) {
+    private List<Path> projectFiles(Path projectRoot) {
         try {
-            return parser.scannedFiles(projectRoot);
+            return GraphParser.projectFiles(projectRoot);
         } catch (RuntimeException e) {
             return List.of();
+        }
+    }
+
+    private ParserTask parserTask(GraphParser parser, Path projectRoot, List<Path> projectFiles) {
+        try {
+            List<Path> scannedFilePaths = parser.scannedFilePaths(projectRoot, projectFiles);
+            return new ParserTask(
+                    parser,
+                    scannedFilePaths,
+                    GraphParser.relativeFileNames(projectRoot, scannedFilePaths));
+        } catch (RuntimeException e) {
+            return new ParserTask(parser, List.of(), List.of());
         }
     }
 
@@ -186,7 +199,7 @@ public class GraphBuilder {
 
     private ProjectGraph deltaFrom(ProjectGraph fragment, ProjectGraph baseGraph) {
         ProjectGraph delta = new ProjectGraph();
-        Set<GraphEdge> baseEdges = new HashSet<>(baseGraph.getEdges());
+        Set<GraphEdge> baseEdges = baseGraph.getEdgeSet();
 
         fragment.getNodes().values().stream()
                 .filter(node -> !Objects.equals(baseGraph.getNode(node.id()), node))
@@ -230,8 +243,8 @@ public class GraphBuilder {
         String message = failure == null || failure.getMessage() == null
                 ? "Parser failed"
                 : failure.getMessage();
-        return new ParserDiagnostic(
-                parserName(parser),
+        return diagnostic(
+                parser,
                 scannedFiles,
                 List.of(),
                 collectWarnings(parser),
@@ -243,8 +256,8 @@ public class GraphBuilder {
     }
 
     private ParserDiagnostic interruptedDiagnostic(GraphParser parser, List<String> scannedFiles) {
-        return new ParserDiagnostic(
-                parserName(parser),
+        return diagnostic(
+                parser,
                 scannedFiles,
                 List.of(),
                 List.of(),
@@ -267,8 +280,8 @@ public class GraphBuilder {
     }
 
     private ParserDiagnostic skippedAfterInterruptionDiagnostic(GraphParser parser, List<String> scannedFiles) {
-        return new ParserDiagnostic(
-                parserName(parser),
+        return diagnostic(
+                parser,
                 scannedFiles,
                 scannedFiles,
                 List.of(),
@@ -280,8 +293,8 @@ public class GraphBuilder {
     }
 
     private ParserDiagnostic timeoutDiagnostic(GraphParser parser, List<String> scannedFiles) {
-        return new ParserDiagnostic(
-                parserName(parser),
+        return diagnostic(
+                parser,
                 scannedFiles,
                 List.of(),
                 List.of(),
@@ -290,6 +303,28 @@ public class GraphBuilder {
                 0,
                 0,
                 parserTimeoutUnit.toMillis(parserTimeout));
+    }
+
+    private ParserDiagnostic diagnostic(
+            GraphParser parser,
+            List<String> scannedFiles,
+            List<String> skippedFiles,
+            List<String> warnings,
+            List<String> failures,
+            boolean timedOut,
+            int nodesAdded,
+            int edgesAdded,
+            long durationMillis) {
+        return new ParserDiagnostic(
+                parserName(parser),
+                scannedFiles,
+                skippedFiles,
+                warnings,
+                failures,
+                timedOut,
+                nodesAdded,
+                edgesAdded,
+                durationMillis);
     }
 
     private String parserName(GraphParser parser) {
@@ -304,7 +339,7 @@ public class GraphBuilder {
         return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
     }
 
-    private record ParserTask(GraphParser parser, List<String> scannedFiles) {
+    private record ParserTask(GraphParser parser, List<Path> scannedFilePaths, List<String> scannedFiles) {
     }
 
     private record ParserFuture(ParserTask task, Future<ParserRun> future, long submittedAt) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuilder.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuilder.java
@@ -3,49 +3,116 @@ package io.github.luigidemasi.camelkit.graph;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.*;
 
+import io.github.luigidemasi.camelkit.graph.model.GraphEdge;
+import io.github.luigidemasi.camelkit.graph.model.GraphNode;
 import io.github.luigidemasi.camelkit.graph.parser.*;
 
 public class GraphBuilder {
 
-    private final PomParser pomParser = new PomParser();
+    private static final long DEFAULT_PARSER_TIMEOUT = 60;
+    private static final TimeUnit DEFAULT_PARSER_TIMEOUT_UNIT = TimeUnit.SECONDS;
 
-    private final List<GraphParser> remainingParsers = List.of(
-            new JavaGraphParser(),
-            new GroovyGraphParser(),
-            new XmlRouteParser(),
-            new MuleXmlFlowParser(),
-            new DataWeaveParser(),
-            new BizTalkParser(),
-            new YamlRouteParser(),
-            new ConfigParser());
+    private final GraphParser pomParser;
+    private final List<GraphParser> remainingParsers;
+    private final long parserTimeout;
+    private final TimeUnit parserTimeoutUnit;
+
+    public GraphBuilder() {
+        this(new PomParser(), List.of(
+                new JavaGraphParser(),
+                new GroovyGraphParser(),
+                new XmlRouteParser(),
+                new MuleXmlFlowParser(),
+                new DataWeaveParser(),
+                new BizTalkParser(),
+                new YamlRouteParser(),
+                new ConfigParser()),
+             DEFAULT_PARSER_TIMEOUT,
+             DEFAULT_PARSER_TIMEOUT_UNIT);
+    }
+
+    GraphBuilder(
+                 GraphParser pomParser, List<GraphParser> remainingParsers,
+                 long parserTimeout, TimeUnit parserTimeoutUnit) {
+        this.pomParser = Objects.requireNonNull(pomParser, "pomParser");
+        this.remainingParsers = List.copyOf(Objects.requireNonNull(remainingParsers, "remainingParsers"));
+        if (parserTimeout <= 0) {
+            throw new IllegalArgumentException("parserTimeout must be positive");
+        }
+        this.parserTimeout = parserTimeout;
+        this.parserTimeoutUnit = Objects.requireNonNull(parserTimeoutUnit, "parserTimeoutUnit");
+    }
 
     public ProjectGraph build(Path projectRoot) {
+        return buildWithDiagnostics(projectRoot).graph();
+    }
+
+    public GraphBuildResult buildWithDiagnostics(Path projectRoot) {
         ProjectGraph graph = new ProjectGraph();
+        List<ParserDiagnostic> diagnostics = new ArrayList<>();
 
         // Run PomParser first so MAVEN_ARTIFACT nodes are available for all other parsers
-        pomParser.parse(projectRoot, graph);
+        ParserRun pomRun
+                = runParser(pomParser, projectRoot, new ProjectGraph(), collectScannedFiles(pomParser, projectRoot));
+        diagnostics.add(pomRun.diagnostic());
+        if (pomRun.diagnostic().successful()) {
+            mergeDeterministically(graph, pomRun.graph());
+        }
 
         ExecutorService executor = Executors.newFixedThreadPool(
-                Math.min(remainingParsers.size(), Runtime.getRuntime().availableProcessors()));
+                Math.max(1, Math.min(remainingParsers.size(), Runtime.getRuntime().availableProcessors())));
         try {
-            List<Future<?>> futures = remainingParsers.stream()
-                    .<Future<?>>map(parser -> executor.submit(() -> parser.parse(projectRoot, graph)))
+            ProjectGraph baseGraph = new ProjectGraph();
+            baseGraph.merge(graph);
+
+            List<ParserTask> tasks = remainingParsers.stream()
+                    .map(parser -> new ParserTask(parser, collectScannedFiles(parser, projectRoot)))
                     .toList();
 
-            for (Future<?> future : futures) {
+            List<ParserFuture> futures = tasks.stream()
+                    .map(task -> new ParserFuture(
+                            task,
+                            executor.submit(
+                                    () -> runParser(task.parser(), projectRoot, baseGraph, task.scannedFiles()))))
+                    .toList();
+
+            for (ParserFuture parserFuture : futures) {
                 try {
-                    future.get(60, TimeUnit.SECONDS);
+                    ParserRun parserRun = parserFuture.future().get(parserTimeout, parserTimeoutUnit);
+                    diagnostics.add(parserRun.diagnostic());
+                    if (parserRun.diagnostic().successful()) {
+                        mergeDeterministically(graph, parserRun.graph());
+                    }
                 } catch (ExecutionException e) {
-                    System.err.println("Parser failed: " + e.getCause().getMessage());
-                } catch (InterruptedException | TimeoutException e) {
+                    ParserDiagnostic diagnostic = failureDiagnostic(
+                            parserFuture.task().parser(),
+                            parserFuture.task().scannedFiles(),
+                            e.getCause(),
+                            0);
+                    diagnostics.add(diagnostic);
+                } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    parserFuture.future().cancel(true);
+                    diagnostics.add(
+                            interruptedDiagnostic(parserFuture.task().parser(), parserFuture.task().scannedFiles()));
+                    break;
+                } catch (TimeoutException e) {
+                    parserFuture.future().cancel(true);
+                    diagnostics
+                            .add(timeoutDiagnostic(parserFuture.task().parser(), parserFuture.task().scannedFiles()));
                 }
             }
         } finally {
-            executor.shutdown();
+            executor.shutdownNow();
         }
 
         CrossLinker crossLinker = new CrossLinker();
@@ -57,7 +124,7 @@ public class GraphBuilder {
 
         crossLinker.expandInterfaces(graph);
 
-        return graph;
+        return new GraphBuildResult(graph, diagnostics);
     }
 
     public void buildAndSerialize(Path projectRoot, Path outputFile) {
@@ -68,5 +135,154 @@ public class GraphBuilder {
         } catch (IOException e) {
             throw new RuntimeException("Failed to serialize graph to " + outputFile, e);
         }
+    }
+
+    private ParserRun runParser(
+            GraphParser parser, Path projectRoot, ProjectGraph baseGraph,
+            List<String> scannedFiles) {
+        long startedAt = System.nanoTime();
+        ProjectGraph delta = new ProjectGraph();
+        try {
+            ProjectGraph fragment = parser.parseFragment(projectRoot, baseGraph);
+            delta = deltaFrom(fragment, baseGraph);
+            ParserDiagnostic diagnostic = new ParserDiagnostic(
+                    parserName(parser),
+                    scannedFiles,
+                    List.of(),
+                    collectWarnings(parser),
+                    List.of(),
+                    false,
+                    delta.nodeCount(),
+                    delta.edgeCount(),
+                    elapsedMillis(startedAt));
+            return new ParserRun(delta, diagnostic);
+        } catch (RuntimeException e) {
+            ParserDiagnostic diagnostic = failureDiagnostic(parser, scannedFiles, e, elapsedMillis(startedAt));
+            return new ParserRun(delta, diagnostic);
+        }
+    }
+
+    private List<String> collectScannedFiles(GraphParser parser, Path projectRoot) {
+        try {
+            return parser.scannedFiles(projectRoot);
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    private List<String> collectWarnings(GraphParser parser) {
+        try {
+            return parser.warnings();
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    private ProjectGraph deltaFrom(ProjectGraph fragment, ProjectGraph baseGraph) {
+        ProjectGraph delta = new ProjectGraph();
+        Set<GraphEdge> baseEdges = new HashSet<>(baseGraph.getEdges());
+
+        fragment.getNodes().values().stream()
+                .filter(node -> !Objects.equals(baseGraph.getNode(node.id()), node))
+                .sorted(Comparator.comparing(GraphNode::id))
+                .forEach(delta::addNode);
+
+        fragment.getEdges().stream()
+                .filter(edge -> !baseEdges.contains(edge))
+                .sorted(GraphBuilder::compareEdges)
+                .forEach(delta::addEdge);
+
+        return delta;
+    }
+
+    private void mergeDeterministically(ProjectGraph target, ProjectGraph source) {
+        source.getNodes().values().stream()
+                .sorted(Comparator.comparing(GraphNode::id))
+                .forEach(target::addNode);
+        source.getEdges().stream()
+                .sorted(GraphBuilder::compareEdges)
+                .forEach(target::addEdge);
+    }
+
+    private static int compareEdges(GraphEdge left, GraphEdge right) {
+        return Comparator.comparing(GraphEdge::from)
+                .thenComparing(GraphEdge::to)
+                .thenComparing(edge -> edge.type().name())
+                .thenComparing(edge -> sortedProperties(edge.properties()))
+                .compare(left, right);
+    }
+
+    private static String sortedProperties(Map<String, String> properties) {
+        return properties.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .toList()
+                .toString();
+    }
+
+    private ParserDiagnostic failureDiagnostic(
+            GraphParser parser, List<String> scannedFiles, Throwable failure,
+            long durationMillis) {
+        Throwable cause = failure == null ? null : failure;
+        String message = cause == null || cause.getMessage() == null
+                ? "Parser failed"
+                : cause.getMessage();
+        return new ParserDiagnostic(
+                parserName(parser),
+                scannedFiles,
+                List.of(),
+                collectWarnings(parser),
+                List.of(message),
+                false,
+                0,
+                0,
+                durationMillis);
+    }
+
+    private ParserDiagnostic interruptedDiagnostic(GraphParser parser, List<String> scannedFiles) {
+        return new ParserDiagnostic(
+                parserName(parser),
+                scannedFiles,
+                List.of(),
+                List.of(),
+                List.of("Parser execution was interrupted"),
+                false,
+                0,
+                0,
+                0);
+    }
+
+    private ParserDiagnostic timeoutDiagnostic(GraphParser parser, List<String> scannedFiles) {
+        return new ParserDiagnostic(
+                parserName(parser),
+                scannedFiles,
+                List.of(),
+                List.of(),
+                List.of(),
+                true,
+                0,
+                0,
+                parserTimeoutUnit.toMillis(parserTimeout));
+    }
+
+    private String parserName(GraphParser parser) {
+        String simpleName = parser.getClass().getSimpleName();
+        if (simpleName == null || simpleName.isBlank()) {
+            return parser.getClass().getName();
+        }
+        return simpleName;
+    }
+
+    private long elapsedMillis(long startedAt) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+    }
+
+    private record ParserTask(GraphParser parser, List<String> scannedFiles) {
+    }
+
+    private record ParserFuture(ParserTask task, Future<ParserRun> future) {
+    }
+
+    private record ParserRun(ProjectGraph graph, ParserDiagnostic diagnostic) {
     }
 }

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuilder.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/GraphBuilder.java
@@ -79,13 +79,18 @@ public class GraphBuilder {
                     .toList();
 
             List<ParserFuture> futures = tasks.stream()
-                    .map(task -> new ParserFuture(
-                            task,
-                            executor.submit(
-                                    () -> runParser(task.parser(), projectRoot, baseGraph, task.scannedFiles()))))
+                    .map(task -> {
+                        long submittedAt = System.nanoTime();
+                        return new ParserFuture(
+                                task,
+                                executor.submit(
+                                        () -> runParser(task.parser(), projectRoot, baseGraph, task.scannedFiles())),
+                                submittedAt);
+                    })
                     .toList();
 
-            for (ParserFuture parserFuture : futures) {
+            for (int i = 0; i < futures.size(); i++) {
+                ParserFuture parserFuture = futures.get(i);
                 try {
                     ParserRun parserRun = parserFuture.future().get(parserTimeout, parserTimeoutUnit);
                     diagnostics.add(parserRun.diagnostic());
@@ -97,13 +102,14 @@ public class GraphBuilder {
                             parserFuture.task().parser(),
                             parserFuture.task().scannedFiles(),
                             e.getCause(),
-                            0);
+                            elapsedMillis(parserFuture.submittedAt()));
                     diagnostics.add(diagnostic);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     parserFuture.future().cancel(true);
                     diagnostics.add(
                             interruptedDiagnostic(parserFuture.task().parser(), parserFuture.task().scannedFiles()));
+                    addSkippedAfterInterruptionDiagnostics(futures, i + 1, diagnostics);
                     break;
                 } catch (TimeoutException e) {
                     parserFuture.future().cancel(true);
@@ -184,12 +190,10 @@ public class GraphBuilder {
 
         fragment.getNodes().values().stream()
                 .filter(node -> !Objects.equals(baseGraph.getNode(node.id()), node))
-                .sorted(Comparator.comparing(GraphNode::id))
                 .forEach(delta::addNode);
 
         fragment.getEdges().stream()
                 .filter(edge -> !baseEdges.contains(edge))
-                .sorted(GraphBuilder::compareEdges)
                 .forEach(delta::addEdge);
 
         return delta;
@@ -223,10 +227,9 @@ public class GraphBuilder {
     private ParserDiagnostic failureDiagnostic(
             GraphParser parser, List<String> scannedFiles, Throwable failure,
             long durationMillis) {
-        Throwable cause = failure == null ? null : failure;
-        String message = cause == null || cause.getMessage() == null
+        String message = failure == null || failure.getMessage() == null
                 ? "Parser failed"
-                : cause.getMessage();
+                : failure.getMessage();
         return new ParserDiagnostic(
                 parserName(parser),
                 scannedFiles,
@@ -246,6 +249,30 @@ public class GraphBuilder {
                 List.of(),
                 List.of(),
                 List.of("Parser execution was interrupted"),
+                false,
+                0,
+                0,
+                0);
+    }
+
+    private void addSkippedAfterInterruptionDiagnostics(
+            List<ParserFuture> futures, int startIndex, List<ParserDiagnostic> diagnostics) {
+        for (int i = startIndex; i < futures.size(); i++) {
+            ParserFuture parserFuture = futures.get(i);
+            parserFuture.future().cancel(true);
+            diagnostics.add(skippedAfterInterruptionDiagnostic(
+                    parserFuture.task().parser(),
+                    parserFuture.task().scannedFiles()));
+        }
+    }
+
+    private ParserDiagnostic skippedAfterInterruptionDiagnostic(GraphParser parser, List<String> scannedFiles) {
+        return new ParserDiagnostic(
+                parserName(parser),
+                scannedFiles,
+                scannedFiles,
+                List.of(),
+                List.of("Parser execution skipped after graph build interruption"),
                 false,
                 0,
                 0,
@@ -280,7 +307,7 @@ public class GraphBuilder {
     private record ParserTask(GraphParser parser, List<String> scannedFiles) {
     }
 
-    private record ParserFuture(ParserTask task, Future<ParserRun> future) {
+    private record ParserFuture(ParserTask task, Future<ParserRun> future, long submittedAt) {
     }
 
     private record ParserRun(ProjectGraph graph, ParserDiagnostic diagnostic) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ParserDiagnostic.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ParserDiagnostic.java
@@ -1,0 +1,37 @@
+package io.github.luigidemasi.camelkit.graph;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ParserDiagnostic(
+        String parserName,
+        List<String> scannedFiles,
+        List<String> skippedFiles,
+        List<String> warnings,
+        List<String> failures,
+        boolean timedOut,
+        int nodesProduced,
+        int edgesProduced,
+        long durationMillis) {
+
+    public ParserDiagnostic {
+        Objects.requireNonNull(parserName, "parserName");
+        scannedFiles = List.copyOf(Objects.requireNonNull(scannedFiles, "scannedFiles"));
+        skippedFiles = List.copyOf(Objects.requireNonNull(skippedFiles, "skippedFiles"));
+        warnings = List.copyOf(Objects.requireNonNull(warnings, "warnings"));
+        failures = List.copyOf(Objects.requireNonNull(failures, "failures"));
+        if (nodesProduced < 0) {
+            throw new IllegalArgumentException("nodesProduced must be non-negative");
+        }
+        if (edgesProduced < 0) {
+            throw new IllegalArgumentException("edgesProduced must be non-negative");
+        }
+        if (durationMillis < 0) {
+            throw new IllegalArgumentException("durationMillis must be non-negative");
+        }
+    }
+
+    public boolean successful() {
+        return !timedOut && failures.isEmpty();
+    }
+}

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ProjectGraph.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ProjectGraph.java
@@ -30,6 +30,10 @@ public class ProjectGraph {
         return List.copyOf(edges);
     }
 
+    public synchronized Set<GraphEdge> getEdgeSet() {
+        return Collections.unmodifiableSet(new HashSet<>(edges));
+    }
+
     public synchronized void addEdge(GraphEdge edge) {
         edges.add(edge);
     }

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ProjectGraph.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ProjectGraph.java
@@ -1,14 +1,13 @@
 package io.github.luigidemasi.camelkit.graph;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import io.github.luigidemasi.camelkit.graph.model.*;
 
 public class ProjectGraph {
 
-    private final Map<String, GraphNode> nodes = new ConcurrentHashMap<>();
+    private final Map<String, GraphNode> nodes = Collections.synchronizedMap(new LinkedHashMap<>());
     private final List<GraphEdge> edges = Collections.synchronizedList(new ArrayList<>());
 
     public void addNode(GraphNode node) {
@@ -62,7 +61,7 @@ public class ProjectGraph {
     }
 
     public void merge(ProjectGraph other) {
-        other.nodes.values().forEach(this::addNode);
-        other.edges.forEach(this::addEdge);
+        other.getNodes().values().forEach(this::addNode);
+        other.getEdges().forEach(this::addEdge);
     }
 }

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ProjectGraph.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/ProjectGraph.java
@@ -7,56 +7,56 @@ import io.github.luigidemasi.camelkit.graph.model.*;
 
 public class ProjectGraph {
 
-    private final Map<String, GraphNode> nodes = Collections.synchronizedMap(new LinkedHashMap<>());
-    private final List<GraphEdge> edges = Collections.synchronizedList(new ArrayList<>());
+    private final Map<String, GraphNode> nodes = new LinkedHashMap<>();
+    private final List<GraphEdge> edges = new ArrayList<>();
 
-    public void addNode(GraphNode node) {
+    public synchronized void addNode(GraphNode node) {
         nodes.put(node.id(), node);
     }
 
-    public boolean hasNode(String id) {
+    public synchronized boolean hasNode(String id) {
         return nodes.containsKey(id);
     }
 
-    public GraphNode getNode(String id) {
+    public synchronized GraphNode getNode(String id) {
         return nodes.get(id);
     }
 
-    public Map<String, GraphNode> getNodes() {
-        return Collections.unmodifiableMap(nodes);
+    public synchronized Map<String, GraphNode> getNodes() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(nodes));
     }
 
-    public List<GraphEdge> getEdges() {
-        return Collections.unmodifiableList(edges);
+    public synchronized List<GraphEdge> getEdges() {
+        return List.copyOf(edges);
     }
 
-    public void addEdge(GraphEdge edge) {
+    public synchronized void addEdge(GraphEdge edge) {
         edges.add(edge);
     }
 
-    public List<GraphNode> findByType(NodeType type) {
+    public synchronized List<GraphNode> findByType(NodeType type) {
         return nodes.values().stream()
                 .filter(n -> n.type() == type)
                 .collect(Collectors.toList());
     }
 
-    public List<GraphEdge> getOutgoingEdges(String nodeId) {
+    public synchronized List<GraphEdge> getOutgoingEdges(String nodeId) {
         return edges.stream()
                 .filter(e -> e.from().equals(nodeId))
                 .collect(Collectors.toList());
     }
 
-    public List<GraphEdge> getIncomingEdges(String nodeId) {
+    public synchronized List<GraphEdge> getIncomingEdges(String nodeId) {
         return edges.stream()
                 .filter(e -> e.to().equals(nodeId))
                 .collect(Collectors.toList());
     }
 
-    public int nodeCount() {
+    public synchronized int nodeCount() {
         return nodes.size();
     }
 
-    public int edgeCount() {
+    public synchronized int edgeCount() {
         return edges.size();
     }
 

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/BizTalkParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/BizTalkParser.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,30 +38,13 @@ public class BizTalkParser implements GraphParser {
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
         warnings.clear();
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    String fileName = file.getFileName().toString();
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
+    }
 
-                    if (fileName.endsWith(".odx")) {
-                        odxParser.parse(file, graph);
-                    } else if (fileName.endsWith(".btm")) {
-                        btmParser.parse(file, graph);
-                    } else if (fileName.endsWith(".btp")) {
-                        btpParser.parse(file, graph);
-                    } else if (fileName.endsWith(".xml") && !fileName.equals("pom.xml")) {
-                        if (isBizTalkBindingXml(file)) {
-                            bindingParser.parse(file, graph);
-                        }
-                    }
-
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for BizTalk files", e);
-        }
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        warnings.clear();
+        files.forEach(file -> parseArtifact(file, graph));
     }
 
     @Override
@@ -72,13 +54,34 @@ public class BizTalkParser implements GraphParser {
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
-        return GraphParser.findFiles(projectRoot, file -> {
-            String fileName = file.getFileName().toString();
-            return fileName.endsWith(".odx")
-                    || fileName.endsWith(".btm")
-                    || fileName.endsWith(".btp")
-                    || (fileName.endsWith(".xml") && !fileName.equals("pom.xml") && isBizTalkBindingXml(file));
-        });
+        return GraphParser.findFiles(projectRoot, this::isBizTalkArtifact);
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, this::isBizTalkArtifact);
+    }
+
+    private void parseArtifact(Path file, ProjectGraph graph) {
+        String fileName = file.getFileName().toString();
+
+        if (fileName.endsWith(".odx")) {
+            odxParser.parse(file, graph);
+        } else if (fileName.endsWith(".btm")) {
+            btmParser.parse(file, graph);
+        } else if (fileName.endsWith(".btp")) {
+            btpParser.parse(file, graph);
+        } else if (fileName.endsWith(".xml") && !fileName.equals("pom.xml")) {
+            bindingParser.parse(file, graph);
+        }
+    }
+
+    private boolean isBizTalkArtifact(Path file) {
+        String fileName = file.getFileName().toString();
+        return fileName.endsWith(".odx")
+                || fileName.endsWith(".btm")
+                || fileName.endsWith(".btp")
+                || (fileName.endsWith(".xml") && !fileName.equals("pom.xml") && isBizTalkBindingXml(file));
     }
 
     /**

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/BizTalkParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/BizTalkParser.java
@@ -6,6 +6,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.github.luigidemasi.camelkit.graph.ProjectGraph;
 import io.github.luigidemasi.camelkit.graph.parser.biztalk.*;
@@ -28,13 +30,15 @@ public class BizTalkParser implements GraphParser {
     private static final String BIZTALK_BINDING_MARKER = "schemas.microsoft.com/BizTalk";
     private static final String BINDING_INFO_MARKER = "BindingInfo";
 
-    private final BizTalkOdxParser odxParser = new BizTalkOdxParser();
-    private final BizTalkBtmParser btmParser = new BizTalkBtmParser();
-    private final BizTalkBtpParser btpParser = new BizTalkBtpParser();
-    private final BizTalkBindingParser bindingParser = new BizTalkBindingParser();
+    private final List<String> warnings = new ArrayList<>();
+    private final BizTalkOdxParser odxParser = new BizTalkOdxParser(warnings::add);
+    private final BizTalkBtmParser btmParser = new BizTalkBtmParser(warnings::add);
+    private final BizTalkBtpParser btpParser = new BizTalkBtpParser(warnings::add);
+    private final BizTalkBindingParser bindingParser = new BizTalkBindingParser(warnings::add);
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
+        warnings.clear();
         try {
             Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
                 @Override
@@ -59,6 +63,22 @@ public class BizTalkParser implements GraphParser {
         } catch (IOException e) {
             throw new RuntimeException("Failed to walk project for BizTalk files", e);
         }
+    }
+
+    @Override
+    public List<String> warnings() {
+        return List.copyOf(warnings);
+    }
+
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, file -> {
+            String fileName = file.getFileName().toString();
+            return fileName.endsWith(".odx")
+                    || fileName.endsWith(".btm")
+                    || fileName.endsWith(".btp")
+                    || (fileName.endsWith(".xml") && !fileName.equals("pom.xml") && isBizTalkBindingXml(file));
+        });
     }
 
     /**

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/ConfigParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/ConfigParser.java
@@ -29,6 +29,16 @@ public class ConfigParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, this::isConfigFile);
+    }
+
+    private boolean isConfigFile(Path file) {
+        String name = file.getFileName().toString();
+        return name.equals("application.properties") || name.matches("application-.*\\.properties");
+    }
+
     private void parseProperties(Path file, Path projectRoot, ProjectGraph graph) {
         Properties props = new Properties();
         try (InputStream in = Files.newInputStream(file)) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/ConfigParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/ConfigParser.java
@@ -3,7 +3,6 @@ package io.github.luigidemasi.camelkit.graph.parser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
 import io.github.luigidemasi.camelkit.graph.ProjectGraph;
@@ -13,25 +12,22 @@ public class ConfigParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    String name = file.getFileName().toString();
-                    if (name.equals("application.properties") || name.matches("application-.*\\.properties")) {
-                        parseProperties(file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for config files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, this::isConfigFile);
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, this::isConfigFile);
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parseProperties(file, projectRoot, graph));
     }
 
     private boolean isConfigFile(Path file) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/DataWeaveParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/DataWeaveParser.java
@@ -2,7 +2,6 @@ package io.github.luigidemasi.camelkit.graph.parser;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,24 +21,22 @@ public class DataWeaveParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.toString().endsWith(".dwl")) {
-                        parseDwlFile(file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for DataWeave files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, file -> file.toString().endsWith(".dwl"));
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, file -> file.toString().endsWith(".dwl"));
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parseDwlFile(file, projectRoot, graph));
     }
 
     private void parseDwlFile(Path file, Path projectRoot, ProjectGraph graph) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/DataWeaveParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/DataWeaveParser.java
@@ -37,6 +37,11 @@ public class DataWeaveParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, file -> file.toString().endsWith(".dwl"));
+    }
+
     private void parseDwlFile(Path file, Path projectRoot, ProjectGraph graph) {
         String content;
         try {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GraphParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GraphParser.java
@@ -1,9 +1,48 @@
 package io.github.luigidemasi.camelkit.graph.parser;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import io.github.luigidemasi.camelkit.graph.ProjectGraph;
 
 public interface GraphParser {
     void parse(Path projectRoot, ProjectGraph graph);
+
+    default ProjectGraph parseFragment(Path projectRoot, ProjectGraph baseGraph) {
+        ProjectGraph fragment = new ProjectGraph();
+        fragment.merge(baseGraph);
+        parse(projectRoot, fragment);
+        return fragment;
+    }
+
+    default List<String> scannedFiles(Path projectRoot) {
+        return List.of();
+    }
+
+    default List<String> warnings() {
+        return List.of();
+    }
+
+    static List<String> findFiles(Path projectRoot, Predicate<Path> matcher) {
+        if (!Files.exists(projectRoot)) {
+            return List.of();
+        }
+
+        try (Stream<Path> paths = Files.walk(projectRoot)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(matcher)
+                    .map(projectRoot::relativize)
+                    .map(Path::toString)
+                    .map(path -> path.replace('\\', '/'))
+                    .sorted()
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to scan files under " + projectRoot, e);
+        }
+    }
 }

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GraphParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GraphParser.java
@@ -13,21 +13,35 @@ public interface GraphParser {
     void parse(Path projectRoot, ProjectGraph graph);
 
     default ProjectGraph parseFragment(Path projectRoot, ProjectGraph baseGraph) {
+        return parseFragment(projectRoot, baseGraph, scannedFilePaths(projectRoot, projectFiles(projectRoot)));
+    }
+
+    default ProjectGraph parseFragment(Path projectRoot, ProjectGraph baseGraph, List<Path> scannedFiles) {
         ProjectGraph fragment = new ProjectGraph();
         fragment.merge(baseGraph);
-        parse(projectRoot, fragment);
+        parseFiles(projectRoot, scannedFiles, fragment);
         return fragment;
+    }
+
+    default void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        parse(projectRoot, graph);
     }
 
     default List<String> scannedFiles(Path projectRoot) {
         return List.of();
     }
 
+    default List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return scannedFiles(projectRoot).stream()
+                .map(projectRoot::resolve)
+                .toList();
+    }
+
     default List<String> warnings() {
         return List.of();
     }
 
-    static List<String> findFiles(Path projectRoot, Predicate<Path> matcher) {
+    static List<Path> projectFiles(Path projectRoot) {
         if (!Files.exists(projectRoot)) {
             return List.of();
         }
@@ -35,14 +49,32 @@ public interface GraphParser {
         try (Stream<Path> paths = Files.walk(projectRoot)) {
             return paths
                     .filter(Files::isRegularFile)
-                    .filter(matcher)
-                    .map(projectRoot::relativize)
-                    .map(Path::toString)
-                    .map(path -> path.replace('\\', '/'))
                     .sorted()
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException("Failed to scan files under " + projectRoot, e);
         }
+    }
+
+    static List<String> findFiles(Path projectRoot, Predicate<Path> matcher) {
+        return relativeFileNames(projectRoot, findFilePaths(projectRoot, projectFiles(projectRoot), matcher));
+    }
+
+    static List<Path> findFilePaths(Path projectRoot, List<Path> projectFiles, Predicate<Path> matcher) {
+        return projectFiles.stream()
+                .filter(matcher)
+                .sorted()
+                .toList();
+    }
+
+    static List<String> relativeFileNames(Path projectRoot, List<Path> files) {
+        return files.stream()
+                .map(file -> relativeFileName(projectRoot, file))
+                .sorted()
+                .toList();
+    }
+
+    static String relativeFileName(Path projectRoot, Path file) {
+        return projectRoot.relativize(file).toString().replace('\\', '/');
     }
 }

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GroovyGraphParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GroovyGraphParser.java
@@ -41,6 +41,11 @@ public class GroovyGraphParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, file -> file.toString().endsWith(".groovy"));
+    }
+
     private void parseGroovyFile(Path file, Path projectRoot, ProjectGraph graph) {
         CompilerConfiguration config = new CompilerConfiguration();
         config.setTargetBytecode(CompilerConfiguration.JDK17);

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GroovyGraphParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/GroovyGraphParser.java
@@ -2,7 +2,6 @@ package io.github.luigidemasi.camelkit.graph.parser;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
 import io.github.luigidemasi.camelkit.graph.ProjectGraph;
@@ -26,24 +25,22 @@ public class GroovyGraphParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.toString().endsWith(".groovy")) {
-                        parseGroovyFile(file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for Groovy files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, file -> file.toString().endsWith(".groovy"));
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, file -> file.toString().endsWith(".groovy"));
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parseGroovyFile(file, projectRoot, graph));
     }
 
     private void parseGroovyFile(Path file, Path projectRoot, ProjectGraph graph) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/JavaGraphParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/JavaGraphParser.java
@@ -2,7 +2,6 @@ package io.github.luigidemasi.camelkit.graph.parser;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,25 +42,23 @@ public class JavaGraphParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
         JavaParser parser = new JavaParser();
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.toString().endsWith(".java")) {
-                        parseJavaFile(parser, file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for Java files", e);
-        }
+        files.forEach(file -> parseJavaFile(parser, file, projectRoot, graph));
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, file -> file.toString().endsWith(".java"));
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, file -> file.toString().endsWith(".java"));
     }
 
     private void parseJavaFile(JavaParser parser, Path file, Path projectRoot, ProjectGraph graph) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/JavaGraphParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/JavaGraphParser.java
@@ -59,6 +59,11 @@ public class JavaGraphParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, file -> file.toString().endsWith(".java"));
+    }
+
     private void parseJavaFile(JavaParser parser, Path file, Path projectRoot, ProjectGraph graph) {
         try {
             var parseResult = parser.parse(file);

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/MuleXmlFlowParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/MuleXmlFlowParser.java
@@ -60,6 +60,14 @@ public class MuleXmlFlowParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, file -> {
+            String fileName = file.getFileName().toString();
+            return fileName.endsWith(".xml") && !fileName.equals("pom.xml") && isMuleXml(file);
+        });
+    }
+
     /**
      * Namespace sniff: read first 1KB and check for the MuleSoft namespace marker.
      */

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/MuleXmlFlowParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/MuleXmlFlowParser.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -42,30 +41,27 @@ public class MuleXmlFlowParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    String fileName = file.getFileName().toString();
-                    if (fileName.endsWith(".xml") && !fileName.equals("pom.xml")) {
-                        if (isMuleXml(file)) {
-                            parseMuleFile(file, projectRoot, graph);
-                        }
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for Mule XML files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
-        return GraphParser.findFiles(projectRoot, file -> {
-            String fileName = file.getFileName().toString();
-            return fileName.endsWith(".xml") && !fileName.equals("pom.xml") && isMuleXml(file);
-        });
+        return GraphParser.findFiles(projectRoot, this::isMuleXmlCandidate);
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, this::isMuleXmlCandidate);
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parseMuleFile(file, projectRoot, graph));
+    }
+
+    private boolean isMuleXmlCandidate(Path file) {
+        String fileName = file.getFileName().toString();
+        return fileName.endsWith(".xml") && !fileName.equals("pom.xml") && isMuleXml(file);
     }
 
     /**

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/PomParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/PomParser.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 import java.util.Map;
 
 import io.github.luigidemasi.camelkit.graph.ProjectGraph;
@@ -30,6 +31,11 @@ public class PomParser implements GraphParser {
         } catch (IOException e) {
             throw new RuntimeException("Failed to walk project for POM files", e);
         }
+    }
+
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, file -> file.getFileName().toString().equals("pom.xml"));
     }
 
     private void parsePom(Path pomFile, Path projectRoot, ProjectGraph graph) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/PomParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/PomParser.java
@@ -1,9 +1,7 @@
 package io.github.luigidemasi.camelkit.graph.parser;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Map;
 
@@ -18,24 +16,23 @@ public class PomParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.getFileName().toString().equals("pom.xml")) {
-                        parsePom(file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for POM files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, file -> file.getFileName().toString().equals("pom.xml"));
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles,
+                file -> file.getFileName().toString().equals("pom.xml"));
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parsePom(file, projectRoot, graph));
     }
 
     private void parsePom(Path pomFile, Path projectRoot, ProjectGraph graph) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/XmlRouteParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/XmlRouteParser.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -25,25 +24,22 @@ public class XmlRouteParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.getFileName().toString().endsWith(".xml")
-                            && !file.getFileName().toString().equals("pom.xml")) {
-                        parseXmlFile(file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for XML files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, this::isCamelXmlCandidate);
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, this::isCamelXmlCandidate);
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parseXmlFile(file, projectRoot, graph));
     }
 
     private boolean isCamelXmlCandidate(Path file) {
@@ -60,20 +56,6 @@ public class XmlRouteParser implements GraphParser {
     }
 
     private void parseXmlFile(Path xmlFile, Path projectRoot, ProjectGraph graph) {
-        // Skip MuleSoft XML files (handled by MuleXmlFlowParser)
-        // Skip BizTalk XML files (handled by BizTalkParser)
-        try {
-            String head = readHead(xmlFile);
-            if (head.contains("mulesoft.org/schema/mule")) {
-                return;
-            }
-            if (BizTalkParser.isBizTalkXml(head)) {
-                return;
-            }
-        } catch (IOException e) {
-            return;
-        }
-
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/XmlRouteParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/XmlRouteParser.java
@@ -37,6 +37,25 @@ public class XmlRouteParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, this::isCamelXmlCandidate);
+    }
+
+    private boolean isCamelXmlCandidate(Path file) {
+        String fileName = file.getFileName().toString();
+        if (!fileName.endsWith(".xml") || fileName.equals("pom.xml")) {
+            return false;
+        }
+        try {
+            String content = Files.readString(file);
+            String head = content.substring(0, Math.min(1024, content.length()));
+            return !head.contains("mulesoft.org/schema/mule") && !BizTalkParser.isBizTalkXml(head);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
     private void parseXmlFile(Path xmlFile, Path projectRoot, ProjectGraph graph) {
         // Skip MuleSoft XML files (handled by MuleXmlFlowParser)
         // Skip BizTalk XML files (handled by BizTalkParser)

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/XmlRouteParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/XmlRouteParser.java
@@ -1,6 +1,8 @@
 package io.github.luigidemasi.camelkit.graph.parser;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
@@ -14,6 +16,8 @@ import io.github.luigidemasi.camelkit.graph.ProjectGraph;
 import io.github.luigidemasi.camelkit.graph.model.*;
 
 public class XmlRouteParser implements GraphParser {
+
+    private static final int SNIFF_BYTES = 1024;
 
     private static final Set<String> EIP_ELEMENTS = Set.of(
             "filter", "split", "aggregate", "marshal", "unmarshal",
@@ -48,8 +52,7 @@ public class XmlRouteParser implements GraphParser {
             return false;
         }
         try {
-            String content = Files.readString(file);
-            String head = content.substring(0, Math.min(1024, content.length()));
+            String head = readHead(file);
             return !head.contains("mulesoft.org/schema/mule") && !BizTalkParser.isBizTalkXml(head);
         } catch (IOException e) {
             return false;
@@ -60,8 +63,7 @@ public class XmlRouteParser implements GraphParser {
         // Skip MuleSoft XML files (handled by MuleXmlFlowParser)
         // Skip BizTalk XML files (handled by BizTalkParser)
         try {
-            String content = Files.readString(xmlFile);
-            String head = content.substring(0, Math.min(1024, content.length()));
+            String head = readHead(xmlFile);
             if (head.contains("mulesoft.org/schema/mule")) {
                 return;
             }
@@ -86,6 +88,17 @@ public class XmlRouteParser implements GraphParser {
             }
         } catch (Exception e) {
             // Skip unparseable XML silently
+        }
+    }
+
+    private String readHead(Path file) throws IOException {
+        try (InputStream input = Files.newInputStream(file)) {
+            byte[] buffer = new byte[SNIFF_BYTES];
+            int read = input.read(buffer);
+            if (read <= 0) {
+                return "";
+            }
+            return new String(buffer, 0, read, StandardCharsets.UTF_8);
         }
     }
 

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/YamlRouteParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/YamlRouteParser.java
@@ -1,8 +1,6 @@
 package io.github.luigidemasi.camelkit.graph.parser;
 
-import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
 import io.github.luigidemasi.camelkit.graph.ProjectGraph;
@@ -22,26 +20,22 @@ public class YamlRouteParser implements GraphParser {
 
     @Override
     public void parse(Path projectRoot, ProjectGraph graph) {
-        try {
-            Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    String fileName = file.getFileName().toString();
-                    if ((fileName.endsWith(".yaml") || fileName.endsWith(".yml"))
-                            && !fileName.startsWith("application")) {
-                        parseYamlFile(file, projectRoot, graph);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to walk project for YAML files", e);
-        }
+        parseFiles(projectRoot, scannedFilePaths(projectRoot, GraphParser.projectFiles(projectRoot)), graph);
     }
 
     @Override
     public List<String> scannedFiles(Path projectRoot) {
         return GraphParser.findFiles(projectRoot, this::isRouteYaml);
+    }
+
+    @Override
+    public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+        return GraphParser.findFilePaths(projectRoot, projectFiles, this::isRouteYaml);
+    }
+
+    @Override
+    public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+        files.forEach(file -> parseYamlFile(file, projectRoot, graph));
     }
 
     private boolean isRouteYaml(Path file) {

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/YamlRouteParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/YamlRouteParser.java
@@ -39,6 +39,17 @@ public class YamlRouteParser implements GraphParser {
         }
     }
 
+    @Override
+    public List<String> scannedFiles(Path projectRoot) {
+        return GraphParser.findFiles(projectRoot, this::isRouteYaml);
+    }
+
+    private boolean isRouteYaml(Path file) {
+        String fileName = file.getFileName().toString();
+        return (fileName.endsWith(".yaml") || fileName.endsWith(".yml"))
+                && !fileName.startsWith("application");
+    }
+
     private void parseYamlFile(Path yamlFile, Path projectRoot, ProjectGraph graph) {
         try {
             JsonNode root = yamlMapper.readTree(yamlFile.toFile());

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkBindingParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkBindingParser.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -26,6 +28,16 @@ import io.github.luigidemasi.camelkit.graph.model.NodeType;
 public class BizTalkBindingParser {
 
     private static final String BIZTALK_NS = "http://schemas.microsoft.com/BizTalk/2003";
+    private final Consumer<String> warningConsumer;
+
+    public BizTalkBindingParser() {
+        this(warning -> {
+        });
+    }
+
+    public BizTalkBindingParser(Consumer<String> warningConsumer) {
+        this.warningConsumer = Objects.requireNonNull(warningConsumer, "warningConsumer");
+    }
 
     /**
      * Parse a single binding XML file and add adapter nodes to the graph.
@@ -41,7 +53,7 @@ public class BizTalkBindingParser {
 
             parseBindingXml(bindingFile, graph);
         } catch (Exception e) {
-            System.err.println("Failed to parse BizTalk binding file: " + bindingFile + " - " + e.getMessage());
+            warningConsumer.accept("Failed to parse BizTalk binding file: " + bindingFile + " - " + e.getMessage());
         }
     }
 

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkBtmParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkBtmParser.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -26,6 +28,17 @@ import io.github.luigidemasi.camelkit.graph.model.NodeType;
  * </p>
  */
 public class BizTalkBtmParser {
+
+    private final Consumer<String> warningConsumer;
+
+    public BizTalkBtmParser() {
+        this(warning -> {
+        });
+    }
+
+    public BizTalkBtmParser(Consumer<String> warningConsumer) {
+        this.warningConsumer = Objects.requireNonNull(warningConsumer, "warningConsumer");
+    }
 
     /**
      * Mapping from Functoid FID to functoid type name. This provides a fallback when FunctoidType attribute is not
@@ -99,7 +112,7 @@ public class BizTalkBtmParser {
 
             parseBtmXml(btmFile, graph);
         } catch (Exception e) {
-            System.err.println("Failed to parse BizTalk BTM file: " + btmFile + " - " + e.getMessage());
+            warningConsumer.accept("Failed to parse BizTalk BTM file: " + btmFile + " - " + e.getMessage());
         }
     }
 

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkBtpParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkBtpParser.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -26,6 +28,17 @@ import io.github.luigidemasi.camelkit.graph.model.NodeType;
  * </p>
  */
 public class BizTalkBtpParser {
+
+    private final Consumer<String> warningConsumer;
+
+    public BizTalkBtpParser() {
+        this(warning -> {
+        });
+    }
+
+    public BizTalkBtpParser(Consumer<String> warningConsumer) {
+        this.warningConsumer = Objects.requireNonNull(warningConsumer, "warningConsumer");
+    }
 
     /**
      * GUID identifying receive pipelines.
@@ -58,7 +71,7 @@ public class BizTalkBtpParser {
 
             parseBtpXml(btpFile, graph);
         } catch (Exception e) {
-            System.err.println("Failed to parse BizTalk BTP file: " + btpFile + " - " + e.getMessage());
+            warningConsumer.accept("Failed to parse BizTalk BTP file: " + btpFile + " - " + e.getMessage());
         }
     }
 

--- a/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkOdxParser.java
+++ b/camel-kit-graph/src/main/java/io/github/luigidemasi/camelkit/graph/parser/biztalk/BizTalkOdxParser.java
@@ -6,7 +6,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -28,6 +30,16 @@ import io.github.luigidemasi.camelkit.graph.model.NodeType;
 public class BizTalkOdxParser {
 
     private static final String BIZTALK_NS = "http://schemas.microsoft.com/BizTalk/2003/DesignerData";
+    private final Consumer<String> warningConsumer;
+
+    public BizTalkOdxParser() {
+        this(warning -> {
+        });
+    }
+
+    public BizTalkOdxParser(Consumer<String> warningConsumer) {
+        this.warningConsumer = Objects.requireNonNull(warningConsumer, "warningConsumer");
+    }
 
     /**
      * Parse a single ODX file and add nodes/edges to the graph.
@@ -49,7 +61,7 @@ public class BizTalkOdxParser {
 
             parseOdxXml(xmlContent, graph);
         } catch (Exception e) {
-            System.err.println("Failed to parse BizTalk ODX file: " + odxFile + " - " + e.getMessage());
+            warningConsumer.accept("Failed to parse BizTalk ODX file: " + odxFile + " - " + e.getMessage());
         }
     }
 

--- a/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/GraphBuilderTest.java
+++ b/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/GraphBuilderTest.java
@@ -119,6 +119,45 @@ class GraphBuilderTest {
     }
 
     @Test
+    void unexpectedParserErrorsKeepElapsedDuration(@TempDir Path tempDir) {
+        GraphBuilder builder = new GraphBuilder(
+                new EmptyParser(),
+                List.of(new ErrorParser()),
+                1,
+                TimeUnit.SECONDS);
+
+        GraphBuildResult result = builder.buildWithDiagnostics(tempDir);
+
+        ParserDiagnostic diagnostic = findDiagnostic(result, "ErrorParser");
+        assertFalse(diagnostic.failures().isEmpty());
+        assertTrue(diagnostic.durationMillis() > 0);
+    }
+
+    @Test
+    void interruptionReportsRemainingParsersAsSkipped(@TempDir Path tempDir) {
+        GraphBuilder builder = new GraphBuilder(
+                new EmptyParser(),
+                List.of(new SleepingParser(), new SkippedParser()),
+                1,
+                TimeUnit.SECONDS);
+
+        GraphBuildResult result;
+        Thread.currentThread().interrupt();
+        try {
+            result = builder.buildWithDiagnostics(tempDir);
+        } finally {
+            Thread.interrupted();
+        }
+
+        ParserDiagnostic interrupted = findDiagnostic(result, "SleepingParser");
+        ParserDiagnostic skipped = findDiagnostic(result, "SkippedParser");
+        assertFalse(interrupted.failures().isEmpty());
+        assertFalse(skipped.failures().isEmpty());
+        assertEquals(List.of("skipped.file"), skipped.scannedFiles());
+        assertEquals(List.of("skipped.file"), skipped.skippedFiles());
+    }
+
+    @Test
     void parserFragmentsMergeInConfiguredOrder(@TempDir Path tempDir) {
         GraphBuilder builder = new GraphBuilder(
                 new EmptyParser(),
@@ -172,6 +211,31 @@ class GraphBuilderTest {
         @Override
         public List<String> scannedFiles(Path projectRoot) {
             return List.of("slow.file");
+        }
+    }
+
+    private static final class ErrorParser implements GraphParser {
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+            try {
+                Thread.sleep(25);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            throw new AssertionError("intentional parser error");
+        }
+    }
+
+    private static final class SkippedParser implements GraphParser {
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+        }
+
+        @Override
+        public List<String> scannedFiles(Path projectRoot) {
+            return List.of("skipped.file");
         }
     }
 

--- a/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/GraphBuilderTest.java
+++ b/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/GraphBuilderTest.java
@@ -174,6 +174,23 @@ class GraphBuilderTest {
         assertEquals(List.of("class:first", "class:second"), edgeSources);
     }
 
+    @Test
+    void builderUsesIndexedScannedFilesForParserExecution(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("indexed.file"), "content");
+        GraphBuilder builder = new GraphBuilder(
+                new EmptyParser(),
+                List.of(new IndexedParser()),
+                1,
+                TimeUnit.SECONDS);
+
+        GraphBuildResult result = builder.buildWithDiagnostics(tempDir);
+
+        ParserDiagnostic diagnostic = findDiagnostic(result, "IndexedParser");
+        assertTrue(diagnostic.successful());
+        assertEquals(List.of("indexed.file"), diagnostic.scannedFiles());
+        assertTrue(result.graph().hasNode("class:indexed.file"));
+    }
+
     private ParserDiagnostic findDiagnostic(GraphBuildResult result, String parserName) {
         return result.diagnostics().stream()
                 .filter(diagnostic -> parserName.equals(diagnostic.parserName()))
@@ -260,6 +277,34 @@ class GraphBuilderTest {
             graph.addNode(new GraphNode(classNodeId, NodeType.CLASS, Map.of("name", name)));
             graph.addNode(new GraphNode("class:target", NodeType.CLASS, Map.of()));
             graph.addEdge(new GraphEdge(classNodeId, "class:target", EdgeType.CALLS, Map.of()));
+        }
+    }
+
+    private static final class IndexedParser implements GraphParser {
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+            throw new AssertionError("GraphBuilder should call parseFiles with indexed candidates");
+        }
+
+        @Override
+        public List<String> scannedFiles(Path projectRoot) {
+            throw new AssertionError("GraphBuilder should use scannedFilePaths from the project file index");
+        }
+
+        @Override
+        public List<Path> scannedFilePaths(Path projectRoot, List<Path> projectFiles) {
+            return projectFiles.stream()
+                    .filter(file -> file.getFileName().toString().equals("indexed.file"))
+                    .toList();
+        }
+
+        @Override
+        public void parseFiles(Path projectRoot, List<Path> files, ProjectGraph graph) {
+            files.forEach(file -> graph.addNode(new GraphNode(
+                    "class:" + GraphParser.relativeFileName(projectRoot, file),
+                    NodeType.CLASS,
+                    Map.of())));
         }
     }
 }

--- a/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/GraphBuilderTest.java
+++ b/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/GraphBuilderTest.java
@@ -2,8 +2,12 @@ package io.github.luigidemasi.camelkit.graph;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.github.luigidemasi.camelkit.graph.model.*;
+import io.github.luigidemasi.camelkit.graph.parser.GraphParser;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -22,6 +26,20 @@ class GraphBuilderTest {
         assertFalse(graph.findByType(NodeType.CAMEL_ENDPOINT).isEmpty());
         assertFalse(graph.findByType(NodeType.MAVEN_ARTIFACT).isEmpty());
         assertFalse(graph.findByType(NodeType.CONFIG_PROPERTY).isEmpty());
+    }
+
+    @Test
+    void buildWithDiagnosticsReportsParserScans() {
+        GraphBuildResult result = new GraphBuilder().buildWithDiagnostics(TEST_PROJECT);
+
+        assertFalse(result.graph().findByType(NodeType.CLASS).isEmpty());
+        ParserDiagnostic pomDiagnostic = findDiagnostic(result, "PomParser");
+        assertEquals(List.of("di/pom.xml", "pom.xml"), pomDiagnostic.scannedFiles());
+        assertTrue(pomDiagnostic.successful());
+
+        ParserDiagnostic bizTalkDiagnostic = findDiagnostic(result, "BizTalkParser");
+        assertTrue(bizTalkDiagnostic.warnings().stream()
+                .anyMatch(warning -> warning.contains("malformed.odx")));
     }
 
     @Test
@@ -66,5 +84,118 @@ class GraphBuilderTest {
                 .toList();
         assertFalse(edges.isEmpty(),
                 "GraphBuilder should run CrossLinker.expandInterfaces to create DEPENDS_ON_VIA_INTERFACE edges");
+    }
+
+    @Test
+    void parserFailuresAreCapturedAsDiagnostics(@TempDir Path tempDir) {
+        GraphBuilder builder = new GraphBuilder(
+                new EmptyParser(),
+                List.of(new FailingParser()),
+                1,
+                TimeUnit.SECONDS);
+
+        GraphBuildResult result = builder.buildWithDiagnostics(tempDir);
+
+        ParserDiagnostic diagnostic = findDiagnostic(result, "FailingParser");
+        assertFalse(diagnostic.failures().isEmpty());
+        assertTrue(diagnostic.failures().get(0).contains("intentional parser failure"));
+        assertFalse(result.graph().hasNode("class:partial"),
+                "Failed parser fragments should not be merged into the final graph");
+    }
+
+    @Test
+    void parserTimeoutsAreCapturedAsDiagnostics(@TempDir Path tempDir) {
+        GraphBuilder builder = new GraphBuilder(
+                new EmptyParser(),
+                List.of(new SleepingParser()),
+                20,
+                TimeUnit.MILLISECONDS);
+
+        GraphBuildResult result = builder.buildWithDiagnostics(tempDir);
+
+        ParserDiagnostic diagnostic = findDiagnostic(result, "SleepingParser");
+        assertTrue(diagnostic.timedOut());
+        assertEquals(List.of("slow.file"), diagnostic.scannedFiles());
+    }
+
+    @Test
+    void parserFragmentsMergeInConfiguredOrder(@TempDir Path tempDir) {
+        GraphBuilder builder = new GraphBuilder(
+                new EmptyParser(),
+                List.of(new OrderedEdgeParser("first", 50), new OrderedEdgeParser("second", 0)),
+                1,
+                TimeUnit.SECONDS);
+
+        GraphBuildResult result = builder.buildWithDiagnostics(tempDir);
+
+        List<String> edgeSources = result.graph().getEdges().stream()
+                .filter(edge -> edge.type() == EdgeType.CALLS)
+                .map(GraphEdge::from)
+                .toList();
+        assertEquals(List.of("class:first", "class:second"), edgeSources);
+    }
+
+    private ParserDiagnostic findDiagnostic(GraphBuildResult result, String parserName) {
+        return result.diagnostics().stream()
+                .filter(diagnostic -> parserName.equals(diagnostic.parserName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static final class EmptyParser implements GraphParser {
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+        }
+    }
+
+    private static final class FailingParser implements GraphParser {
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+            graph.addNode(new GraphNode("class:partial", NodeType.CLASS, Map.of()));
+            throw new IllegalStateException("intentional parser failure");
+        }
+    }
+
+    private static final class SleepingParser implements GraphParser {
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public List<String> scannedFiles(Path projectRoot) {
+            return List.of("slow.file");
+        }
+    }
+
+    private static final class OrderedEdgeParser implements GraphParser {
+
+        private final String name;
+        private final long delayMillis;
+
+        private OrderedEdgeParser(String name, long delayMillis) {
+            this.name = name;
+            this.delayMillis = delayMillis;
+        }
+
+        @Override
+        public void parse(Path projectRoot, ProjectGraph graph) {
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            String classNodeId = "class:" + name;
+            graph.addNode(new GraphNode(classNodeId, NodeType.CLASS, Map.of("name", name)));
+            graph.addNode(new GraphNode("class:target", NodeType.CLASS, Map.of()));
+            graph.addEdge(new GraphEdge(classNodeId, "class:target", EdgeType.CALLS, Map.of()));
+        }
     }
 }

--- a/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/ProjectGraphTest.java
+++ b/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/ProjectGraphTest.java
@@ -2,6 +2,7 @@ package io.github.luigidemasi.camelkit.graph;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.github.luigidemasi.camelkit.graph.model.*;
 
@@ -108,15 +109,19 @@ class ProjectGraphTest {
 
         Map<String, GraphNode> nodes = graph.getNodes();
         List<GraphEdge> edges = graph.getEdges();
+        Set<GraphEdge> edgeSet = graph.getEdgeSet();
 
         graph.addNode(new GraphNode("class:Later", NodeType.CLASS, Map.of()));
         graph.addEdge(new GraphEdge("class:Later", "class:Original", EdgeType.CALLS, Map.of()));
 
         assertEquals(1, nodes.size());
         assertEquals(1, edges.size());
+        assertEquals(1, edgeSet.size());
         assertThrows(UnsupportedOperationException.class,
                 () -> nodes.put("class:Rejected", new GraphNode("class:Rejected", NodeType.CLASS, Map.of())));
         assertThrows(UnsupportedOperationException.class,
                 () -> edges.add(new GraphEdge("class:Rejected", "class:Original", EdgeType.CALLS, Map.of())));
+        assertThrows(UnsupportedOperationException.class,
+                () -> edgeSet.add(new GraphEdge("class:Rejected", "class:Original", EdgeType.CALLS, Map.of())));
     }
 }

--- a/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/ProjectGraphTest.java
+++ b/camel-kit-graph/src/test/java/io/github/luigidemasi/camelkit/graph/ProjectGraphTest.java
@@ -100,4 +100,23 @@ class ProjectGraphTest {
         assertEquals(2, graph.nodeCount());
         assertTrue(graph.hasNode("class:Other"));
     }
+
+    @Test
+    void accessorsReturnSnapshots() {
+        graph.addNode(new GraphNode("class:Original", NodeType.CLASS, Map.of()));
+        graph.addEdge(new GraphEdge("class:Original", "class:Original", EdgeType.CALLS, Map.of()));
+
+        Map<String, GraphNode> nodes = graph.getNodes();
+        List<GraphEdge> edges = graph.getEdges();
+
+        graph.addNode(new GraphNode("class:Later", NodeType.CLASS, Map.of()));
+        graph.addEdge(new GraphEdge("class:Later", "class:Original", EdgeType.CALLS, Map.of()));
+
+        assertEquals(1, nodes.size());
+        assertEquals(1, edges.size());
+        assertThrows(UnsupportedOperationException.class,
+                () -> nodes.put("class:Rejected", new GraphNode("class:Rejected", NodeType.CLASS, Map.of())));
+        assertThrows(UnsupportedOperationException.class,
+                () -> edges.add(new GraphEdge("class:Rejected", "class:Original", EdgeType.CALLS, Map.of())));
+    }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,9 @@ Shared guides live at `camel-kit-core/src/main/resources/skills/shared/` and are
 
 ### Project Graph Parsers
 
-The `camel-kit-graph` module builds a property graph of the project structure by running a set of parsers over the project's source files. Each parser produces typed nodes and edges that the graph consumers (validation, implementation, testing, migration) can query.
+The `camel-kit-graph` module builds a property graph of the project structure by running a set of parsers over the project's source files. Each parser produces typed nodes and edges that the graph consumers (validation, implementation, testing, migration) can query. `GraphBuilder.build(Path)` preserves the original graph-only API, while `GraphBuilder.buildWithDiagnostics(Path)` returns a `GraphBuildResult` containing the graph plus parser diagnostics.
+
+`PomParser` runs first to produce the Maven/runtime context needed by other parsers. The remaining parsers run in parallel against parser-local graph fragments initialized from that base context. `GraphBuilder` then merges successful fragments in the configured parser order, so final graph construction is not coupled to future completion timing. Parser diagnostics include the parser name, scanned files, warnings, failures, timeout state, produced node count, and produced edge count.
 
 **9 content parsers and 2 post-processors** are registered in `GraphBuilder`:
 


### PR DESCRIPTION
Closes #104.

Summary:
- Add GraphBuildResult and ParserDiagnostic for structured graph build diagnostics.
- Build parser-local graph fragments and merge successful fragments in configured order.
- Capture parser failures, timeouts, scanned files, and BizTalk parse warnings without stderr-only reporting.
- Document the updated graph build pipeline.

Validation:
- ./mvnw -pl camel-kit-graph test -Dformat.skip=true
- ./mvnw -pl camel-kit-graph process-sources
- ./mvnw clean install -DskipTests

## Summary by Sourcery

Introduce structured diagnostics and deterministic merging for project graph building while preserving the existing graph-only API.

New Features:
- Add GraphBuildResult and ParserDiagnostic to expose parser-level diagnostics alongside the built project graph.
- Expose a buildWithDiagnostics entry point on GraphBuilder that returns both the graph and per-parser diagnostic information.

Bug Fixes:
- Prevent partial or failed parser output from being merged into the final project graph.
- Avoid misclassifying XML files between Mule, BizTalk, and generic Camel XML parsers by tightening candidate file detection.

Enhancements:
- Refactor GraphBuilder to run parsers against local graph fragments and merge successful fragments in a deterministic, configured order.
- Add timeout, interruption, and failure handling for individual parsers with corresponding diagnostic records.
- Extend GraphParser with hooks for parser-local fragments, scanned file reporting, and warnings collection.
- Switch ProjectGraph to use ordered collections to preserve insertion order while remaining thread-safe.
- Plumb BizTalk parsers to report non-fatal parse problems via structured warnings instead of stderr logging.

Documentation:
- Document the updated graph build pipeline, including parser ordering, fragment merging, and the new diagnostics model, in the architecture guide.

Tests:
- Add tests covering diagnostic reporting of scanned files and BizTalk warnings, parser failure and timeout handling, and deterministic merging order of parser fragments.