### PR TITLE
Update to Camel 4.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Default Camel version updated to 4.21.0** — Camel Main and Spring Boot runtimes now default to Camel `4.21.0`, with the Spring Boot framework mapped to `4.1.0` (`spring.boot.4.21.0=4.1.0`, matching camel-parent 4.21.0). Supported version lists move to `4.21.0, 4.18.2, 4.14.7`.
   - Camel MCP server now pinned to the released `4.21.0` instead of `4.21.0-SNAPSHOT`
   - Compiled-in fallback defaults in `DistributionConfig` kept in lockstep with `distribution.properties`
+  - `spring.boot.4.20.0` mapping removed — 4.20 is not an LTS line; 4.21.0 is the current latest release alongside LTS `4.18.2` and `4.14.7`
 
 - **Default AI target changed to IBM Bob 2** — `camel-kit init` and `camel kit init` now default to `--ai bob2` when no `--ai` option is supplied.
   - CLI help and documentation now mark Bob 2 as the default target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Default Camel version updated to 4.21.0** — Camel Main and Spring Boot runtimes now default to Camel `4.21.0`, with the Spring Boot framework mapped to `4.1.0` (`spring.boot.4.21.0=4.1.0`, matching camel-parent 4.21.0). Supported version lists move to `4.21.0, 4.18.2, 4.14.7`.
+- **Default Camel version updated to 4.21.0** — Camel Main and Spring Boot runtimes now default to Camel `4.21.0`, with the Spring Boot framework mapped to `4.1.0` (`spring.boot.4.21.0=4.1.0`, matching camel-parent 4.21.0). Supported version lists for Main and Spring Boot move to `4.21.0, 4.18.3, 4.14.7` (LTS fix release 4.18.3 maps to Spring Boot `3.5.16`).
   - Camel MCP server now pinned to the released `4.21.0` instead of `4.21.0-SNAPSHOT`
   - Compiled-in fallback defaults in `DistributionConfig` kept in lockstep with `distribution.properties`
-  - `spring.boot.4.20.0` mapping removed — 4.20 is not an LTS line; 4.21.0 is the current latest release alongside LTS `4.18.2` and `4.14.7`
+  - `spring.boot.4.20.0` mapping removed — 4.20 is not an LTS line; 4.21.0 is the current latest release alongside LTS `4.18.3` and `4.14.7`
+  - Quarkus runtime stays on Camel `4.18.2` — the latest camel-quarkus release (3.33.1, Quarkus platform 3.33.2.x) still bundles Camel 4.18.2
 
 - **Default AI target changed to IBM Bob 2** — `camel-kit init` and `camel kit init` now default to `--ai bob2` when no `--ai` option is supplied.
   - CLI help and documentation now mark Bob 2 as the default target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Default Camel version updated to 4.21.0** — Camel Main and Spring Boot runtimes now default to Camel `4.21.0`, with the Spring Boot framework mapped to `4.1.0` (`spring.boot.4.21.0=4.1.0`, matching camel-parent 4.21.0). Supported version lists move to `4.21.0, 4.18.2, 4.14.7`.
