### PR TITLE
Fix #119: Add IBM Bob 2 AI target support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Default AI target changed to IBM Bob 2** — `camel-kit init` and `camel kit init` now default to `--ai bob2` when no `--ai` option is supplied.
+  - CLI help and documentation now mark Bob 2 as the default target
+  - `--ai bob` remains supported for IBM Bob 1 legacy workspaces
+  - Selecting `--ai bob` emits a non-blocking legacy warning recommending `--ai bob2` for new IBM Bob projects
+
+- **Bob documentation split by generation** — README, user guide, command reference, and architecture docs now describe `--ai bob` as IBM Bob 1 legacy support and `--ai bob2` as IBM Bob 2 support.
+  - Bob 1 mode/gate architecture remains documented as legacy behavior
+  - Bob 2 documentation describes native subagents and no longer inherits broad "Bob does not support subagents" language
+  - The "Adding a New Agent" architecture guide now includes registry descriptor and `camel-kit doctor` validation steps
+
 - **Progressive skill loading via meta-router** — introduced `/camel-start` as the single auto-discovered skill that routes users into two pipelines (greenfield: brainstorm → plan → execute → verify, migration: migrate → plan → execute → verify). All other skills set to `user_invocable: false` — slash commands still work as on-demand loaders. Context baseline reduced from ~1,260 to ~110 tokens (91% reduction).
   - New `camel-start/SKILL.md` with decision tree, "When NOT to use" table, pipeline overview, and Tier 2 utility references
   - AGENTS.md rewritten to ultra-minimal bootstrap (~80 tokens): compressed iron laws + entry point directive
@@ -21,10 +31,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`camel-kit doctor` Bob 2 MCP validation** — doctor now resolves MCP config paths through the agent registry descriptor instead of a duplicated hard-coded switch, so Bob 2 projects validate `.bob/mcp.json` correctly.
 - **Incorrect relative path in Bob test template** — `camel-test.md` used `../main/resources/` instead of `../../main/resources/` for route YAML references in test examples
 - **Stale body text in `camel-validate` and `camel-knowledge`** — both had "NOT user-invocable" text contradicting their actual invocability via slash commands
 
 ### Added
+
+- **IBM Bob 2 AI target (`--ai bob2`)** — added a new Bob 2 target while preserving `--ai bob` as the IBM Bob 1 legacy path.
+  - New `bob2` agent registry descriptor, generator strategy, and `Bob2Generator`
+  - Bob 2 workspaces still generate under `.bob/` with `.bob/commands`, `.bob/skills`, `.bob/custom_modes.yaml`, and `.bob/mcp.json`
+  - Bob 2 custom modes use the current Bob 2 tool groups (`read`, `edit`, `execute`, `mcp`, `skill`, `todo`, `artifact`, `subagent`, `mode`) with `allowedSubagents`
+  - New Bob 2 rules, dispatch template, and traits for native `spawn_subagent` orchestration with `explore`, `general`, and `fork_context`
+  - Bob 2 command stubs include markdown frontmatter from workflow metadata, including `description` and argument hints
+  - Bob 2 generated skills keep the shared `SKILL.md` content and append Bob 2 traits instead of replacing skills with Bob 1 monolithic gates
+  - Bob 2 skill metadata includes Bob-readable `user-invocable` aliases while preserving existing metadata for other agents
+
+- **Bob 2 coverage and regression tests** — added registry, factory, generator, command-frontmatter, skill-metadata, custom-mode, doctor, and CLI default tests for Bob 2, plus explicit guards that legacy Bob 1 output remains unchanged.
 
 - **Project graph analysis (`camel-kit-graph` module)** — new module that builds an in-memory graph of an entire Camel project and exposes it through CLI commands
   - 9 parsers: `YamlRouteParser`, `XmlRouteParser`, `JavaGraphParser`, `GroovyGraphParser`, `ConfigParser`, `PomParser`, `MuleXmlFlowParser`, `DataWeaveParser`, `CrossLinker` (for direct/seda, component, and config cross-references)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ camel plugin add kit \
   --description "Design Apache Camel Integrations with AI"
 
 # Then use via the camel CLI
-camel kit init my-integration --ai bob
+camel kit init my-integration
 ```
 
 ### Build from Source (development version)
@@ -128,8 +128,10 @@ cd camel-kit-knowledge
 
 ```bash
 # 1. Create a new project (choose your AI assistant)
+camel-kit init my-integration             # IBM Bob 2 (default)
 camel-kit init my-integration --ai claude   # Anthropic Claude Code
-camel-kit init my-integration --ai bob      # IBM Project Bob
+camel-kit init my-integration --ai bob      # IBM Bob 1 legacy
+camel-kit init my-integration --ai bob2     # IBM Bob 2
 camel-kit init my-integration --ai gemini   # Google Gemini CLI
 camel-kit init my-integration --ai qwen     # Qwen (requires dev build)
 camel-kit init my-integration --ai opencode # OpenCode (requires dev build)
@@ -151,7 +153,8 @@ cd my-integration
 | Agent | Init Flag | Instruction File | MCP Config |
 |-------|-----------|-----------------|------------|
 | Anthropic Claude Code | `--ai claude` | `CLAUDE.md` | `.mcp.json` |
-| IBM Project Bob | `--ai bob` | `custom_modes.yaml` + rules | `.bob/mcp.json` |
+| IBM Bob 1 legacy | `--ai bob` | `custom_modes.yaml` + rules + gates | `.bob/mcp.json` |
+| IBM Bob 2 (default) | `--ai bob2` | `custom_modes.yaml` + rules + skills | `.bob/mcp.json` |
 | Google Gemini CLI | `--ai gemini` | `GEMINI.md` | `.gemini/mcp.json` |
 | Qwen | `--ai qwen` | `QWEN.md` | `.qwen/mcp.json` |
 | OpenCode | `--ai opencode` | `AGENTS.md` | `.opencode/mcp.json` |
@@ -193,7 +196,7 @@ All agents use the same skills — camel-kit generates agent-specific instructio
 
 ### Multi-Agent
 
-- **5 AI agents** — same skills work across Claude Code, IBM Bob, Gemini CLI, Qwen, and OpenCode. Agent-specific traits customize behavior (pacing, approval modes, tool usage) without changing the shared skills. [Learn more →](docs/architecture.md)
+- **6 AI targets** — same skills work across Claude Code, IBM Bob 1 legacy, IBM Bob 2, Gemini CLI, Qwen, and OpenCode. Agent-specific traits customize behavior (pacing, approval modes, tool usage) without changing the shared skills. [Learn more →](docs/architecture.md)
 
 ---
 

