### PR TITLE
[ci]: skip PR status comment on fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,8 @@ jobs:
     name: Comment PR Status
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request' && always()
+    # Fork PRs run with a read-only GITHUB_TOKEN, so posting the comment would 403.
+    if: github.event_name == 'pull_request' && always() && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
## Why

The `Comment PR Status` job fails on every PR opened from a fork (seen on #125): under the `pull_request` event, fork PRs get a read-only `GITHUB_TOKEN` regardless of the job's `permissions:` block, so `issues.createComment` returns `403 Resource not accessible by integration` — even though the build itself passed.

## What

Guard the `comment-pr` job with `github.event.pull_request.head.repo.full_name == github.repository` so it only runs for same-repo PRs, where the token has write access. Fork PRs still get full build/test checks; they just skip the courtesy comment (the Checks tab already shows the result).

Alternatives considered: `continue-on-error` (hides the failure but still churns a job), and `pull_request_target`/`workflow_run` (write token for forks, but more moving parts and a standing pwn-request risk if the workflow ever evolves to touch PR code — not worth it for a status comment).

## Summary by Sourcery

CI:
- Guard the Comment PR Status job so it only posts status comments for same-repo pull requests, skipping fork PRs where the workflow token is read-only.