+  - Camel MCP server now pinned to the released `4.21.0` instead of `4.21.0-SNAPSHOT`
+  - Compiled-in fallback defaults in `DistributionConfig` kept in lockstep with `distribution.properties`
+
 - **Default AI target changed to IBM Bob 2** — `camel-kit init` and `camel kit init` now default to `--ai bob2` when no `--ai` option is supplied.
   - CLI help and documentation now mark Bob 2 as the default target
   - `--ai bob` remains supported for IBM Bob 1 legacy workspaces

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ camel-kit init my-integration --ai qwen     # Qwen (requires dev build)
 camel-kit init my-integration --ai opencode # OpenCode (requires dev build)
 
 # 2. Override configuration if needed
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
 
 # 3. Open in your AI assistant
 cd my-integration

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -57,8 +57,8 @@ public class DistributionConfig {
         this.springbootBomVersion = props.getProperty("springboot.bom.version", "4.21.0");
         this.springBootVersion = props.getProperty("spring.boot.version", "4.1.0");
         this.quarkusPlatformVersion = props.getProperty("quarkus.platform.version", "3.33.1");
-        this.camelMainSupported = props.getProperty("camel.main.supported", "4.21.0,4.18.2,4.14.7");
-        this.camelSpringbootSupported = props.getProperty("camel.springboot.supported", "4.21.0,4.18.2,4.14.7");
+        this.camelMainSupported = props.getProperty("camel.main.supported", "4.21.0,4.18.3,4.14.7");
+        this.camelSpringbootSupported = props.getProperty("camel.springboot.supported", "4.21.0,4.18.3,4.14.7");
         this.camelQuarkusSupported = props.getProperty("camel.quarkus.supported", "4.18.2,4.14.7");
         this.citrusVersion = props.getProperty("citrus.version", DEFAULT_CITRUS_VERSION);
         this.camelMcpVersion = props.getProperty("camel.mcp.version", "4.21.0");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -51,17 +51,17 @@ public class DistributionConfig {
 
     private DistributionConfig(Properties props, int overrideCount) {
         this.rawProps = props;
-        this.camelMainVersion = props.getProperty("camel.main.version", "4.20.0");
-        this.camelSpringbootVersion = props.getProperty("camel.springboot.version", "4.20.0");
+        this.camelMainVersion = props.getProperty("camel.main.version", "4.21.0");
+        this.camelSpringbootVersion = props.getProperty("camel.springboot.version", "4.21.0");
         this.camelQuarkusVersion = props.getProperty("camel.quarkus.version", "4.18.2");
-        this.springbootBomVersion = props.getProperty("springboot.bom.version", "4.20.0");
-        this.springBootVersion = props.getProperty("spring.boot.version", "4.0.5");
+        this.springbootBomVersion = props.getProperty("springboot.bom.version", "4.21.0");
+        this.springBootVersion = props.getProperty("spring.boot.version", "4.1.0");
         this.quarkusPlatformVersion = props.getProperty("quarkus.platform.version", "3.33.1");
-        this.camelMainSupported = props.getProperty("camel.main.supported", "4.20.0,4.18.2,4.14.7");
-        this.camelSpringbootSupported = props.getProperty("camel.springboot.supported", "4.20.0,4.18.2,4.14.7");
+        this.camelMainSupported = props.getProperty("camel.main.supported", "4.21.0,4.18.2,4.14.7");
+        this.camelSpringbootSupported = props.getProperty("camel.springboot.supported", "4.21.0,4.18.2,4.14.7");
         this.camelQuarkusSupported = props.getProperty("camel.quarkus.supported", "4.18.2,4.14.7");
         this.citrusVersion = props.getProperty("citrus.version", DEFAULT_CITRUS_VERSION);
-        this.camelMcpVersion = props.getProperty("camel.mcp.version", "4.21.0-SNAPSHOT");
+        this.camelMcpVersion = props.getProperty("camel.mcp.version", "4.21.0");
         this.knowledgeMcpVersion = props.getProperty("knowledge.mcp.version", "0.0.1-SNAPSHOT");
         this.citrusMcpVersion = props.getProperty("citrus.mcp.version", DEFAULT_CITRUS_MCP_VERSION);
         this.camelMcpRepos = props.getProperty("camel.mcp.repos",

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/catalog/CatalogDownloaderTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CatalogDownloaderTest {
 
-    private static final Set<String> LTS_VERSIONS = Set.of("4.14", "4.18", "4.20");
+    private static final Set<String> LTS_VERSIONS = Set.of("4.14", "4.18", "4.21");
 
     @TempDir
     Path tempDir;
@@ -38,7 +38,7 @@ class CatalogDownloaderTest {
 
     @Test
     void rejectsNullLtsVersions() {
-        assertThrows(NullPointerException.class, () -> new CatalogDownloader(tempDir, "4.20.0", null));
+        assertThrows(NullPointerException.class, () -> new CatalogDownloader(tempDir, "4.21.0", null));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -21,11 +21,11 @@ class DistributionConfigTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig config = DistributionConfig.load(in);
 
-        assertEquals("4.20.0", config.camelMainVersion());
-        assertEquals("4.20.0", config.camelSpringbootVersion());
+        assertEquals("4.21.0", config.camelMainVersion());
+        assertEquals("4.21.0", config.camelSpringbootVersion());
         assertEquals("4.18.2", config.camelQuarkusVersion());
-        assertEquals("4.20.0", config.springbootBomVersion());
-        assertEquals("4.0.5", config.springBootVersion());
+        assertEquals("4.21.0", config.springbootBomVersion());
+        assertEquals("4.1.0", config.springBootVersion());
         assertEquals("3.33.1", config.quarkusPlatformVersion());
     }
 
@@ -34,8 +34,8 @@ class DistributionConfigTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig config = DistributionConfig.load(in);
 
-        assertEquals("4.20.0,4.18.2,4.14.7", config.camelMainSupported());
-        assertEquals("4.20.0,4.18.2,4.14.7", config.camelSpringbootSupported());
+        assertEquals("4.21.0,4.18.2,4.14.7", config.camelMainSupported());
+        assertEquals("4.21.0,4.18.2,4.14.7", config.camelSpringbootSupported());
         assertEquals("4.18.2,4.14.7", config.camelQuarkusSupported());
     }
 
@@ -69,7 +69,7 @@ class DistributionConfigTest {
         DistributionConfig config = DistributionConfig.load(in);
 
         var mappings = config.springBootMappings();
-        assertEquals("4.0.5", mappings.get("4.20.0"));
+        assertEquals("4.1.0", mappings.get("4.21.0"));
         assertEquals("3.5.13", mappings.get("4.18.2"));
         assertEquals("3.5.12", mappings.get("4.14.7"));
         assertFalse(mappings.containsKey("version"), "Default spring.boot.version must be excluded");
@@ -80,7 +80,7 @@ class DistributionConfigTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig config = DistributionConfig.load(in);
 
-        assertEquals("4.21.0-SNAPSHOT", config.camelMcpVersion());
+        assertEquals("4.21.0", config.camelMcpVersion());
         assertEquals("0.0.1-SNAPSHOT", config.knowledgeMcpVersion());
         assertEquals("5.0.0-M2", config.citrusVersion());
         assertEquals("5.0.0-M2", config.citrusMcpVersion());
@@ -96,7 +96,7 @@ class DistributionConfigTest {
     void camelMcpVersionCanBeOverriddenViaProperties() {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig baselineConfig = DistributionConfig.load(in);
-        assertEquals("4.21.0-SNAPSHOT", baselineConfig.camelMcpVersion());
+        assertEquals("4.21.0", baselineConfig.camelMcpVersion());
 
         Properties properties = new Properties();
         properties.setProperty("camel.mcp.version", "9.9.9-TEST");
@@ -113,8 +113,8 @@ class DistributionConfigTest {
         DistributionConfig config = DistributionConfig.loadFromFileWithClasspathBaseline(overrideFile);
 
         assertEquals("9.9.9", config.camelMainVersion());
-        assertEquals("4.20.0", config.camelSpringbootVersion());
-        assertEquals("4.21.0-SNAPSHOT", config.camelMcpVersion());
+        assertEquals("4.21.0", config.camelSpringbootVersion());
+        assertEquals("4.21.0", config.camelMcpVersion());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -34,8 +34,8 @@ class DistributionConfigTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig config = DistributionConfig.load(in);
 
-        assertEquals("4.21.0,4.18.2,4.14.7", config.camelMainSupported());
-        assertEquals("4.21.0,4.18.2,4.14.7", config.camelSpringbootSupported());
+        assertEquals("4.21.0,4.18.3,4.14.7", config.camelMainSupported());
+        assertEquals("4.21.0,4.18.3,4.14.7", config.camelSpringbootSupported());
         assertEquals("4.18.2,4.14.7", config.camelQuarkusSupported());
     }
 
@@ -70,7 +70,7 @@ class DistributionConfigTest {
 
         var mappings = config.springBootMappings();
         assertEquals("4.1.0", mappings.get("4.21.0"));
-        assertEquals("3.5.13", mappings.get("4.18.2"));
+        assertEquals("3.5.16", mappings.get("4.18.3"));
         assertEquals("3.5.12", mappings.get("4.14.7"));
         assertFalse(mappings.containsKey("version"), "Default spring.boot.version must be excluded");
     }

--- a/distribution.properties
+++ b/distribution.properties
@@ -26,8 +26,8 @@ quarkus.platform.version=3.33.1
 #
 # Comma-separated list of supported Camel versions per runtime.
 # Shown to the user during /camel-design version selection.
-camel.main.supported=4.21.0,4.18.2,4.14.7
-camel.springboot.supported=4.21.0,4.18.2,4.14.7
+camel.main.supported=4.21.0,4.18.3,4.14.7
+camel.springboot.supported=4.21.0,4.18.3,4.14.7
 camel.quarkus.supported=4.18.2,4.14.7
 
 # ─── Quarkus Platform BOM Mapping ──────────────────────────────────────────
@@ -41,7 +41,7 @@ quarkus.platform.4.14.7=3.27.3
 # Maps each supported Camel Spring Boot version to the Spring Boot framework
 # version used by the Spring Boot Maven plugin.
 spring.boot.4.21.0=4.1.0
-spring.boot.4.18.2=3.5.13
+spring.boot.4.18.3=3.5.16
 spring.boot.4.14.7=3.5.12
 
 # ─── MCP Server Versions ───────────────────────────────────────────────────

--- a/distribution.properties
+++ b/distribution.properties
@@ -11,12 +11,12 @@
 # differ. Quarkus typically lags behind the main Camel release.
 
 # Main / JBang runtime
-camel.main.version=4.20.0
+camel.main.version=4.21.0
 
 # Spring Boot runtime
-camel.springboot.version=4.20.0
-springboot.bom.version=4.20.0
-spring.boot.version=4.0.5
+camel.springboot.version=4.21.0
+springboot.bom.version=4.21.0
+spring.boot.version=4.1.0
 
 # Quarkus runtime
 camel.quarkus.version=4.18.2
@@ -26,8 +26,8 @@ quarkus.platform.version=3.33.1
 #
 # Comma-separated list of supported Camel versions per runtime.
 # Shown to the user during /camel-design version selection.
-camel.main.supported=4.20.0,4.18.2,4.14.7
-camel.springboot.supported=4.20.0,4.18.2,4.14.7
+camel.main.supported=4.21.0,4.18.2,4.14.7
+camel.springboot.supported=4.21.0,4.18.2,4.14.7
 camel.quarkus.supported=4.18.2,4.14.7
 
 # ─── Quarkus Platform BOM Mapping ──────────────────────────────────────────
@@ -40,12 +40,12 @@ quarkus.platform.4.14.7=3.27.3
 #
 # Maps each supported Camel Spring Boot version to the Spring Boot framework
 # version used by the Spring Boot Maven plugin.
-spring.boot.4.20.0=4.0.5
+spring.boot.4.21.0=4.1.0
 spring.boot.4.18.2=3.5.13
 spring.boot.4.14.7=3.5.12
 
 # ─── MCP Server Versions ───────────────────────────────────────────────────
-camel.mcp.version=4.21.0-SNAPSHOT
+camel.mcp.version=4.21.0
 knowledge.mcp.version=0.0.1-SNAPSHOT
 citrus.version=5.0.0-M2
 citrus.mcp.version=5.0.0-M2

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -159,9 +159,9 @@ Any property from `distribution.properties` can be overridden at layers 2 or 3. 
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `camel.main.version` | `4.20.0` | Apache Camel version for Camel Main / JBang projects |
-| `camel.springboot.version` | `4.20.0` | Apache Camel version for Spring Boot projects |
-| `springboot.bom.version` | `4.20.0` | Spring Boot BOM version |
+| `camel.main.version` | `4.21.0` | Apache Camel version for Camel Main / JBang projects |
+| `camel.springboot.version` | `4.21.0` | Apache Camel version for Spring Boot projects |
+| `springboot.bom.version` | `4.21.0` | Spring Boot BOM version |
 | `camel.quarkus.version` | `4.18.2` | Apache Camel version for Quarkus projects |
 | `quarkus.platform.version` | `3.33.1` | Quarkus platform BOM version |
 | `camel.mcp.version` | See `distribution.properties` | Camel MCP server version |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -52,7 +52,7 @@ camel-kit init --here [options]
 | `--citrus-version` | `5.0.0-M2` | Citrus Framework version for test schemas and generated test dependencies |
 | `--here` | `false` | Initialize in current directory |
 | `--no-fetch` | `false` | Skip external catalog fetching |
-| `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.main.version=4.18.2"` |
+| `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.main.version=4.18.3"` |
 | `-c`, `--config` | `~/.camel-kit/config.properties` | Path to a custom config properties file |
 | `--source-platform` | `auto` | Source platform for migration: `mulesoft`, `camel`, `biztalk`, `auto` |
 | `--force` | `false` | Overwrite existing project without prompting (skips overwrite detection) |
@@ -87,7 +87,7 @@ camel-kit init my-integration --ai opencode
 camel-kit init --here
 
 # Override config properties via CLI
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
 
 # Override multiple properties
 camel-kit init my-integration --ai claude -p "camel.quarkus.version=4.18.2" -p "quarkus.platform.version=3.33.1"

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,13 +159,13 @@ All defaults (Camel version, BOM versions, MCP server versions) are read from a 
 
 **Per-invocation overrides** (highest priority):
 ```bash
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
 ```
 
 **Persistent user config** (applies to all invocations):
 Create `~/.camel-kit/config.properties` with your overrides:
 ```properties
-camel.main.version=4.18.2
+camel.main.version=4.18.3
 camel.quarkus.version=4.18.2
 quarkus.platform.version=3.33.1
 ```

--- a/examples/order-processing/README.md
+++ b/examples/order-processing/README.md
@@ -17,7 +17,7 @@ camel-kit init my-integration --ai opencode   # OpenCode
 You can also override configuration at init time:
 ```bash
 # With custom Camel version
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.2"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
 
 # With custom config file
 camel-kit init my-integration --ai claude -c team-config.properties

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <tamboui.version>0.1.0</tamboui.version>
         <quarkus.version>3.20.2.2</quarkus.version>
         <quarkus-mcp.version>1.6.1</quarkus-mcp.version>
-        <camel.version>4.20.0</camel.version>
+        <camel.version>4.21.0</camel.version>
         <!-- Also in distribution.properties (runtime source of truth).
              Duplicated here because maven-dependency-plugin resolves
              artifact versions at POM parse time, before any lifecycle phase. -->

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- Also in distribution.properties (runtime source of truth).
              Duplicated here because maven-dependency-plugin resolves
              artifact versions at POM parse time, before any lifecycle phase. -->
-        <camel.mcp.version>4.21.0-SNAPSHOT</camel.mcp.version>
+        <camel.mcp.version>4.21.0</camel.mcp.version>
 
         <!-- Code quality -->
         <impsort-maven-plugin.version>1.13.0</impsort-maven-plugin.version>


### PR DESCRIPTION
## Summary by Sourcery

Update default distribution and build configuration to Camel 4.21 and align related Spring Boot and MCP versions.

Enhancements:
- Refresh default Camel Main and Spring Boot versions to 4.21.0 across distribution, config, and tests.
- Align Spring Boot BOM and framework versions with Camel 4.21.0 defaults.
- Promote Camel MCP server version from snapshot to 4.21.0 and update documented defaults accordingly.

Build:
- Bump Maven Camel dependency version to 4.21.0 to match runtime defaults.

Documentation:
- Update command reference documentation to reflect new default Camel and MCP versions.

Tests:
- Adjust catalog downloader LTS version expectations and test defaults for the new 4.21 line.