--- a/camel-jbang-plugin-kit/README.md
+++ b/camel-jbang-plugin-kit/README.md
@@ -39,13 +39,13 @@ Once installed, you can use camel-kit commands through the `camel` CLI:
 ### Initialize a New Project
 
 ```bash
-# Initialize in a new directory
+# Initialize in a new directory (IBM Bob 2 by default)
 camel kit init my-integration
 
 # Initialize in current directory
 camel kit init --here
 
-# Specify AI agent (bob, gemini, or claude)
+# Specify AI agent (bob2, bob, gemini, claude, qwen, or opencode)
 camel kit init my-integration --ai claude
 
 # Specify Camel version

--- a/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/KitInitCommand.java
+++ b/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/KitInitCommand.java
@@ -22,8 +22,10 @@ public class KitInitCommand extends CamelCommand {
     @Parameters(index = "0", description = "Project name", arity = "0..1")
     String projectName;
 
-    @Option(names = {"-a", "--ai"}, description = "AI agent: bob, gemini, claude, qwen, opencode",
-            defaultValue = "bob")
+    @Option(names = {"-a", "--ai"},
+            description = "AI agent: bob2 (IBM Bob 2, default), bob (IBM Bob 1 legacy), "
+                          + "gemini, claude, qwen, opencode",
+            defaultValue = "bob2")
     String ai;
 
     @Option(names = {"--here"}, description = "Initialize in current directory")

--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
@@ -10,6 +10,15 @@ import static org.junit.jupiter.api.Assertions.*;
 class CamelKitPluginTest {
 
     @Test
+    void kitInitDefaultsToBob2WhenAgentOptionIsOmitted() {
+        KitInitCommand command = new KitInitCommand(new CamelJBangMain());
+
+        new CommandLine(command).parseArgs("orders");
+
+        assertEquals("bob2", command.ai);
+    }
+
+    @Test
     void registersDoctorUnderKitCommand() {
         CamelJBangMain main = new CamelJBangMain();
         CommandLine root = new CommandLine(main);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -31,8 +31,10 @@ public class InitCommand extends CamelKitCommand {
     @Parameters(index = "0", description = "Project name", arity = "0..1")
     public String projectName;
 
-    @Option(names = {"-a", "--ai"}, description = "AI agent: bob, gemini, claude, qwen, opencode",
-            defaultValue = "bob")
+    @Option(names = {"-a", "--ai"},
+            description = "AI agent: bob2 (IBM Bob 2, default), bob (IBM Bob 1 legacy), "
+                          + "gemini, claude, qwen, opencode",
+            defaultValue = "bob2")
     public String ai;
 
     @Option(names = {"--here"}, description = "Initialize in current directory")

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 public enum AgentGeneratorStrategy {
     DEFAULT("default"),
     BOB("bob"),
+    BOB2("bob2"),
     CLAUDE("claude"),
     GEMINI("gemini"),
     OPENCODE("opencode"),

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
@@ -12,6 +12,7 @@ public final class AgentGeneratorFactory {
     public static AgentGenerator create(String agentName) {
         return switch (generatorStrategy(agentName)) {
             case BOB -> new BobGenerator();
+            case BOB2 -> new Bob2Generator();
             case CLAUDE -> new ClaudeGenerator();
             case GEMINI -> new GeminiGenerator();
             case OPENCODE -> new OpenCodeGenerator();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/Bob2Generator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/Bob2Generator.java
@@ -1,0 +1,45 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+public class Bob2Generator extends DefaultGenerator {
+
+    private static final Map<String, String> RULE_MODE_FILES = Map.of(
+            "camel-brainstorm", "brainstorm.md",
+            "camel-plan", "plan.md",
+            "camel-implement", "implement.md",
+            "camel-execute", "execute.md",
+            "camel-validate", "validate.md",
+            "camel-test", "test.md",
+            "camel-debug", "debug.md",
+            "camel-ship", "ship.md");
+
+    @Override
+    public void generate(InitContext ctx) throws Exception {
+        super.generate(ctx);
+        generateCustomModes(ctx);
+        generateRules(ctx);
+    }
+
+    private void generateCustomModes(InitContext ctx) throws Exception {
+        Path modesFile = ctx.projectDir().resolve(".bob/custom_modes.yaml");
+        Files.createDirectories(modesFile.getParent());
+        copyTemplateResource("templates/bob2/custom_modes.yaml", modesFile);
+    }
+
+    private void generateRules(InitContext ctx) throws Exception {
+        Path sharedRulesDir = ctx.projectDir().resolve(".bob/rules");
+        Files.createDirectories(sharedRulesDir);
+        copyTemplateResource("templates/bob2/rules/iron-laws.md", sharedRulesDir.resolve("iron-laws.md"));
+
+        for (Map.Entry<String, String> rule : RULE_MODE_FILES.entrySet()) {
+            Path modeRulesDir = ctx.projectDir().resolve(".bob/rules-" + rule.getKey());
+            Files.createDirectories(modeRulesDir);
+            copyTemplateResource(
+                    "templates/bob2/rules-" + rule.getKey() + "/" + rule.getValue(),
+                    modeRulesDir.resolve(rule.getValue()));
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CommandStubGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CommandStubGenerator.java
@@ -29,7 +29,20 @@ class CommandStubGenerator {
         if ("toml".equals(ctx.agent().fileFormat())) {
             return wrapInToml(command.shortName(), content);
         }
+        if ("bob2".equals(ctx.agentName())) {
+            return wrapInBobMarkdown(command, content);
+        }
         return content;
+    }
+
+    private String wrapInBobMarkdown(WorkflowCommand command, String content) {
+        return String.format(Locale.ROOT, """
+                ---
+                description: "%s"
+                argument-hint: "%s"
+                ---
+                %s
+                """, yamlDoubleQuoted(command.description()), yamlDoubleQuoted(commandArgumentHint(command)), content);
     }
 
     private String wrapInToml(String cmd, String content) {
@@ -41,5 +54,24 @@ class CommandStubGenerator {
                 %s
                 \"\"\"
                 """, cmd, escaped);
+    }
+
+    private String commandArgumentHint(WorkflowCommand command) {
+        return switch (command.name()) {
+            case "camel-start" -> "<request>";
+            case "camel-brainstorm" -> "<integration-request>";
+            case "camel-migrate" -> "<source-platform-or-artifacts>";
+            case "camel-plan" -> "<design-spec-or-pipeline-id>";
+            case "camel-execute" -> "<pipeline-id-or-plan>";
+            case "camel-validate" -> "<pipeline-id-or-route-path>";
+            case "camel-ship" -> "<integration-request>";
+            case "camel-knowledge" -> "<camel-question>";
+            case "camel-debug" -> "<error-or-route-path>";
+            default -> "<arguments>";
+        };
+    }
+
+    private String yamlDoubleQuoted(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
@@ -110,6 +110,9 @@ class SkillResourceInstaller {
             Files.copy(in, destination, StandardCopyOption.REPLACE_EXISTING);
         }
         if (destination.getFileName().toString().equals("SKILL.md")) {
+            if ("bob2".equals(ctx.agentName())) {
+                addBobReadableUserInvocableMetadata(destination);
+            }
             dispatchBlockAppender.append(destination, ctx.agentName());
         }
         if (destination.getFileName().toString().endsWith(".md")) {
@@ -119,6 +122,34 @@ class SkillResourceInstaller {
                 ctx.printer().println(AnsiColors.yellow("  Warning: Failed to substitute version placeholders in "
                                                         + destination + ": " + e.getMessage()));
             }
+        }
+    }
+
+    private void addBobReadableUserInvocableMetadata(Path skillFile) throws Exception {
+        String content = Files.readString(skillFile);
+        if (!content.startsWith("---\n") || content.contains("\nuser-invocable:")) {
+            return;
+        }
+
+        String[] lines = content.split("\n", -1);
+        StringBuilder updated = new StringBuilder(content.length() + 24);
+        boolean inserted = false;
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            updated.append(line);
+            if (!inserted && line.startsWith("user_invocable:")) {
+                updated.append('\n');
+                updated.append("user-invocable:").append(line.substring("user_invocable:".length()));
+                if (i < lines.length - 1) {
+                    updated.append('\n');
+                }
+                inserted = true;
+            } else if (i < lines.length - 1) {
+                updated.append('\n');
+            }
+        }
+        if (inserted) {
+            Files.writeString(skillFile, updated.toString());
         }
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -459,14 +459,12 @@ public class DoctorService {
     }
 
     private Path mcpConfigPath(Path root, String agentName) {
-        return switch (agentName.toLowerCase(Locale.ROOT)) {
-            case "claude" -> root.resolve(".mcp.json");
-            case "bob" -> root.resolve(".bob/mcp.json");
-            case "gemini" -> root.resolve(".gemini/settings.json");
-            case "qwen" -> root.resolve(".qwen/settings.json");
-            case "opencode" -> root.resolve("opencode.json");
-            default -> null;
-        };
+        String key = agentName == null ? "" : agentName.toLowerCase(Locale.ROOT);
+        AgentConfig agent = AgentRegistry.get(key);
+        if (agent == null) {
+            return null;
+        }
+        return root.resolve(agent.mcpConfigPath());
     }
 
     private String commandName(String filename) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
@@ -29,6 +29,9 @@ import io.github.luigidemasi.camelkit.util.TemplateUtils;
 public class InitService {
 
     private static final String MAVEN_WRAPPER_VERSION = "3.9.9";
+    private static final String BOB_LEGACY_WARNING = "IBM Bob 1 legacy selected; use --ai bob2 for new IBM Bob "
+                                                     + "projects. Bob 1 generation remains supported for existing "
+                                                     + "projects.";
 
     public InitResult initialize(InitRequest request) throws Exception {
         AgentConfig agent = AgentRegistry.get(request.agentName());
@@ -46,6 +49,9 @@ public class InitService {
         List<Path> createdPaths = new ArrayList<>();
         List<InitWarning> warnings = new ArrayList<>();
         InitProgress progress = request.progress();
+        if ("bob".equals(request.agentName())) {
+            reportWarning(request, warnings, BOB_LEGACY_WARNING);
+        }
 
         progress.startTask("\uD83D\uDCC1", "Creating project structure");
         createProjectStructure(targetDir, commandsDir, camelKitDir, docsDir, createdPaths);

--- a/camel-kit-core/src/main/resources/agents/registry/bob2.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/bob2.yaml
@@ -1,0 +1,42 @@
+id: bob2
+displayName: IBM Bob 2
+commandDirectory: .bob/commands
+commandFileFormat: md
+argumentPlaceholder: $ARGUMENTS
+mcpConfigPath: .bob/mcp.json
+mcpConfigTemplatePath: templates/mcp-configs/bob-mcp.json
+mcpServerContainerKey: mcpServers
+description: IBM Bob 2 with native skills and subagents
+generatorStrategy: bob2
+dispatchTemplatePath: templates/dispatch/bob2.md
+templates:
+  - source: templates/bob2/custom_modes.yaml
+    target: .bob/custom_modes.yaml
+  - source: templates/bob2/rules/iron-laws.md
+    target: .bob/rules/iron-laws.md
+  - source: templates/bob2/rules-camel-brainstorm/brainstorm.md
+    target: .bob/rules-camel-brainstorm/brainstorm.md
+  - source: templates/bob2/rules-camel-plan/plan.md
+    target: .bob/rules-camel-plan/plan.md
+  - source: templates/bob2/rules-camel-implement/implement.md
+    target: .bob/rules-camel-implement/implement.md
+  - source: templates/bob2/rules-camel-execute/execute.md
+    target: .bob/rules-camel-execute/execute.md
+  - source: templates/bob2/rules-camel-validate/validate.md
+    target: .bob/rules-camel-validate/validate.md
+  - source: templates/bob2/rules-camel-test/test.md
+    target: .bob/rules-camel-test/test.md
+  - source: templates/bob2/rules-camel-debug/debug.md
+    target: .bob/rules-camel-debug/debug.md
+  - source: templates/bob2/rules-camel-ship/ship.md
+    target: .bob/rules-camel-ship/ship.md
+supportsSubagents: true
+supportsTraits: true
+capabilities:
+  - subagent-dispatch
+  - parallel-subagent-dispatch
+  - parallel-tool-calls
+  - custom-modes
+  - mode-rules
+  - mcp
+  - skills

--- a/camel-kit-core/src/main/resources/templates/bob2/custom_modes.yaml
+++ b/camel-kit-core/src/main/resources/templates/bob2/custom_modes.yaml
@@ -1,0 +1,203 @@
+customModes:
+  - slug: camel-brainstorm
+    name: "Camel Brainstorm"
+    description: "Design Camel integrations and migrations without implementation edits."
+    roleDefinition: >
+      You are a Camel integration architect conducting focused discovery and design.
+      Ask one question at a time, prefer concise choices, and create design artifacts
+      only after the user has supplied enough context.
+    whenToUse: >
+      Use this mode for greenfield integration discovery, migration analysis, BRD
+      creation, TDD creation, and design-spec refinement before implementation.
+    customInstructions: >
+      Do not generate implementation artifacts. Use the camel-brainstorm skill for
+      phase behavior. Use explore subagents for self-contained codebase or migration
+      source discovery when a summary is enough.
+    groups:
+      - read
+      - - edit
+        - fileRegex: ".*\\.(md|txt)$"
+          description: Markdown and text files only
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore]
+
+  - slug: camel-plan
+    name: "Camel Plan"
+    description: "Create task-based Camel implementation plans."
+    roleDefinition: >
+      You are a Camel integration planner creating detailed, dependency-aware
+      implementation plans from approved design specs and TDDs.
+    whenToUse: >
+      Use this mode after design approval to produce implementation-plan.md
+      and wave metadata before code generation starts.
+    customInstructions: >
+      Plans follow TDD and include exact files, commands, expected results, and
+      wave metadata. Use explore subagents for isolated codebase research.
+    groups:
+      - read
+      - - edit
+        - fileRegex: ".*\\.(md|txt)$"
+          description: Markdown and text files only
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore]
+
+  - slug: camel-implement
+    name: "Camel Implement"
+    description: "Generate Camel route and application artifacts."
+    roleDefinition: >
+      You are a Camel implementation engineer generating route, configuration,
+      dependency, and support files from an approved plan and TDD.
+    whenToUse: >
+      Use this mode for focused implementation tasks delegated by camel-execute.
+    customInstructions: >
+      Verify Camel components through MCP before use. Prefer precise edits such
+      as insert_content or apply_diff for existing files. Do not spawn subagents
+      from inside implementation subagent work.
+    groups:
+      - read
+      - edit
+      - execute
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore, general]
+
+  - slug: camel-execute
+    name: "Camel Execute"
+    description: "Orchestrate implementation waves with Bob 2 subagents."
+    roleDefinition: >
+      You are the parent Bob orchestration task for approved implementation
+      plans. You dispatch independent implementation, testing, and review work
+      while keeping orchestration state in the main conversation.
+    whenToUse: >
+      Use this mode when an approved implementation plan is ready for execution.
+    customInstructions: >
+      Use camel-kit plan analyze to identify waves. Spawn independent tasks in
+      the same wave in one turn so Bob runs them in parallel. Use explore for
+      read-only review and general for implementation, testing, and fixes.
+    groups:
+      - read
+      - edit
+      - execute
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore, general]
+
+  - slug: camel-validate
+    name: "Camel Validate"
+    description: "Validate generated Camel routes and write validation reports."
+    roleDefinition: >
+      You are a Camel quality analyst checking routes against the constitution,
+      design specs, TDDs, execution reports, and project norms.
+    whenToUse: >
+      Use this mode after execute or for standalone static quality analysis.
+    customInstructions: >
+      Report findings with severity. Use explore subagents for isolated route,
+      MCP, security, or graph analysis. Write only validation report markdown
+      and metadata updates required by the shared skill.
+    groups:
+      - read
+      - - edit
+        - fileRegex: ".*\\.(md|txt)$"
+          description: Markdown and text files only
+      - execute
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore]
+
+  - slug: camel-test
+    name: "Camel Test"
+    description: "Generate and run Camel route tests."
+    roleDefinition: >
+      You are a Camel test engineer generating Citrus and route tests from TDDs
+      and implementation outputs.
+    whenToUse: >
+      Use this mode for focused test generation or test-fix tasks delegated by
+      camel-execute.
+    customInstructions: >
+      Follow TDD. Keep test files under test/ unless the plan specifies another
+      path. Use general subagents only for self-contained test or fix tasks.
+    groups:
+      - read
+      - - edit
+        - fileRegex: "(^test/|.*\\.test\\..*|.*Test\\.java$|.*\\.md$)"
+          description: Test and markdown files only
+      - execute
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore, general]
+
+  - slug: camel-debug
+    name: "Camel Debug"
+    description: "Diagnose and fix broken Camel routes."
+    roleDefinition: >
+      You are a Camel debugger following STOP, PRESERVE, DIAGNOSE, FIX, and
+      GUARD phases.
+    whenToUse: >
+      Use this mode for ad-hoc broken-route troubleshooting outside a normal
+      pipeline run.
+    customInstructions: >
+      Use explore subagents for route analysis, MCP verification, and log
+      classification. Use general only after a fix is approved or clearly
+      requested.
+    groups:
+      - read
+      - edit
+      - execute
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore, general]
+
+  - slug: camel-ship
+    name: "Camel Ship"
+    description: "Run the Camel-Kit pipeline with configurable oversight."
+    roleDefinition: >
+      You are the parent Bob orchestration task for the end-to-end Camel-Kit
+      pipeline. You keep stage state, switch modes, and invoke skills.
+    whenToUse: >
+      Use this mode for full pipeline execution across brainstorm, plan, execute,
+      and validate.
+    customInstructions: >
+      Keep orchestration in the parent Bob task. Use skills for stage behavior,
+      switch_mode for phase-level tool restrictions, and spawn_subagent only
+      inside stages that call for isolated work.
+    groups:
+      - read
+      - edit
+      - execute
+      - mcp
+      - skill
+      - todo
+      - artifact
+      - subagent
+      - mode
+    allowedSubagents: [explore, general]

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-brainstorm/brainstorm.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-brainstorm/brainstorm.md
@@ -1,0 +1,7 @@
+# Brainstorm Mode Rules
+
+- Ask one question at a time and wait for the user's answer.
+- Prefer short multiple-choice prompts when they reduce ambiguity.
+- Do not generate routes, tests, POM changes, or runtime configuration.
+- Use `explore` subagents only for self-contained discovery such as reading an existing integration source tree or summarizing a migration artifact set.
+- Present the design spec for explicit approval before planning.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-debug/debug.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-debug/debug.md
@@ -1,0 +1,7 @@
+# Debug Mode Rules
+
+- Follow STOP, PRESERVE, DIAGNOSE, FIX, and GUARD.
+- Use `explore` subagents for route analysis, MCP verification, and log/error classification.
+- Do not edit files before diagnosis unless the user has explicitly requested an immediate fix.
+- Use `general` for approved self-contained fix tasks.
+- Verify the fix and summarize the cause, changes, and guardrails added.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-execute/execute.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-execute/execute.md
@@ -1,0 +1,8 @@
+# Execute Mode Rules
+
+- The parent Bob task is the orchestrator for `/camel-execute`.
+- Use `spawn_subagent` with `name: "explore"` for read-only discovery, spec review, quality review, and route analysis.
+- Use `spawn_subagent` with `name: "general"` for implementation, test generation, and fix tasks.
+- Spawn all independent tasks in the same wave in one turn so Bob runs them in parallel.
+- Set `fork_context: true` only when the subagent needs prior decisions from the parent conversation.
+- Subagents must not spawn subagents.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-implement/implement.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-implement/implement.md
@@ -1,0 +1,7 @@
+# Implement Mode Rules
+
+- Verify Camel components and options with MCP before use.
+- Prefer targeted edits for existing files. Use insert-style edits when adding properties, dependencies, beans, or route fragments.
+- Follow the TDD and guide paths passed by the parent Bob task.
+- Do not spawn subagents when running as an implementation subagent.
+- Return a concise summary of files changed, commands run, and remaining issues.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-plan/plan.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-plan/plan.md
@@ -1,0 +1,7 @@
+# Plan Mode Rules
+
+- Produce task-based implementation plans with exact files, commands, expected outcomes, dependencies, and wave metadata.
+- Run `camel-kit plan analyze` when an implementation plan exists and use the result to identify independent waves.
+- Use `explore` subagents for isolated codebase research or dependency discovery.
+- Do not implement code in planning mode.
+- Return control to `camel-ship` in chained mode after the plan is saved.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-ship/ship.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-ship/ship.md
@@ -1,0 +1,7 @@
+# Ship Mode Rules
+
+- Keep pipeline orchestration in the parent Bob task.
+- Use `switch_mode` for phase-level tool restrictions.
+- Invoke Camel-Kit skills for stage behavior; do not duplicate the skill workflow in the mode rule.
+- Use `spawn_subagent` only inside execute, validate, debug, or other stages whose shared skill calls for isolated work.
+- Preserve oversight decisions from the shared `camel-ship` skill.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-test/test.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-test/test.md
@@ -1,0 +1,6 @@
+# Test Mode Rules
+
+- Follow TDD: write or update tests before using test results to justify fixes.
+- Keep generated test assets under `test/` unless the implementation plan gives another path.
+- Use `general` subagents for self-contained test generation or test-fix work; use `explore` for read-only test analysis.
+- Subagents must return changed files, commands run, and failures still present.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules-camel-validate/validate.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules-camel-validate/validate.md
@@ -1,0 +1,7 @@
+# Validate Mode Rules
+
+- Validate routes against `docs/constitution.md`, design specs, TDDs, generated reports, and project norms.
+- Use `explore` subagents for isolated route review, security review, MCP verification, and graph analysis.
+- Do not modify route or application code in validation mode.
+- Write only validation report markdown and required Camel-Kit document metadata.
+- Report findings with severity and concrete file references.

--- a/camel-kit-core/src/main/resources/templates/bob2/rules/iron-laws.md
+++ b/camel-kit-core/src/main/resources/templates/bob2/rules/iron-laws.md
@@ -1,0 +1,14 @@
+# Camel-Kit Iron Laws for Bob 2
+
+These rules apply across all Camel-Kit Bob 2 modes.
+
+1. Verify every Camel component, EIP, dataformat, and language through the configured MCP tools before writing it into a design, plan, route, or test.
+2. Read and follow `docs/constitution.md` in every pipeline phase.
+3. Do not generate implementation artifacts before the design spec and implementation plan exist.
+4. Run spec compliance and code quality review after implementation work. Use `explore` subagents for independent read-only review when the review is self-contained.
+5. Use the Camel versions from `.camel-kit/config.properties`; do not guess versions from model memory.
+6. Keep changes surgical. Do not refactor unrelated code or remove user content.
+7. Verify generated applications with the runtime and test commands required by the active skill.
+8. Treat project graph data as an enhancement. If graph data is unavailable, continue with the shared skill fallback.
+
+Bob 2-specific rule: the parent Bob task remains the orchestrator. Subagents must perform their assigned focused task and return a summary; they must not spawn subagents.

--- a/camel-kit-core/src/main/resources/templates/dispatch/bob2.md
+++ b/camel-kit-core/src/main/resources/templates/dispatch/bob2.md
@@ -1,0 +1,20 @@
+## Dispatch
+
+For each computational step in the Guide Manifest, use Bob 2 native subagents when the step is self-contained and only a summary needs to return.
+
+- Use `spawn_subagent` with `name: "explore"` for read-only research, route inspection, spec review, quality review, MCP verification summaries, and migration source discovery.
+- Use `spawn_subagent` with `name: "general"` for implementation, test generation, build/test fixing, and other tasks that need edit or execute access.
+- Include `fork_context: true` only when the subagent needs prior parent-conversation decisions, constraints, or user preferences. Keep it omitted for clean-context tasks.
+- Multiple `spawn_subagent` calls made in one parent turn run in parallel. Spawn every independent task in the current wave in the same turn.
+- The parent Bob task remains the orchestrator. Subagents must complete their focused task and return a summary; subagents must not spawn subagents.
+
+Include in each subagent description:
+- The flow/task name and task ID
+- Camel version from `.camel-kit/config.properties`
+- Relevant user decisions and design/TDD paths
+- Required skill and guide paths
+- Exact output paths and verification commands
+
+### Fallback
+
+If subagents are unavailable in the active Bob client, execute the work inline with the shared guides. This uses more context but preserves the workflow.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-brainstorm.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-brainstorm.append.md
@@ -1,0 +1,10 @@
+## Agent Optimization: IBM Bob 2
+
+Use Bob 2 `explore` subagents for self-contained discovery during brainstorming:
+
+- Spawn `explore` for codebase scans, migration source summaries, or dependency discovery when only a compact summary is needed.
+- Keep the parent Bob task focused on the interview, decisions, and design artifact assembly.
+- Use `fork_context: true` only when an `explore` subagent needs prior user answers from the conversation.
+- Do not ask multiple user questions in one turn.
+
+Multiple independent `spawn_subagent` calls in one turn run in parallel, but use them only when each discovery task is independent.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-debug.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-debug.append.md
@@ -1,0 +1,8 @@
+## Agent Optimization: IBM Bob 2
+
+Use Bob 2 subagents to keep noisy diagnosis out of the parent context:
+
+- `spawn_subagent` with `name: "explore"` for route analysis, MCP verification, and log classification.
+- `spawn_subagent` with `name: "general"` only for approved fix tasks that need edit or execute access.
+- Use `fork_context: true` only when the subagent needs earlier troubleshooting decisions.
+- Subagents return summaries; the parent Bob task decides the diagnosis and fix sequence.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-execute.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-execute.append.md
@@ -1,0 +1,14 @@
+## Agent Optimization: IBM Bob 2
+
+Use Bob 2 native subagents for execution while the parent Bob task remains the orchestrator.
+
+1. Run `camel-kit plan analyze` on the approved implementation plan to identify waves.
+2. For read-only discovery and review tasks, call `spawn_subagent` with `name: "explore"`.
+3. For implementation, test generation, and fix tasks, call `spawn_subagent` with `name: "general"`.
+4. Spawn every independent task in the current wave in the same parent turn so Bob runs them in parallel.
+5. Use `fork_context: true` only when a subagent needs prior parent-conversation decisions; otherwise keep the subagent context clean.
+6. Pass concise task context: task text, TDD path, design spec path, Camel version source, output paths, required guide paths, and verification commands.
+7. Subagents must not spawn subagents. If a subagent reports that more isolated work is needed, the parent Bob task decides whether to spawn another subagent.
+8. After each implementation subagent returns, the parent dispatches spec compliance and quality reviews as separate `explore` subagents before accepting the task.
+
+If Bob refuses a spawn because the active mode disallows it, switch to `camel-execute` or execute that task inline with the shared guides.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-execute/implementer-context.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-execute/implementer-context.append.md
@@ -1,0 +1,13 @@
+## Agent Optimization: IBM Bob 2
+
+### Precise Edits
+
+When generating implementation artifacts, prefer targeted Bob 2 edit tools:
+
+- Use insert-style edits for additive changes to `application.properties`, XML dependency blocks, and route fragments.
+- Use apply-style diffs for focused changes to existing files.
+- Avoid full-file rewrites unless the file is newly generated or the task explicitly requires replacement.
+
+### Subagent Boundary
+
+When this guide is used inside a `general` implementation subagent, complete only the assigned task and return a concise summary. Do not call `spawn_subagent`; the parent Bob task owns orchestration and parallel dispatch.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-plan.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-plan.append.md
@@ -1,0 +1,8 @@
+## Agent Optimization: IBM Bob 2
+
+Use Bob 2 Plan mode or the `camel-plan` custom mode for planning.
+
+- Use `spawn_subagent` with `name: "explore"` for isolated codebase research, dependency discovery, and migration artifact summaries.
+- Keep implementation planning in the parent Bob task so task IDs, dependencies, and wave metadata stay coherent.
+- Run `camel-kit plan analyze` after the plan exists to validate wave grouping for `/camel-execute`.
+- In chained mode, save the plan and return control to `camel-ship` instead of invoking execution directly.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-ship.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-ship.append.md
@@ -1,0 +1,9 @@
+## Agent Optimization: IBM Bob 2
+
+Use Bob 2 modes and skills together:
+
+- Use `switch_mode` for phase-level tool restrictions when moving between brainstorm, plan, execute, and validate.
+- Use `use_skill` for stage behavior instead of duplicating the shared skill instructions in the parent prompt.
+- Use `spawn_subagent` inside execute, validate, and debug when the shared skill calls for isolated work.
+- Keep pipeline state, oversight decisions, and stage transitions in the parent Bob task.
+- Subagents must not spawn subagents.

--- a/camel-kit-core/src/main/resources/templates/traits/bob2/camel-validate.append.md
+++ b/camel-kit-core/src/main/resources/templates/traits/bob2/camel-validate.append.md
@@ -1,0 +1,10 @@
+## Agent Optimization: IBM Bob 2
+
+Use `spawn_subagent` with `name: "explore"` for validation lanes that can run independently:
+
+- Route structure and endpoint review
+- MCP component verification summary
+- Security and anti-pattern scan
+- Graph/project-norm comparison when graph data exists
+
+Spawn independent validation lanes in one turn so Bob runs them in parallel. The parent Bob task merges returned summaries into the final validation report.

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
@@ -163,7 +163,7 @@ class DoctorCommandTest {
 
     @Test
     void generatedWorkspacesMatchDoctorExpectations() throws Exception {
-        for (String agentName : List.of("bob", "claude", "gemini", "qwen", "opencode")) {
+        for (String agentName : List.of("bob", "bob2", "claude", "gemini", "qwen", "opencode")) {
             Path root = tempDir.resolve(agentName);
             createGeneratedWorkspace(root, agentName);
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
@@ -4,10 +4,20 @@ import io.github.luigidemasi.camelkit.CamelKitMain;
 import io.github.luigidemasi.camelkit.output.Printer;
 
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class InitCommandTest {
+
+    @Test
+    void defaultsToBob2WhenAgentOptionIsOmitted() {
+        InitCommand command = new InitCommand(new CamelKitMain());
+
+        new CommandLine(command).parseArgs("orders");
+
+        assertEquals("bob2", command.ai);
+    }
 
     @Test
     void nextStepsUseCurrentSkillRouterCommands() {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
@@ -23,7 +23,7 @@ class AgentRegistryTest {
 
     @Test
     void builtInAgentsAreLoadedFromResourceDescriptors() {
-        assertEquals(Set.of("bob", "claude", "gemini", "opencode", "qwen"), AgentRegistry.names());
+        assertEquals(Set.of("bob", "bob2", "claude", "gemini", "opencode", "qwen"), AgentRegistry.names());
 
         AgentConfig claude = AgentRegistry.get("claude");
         assertNotNull(claude);
@@ -45,6 +45,30 @@ class AgentRegistryTest {
         assertTrue(descriptor.supportsSubagents());
         assertTrue(descriptor.supportsTraits());
         assertTrue(descriptor.capabilities().contains("parallel-subagent-dispatch"));
+    }
+
+    @Test
+    void bob2DescriptorKeepsBobWorkspacePathsAndEnablesNativeSubagents() {
+        AgentConfig bob2 = AgentRegistry.get("bob2");
+        assertNotNull(bob2);
+        assertEquals("IBM Bob 2", bob2.name());
+        assertEquals(".bob/commands", bob2.folder());
+        assertEquals("md", bob2.fileFormat());
+        assertEquals(".bob/mcp.json", bob2.mcpConfigPath());
+        assertEquals("templates/mcp-configs/bob-mcp.json", bob2.mcpConfigTemplatePath());
+
+        AgentDescriptor descriptor = AgentRegistry.descriptor("bob2");
+        assertNotNull(descriptor);
+        assertEquals("bob2", descriptor.generatorStrategy());
+        assertEquals(AgentGeneratorStrategy.BOB2, descriptor.generatorStrategyType());
+        assertEquals("templates/dispatch/bob2.md", descriptor.dispatchTemplatePath());
+        assertTrue(descriptor.supportsSubagents());
+        assertTrue(descriptor.supportsTraits());
+        assertTrue(descriptor.capabilities().contains("subagent-dispatch"));
+        assertTrue(descriptor.capabilities().contains("parallel-subagent-dispatch"));
+        assertTrue(descriptor.capabilities().contains("parallel-tool-calls"));
+        assertTrue(descriptor.capabilities().contains("skills"));
+        assertFalse(descriptor.capabilities().contains("monolithic-gates"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
@@ -12,6 +12,11 @@ class AgentGeneratorFactoryTest {
     }
 
     @Test
+    void bob2ReturnsBob2Generator() {
+        assertInstanceOf(Bob2Generator.class, AgentGeneratorFactory.create("bob2"));
+    }
+
+    @Test
     void claudeReturnsClaudeGenerator() {
         assertInstanceOf(ClaudeGenerator.class, AgentGeneratorFactory.create("claude"));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/Bob2GeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/Bob2GeneratorTest.java
@@ -1,0 +1,133 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Bob2GeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private InitContext createContext() {
+        AgentConfig agent = AgentRegistry.get("bob2");
+        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
+        Path commandsDir = tempDir.resolve(agent.folder());
+        Path skillsDir = tempDir.resolve(agentBaseFolder + "/skills");
+        return new InitContext(
+                agent, "bob2", commandsDir, skillsDir, tempDir,
+                "camel-kit", Printer.noop());
+    }
+
+    @Test
+    void generatesBobWorkspaceFilesUnderDotBob() throws Exception {
+        InitContext ctx = createContext();
+        new Bob2Generator().generate(ctx);
+
+        assertTrue(Files.isDirectory(tempDir.resolve(".bob/commands")));
+        assertTrue(Files.isDirectory(tempDir.resolve(".bob/skills")));
+        assertTrue(Files.isRegularFile(tempDir.resolve(".bob/mcp.json")));
+        assertTrue(Files.isRegularFile(tempDir.resolve(".bob/custom_modes.yaml")));
+        assertTrue(Files.isRegularFile(tempDir.resolve(".bob/rules/iron-laws.md")));
+        assertTrue(Files.isRegularFile(tempDir.resolve(".bob/rules-camel-execute/execute.md")));
+    }
+
+    @Test
+    void customModesUseBob2ToolGroupsAndAllowedSubagents() throws Exception {
+        InitContext ctx = createContext();
+        new Bob2Generator().generate(ctx);
+
+        String content = Files.readString(tempDir.resolve(".bob/custom_modes.yaml"));
+        assertTrue(content.contains("- execute"));
+        assertTrue(content.contains("- skill"));
+        assertTrue(content.contains("- todo"));
+        assertTrue(content.contains("- artifact"));
+        assertTrue(content.contains("- subagent"));
+        assertTrue(content.contains("- mode"));
+        assertTrue(content.contains("allowedSubagents: [explore]"));
+        assertTrue(content.contains("allowedSubagents: [explore, general]"));
+        assertFalse(content.contains("\n      - command\n"));
+    }
+
+    @Test
+    void keepsSharedSkillsAndAppendsBob2Traits() throws Exception {
+        InitContext ctx = createContext();
+        new Bob2Generator().generate(ctx);
+
+        Path executeSkill = ctx.skillsDir().resolve("camel-execute/SKILL.md");
+        assertTrue(Files.isRegularFile(executeSkill));
+        String content = Files.readString(executeSkill);
+        assertTrue(content.contains("# Camel Execute"));
+        assertTrue(content.contains("<!-- TRAIT:bob2 -->"));
+        assertTrue(content.contains("spawn_subagent"));
+        assertTrue(content.contains("name: \"explore\""));
+        assertTrue(content.contains("name: \"general\""));
+        assertFalse(content.contains("APPROVAL GATE"));
+        assertFalse(content.contains("gates/camel-execute.md"));
+    }
+
+    @Test
+    void commandStubsIncludeBob2Frontmatter() throws Exception {
+        InitContext ctx = createContext();
+        new Bob2Generator().generate(ctx);
+
+        Path command = ctx.commandsDir().resolve("camel-execute.md");
+        assertTrue(Files.isRegularFile(command));
+        String content = Files.readString(command);
+        assertTrue(content.startsWith("---\n"));
+        assertTrue(content.contains("description: \"Execute an approved implementation plan with two-stage review.\""));
+        assertTrue(content.contains("argument-hint: \"<pipeline-id-or-plan>\""));
+        assertTrue(content.contains("Read .bob/skills/camel-execute/SKILL.md and follow those instructions"));
+    }
+
+    @Test
+    void skillFrontmatterKeepsSharedMetadataAndAddsBobReadableUserInvocable() throws Exception {
+        InitContext ctx = createContext();
+        new Bob2Generator().generate(ctx);
+
+        String startSkill = Files.readString(ctx.skillsDir().resolve("camel-start/SKILL.md"));
+        assertTrue(startSkill.contains("user_invocable: true"));
+        assertTrue(startSkill.contains("user-invocable: true"));
+        assertSingleBlankLineBeforeDispatch(startSkill);
+
+        String executeSkill = Files.readString(ctx.skillsDir().resolve("camel-execute/SKILL.md"));
+        assertTrue(executeSkill.contains("user_invocable: false"));
+        assertTrue(executeSkill.contains("user-invocable: false"));
+        assertSingleBlankLineBeforeDispatch(executeSkill);
+    }
+
+    @Test
+    void doesNotChangeLegacyBobGenerationContract() throws Exception {
+        AgentConfig bob = AgentRegistry.get("bob");
+        String agentBaseFolder = bob.folder().substring(0, bob.folder().lastIndexOf("/"));
+        InitContext bobCtx = new InitContext(
+                bob, "bob", tempDir.resolve("legacy").resolve(bob.folder()),
+                tempDir.resolve("legacy").resolve(agentBaseFolder + "/skills"),
+                tempDir.resolve("legacy"), "camel-kit", Printer.noop());
+
+        new BobGenerator().generate(bobCtx);
+
+        String command = Files.readString(bobCtx.commandsDir().resolve("camel-execute.md"));
+        assertEquals("Read .bob/skills/camel-execute/SKILL.md and follow those instructions", command);
+
+        String executeSkill = Files.readString(bobCtx.skillsDir().resolve("camel-execute/SKILL.md"));
+        assertTrue(executeSkill.contains("CHECKPOINT"));
+        assertTrue(executeSkill.contains("Switch to"));
+        assertFalse(executeSkill.contains("user-invocable:"));
+        assertFalse(executeSkill.contains("<!-- TRAIT:bob2 -->"));
+    }
+
+    private void assertSingleBlankLineBeforeDispatch(String content) {
+        int dispatchIndex = content.indexOf("\n---\n\n## Dispatch");
+        assertTrue(dispatchIndex > 0);
+        assertFalse(content.substring(0, dispatchIndex).endsWith("\n\n"));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CommandStubGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CommandStubGeneratorTest.java
@@ -55,6 +55,24 @@ class CommandStubGeneratorTest {
     }
 
     @Test
+    void writesBob2MarkdownCommandsWithFrontmatter() throws Exception {
+        InitContext ctx = createContext("bob2");
+        Files.createDirectories(ctx.commandsDir());
+
+        WorkflowManifest workflow = WorkflowManifestLoader.loadDefault();
+        new CommandStubGenerator().generate(ctx, workflow);
+
+        Path executeCommand = ctx.commandsDir().resolve("camel-execute.md");
+        assertTrue(Files.isRegularFile(executeCommand));
+
+        String content = Files.readString(executeCommand);
+        assertTrue(content.startsWith("---\n"));
+        assertTrue(content.contains("description: \"Execute an approved implementation plan with two-stage review.\""));
+        assertTrue(content.contains("argument-hint: \"<pipeline-id-or-plan>\""));
+        assertTrue(content.contains("Read .bob/skills/camel-execute/SKILL.md and follow those instructions"));
+    }
+
+    @Test
     void escapesTripleQuotesInTomlWrappedContent() throws Exception {
         InitContext ctx = createContext("gemini");
         Files.createDirectories(ctx.commandsDir());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -6,6 +6,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -20,7 +23,7 @@ class DoctorServiceTest {
 
     @Test
     void healthyWorkspaceReturnsStructuredFindings() throws Exception {
-        createHealthyWorkspace(tempDir);
+        createHealthyWorkspace(tempDir, "bob");
 
         DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
 
@@ -33,6 +36,34 @@ class DoctorServiceTest {
     }
 
     @Test
+    void healthyBob2WorkspaceUsesRegisteredMcpPath() throws Exception {
+        createHealthyWorkspace(tempDir, "bob2");
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertFalse(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
+                "MCP config exists and tool allowlists match Camel-Kit expectations",
+                "No action required."));
+    }
+
+    @Test
+    void mixedCaseAgentNameStillResolvesRegisteredMcpPathForMcpChecks() throws Exception {
+        createHealthyWorkspace(tempDir, "bob");
+        Path configFile = tempDir.resolve(".camel-kit/config.properties");
+        Files.writeString(configFile, Files.readString(configFile).replace("agent.name=bob", "agent.name=Bob"));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "config", "Unknown agent.name 'Bob'", null));
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
+                "MCP config exists and tool allowlists match Camel-Kit expectations",
+                "No action required."));
+        assertFalse(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                "Cannot determine MCP config path for agent 'Bob'", null));
+    }
+
+    @Test
     void missingConfigReturnsActionableFailure() {
         DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
 
@@ -42,34 +73,37 @@ class DoctorServiceTest {
                 "Run camel-kit init --here --ai <agent>"));
     }
 
-    private void createHealthyWorkspace(Path root) throws Exception {
+    private void createHealthyWorkspace(Path root, String agentName) throws Exception {
+        AgentConfig agent = AgentRegistry.get(agentName);
         Files.createDirectories(root.resolve(".camel-kit"));
-        Files.writeString(root.resolve(".camel-kit/config.properties"), """
+        Files.writeString(root.resolve(".camel-kit/config.properties"), String.format(Locale.ROOT, """
                 project.name=orders
                 project.command-prefix=camel-kit
-                agent.name=bob
-                agent.folder=.bob/commands
-                """);
+                agent.name=%s
+                agent.folder=%s
+                """, agentName, agent.folder()));
         Files.writeString(root.resolve(".camel-kit/project-graph.json"), "{}");
         Files.writeString(root.resolve("AGENTS.md"), "Integration work -> /camel-start\n");
         Files.writeString(root.resolve("mvnw"), "#!/bin/sh\n");
 
-        Path commands = root.resolve(".bob/commands");
+        Path commands = root.resolve(agent.folder());
+        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf('/'));
         Files.createDirectories(commands);
         for (String command : EXPECTATIONS.userCommands()) {
             Files.writeString(commands.resolve(command + ".md"),
-                    "Read .bob/skills/" + command + "/SKILL.md and follow those instructions\n");
+                    "Read " + agentBaseFolder + "/skills/" + command + "/SKILL.md and follow those instructions\n");
         }
 
-        Path skills = root.resolve(".bob/skills");
+        Path skills = commands.getParent().resolve("skills");
         for (String skill : EXPECTATIONS.requiredSkills()) {
             Path skillDir = skills.resolve(skill);
             Files.createDirectories(skillDir);
             Files.writeString(skillDir.resolve("SKILL.md"), "# " + skill + "\n");
         }
 
-        Files.createDirectories(root.resolve(".bob"));
-        Files.writeString(root.resolve(".bob/mcp.json"),
+        Path mcpFile = root.resolve(agent.mcpConfigPath());
+        Files.createDirectories(mcpFile.getParent());
+        Files.writeString(mcpFile,
                 mcpJson(EXPECTATIONS.camelMcpTools(), EXPECTATIONS.knowledgeMcpTools()));
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -48,7 +48,24 @@ class InitServiceTest {
         assertTrue(progress.events().contains("start:Creating project structure"));
         assertTrue(progress.events().contains("start:Generating IBM Project Bob workspace"));
         assertEquals("3.9.9", reporter.mavenVersion());
+        assertTrue(result.warnings().stream()
+                .anyMatch(warning -> warning.message().contains("IBM Bob 1 legacy selected")));
+        assertTrue(reporter.hasWarningContaining("use --ai bob2 for new IBM Bob projects"));
         assertTrue(reporter.wasGraphSkipped() || reporter.graph() != null || !reporter.warnings().isEmpty());
+    }
+
+    @Test
+    void bob2InitializationDoesNotReportBob1LegacyWarning() throws Exception {
+        RecordingReporter reporter = new RecordingReporter();
+        Path targetDir = tempDir.resolve("orders");
+
+        InitResult result = new InitService().initialize(
+                request(targetDir, "bob2", InitProgress.noop(), reporter));
+
+        assertEquals("bob2", result.agentName());
+        assertFalse(result.warnings().stream()
+                .anyMatch(warning -> warning.message().contains("IBM Bob 1 legacy selected")));
+        assertFalse(reporter.hasWarningContaining("IBM Bob 1 legacy selected"));
     }
 
     @Test
@@ -141,6 +158,10 @@ class InitServiceTest {
 
         List<InitWarning> warnings() {
             return warnings;
+        }
+
+        boolean hasWarningContaining(String text) {
+            return warnings.stream().anyMatch(warning -> warning.message().contains(text));
         }
     }
 }

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -54,10 +54,10 @@ Each agent uses a different architecture designed to **maximize that agent's nat
 - Dispatch mechanism (subagents vs. modes vs. inline)
 - Tool restriction model (each agent's permission system is different)
 - File reading patterns (context isolation varies)
-- Parallelization strategy (only Claude supports parallel subagent dispatch)
+- Parallelization strategy (Claude and Bob 2 support parallel implementation-wave dispatch; other agents vary)
 - Configuration format (YAML modes, TOML policies, markdown frontmatter)
 
-**Agent traits** bridge the gap: they append agent-specific instructions to shared skill files during `camel-kit init`. For example, all agents share the same `camel-execute/SKILL.md`, but Claude's trait adds `Agent` tool parallel dispatch, Gemini's adds named agent delegation, Bob's adds `switch_mode` orchestration, and OpenCode's adds step-limited subagents. See [Architecture Guide](architecture.md#agent-traits) for details.
+**Agent traits** bridge the gap: they append agent-specific instructions to shared skill files during `camel-kit init`. For example, all agents share the same `camel-execute/SKILL.md`, but Claude's trait adds `Agent` tool parallel dispatch, Bob 1 legacy adds `switch_mode` orchestration, Bob 2 adds `spawn_subagent` orchestration, Gemini adds named agent delegation, and OpenCode adds step-limited subagents. See [Architecture Guide](architecture.md#agent-traits) for details.
 
 ---
 
@@ -102,11 +102,11 @@ Claude has no formal permission system. It relies on skill instructions to const
 
 ---
 
-## IBM Project Bob -- B+A Hybrid with Custom Modes
+## IBM Bob 1 Legacy -- B+A Hybrid with Custom Modes
 
 ### Dispatch Model
 
-Bob uses a "Behavior + Advanced" hybrid. Skills load in **Advanced mode** (unrestricted), then the first step in each gate file switches to a **restricted custom mode**. This two-phase approach gives initial access to load all skill files, then constrains behavior for the actual work.
+The `--ai bob` target is the Bob 1 legacy path. It uses a "Behavior + Advanced" hybrid. Skills load in **Advanced mode** (unrestricted), then the first step in each gate file switches to a **restricted custom mode**. This two-phase approach gives initial access to load all skill files, then constrains behavior for the actual work.
 
 ### Template Files
 
@@ -117,7 +117,7 @@ Bob uses a "Behavior + Advanced" hybrid. Skills load in **Advanced mode** (unres
 | `templates/bob/rules/iron-laws.md` | Shared iron laws loaded across all modes |
 | `templates/bob/rules-camel-{phase}/*.md` | Per-mode custom rules |
 
-Bob has the most template files (17+) because it cannot chain skill references -- each gate file must be self-contained, inlining the complete orchestration logic for its phase (6-10 KB each).
+Bob 1 has the most template files (17+) because it cannot chain skill references -- each gate file must be self-contained, inlining the complete orchestration logic for its phase (6-10 KB each).
 
 ### How It Works
 
@@ -155,6 +155,45 @@ Bob supports three checkpoint types used in gate files:
 - **Custom rules per mode:** each mode loads additional rules files (e.g., `interview-gates.md` enforces one-question-at-a-time during brainstorm)
 - **Monolithic gate files:** complete phase logic in a single file -- most self-contained of any agent
 - **File-type-scoped edits:** brainstorm and plan modes can only edit `.md` files (via `fileRegex` in tool groups)
+
+---
+
+## IBM Bob 2 -- Native Subagents with Bob Modes
+
+### Dispatch Model
+
+The `--ai bob2` target uses Bob 2 native `spawn_subagent` while still generating files under `.bob/`. The target name is only the Camel-Kit selector; Bob reads `.bob/commands`, `.bob/skills`, `.bob/custom_modes.yaml`, and `.bob/mcp.json`.
+
+Bob 2 keeps the shared Camel-Kit skills and appends Bob 2 traits. It does not replace `SKILL.md` files with monolithic gates.
+
+### Template Files
+
+| File | Purpose |
+|------|---------|
+| `templates/bob2/custom_modes.yaml` | Bob 2 custom modes using `read`, `edit`, `execute`, `mcp`, `skill`, `todo`, `artifact`, `subagent`, and `mode` groups |
+| `templates/bob2/rules*/` | Lightweight project and mode rules |
+| `templates/traits/bob2/*.append.md` | Native `spawn_subagent` orchestration guidance |
+| `templates/dispatch/bob2.md` | Shared dispatch block naming `spawn_subagent`, `explore`, `general`, and `fork_context` |
+
+### How It Works
+
+```
+User: /camel-execute
+  └── Parent Bob task loads shared camel-execute skill
+      ├── camel-kit plan analyze groups independent waves
+      ├── spawn_subagent name="general" for implementation/test/fix tasks
+      ├── spawn_subagent name="explore" for research and reviews
+      └── Parent merges summaries and keeps orchestration state
+```
+
+Multiple `spawn_subagent` calls in one parent turn run in parallel. Subagents return summaries and must not spawn subagents; the parent Bob task owns orchestration and follow-up dispatch.
+
+### Unique Capabilities
+
+- **Native isolated subagents:** `explore` for read-only work and `general` for edit/execute work
+- **Parallel same-turn dispatch:** independent tasks in the current wave can be spawned together
+- **Mode restrictions plus shared skills:** Bob 2 modes constrain tools while shared Camel-Kit skills define behavior
+- **Bob-readable metadata:** command stubs use markdown frontmatter and skills include `user-invocable`
 
 ---
 
@@ -456,15 +495,14 @@ Each agent has a `steps` limit. When reached, OpenCode instructs the agent to su
 
 ## Agent Comparison
 
-| Aspect | Claude | Bob | Gemini | Qwen | OpenCode |
-|--------|--------|-----|--------|------|----------|
-| Dispatch model | Parallel subagents | Mode switching | `invoke_subagent` unified tool (local/remote/browser) | Dual: named subagent + fork (context-sharing background task) | `task` tool creating child sessions with `parentID` |
-| Template files | 3 | 17+ | 12 | 9 | 8 |
-| Tool restriction | Instruction-based | Mode tool groups | Allowlist + TOML policy + server-scoped wildcards | Allowlist + blocklist (`disallowedTools`) | 3-state (`allow`/`ask`/`deny`) + bash glob patterns |
-| Path-scoped edits | No | `.md` only (via fileRegex) | Yes (Policy Engine `argsPattern` regex + `subagent` field) | No | Yes (glob patterns) |
-| MCP auto-approval | No (manual) | No (manual) | Yes (TOML policy) | No (manual) | No (manual) |
-| Parallel execution | Yes (graph-based) | No | Yes (scheduler `Promise.all()`, default-parallel) | Partial (read-only tools concurrent, max 10; fork runs in background) | Partial (LLM-level parallel tool calls; true async requested) |
-| Subagent recursion | Yes (no limit) | N/A | No (hardcoded `Kind.Agent` filter) | No (fork-of-fork blocked via `AsyncLocalStorage`) | Opt-in (PR #7756, configurable depth limits) |
-| Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Main agent (recursion prevention) | Sub-agent with `task` tool | Agent with `task` permission |
-| Agent-specific ignore | No | No | `.geminiignore` | `.qwenignore` | No (uses `.gitignore`) |
-| Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | `@file.md` modular imports | Single `QWEN.md` | Ultra-minimal `AGENTS.md` (~80 tokens) |
+| Aspect | Claude | Bob 1 legacy | Bob 2 | Gemini | Qwen | OpenCode |
+|--------|--------|--------------|-------|--------|------|----------|
+| Dispatch model | Parallel subagents | Mode switching | `spawn_subagent` (`explore`, `general`) | `invoke_subagent` unified tool (local/remote/browser) | Dual: named subagent + fork | `task` tool creating child sessions |
+| Template files | 3 | 17+ | Bob 2 modes + traits + rules | 12 | 9 | 8 |
+| Tool restriction | Instruction-based | Mode tool groups | Mode tool groups + `allowedSubagents` | Allowlist + TOML policy + server-scoped wildcards | Allowlist + blocklist | 3-state permissions + bash glob patterns |
+| Path-scoped edits | No | `.md` only (via fileRegex) | Mode-dependent `fileRegex` | Yes (Policy Engine) | No | Yes (glob patterns) |
+| MCP auto-approval | No (manual) | No (manual) | No (manual) | Yes (TOML policy) | No (manual) | No (manual) |
+| Parallel execution | Yes (graph-based) | No | Yes (same-turn `spawn_subagent`) | Yes (scheduler `Promise.all()`) | Partial (read-only tools concurrent; fork background) | Partial (LLM-level parallel tool calls) |
+| Subagent recursion | Yes (no limit) | N/A | No (subagents must not spawn subagents) | No (hardcoded `Kind.Agent` filter) | No (fork-of-fork blocked) | Opt-in configurable depth |
+| Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Parent task orchestrates subagents | Main agent (recursion prevention) | Sub-agent with `task` tool | Agent with `task` permission |
+| Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | Shared skills + Bob 2 traits + modes | `@file.md` modular imports | Single `QWEN.md` | Ultra-minimal `AGENTS.md` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,15 +242,16 @@ Entry points diverge (`camel-brainstorm` for greenfield, `camel-migrate` for mig
 
 After execute completes, the pipeline continues to **validation** (`camel-validate`) as Stage 3 — the final quality gate.
 
-All reviews, verification, and catalog lookups run as sub-agents with isolated context windows. Only structured reports flow back to the orchestrator -- preventing ~60-70% of pipeline tokens from accumulating in the main conversation.
+For subagent-capable targets, reviews, verification, and catalog lookups run in isolated contexts and only structured reports flow back to the orchestrator. Bob 1 legacy keeps this work in one session and relies on mode gates instead.
 
 ### Agent-Specific Execution
 
 The dispatch model varies by AI agent:
 
 - **Claude Code** -- dispatches fresh sub-agents per task. Each sub-agent runs in isolated context with no cross-contamination between tasks.
-- **IBM Project Bob** -- switches between custom modes (`brainstorm`, `plan`, `implement`, `validate`, `test`) with scoped tool permissions per mode.
-- **Gemini CLI, Qwen, OpenCode** -- inline execution within the same session. Skills are loaded as instruction context rather than dispatched as separate agents.
+- **IBM Bob 1 legacy** -- switches between custom modes and monolithic gate files with scoped tool permissions per mode.
+- **IBM Bob 2** -- uses native `spawn_subagent` (`explore` and `general`) while retaining Bob custom modes for tool restrictions.
+- **Gemini CLI, Qwen, OpenCode** -- use their native agent/delegation models with shared Camel-Kit skills and traits.
 
 ### The BRD+TDD Contract
 
@@ -346,7 +347,8 @@ registry loading with a descriptor-specific error.
 | Agent | Template Dir | Instruction File | MCP Config | Skills Location |
 |-------|-------------|-----------------|------------|-----------------|
 | Claude Code | `templates/claude/` | `CLAUDE.md` | `.mcp.json` | `.claude/skills/` |
-| IBM Project Bob | `templates/bob/` | `custom_modes.yaml` + rules + gates | `.bob/mcp.json` | `.bob/skills/` |
+| IBM Bob 1 legacy | `templates/bob/` | `custom_modes.yaml` + rules + gates | `.bob/mcp.json` | `.bob/skills/` |
+| IBM Bob 2 | `templates/bob2/` | `custom_modes.yaml` + rules + shared skills | `.bob/mcp.json` | `.bob/skills/` |
 | Gemini CLI | `templates/gemini/` | `GEMINI.md` + `@file.md` imports + policies | `.gemini/settings.json` | `.gemini/skills/` |
 | Qwen | `templates/qwen/` | `QWEN.md` + sub-agent definitions | `.qwen/settings.json` | `.qwen/skills/` |
 | OpenCode | `templates/opencode/` | `AGENTS.md` + permission-based agents | `opencode.json` | `.opencode/skills/` |
@@ -427,24 +429,32 @@ Four of the five agents support this natively through **sub-agent dispatch**:
 
 - **OpenCode** -- 7 agents with granular, per-type glob permissions. The executor agent has `task: {"*": allow}` permission. Sub-agent-to-sub-agent delegation is now opt-in (PR #7756) with configurable depth limits and call budgets. LLM-level parallel tool calls are supported. Each agent has a `steps` limit (implementer: 50, executor: 100) that triggers graceful summarization rather than hard failure.
 
-**IBM Project Bob does not support sub-agents.** It uses a fundamentally different architecture -- the **B+A (Behavior + Advanced) hybrid with mode switching**:
+**IBM Bob 2** uses Bob's native `spawn_subagent` tool. Camel-Kit exposes this as `--ai bob2`, but generated project files still live under `.bob/` because Bob reads `.bob/commands`, `.bob/skills`, `.bob/custom_modes.yaml`, and `.bob/mcp.json`.
+
+- `explore` is used for read-only research, route inspection, spec review, quality review, and MCP verification summaries.
+- `general` is used for implementation, test generation, and fix tasks that need edit or execute access.
+- Multiple `spawn_subagent` calls in one parent turn run in parallel, so `/camel-execute` dispatches all independent tasks in the current `camel-kit plan analyze` wave together.
+- The parent Bob task remains the orchestrator. Subagents return summaries and must not spawn subagents.
+- Bob 2 skills are the shared Camel-Kit `SKILL.md` files with Bob 2 traits appended; Bob 2 does not replace them with monolithic gates.
+
+**IBM Bob 1 legacy (`--ai bob`)** uses a fundamentally different architecture -- the **B+A (Behavior + Advanced) hybrid with mode switching**:
 
 1. Each pipeline phase starts in **Advanced mode** (unrestricted), allowing the agent to read all skill files and project context
 2. The first instruction in the gate file switches to a **restricted custom mode** (e.g., `camel-brainstorm`, `camel-implement`) with scoped tool permissions
 3. The mode's tool group constrains what the AI can do for the remainder of that phase
 
-This means Bob cannot isolate tasks into separate context windows or use independent reviewer agents. The compensation is that Bob's tool restrictions are **platform-enforced**, not instruction-based. During design, Bob's `camel-brainstorm` mode grants only `read`, `edit` (`.md` files only via `fileRegex`), `mcp`, and `browser` -- the AI physically cannot edit code files because the mode excludes the edit tool for non-markdown files. This is stricter than any instruction-based constraint, which the AI could rationalize away.
+This means Bob 1 cannot isolate tasks into separate context windows or use independent reviewer agents. The compensation is that Bob's tool restrictions are **platform-enforced**, not instruction-based. During design, Bob's `camel-brainstorm` mode grants only `read`, `edit` (`.md` files only via `fileRegex`), `mcp`, and `browser` -- the AI physically cannot edit code files because the mode excludes the edit tool for non-markdown files. This is stricter than any instruction-based constraint, which the AI could rationalize away.
 
-Bob also requires **monolithic gate files** (one per pipeline phase, 6-10 KB each) that inline complete orchestration logic, because it cannot chain skill references across mode switches the way sub-agent-based agents load skills into fresh contexts.
+Bob 1 also requires **monolithic gate files** (one per pipeline phase, 6-10 KB each) that inline complete orchestration logic, because it cannot chain skill references across mode switches the way sub-agent-based agents load skills into fresh contexts.
 
 The trade-off table:
 
-| Design Dimension | Sub-agent Dispatch | Mode Switching (Bob) |
-|-----------------|-------------------|---------------------|
+| Design Dimension | Sub-agent Dispatch | Mode Switching (Bob 1 Legacy) |
+|-----------------|-------------------|------------------------------|
 | Context isolation | Per-task (fresh sub-agent) | Per-session (accumulated) |
 | Reviewer independence | Separate sub-agent | Same session self-reviews |
 | Tool restriction mechanism | Instruction-based / tool whitelists / policies | Platform-enforced mode tool groups |
-| Parallel execution | Claude (graph topology), Gemini (scheduler `Promise.all()`), Qwen (fork), OpenCode (LLM-level) | Not possible |
+| Parallel execution | Claude (graph topology), Bob 2 (`spawn_subagent` in one turn), Gemini (scheduler `Promise.all()`), Qwen (fork), OpenCode (LLM-level) | Not possible |
 | Skill loading | Loaded into sub-agent context on dispatch | Inlined in monolithic gate files |
 | Template complexity | 3-12 files per agent | 17+ files (gates + rules + modes) |
 | Failure isolation | Sub-agent failure doesn't affect other tasks | Phase failure affects entire session |
@@ -454,7 +464,8 @@ The trade-off table:
 | Agent | Dispatch Model | Key Differentiator |
 |-------|---------------|-------------------|
 | Claude Code | Parallel sub-agent dispatch | Route graph topology, research isolation, parallel fan-out, adversarial code review |
-| IBM Project Bob | B+A hybrid with 5 custom modes | Monolithic gate files, 3 checkpoint types |
+| IBM Bob 1 legacy | B+A hybrid with custom modes | Monolithic gate files, 3 checkpoint types |
+| IBM Bob 2 | Native `spawn_subagent` plus custom modes | `explore`/`general` subagents, parallel same-turn dispatch, shared skills |
 | Gemini CLI | `invoke_subagent` + parallel scheduler | Default-parallel `Promise.all()`, TOML policy, MCP wildcards, A2A remote agents |
 | Qwen | Dual dispatch (named + fork) | Fork background tasks, DashScope cache sharing, auto-delegation |
 | OpenCode | `task` child sessions + opt-in delegation | 14 permission types, glob patterns, configurable depth limits |
@@ -465,13 +476,16 @@ For full per-agent deep dives (template files, tool restriction models, configur
 
 To add support for a new AI coding assistant:
 
-1. Create a template directory: `templates/{agent-name}/`
-2. Implement `{Agent}Generator extends DefaultGenerator` in `io.github.luigidemasi.camelkit.generator`
-3. Register in `AgentGeneratorFactory` (`{agent-name}` → `{Agent}Generator`)
-4. Generate the agent's instruction file with embedded iron laws and skill references
-5. Map pipeline phases to the agent's native dispatch mechanism (modes, sub-agents, permissions, etc.)
-6. Add MCP configuration for the agent's MCP config format
-7. Write tests following existing patterns (verify structure + key content markers)
+1. Add `agents/registry/{agent-name}.yaml` with command paths, MCP config path, generator strategy,
+   dispatch template, and capabilities.
+2. Create a template directory: `templates/{agent-name}/`
+3. Implement `{Agent}Generator extends DefaultGenerator` in `io.github.luigidemasi.camelkit.generator`
+4. Register the generator strategy in `AgentGeneratorStrategy` and `AgentGeneratorFactory`
+5. Generate the agent's instruction file with embedded iron laws and skill references
+6. Map pipeline phases to the agent's native dispatch mechanism (modes, sub-agents, permissions, etc.)
+7. Add MCP configuration for the agent's MCP config format
+8. Verify `camel-kit doctor` can validate a generated workspace using the descriptor MCP path.
+9. Write tests following existing patterns (registry, factory, generated structure, doctor, and key content markers)
 
 The `DefaultGenerator` orchestrates shared generation services such as `CommandStubGenerator`, `SkillResourceInstaller`, `TraitApplicator`, and `McpConfigGenerator`. Each agent-specific generator adds or overrides template generation to produce the agent's native format.
 
@@ -718,7 +732,7 @@ Camel-Kit defaults to the latest Apache Camel version, configured in `distributi
 
 ### Multi-Agent Parity
 
-Skills are markdown instruction files -- the same skill works across all five supported agents. Agent-specific differences (sub-agent dispatch vs. custom modes vs. inline execution) are handled by the template layer, not the skill layer. A bug fix or improvement to a guide file benefits every agent.
+Skills are markdown instruction files -- the same skill works across all supported agents. Agent-specific differences (sub-agent dispatch vs. custom modes vs. inline execution) are handled by the template layer, not the skill layer. A bug fix or improvement to a guide file benefits every agent.
 
 ### Constitution vs Iron Laws
 
@@ -764,7 +778,8 @@ user_invocable: false
 
 5. **If registering slash commands:** update agent-specific guidance only where the command needs custom behavior beyond the generated stub. The default generator creates command stubs from the manifest. Agent templates still need updates when they contain human-readable command tables, custom modes, policies, or sub-agent dispatch:
    - Claude Code: update `templates/claude/claude-md.md`
-   - IBM Project Bob: update `templates/bob/custom_modes.yaml` and add rules directory
+   - IBM Bob 1 legacy: update `templates/bob/custom_modes.yaml`, gate files, and rules directories
+   - IBM Bob 2: update `templates/bob2/custom_modes.yaml`, `templates/traits/bob2/`, and rules directories
    - Gemini CLI: update `templates/gemini/gemini-md.md`
    - Qwen: update `templates/qwen/qwen-md.md`
    - OpenCode: update `templates/opencode/agents-md.md`

--- a/docs/camel-kit-overview.md
+++ b/docs/camel-kit-overview.md
@@ -2,7 +2,7 @@
 
 ## What Is Camel-Kit?
 
-Camel-Kit is an open-source toolkit that brings structured AI assistance to Apache Camel integration development. It works as a layer on top of AI coding assistants (Claude, IBM Project Bob, Gemini, Qwen, OpenCode), giving them domain-specific knowledge and a disciplined workflow for designing, implementing, and verifying integration routes.
+Camel-Kit is an open-source toolkit that brings structured AI assistance to Apache Camel integration development. It works as a layer on top of AI coding assistants (Claude, IBM Bob 1 legacy, IBM Bob 2, Gemini, Qwen, OpenCode), giving them domain-specific knowledge and a disciplined workflow for designing, implementing, and verifying integration routes.
 
 Instead of an engineer writing boilerplate code by hand -- or an AI assistant generating plausible-looking but unverified code from its training data -- Camel-Kit guides the process through a structured pipeline that enforces quality at every step.
 
@@ -94,7 +94,7 @@ Camel-Kit addresses this with **skills** -- markdown instruction files that teac
 
 Skills compose together: the brainstorm skill loads design guides for component selection and EIP patterns; the execute skill loads implementation, validation, testing, and verification guides. Each guide is a self-contained document that the AI reads and follows step by step.
 
-Because skills are plain markdown, they are easy to read, review, audit, and extend. Adding a new capability to Camel-Kit means writing a new skill guide -- not modifying code. And because all five supported AI agents read the same skill files, a fix or improvement to a guide benefits every agent simultaneously.
+Because skills are plain markdown, they are easy to read, review, audit, and extend. Adding a new capability to Camel-Kit means writing a new skill guide -- not modifying code. And because all supported AI agents read the same skill files, a fix or improvement to a guide benefits every agent simultaneously.
 
 ### Context Isolation and Role Separation
 
@@ -103,8 +103,8 @@ When an AI generates code and then reviews its own work, it tends to confirm its
 Camel-Kit enforces role separation at multiple levels:
 
 - **Implementer and reviewer are separate.** After each task, a spec compliance reviewer checks whether the output matches the design -- this is not the same agent that wrote the code. Then a code quality reviewer checks against the constitution rules. Two independent reviews, each with a different focus.
-- **Fresh context per task.** When using Claude, each task is dispatched to a fresh subagent with an isolated context window. The subagent has no memory of previous tasks, no accumulated assumptions, and no temptation to reuse a pattern that worked before but doesn't fit now.
-- **Tool restrictions per phase.** When using Bob, the brainstorm phase physically cannot edit code files -- the custom mode restricts available tools to read-only access plus MCP queries. The AI cannot jump ahead to implementation because the tools required for implementation are not available. This is not a rule the AI follows; it is a platform constraint the AI cannot override.
+- **Fresh context per task.** When using Claude or Bob 2, each task can be dispatched to a fresh subagent with an isolated context window. The subagent has no memory of previous tasks, no accumulated assumptions, and no temptation to reuse a pattern that worked before but doesn't fit now.
+- **Tool restrictions per phase.** When using Bob 1 legacy or Bob 2, the brainstorm phase physically cannot edit code files -- the custom mode restricts available tools to read-only access plus MCP queries. The AI cannot jump ahead to implementation because the tools required for implementation are not available. This is not a rule the AI follows; it is a platform constraint the AI cannot override.
 
 ### Why Not Just Generate Code?
 
@@ -210,7 +210,7 @@ This gives the AI structural intelligence that goes beyond reading individual fi
 | **DI-aware dependency tracking** | Discovers dependency injection relationships through annotation analysis (@Inject, @Autowired, @Value, @ConfigProperty) and property-based bean wiring (#class:, #bean:, #autowired) | "Show all routes and beans that depend on the `CustomerRepository` interface, including classes injected via property configuration" |
 | **Interface expansion** | Traces interface-to-implementation relationships, connecting consumers to all concrete implementations of injected interfaces | "This route uses `PaymentProcessor` interface -- which concrete implementations are wired at runtime, and what other routes depend on them?" |
 | **Dead code detection** | Identifies unused Maven dependencies, orphaned routes (not referenced by any other route), and stale configuration properties | "This project has 12 Maven dependencies but only 8 are actually used in routes" |
-| **Route topology mapping** | Maps route-to-route connections to determine which routes are independent | Used by Claude to dispatch independent routes to parallel subagents for simultaneous implementation |
+| **Route topology mapping** | Maps route-to-route connections to determine which routes are independent | Used by Claude and Bob 2 to dispatch independent routes to parallel subagents for simultaneous implementation |
 | **Project norm extraction** | Computes statistical norms from the existing codebase -- naming patterns, error handling coverage, route complexity percentiles | Validation thresholds adapt to the project's actual conventions rather than using hardcoded defaults |
 | **Migration context analysis** | Produces structured JSON output capturing all dependencies, bean wiring, external service requirements, and call chains for a specific route | Used during migration to understand the complete context a route depends on before translating it to Camel |
 | **MuleSoft flow analysis** | Parses MuleSoft XML configs into graph nodes (flows, sub-flows, connectors, endpoints, transforms, error handlers) and analyzes DataWeave scripts for complexity | Understanding MuleSoft project structure before migration -- graph-accelerated analysis replaces manual XML deep-dives |
@@ -327,7 +327,7 @@ These rules are enforced automatically during the validation step. Violations ar
 
 ## Multi-Agent Support
 
-Camel-Kit works across five AI coding assistants. The same design-plan-execute pipeline runs identically regardless of which agent is chosen. This is possible because the pipeline logic lives in shared markdown instruction files ("skills") that all agents read and follow.
+Camel-Kit works across multiple AI coding assistants. The same design-plan-execute pipeline runs identically regardless of which agent is chosen. This is possible because the pipeline logic lives in shared markdown instruction files ("skills") that all agents read and follow.
 
 | Agent | Provider |
 |-------|----------|
@@ -342,7 +342,7 @@ Camel-Kit works across five AI coding assistants. The same design-plan-execute p
 - **Consistent output.** Regardless of which agent generates the routes, the same quality rules are enforced and the same catalog verification runs. The output artifacts are identical.
 - **Future-proof.** Adding support for a new agent requires writing template files for that agent's instruction format, not rewriting the pipeline logic.
 
-Each agent uses a different internal architecture optimized for its native capabilities (parallel subagent dispatch for Claude, custom modes with tool restrictions for Bob, policy engines for Gemini, etc.), but these differences are transparent to the user. The commands, workflow, and output are the same.
+Each agent uses a different internal architecture optimized for its native capabilities (parallel subagent dispatch for Claude and Bob 2, custom modes with tool restrictions for Bob 1 legacy, policy engines for Gemini, etc.), but these differences are transparent to the user. The commands, workflow, and output are the same.
 
 ---
 
@@ -354,7 +354,7 @@ flowchart TB
 
     subgraph templates ["Agent Templates"]
         claude["CLAUDE.md\n(Claude)"]
-        bob["custom_modes.yaml\n(Bob)"]
+        bob["custom_modes.yaml\n(Bob 1/Bob 2)"]
         gemini["GEMINI.md\n(Gemini)"]
         qwen["QWEN.md\n(Qwen)"]
         opencode["AGENTS.md\n(OpenCode)"]
@@ -395,7 +395,7 @@ flowchart TB
 
 **Knowledge MCP** provides documentation intelligence -- component availability, official documentation, and version-specific guidance.
 
-**Templates** adapt the skill delivery format to each AI agent's native instruction mechanism. A single set of skills serves all five agents.
+**Templates** adapt the skill delivery format to each AI agent's native instruction mechanism. A single set of skills serves all supported agents.
 
 ---
 
@@ -407,7 +407,7 @@ flowchart TB
 | **Higher quality output** | 7 quality rules enforced automatically. Every component verified against the live catalog. No hardcoded credentials, unnamed routes, or unsupported components. |
 | **Reduced runtime failures** | Real-time catalog verification catches configuration errors at design time. Runtime verification catches remaining issues before deployment. |
 | **Migration de-risking** | Automated analysis of MuleSoft, legacy Camel, Fuse, and BizTalk projects. DI-aware graph analysis discovers bean dependencies through annotation scanning and property-based wiring, traces interface implementations, and produces structured migration context for accurate route translation. Graph-accelerated MuleSoft analysis parses flows, sub-flows, connectors, and DataWeave scripts automatically. Graph-accelerated BizTalk analysis parses orchestrations, maps, pipelines, and bindings automatically. Component-by-component mapping against verified Camel equivalents, with gap identification before implementation begins. |
-| **No AI vendor lock-in** | Works with 5 AI agents. Same pipeline, same output, same quality -- regardless of provider. |
+| **No AI vendor lock-in** | Works with multiple AI agents. Same pipeline, same output, same quality -- regardless of provider. |
 | **Maintainable and extensible** | Skills are plain markdown. Adding new capabilities means writing a new skill guide, not modifying code. |
 
 ---
@@ -424,7 +424,7 @@ flowchart TB
 | Documentation | Knowledge MCP server (Apache Camel docs -- hybrid semantic search) |
 | Testing | Citrus + Testcontainers |
 | IDE support | Kaoto (visual route and DataMapper editing) |
-| AI agents | Claude Code, IBM Project Bob, Gemini CLI, Qwen, OpenCode |
+| AI agents | Claude Code, IBM Bob 1 legacy, IBM Bob 2, Gemini CLI, Qwen, OpenCode |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,7 +48,7 @@ camel-kit init --here [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--ai`, `-a` | `bob` | AI coding assistant to configure (`bob`, `gemini`, `claude`, `qwen`, `opencode`) |
+| `--ai`, `-a` | `bob2` | AI coding assistant to configure (`bob2` for IBM Bob 2, `bob` for IBM Bob 1 legacy, `gemini`, `claude`, `qwen`, `opencode`) |
 | `--citrus-version` | `4.9.2` | Citrus Framework version for test schemas |
 | `--here` | `false` | Initialize in current directory |
 | `--no-fetch` | `false` | Skip external catalog fetching |
@@ -62,8 +62,14 @@ camel-kit init --here [options]
 **Examples:**
 
 ```bash
-# Create new project for IBM Project Bob
+# Create new project for IBM Bob 2 (default)
+camel-kit init my-integration
+
+# Create new project for IBM Bob 1 legacy
 camel-kit init my-integration --ai bob
+
+# Create new project for IBM Bob 2
+camel-kit init my-integration --ai bob2
 
 # Create new project for Gemini CLI
 camel-kit init my-integration --ai gemini
@@ -77,8 +83,8 @@ camel-kit init my-integration --ai qwen
 # Create new project for OpenCode
 camel-kit init my-integration --ai opencode
 
-# Initialize in current directory
-camel-kit init --here --ai bob
+# Initialize in current directory with the default IBM Bob 2 target
+camel-kit init --here
 
 # Override config properties via CLI
 camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
@@ -96,7 +102,7 @@ camel-kit init my-integration --ai claude --source-platform mulesoft
 camel-kit init my-integration --ai claude --source-platform biztalk
 
 # Skip catalog fetch (faster)
-camel-kit init my-integration --ai bob --no-fetch
+camel-kit init my-integration --no-fetch
 
 # Overwrite an existing project
 camel-kit init my-integration --ai claude --force
@@ -653,8 +659,9 @@ After `/camel-execute` completes, the pipeline continues to `/camel-validate` as
 | Agent | Execution Model |
 |-------|----------------|
 | Claude Code | Dispatches fresh subagents per task (isolated context) |
-| IBM Project Bob | Switches between custom modes (brainstorm, plan, implement, validate, test) |
-| Gemini CLI, Qwen, OpenCode | Inline execution within the same session |
+| IBM Bob 1 legacy | Switches between custom modes and monolithic gate files |
+| IBM Bob 2 | Uses native `spawn_subagent` plus Bob custom modes and shared skills |
+| Gemini CLI, Qwen, OpenCode | Use their native agent/delegation models with shared Camel-Kit skills |
 
 **Orchestrated internal skills:**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -82,7 +82,7 @@ Skills tell the AI:
 - How to handle data transformation (choose the right engine for the mapping complexity)
 - How to diagnose errors (14 error patterns, each with a fix strategy)
 
-Because skills are plain markdown files shared across all five agents, the pipeline behavior is consistent regardless of which AI assistant you choose. You get the same quality gates, the same MCP verification, and the same output formats -- the skills are the guarantee.
+Because skills are plain markdown files shared across all supported agents, the pipeline behavior is consistent regardless of which AI assistant you choose. You get the same quality gates, the same MCP verification, and the same output formats -- the skills are the guarantee.
 
 ### Role Separation
 
@@ -129,7 +129,7 @@ The verification loop treats code, dependencies, and the execution environment a
 - **JDK 17+** -- required for building and running Camel applications
 - **JBang** -- runtime for camel-kit itself
 - **Docker** (optional) -- for running external services (databases, message brokers) during verification
-- **AI coding assistant** -- one of the five supported agents (see [Multi-Agent Support](#8-multi-agent-support))
+- **AI coding assistant** -- one of the supported agents (see [Multi-Agent Support](#8-multi-agent-support))
 
 ### Initializing a Project
 
@@ -138,8 +138,10 @@ The verification loop treats code, dependencies, and the execution environment a
 curl -Ls https://sh.jbang.dev | bash -s - app setup
 
 # Create a new project (choose your AI assistant)
+camel-kit init order-processing             # IBM Bob 2 (default)
 camel-kit init order-processing --ai claude
-camel-kit init order-processing --ai bob
+camel-kit init order-processing --ai bob      # IBM Bob 1 legacy
+camel-kit init order-processing --ai bob2     # IBM Bob 2
 camel-kit init order-processing --ai gemini
 camel-kit init order-processing --ai qwen
 camel-kit init order-processing --ai opencode
@@ -705,14 +707,15 @@ For BizTalk projects, `graph generate` automatically detects BizTalk artifacts (
 
 ## 9. Multi-Agent Support
 
-The same skills work across all five supported AI coding assistants. Camel-Kit uses markdown instruction files that are loaded by whichever agent you choose -- the workflow, rules, and output quality are identical regardless of agent.
+The same skills work across all supported AI coding assistants. Camel-Kit uses markdown instruction files that are loaded by whichever agent you choose -- the workflow, rules, and output quality are identical regardless of agent.
 
 ### Supported Agents
 
 | Agent | Init Flag | How `/camel-execute` Dispatches Work |
 |-------|-----------|--------------------------------------|
 | **Claude** (Anthropic Claude Code) | `--ai claude` | Dispatches subagents in parallel per independent task |
-| **Bob** (IBM Project Bob) | `--ai bob` | Switches between 5 custom modes with scoped tool permissions |
+| **Bob 1 legacy** (IBM Bob) | `--ai bob` | Switches between custom modes and monolithic gate files |
+| **Bob 2** (IBM Bob, default) | `--ai bob2` | Uses native `spawn_subagent` plus Bob custom modes and shared skills |
 | **Gemini** (Google Gemini CLI) | `--ai gemini` | Dispatches to 6 subagents; execute phase runs in main agent |
 | **Qwen** (Alibaba Qwen CLI) | `--ai qwen` | Auto-delegates to 7 sub-agents based on intent matching |
 | **OpenCode** | `--ai opencode` | Dispatches to 7 agents with granular permission control |
@@ -723,8 +726,8 @@ All agents produce the same output (YAML routes, properties files, tests). The d
 
 | If you value... | Consider |
 |-----------------|----------|
-| **Speed** (parallel implementation of independent flows) | Claude |
-| **Safety** (strictest tool restrictions per phase) | Bob or OpenCode |
+| **Speed** (parallel implementation of independent flows) | Claude or Bob 2 |
+| **Safety** (strictest tool restrictions per phase) | Bob 1 legacy, Bob 2, or OpenCode |
 | **Automatic routing** (say what you want, agent picks the right phase) | Qwen |
 | **Customizability** (override policies, compose instructions) | Gemini |
 | **Fine-grained file permissions** (auto-allow test dirs, ask for source) | OpenCode |
@@ -733,9 +736,9 @@ All agents produce the same output (YAML routes, properties files, tests). The d
 
 | Aspect | What You'll Notice |
 |--------|-------------------|
-| **Dispatch transparency** | Claude shows subagent dispatch; Bob shows mode switching; Gemini/Qwen/OpenCode delegate to specialized agents |
-| **Tool restrictions** | During brainstorm, Bob physically cannot edit code files (mode restriction). Claude and Qwen rely on skill instructions. OpenCode uses glob-pattern permissions. |
-| **Parallel execution** | Only Claude can implement multiple independent flows simultaneously |
+| **Dispatch transparency** | Claude and Bob 2 show subagent dispatch; Bob 1 legacy shows mode switching; Gemini/Qwen/OpenCode delegate to specialized agents |
+| **Tool restrictions** | During brainstorm, Bob modes can physically prevent code edits. Claude and Qwen rely on skill instructions. OpenCode uses glob-pattern permissions. |
+| **Parallel execution** | Claude and Bob 2 can dispatch independent tasks in the same wave; other agents have more limited parallelism |
 | **MCP approval prompts** | Gemini auto-approves MCP tool calls via its policy engine. Other agents may prompt you for each MCP call. |
 | **Execution limits** | OpenCode and Gemini enforce step/turn limits per phase. Other agents have no hard limits. |
 
@@ -743,7 +746,7 @@ All agents produce the same output (YAML routes, properties files, tests). The d
 
 During `/camel-execute`, the AI must implement multiple tasks, review each one, and fix issues -- all autonomously. How it manages this work internally depends on the agent's native capabilities.
 
-**Agents with subagent support (Claude, Gemini, Qwen, OpenCode)** dispatch each pipeline task to a fresh, isolated subagent. The subagent receives only the information it needs -- the task description, the relevant design spec section, and the skill guides -- and works in its own context window. When it finishes, a separate reviewer subagent checks the output. This isolation prevents cross-contamination: a mistake in one task cannot leak into the next, and the reviewer has no bias from having written the code.
+**Agents with subagent support (Claude, Bob 2, Gemini, Qwen, OpenCode)** dispatch each pipeline task to a fresh, isolated subagent. The subagent receives only the information it needs -- the task description, the relevant design spec section, and the skill guides -- and works in its own context window. When it finishes, a separate reviewer subagent checks the output. This isolation prevents cross-contamination: a mistake in one task cannot leak into the next, and the reviewer has no bias from having written the code.
 
 The execution loop for these agents:
 
@@ -754,19 +757,19 @@ The execution loop for these agents:
 5. If either reviewer finds issues, the implementer fixes them and the reviewer re-checks
 6. Mark task complete and move to the next
 
-**Claude** goes further: it uses `camel-kit plan analyze` waves from structured task metadata, logical dependencies, and file overlap, then dispatches independent tasks to parallel subagents simultaneously. This is the only agent that can implement multiple flows at the same time.
+**Claude and Bob 2** use `camel-kit plan analyze` waves from structured task metadata, logical dependencies, and file overlap, then dispatch independent tasks to subagents in the same wave. For Bob 2, the parent Bob task calls `spawn_subagent`; multiple spawn calls in one turn run in parallel. Bob 2 uses `explore` for read-only research/review and `general` for implementation/test/fix work.
 
-**Bob does not support subagents.** Instead, it uses a **mode-switching** approach: the pipeline loads in Advanced mode (unrestricted, so it can read all skill files and context), then the first instruction switches to a restricted custom mode (`camel-implement`, `camel-validate`, etc.) with scoped tool permissions. Each mode constrains what the AI can do -- during brainstorm, Bob physically cannot edit code files because the mode's tool group excludes file editing. This is enforced at the platform level, not through instructions the AI could ignore.
+**Bob 1 legacy (`--ai bob`)** uses a **mode-switching** approach instead of native subagents. The pipeline loads in Advanced mode (unrestricted, so it can read all skill files and context), then switches to a restricted custom mode (`camel-implement`, `camel-validate`, etc.) with scoped tool permissions. Each mode constrains what the AI can do -- during brainstorm, Bob physically cannot edit code files because the mode's tool group excludes file editing. This is enforced at the platform level, not through instructions the AI could ignore.
 
-The trade-off: Bob cannot isolate tasks into separate context windows (all work happens in a single session), and it cannot run reviewer checks in a separate agent (the same session reviews its own work). The compensation is that Bob's mode restrictions are the strictest of any agent -- the platform prevents the AI from using tools outside the current phase, which provides a different kind of safety guarantee.
+The Bob 1 trade-off is that work stays in a single session and reviewer checks are not isolated. The compensation is strict platform-enforced mode restrictions. Bob 2 keeps those mode restrictions where useful and adds native isolated subagents.
 
-| Capability | Subagent Agents (Claude, Gemini, Qwen, OpenCode) | Mode-Switching Agent (Bob) |
-|-----------|--------------------------------------------------|---------------------------|
+| Capability | Subagent Agents (Claude, Bob 2, Gemini, Qwen, OpenCode) | Bob 1 Legacy Mode Switching |
+|-----------|----------------------------------------------------------|-----------------------------|
 | Context isolation per task | Fresh subagent with clean context | Same session, accumulated context |
 | Reviewer independence | Separate subagent reviews the work | Same session reviews its own work |
-| Parallel execution | Claude only (graph-based independence detection) | Not possible |
-| Tool restriction enforcement | Varies: instruction-based (Claude), tool whitelists (Qwen), glob permissions (OpenCode), TOML policies (Gemini) | Platform-enforced mode restrictions (strictest) |
-| Phase transition | Dispatch new subagent | Switch custom mode |
+| Parallel execution | Claude and Bob 2 for implementation waves; other agents vary | Not possible |
+| Tool restriction enforcement | Varies by agent; Bob 2 combines modes with subagent restrictions | Platform-enforced mode restrictions |
+| Phase transition | Dispatch subagent or switch mode depending on agent | Switch custom mode |
 
 Despite these architectural differences, the output is identical -- same YAML routes, same quality rules enforced, same MCP verification. The equalization layer ensures that the *what* is consistent; only the *how* differs.
 


### PR DESCRIPTION
## Summary

- Add IBM Bob 2 as a new Camel Kit AI target via `--ai bob2`, with registry, generator, templates, traits, dispatch, and Bob 2 command/skill metadata.
- Preserve `--ai bob` as IBM Bob 1 legacy support, including legacy gate-based output and regression coverage.
- Make Bob 2 the default AI target, warn when selecting Bob 1 legacy, and update README, user guide, command reference, architecture docs, and changelog.
- Fix `camel-kit doctor` to resolve MCP config paths from the agent registry so Bob 2 projects validate `.bob/mcp.json` correctly.

## Validation

- `./mvnw -pl camel-kit-core -Dtest=DoctorServiceTest,DoctorCommandTest,CommandStubGeneratorTest,Bob2GeneratorTest,AgentRegistryTest,AgentGeneratorFactoryTest test`
- `./mvnw -pl camel-kit-core -Dtest=InitCommandTest,InitServiceTest test`
- `./mvnw -pl camel-jbang-plugin-kit -Dtest=CamelKitPluginTest test`
- `./mvnw -pl camel-kit-core,camel-jbang-plugin-kit test`
- `./mvnw -pl camel-kit-core,camel-jbang-plugin-kit -Psourcecheck validate`
- `git diff --check origin/main...HEAD`

Fixes #119