### PR TITLE
Fix #117: apply all shipped agent traits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,7 +389,9 @@ templates/traits/{agent}/{skill-name}/{guide-name}.append.md  # Guide-level trai
 
 Traits are appended to the corresponding skill files during `camel-kit init` with idempotent sentinels. Each trait should contain instructions specific to that agent's tools and capabilities — not generic content that belongs in the shared skill.
 
-To register a new SKILL.md-level trait, add the skill name to the `skillNames` list in `DefaultGenerator.applyTraits()`. For guide-level traits, add the guide name to the `guideNames` list in `DefaultGenerator.applyGuideTraits()`.
+No code registration is required for a new trait file. `TraitApplicator` applies SKILL.md-level traits for workflow skills and discovers guide-level traits from the shipped `.append.md` files under each `templates/traits/{agent}/{skill-name}/` directory. Bob is the exception in ordering only: it installs its monolithic gate templates first, then appends Bob traits to the final generated files.
+
+`ShippedAssetStructureTest` verifies both sides of the contract: trait files must target existing shipped skills or guides, and every shipped trait must appear in generated output for the production generator of its agent.
 
 See [Architecture Guide](docs/architecture.md#agent-traits) for details on the trait system.
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/BobGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/BobGenerator.java
@@ -28,10 +28,7 @@ public class BobGenerator extends DefaultGenerator {
             "camel-test", "testing.md");
 
     @Override
-    public void generate(InitContext ctx) throws Exception {
-        WorkflowManifest workflow = loadWorkflowManifest();
-        generateBaseAssets(ctx, workflow);
-
+    protected void beforeApplyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {
         Map<String, Object> templateData = new HashMap<>(
                 Map.of(
                         "COMMAND_PREFIX", ctx.commandPrefix()));
@@ -43,9 +40,6 @@ public class BobGenerator extends DefaultGenerator {
 
         // Bob-specific: replace SKILL.md files with monolithic gate versions
         replaceSkillsWithGates(ctx, templateData);
-
-        applyTraits(ctx, workflow);
-        generateMcpConfig(ctx, workflow);
     }
 
     private void generateCustomModes(InitContext ctx) throws Exception {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/BobGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/BobGenerator.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.github.luigidemasi.camelkit.util.TemplateUtils;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
 
 public class BobGenerator extends DefaultGenerator {
 
@@ -28,8 +29,8 @@ public class BobGenerator extends DefaultGenerator {
 
     @Override
     public void generate(InitContext ctx) throws Exception {
-        // Run default generation (commands, skills, MCP config)
-        super.generate(ctx);
+        WorkflowManifest workflow = loadWorkflowManifest();
+        generateBaseAssets(ctx, workflow);
 
         Map<String, Object> templateData = new HashMap<>(
                 Map.of(
@@ -42,6 +43,9 @@ public class BobGenerator extends DefaultGenerator {
 
         // Bob-specific: replace SKILL.md files with monolithic gate versions
         replaceSkillsWithGates(ctx, templateData);
+
+        applyTraits(ctx, workflow);
+        generateMcpConfig(ctx, workflow);
     }
 
     private void generateCustomModes(InitContext ctx) throws Exception {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/BobGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/BobGenerator.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.github.luigidemasi.camelkit.util.TemplateUtils;
-import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
 
 public class BobGenerator extends DefaultGenerator {
 
@@ -28,7 +27,7 @@ public class BobGenerator extends DefaultGenerator {
             "camel-test", "testing.md");
 
     @Override
-    protected void beforeApplyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {
+    protected void beforeApplyTraits(InitContext ctx) throws Exception {
         Map<String, Object> templateData = new HashMap<>(
                 Map.of(
                         "COMMAND_PREFIX", ctx.commandPrefix()));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -45,6 +45,7 @@ public class DefaultGenerator implements AgentGenerator {
     public void generate(InitContext ctx) throws Exception {
         WorkflowManifest workflow = loadWorkflowManifest();
         generateBaseAssets(ctx, workflow);
+        beforeApplyTraits(ctx, workflow);
         applyTraits(ctx, workflow);
         generateMcpConfig(ctx, workflow);
     }
@@ -59,6 +60,10 @@ public class DefaultGenerator implements AgentGenerator {
         agentsMdGenerator.generate(ctx);
         commandStubGenerator.generate(ctx, workflow);
         skillResourceInstaller.install(ctx);
+    }
+
+    protected void beforeApplyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {
+        // Extension hook for generators that need to prepare generated assets before trait application.
     }
 
     protected void applyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -45,12 +45,12 @@ public class DefaultGenerator implements AgentGenerator {
     public void generate(InitContext ctx) throws Exception {
         WorkflowManifest workflow = loadWorkflowManifest();
         generateBaseAssets(ctx, workflow);
-        beforeApplyTraits(ctx, workflow);
+        beforeApplyTraits(ctx);
         applyTraits(ctx, workflow);
         generateMcpConfig(ctx, workflow);
     }
 
-    protected WorkflowManifest loadWorkflowManifest() throws IOException {
+    private WorkflowManifest loadWorkflowManifest() throws IOException {
         return WorkflowManifestLoader.loadDefault();
     }
 
@@ -62,7 +62,7 @@ public class DefaultGenerator implements AgentGenerator {
         skillResourceInstaller.install(ctx);
     }
 
-    protected void beforeApplyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {
+    protected void beforeApplyTraits(InitContext ctx) throws Exception {
         // Extension hook for generators that need to prepare generated assets before trait application.
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -43,14 +43,29 @@ public class DefaultGenerator implements AgentGenerator {
 
     @Override
     public void generate(InitContext ctx) throws Exception {
-        WorkflowManifest workflow = WorkflowManifestLoader.loadDefault();
+        WorkflowManifest workflow = loadWorkflowManifest();
+        generateBaseAssets(ctx, workflow);
+        applyTraits(ctx, workflow);
+        generateMcpConfig(ctx, workflow);
+    }
 
+    protected WorkflowManifest loadWorkflowManifest() throws IOException {
+        return WorkflowManifestLoader.loadDefault();
+    }
+
+    protected void generateBaseAssets(InitContext ctx, WorkflowManifest workflow) throws Exception {
         Files.createDirectories(ctx.commandsDir());
         Files.createDirectories(ctx.skillsDir());
         agentsMdGenerator.generate(ctx);
         commandStubGenerator.generate(ctx, workflow);
         skillResourceInstaller.install(ctx);
+    }
+
+    protected void applyTraits(InitContext ctx, WorkflowManifest workflow) throws Exception {
         traitApplicator.apply(ctx, workflow);
+    }
+
+    protected void generateMcpConfig(InitContext ctx, WorkflowManifest workflow) throws Exception {
         mcpConfigGenerator.generate(ctx, workflow);
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/TraitApplicator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/TraitApplicator.java
@@ -11,10 +11,7 @@ import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
 
 class TraitApplicator {
 
-    private static final List<String> GUIDE_TRAIT_NAMES = List.of(
-            "implementer-context", "spec-reviewer-criteria",
-            "quality-reviewer-criteria", "verify-loop",
-            "test-generation", "test-runner");
+    private static final String APPEND_TRAIT_SUFFIX = ".append.md";
 
     void apply(InitContext ctx, WorkflowManifest workflow) throws Exception {
         String traitsBasePath = "templates/traits/" + ctx.agentName() + "/";
@@ -45,8 +42,9 @@ class TraitApplicator {
 
     private int applyGuideTraits(String traitDirPath, Path guidesDir, String agentName) throws Exception {
         int count = 0;
-        for (String guideName : GUIDE_TRAIT_NAMES) {
-            String traitResourcePath = traitDirPath + guideName + ".append.md";
+        for (String traitFileName : TemplateUtils.listTemplateFiles(traitDirPath, APPEND_TRAIT_SUFFIX)) {
+            String guideName = stripAppendSuffix(traitFileName);
+            String traitResourcePath = traitDirPath + guideName + APPEND_TRAIT_SUFFIX;
             Path targetGuide = guidesDir.resolve(guideName + ".md");
             if (appendTraitIfExists(traitResourcePath, targetGuide, agentName)) {
                 count++;
@@ -76,5 +74,9 @@ class TraitApplicator {
         Files.writeString(targetFile,
                 existing + "\n---\n\n" + sentinel + "\n" + traitContent + "\n" + closeSentinel + "\n");
         return true;
+    }
+
+    private static String stripAppendSuffix(String fileName) {
+        return fileName.substring(0, fileName.length() - APPEND_TRAIT_SUFFIX.length());
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/TemplateUtils.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/TemplateUtils.java
@@ -1,14 +1,25 @@
 package io.github.luigidemasi.camelkit.util;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Utility for reading template files from resources or filesystem.
@@ -63,6 +74,25 @@ public final class TemplateUtils {
     }
 
     /**
+     * List immediate files under a bundled template directory.
+     *
+     * @param  templateDirPath directory path, e.g. {@code templates/traits/claude/camel-execute}
+     * @param  suffix          optional filename suffix filter, e.g. {@code .append.md}
+     * @return                 sorted matching file names, without the directory prefix
+     * @throws IOException     if a matching directory exists but cannot be read
+     */
+    public static List<String> listTemplateFiles(String templateDirPath, String suffix) throws IOException {
+        String normalizedDir = normalizeDirectory(templateDirPath);
+        Set<String> names = new TreeSet<>();
+
+        collectFromFilesystem(Path.of(normalizedDir), suffix, names);
+        collectFromClassLoader(normalizedDir, suffix, names);
+        collectFromClassPath(normalizedDir, suffix, names);
+
+        return List.copyOf(names);
+    }
+
+    /**
      * Read a resource file as an array of lines.
      *
      * @param  resourcePath the path to the resource (e.g., "art/camelLines.txt")
@@ -90,5 +120,95 @@ public final class TemplateUtils {
         }
 
         throw new IOException("Resource not found: " + resourcePath);
+    }
+
+    private static String normalizeDirectory(String templateDirPath) {
+        String normalized = templateDirPath.replace("\\", "/");
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static void collectFromFilesystem(Path directory, String suffix, Set<String> names) throws IOException {
+        if (!Files.isDirectory(directory)) {
+            return;
+        }
+
+        try (Stream<Path> paths = Files.list(directory)) {
+            paths.filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .filter(name -> suffix == null || name.endsWith(suffix))
+                    .forEach(names::add);
+        }
+    }
+
+    private static void collectFromClassLoader(String directory, String suffix, Set<String> names) throws IOException {
+        ClassLoader loader = TemplateUtils.class.getClassLoader();
+        Enumeration<URL> urls = loader.getResources(directory);
+        while (urls.hasMoreElements()) {
+            URL url = urls.nextElement();
+            if ("file".equals(url.getProtocol())) {
+                collectFromFilesystem(toPath(url), suffix, names);
+            } else if ("jar".equals(url.getProtocol())) {
+                collectFromJarUrl(url, directory, suffix, names);
+            }
+        }
+    }
+
+    private static void collectFromClassPath(String directory, String suffix, Set<String> names) throws IOException {
+        String classPath = System.getProperty("java.class.path", "");
+        if (classPath.isBlank()) {
+            return;
+        }
+
+        for (String entry : classPath.split(Pattern.quote(File.pathSeparator))) {
+            if (entry.isBlank()) {
+                continue;
+            }
+            Path classPathEntry = Path.of(entry);
+            if (Files.isDirectory(classPathEntry)) {
+                collectFromFilesystem(classPathEntry.resolve(directory), suffix, names);
+            } else if (Files.isRegularFile(classPathEntry) && entry.endsWith(".jar")) {
+                try (JarFile jarFile = new JarFile(classPathEntry.toFile())) {
+                    collectFromJar(jarFile, directory, suffix, names);
+                }
+            }
+        }
+    }
+
+    private static Path toPath(URL url) throws IOException {
+        try {
+            return Path.of(url.toURI());
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid template resource URL: " + url, e);
+        }
+    }
+
+    private static void collectFromJarUrl(URL url, String directory, String suffix, Set<String> names)
+            throws IOException {
+        JarURLConnection connection = (JarURLConnection) url.openConnection();
+        collectFromJar(connection.getJarFile(), directory, suffix, names);
+    }
+
+    private static void collectFromJar(JarFile jarFile, String directory, String suffix, Set<String> names) {
+        String prefix = directory + "/";
+        Enumeration<JarEntry> entries = jarFile.entries();
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            String entryName = entry.getName();
+            if (entry.isDirectory() || !entryName.startsWith(prefix)) {
+                continue;
+            }
+
+            String relative = entryName.substring(prefix.length());
+            if (relative.contains("/") || suffix != null && !relative.endsWith(suffix)) {
+                continue;
+            }
+            names.add(relative);
+        }
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/TemplateUtils.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/util/TemplateUtils.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -84,10 +85,11 @@ public final class TemplateUtils {
     public static List<String> listTemplateFiles(String templateDirPath, String suffix) throws IOException {
         String normalizedDir = normalizeDirectory(templateDirPath);
         Set<String> names = new TreeSet<>();
+        Set<String> scannedJarUrls = new HashSet<>();
 
         collectFromFilesystem(Path.of(normalizedDir), suffix, names);
-        collectFromClassLoader(normalizedDir, suffix, names);
-        collectFromClassPath(normalizedDir, suffix, names);
+        collectFromClassLoader(normalizedDir, suffix, names, scannedJarUrls);
+        collectFromClassPath(normalizedDir, suffix, names, scannedJarUrls);
 
         return List.copyOf(names);
     }
@@ -146,7 +148,9 @@ public final class TemplateUtils {
         }
     }
 
-    private static void collectFromClassLoader(String directory, String suffix, Set<String> names) throws IOException {
+    private static void collectFromClassLoader(
+            String directory, String suffix, Set<String> names, Set<String> scannedJarUrls)
+            throws IOException {
         ClassLoader loader = TemplateUtils.class.getClassLoader();
         Enumeration<URL> urls = loader.getResources(directory);
         while (urls.hasMoreElements()) {
@@ -154,12 +158,14 @@ public final class TemplateUtils {
             if ("file".equals(url.getProtocol())) {
                 collectFromFilesystem(toPath(url), suffix, names);
             } else if ("jar".equals(url.getProtocol())) {
-                collectFromJarUrl(url, directory, suffix, names);
+                collectFromJarUrl(url, directory, suffix, names, scannedJarUrls);
             }
         }
     }
 
-    private static void collectFromClassPath(String directory, String suffix, Set<String> names) throws IOException {
+    private static void collectFromClassPath(
+            String directory, String suffix, Set<String> names, Set<String> scannedJarUrls)
+            throws IOException {
         String classPath = System.getProperty("java.class.path", "");
         if (classPath.isBlank()) {
             return;
@@ -173,6 +179,10 @@ public final class TemplateUtils {
             if (Files.isDirectory(classPathEntry)) {
                 collectFromFilesystem(classPathEntry.resolve(directory), suffix, names);
             } else if (Files.isRegularFile(classPathEntry) && entry.endsWith(".jar")) {
+                String jarUrl = classPathEntry.toAbsolutePath().normalize().toUri().toString();
+                if (!scannedJarUrls.add(jarUrl)) {
+                    continue;
+                }
                 try (JarFile jarFile = new JarFile(classPathEntry.toFile())) {
                     collectFromJar(jarFile, directory, suffix, names);
                 }
@@ -188,10 +198,23 @@ public final class TemplateUtils {
         }
     }
 
-    private static void collectFromJarUrl(URL url, String directory, String suffix, Set<String> names)
+    private static void collectFromJarUrl(
+            URL url, String directory, String suffix, Set<String> names, Set<String> scannedJarUrls)
             throws IOException {
         JarURLConnection connection = (JarURLConnection) url.openConnection();
-        collectFromJar(connection.getJarFile(), directory, suffix, names);
+        if (!scannedJarUrls.add(connection.getJarFileURL().toExternalForm())) {
+            return;
+        }
+
+        boolean useCaches = connection.getUseCaches();
+        JarFile jarFile = connection.getJarFile();
+        try {
+            collectFromJar(jarFile, directory, suffix, names);
+        } finally {
+            if (!useCaches) {
+                jarFile.close();
+            }
+        }
     }
 
     private static void collectFromJar(JarFile jarFile, String directory, String suffix, Set<String> names) {
@@ -205,7 +228,7 @@ public final class TemplateUtils {
             }
 
             String relative = entryName.substring(prefix.length());
-            if (relative.contains("/") || suffix != null && !relative.endsWith(suffix)) {
+            if (relative.contains("/") || (suffix != null && !relative.endsWith(suffix))) {
                 continue;
             }
             names.add(relative);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
@@ -171,6 +171,34 @@ class ShippedAssetStructureTest {
     }
 
     @Test
+    void generatedAgentAssetsIncludeShippedTraits() throws Exception {
+        Path resourcesDir = resourceRoot();
+        Path traitsDir = resourcesDir.resolve("templates/traits");
+
+        List<String> missingTraits = new ArrayList<>();
+        for (String agentName : sortedAgentNames()) {
+            InitContext ctx = createContext(agentName, tempDir.resolve("traits-" + agentName));
+            AgentGeneratorFactory.create(agentName).generate(ctx);
+
+            Path agentTraitsDir = traitsDir.resolve(agentName);
+            if (!Files.isDirectory(agentTraitsDir)) {
+                continue;
+            }
+
+            try (Stream<Path> paths = Files.walk(agentTraitsDir)) {
+                paths.filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().endsWith(".append.md"))
+                        .sorted()
+                        .forEach(path -> validateGeneratedTrait(resourcesDir, traitsDir, ctx, path, missingTraits));
+            }
+        }
+
+        assertTrue(missingTraits.isEmpty(),
+                "Generated agent assets are missing shipped trait content:\n"
+                                            + String.join("\n", missingTraits));
+    }
+
+    @Test
     void generatedAgentAssetsAreStructurallyCoherent() throws Exception {
         WorkflowManifest manifest = WorkflowManifestLoader.loadDefault();
         Map<String, WorkflowManifest.WorkflowCommand> generatedCommands = manifest.generatedCommandStubs().stream()
@@ -359,6 +387,44 @@ class ShippedAssetStructureTest {
             invalidTraits.add(resourcesDir.relativize(traitFile) + " targets missing "
                               + resourcesDir.relativize(target));
         }
+    }
+
+    private static void validateGeneratedTrait(
+            Path resourcesDir, Path traitsDir, InitContext ctx, Path traitFile, List<String> missingTraits) {
+        Path target = generatedTraitTarget(traitsDir, ctx, traitFile);
+        String source = resourcesDir.relativize(traitFile).toString();
+        String targetDisplay = ctx.projectDir().relativize(target).toString();
+        try {
+            if (!Files.isRegularFile(target)) {
+                missingTraits.add(source + " target was not generated at " + targetDisplay);
+                return;
+            }
+
+            String generatedContent = Files.readString(target);
+            String sentinel = "<!-- TRAIT:" + ctx.agentName() + " -->";
+            if (!generatedContent.contains(sentinel)) {
+                missingTraits.add(source + " did not add sentinel to generated " + targetDisplay);
+            }
+
+            String traitContent = Files.readString(traitFile).strip();
+            if (!traitContent.isEmpty() && !generatedContent.contains(traitContent)) {
+                missingTraits.add(source + " content was not appended to generated " + targetDisplay);
+            }
+        } catch (IOException e) {
+            missingTraits.add(source + " could not be verified against generated " + targetDisplay
+                              + ": " + e.getMessage());
+        }
+    }
+
+    private static Path generatedTraitTarget(Path traitsDir, InitContext ctx, Path traitFile) {
+        Path relative = traitsDir.relativize(traitFile);
+        String skillName = stripAppendSuffix(relative.getName(1).toString());
+        if (relative.getNameCount() == 2) {
+            return ctx.skillsDir().resolve(skillName).resolve("SKILL.md");
+        }
+
+        String guideName = stripAppendSuffix(relative.getFileName().toString());
+        return ctx.skillsDir().resolve(skillName).resolve("guides").resolve(guideName + ".md");
     }
 
     private static String stripAppendSuffix(String fileName) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -359,7 +359,7 @@ The active scan covers `camel-kit-core/src/main/resources/skills`, `camel-kit-co
 
 Docs subdirectories are intentionally out of scope; this keeps ignored archives such as `docs/plans/` and `docs/superpowers/`, image assets, and generated planning material out of the contract check.
 
-`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent descriptor has dispatch and MCP config templates, descriptor template sources exist, trait files target existing skills or guides, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as JSON with the expected server containers.
+`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent descriptor has dispatch and MCP config templates, descriptor template sources exist, trait files target existing skills or guides, every shipped trait appears in generated output for its production agent generator, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as JSON with the expected server containers.
 
 Historical release notes, old planning material, and archived ADR-style documents are outside the active contract unless they are copied into generated projects or used as live instructions. Keep historical context in those files as history; do not exclude an active shipped instruction just because it is inconvenient to update.
 
@@ -387,7 +387,7 @@ Traits are agent-specific instruction fragments that are appended to shared skil
 
 **Location:** `camel-kit-core/src/main/resources/templates/traits/{agent}/`
 
-**How it works:** During `camel-kit init --ai {agent}`, `TraitApplicator` scans the traits directory for the selected agent and appends each `.append.md` file to the corresponding skill file. Idempotent HTML comment sentinels (`<!-- TRAIT:{agent} -->` / `<!-- /TRAIT:{agent} -->`) prevent duplicate application on re-init.
+**How it works:** During `camel-kit init --ai {agent}`, `TraitApplicator` applies trait files for the selected agent to the corresponding generated skill files. SKILL.md-level traits are applied for skills in the workflow manifest. Guide-level traits are discovered from the actual `.append.md` files under `traits/{agent}/{skill-name}/`, so adding a new guide trait does not require registering the guide name in Java code. Idempotent HTML comment sentinels (`<!-- TRAIT:{agent} -->` / `<!-- /TRAIT:{agent} -->`) prevent duplicate application on re-init.
 
 **Two granularity levels:**
 
@@ -399,6 +399,8 @@ Traits are agent-specific instruction fragments that are appended to shared skil
 **Example:** `traits/claude/camel-execute.append.md` appends Claude-specific instructions to `camel-execute/SKILL.md` -- parallel sub-agent dispatch via the `Agent` tool, worktree isolation via `EnterWorktree`, build health monitoring via `CronCreate`. The same skill on Gemini gets different trait content: named agent delegation, TOML policy guidance, batch context loading via `read_many_files`.
 
 **What traits contain:** Agent-specific tool usage, dispatch strategies, state persistence mechanisms, and execution optimizations. Each trait is written for the specific agent's capabilities -- Claude traits reference `Agent`, `ScheduleWakeup`, `TaskCreate`; Gemini traits reference `save_memory`, `read_many_files`; Bob traits reference `switch_mode`, `insert_content`.
+
+**Bob ordering:** IBM Project Bob replaces several generated `SKILL.md` files with monolithic gate templates. Bob traits are applied after that replacement, so Bob-specific trait content is appended to the final gate-backed skill files rather than being overwritten. Bob guide-level traits still apply to the copied guide files.
 
 ### Iron Laws
 


### PR DESCRIPTION
## Summary
- Discover guide-level agent trait files dynamically from shipped .append.md resources.
- Apply Bob traits after monolithic gate replacement so final Bob skills keep trait content.
- Add generated-output coverage for every shipped trait and document discovery/testing behavior.

## Verification
- ./mvnw -pl camel-kit-core -am -Dtest=ShippedAssetStructureTest,BobGeneratorTest,DefaultGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw clean install -DskipTests

Fixes #117