### PR TITLE
[chore]: harden Copilot generator metadata handling

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CopilotGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CopilotGenerator.java
@@ -4,12 +4,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import io.github.luigidemasi.camelkit.config.AgentDescriptor;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.util.AnsiColors;
 
 public class CopilotGenerator extends DefaultGenerator {
+
+    private static final Set<String> RENDERED_TEMPLATES = Set.of(
+            "templates/copilot/copilot-instructions.md",
+            "templates/copilot/agents-md.md");
 
     private final QuteTemplateEngine templateEngine = new QuteTemplateEngine();
 
@@ -37,7 +42,7 @@ public class CopilotGenerator extends DefaultGenerator {
             if (parent != null) {
                 Files.createDirectories(parent);
             }
-            if (template.source().endsWith(".md")) {
+            if (RENDERED_TEMPLATES.contains(template.source())) {
                 Files.writeString(target, templateEngine.render(template.source(), data));
             } else {
                 copyTemplateResource(template.source(), target);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
@@ -169,7 +169,7 @@ class SkillResourceInstaller {
         }
     }
 
-    private void addCopilotReadableInternalSkillMetadata(Path skillFile) throws Exception {
+    void addCopilotReadableInternalSkillMetadata(Path skillFile) throws Exception {
         String skillName = skillFile.getParent().getFileName().toString();
         if (!COPILOT_INTERNAL_SKILLS.contains(skillName)) {
             return;
@@ -188,10 +188,11 @@ class SkillResourceInstaller {
         if (hasUserInvocable && hasDisableModelInvocation) {
             return;
         }
-        if (!normalized.contains("\nuser_invocable:")) {
+        boolean hasCamelKitUserInvocable = normalized.contains("\nuser_invocable:");
+        if (!hasCamelKitUserInvocable && !hasUserInvocable) {
             throw new IOException(
                     "Internal Copilot skill '" + skillName
-                                  + "' must declare user_invocable so Copilot invocation metadata can be generated");
+                                  + "' must declare user_invocable or user-invocable so Copilot invocation metadata can be generated");
         }
 
         String[] lines = normalized.split("\n", -1);
@@ -200,7 +201,7 @@ class SkillResourceInstaller {
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
             updated.append(line);
-            if (!inserted && line.startsWith("user_invocable:")) {
+            if (!inserted && (line.startsWith("user_invocable:") || line.startsWith("user-invocable:"))) {
                 if (!hasUserInvocable) {
                     updated.append('\n').append("user-invocable: false");
                 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
@@ -177,17 +177,26 @@ class SkillResourceInstaller {
 
         String content = Files.readString(skillFile);
         String normalized = content.replace("\r\n", "\n");
-        if (!normalized.startsWith("---\n")
-                || (normalized.contains("\nuser-invocable:")
-                        && normalized.contains("\ndisable-model-invocation:"))) {
+        if (!normalized.startsWith("---\n")) {
+            throw new IOException(
+                    "Internal Copilot skill '" + skillName
+                                  + "' must declare frontmatter so Copilot invocation metadata can be generated");
+        }
+
+        boolean hasUserInvocable = normalized.contains("\nuser-invocable:");
+        boolean hasDisableModelInvocation = normalized.contains("\ndisable-model-invocation:");
+        if (hasUserInvocable && hasDisableModelInvocation) {
             return;
+        }
+        if (!normalized.contains("\nuser_invocable:")) {
+            throw new IOException(
+                    "Internal Copilot skill '" + skillName
+                                  + "' must declare user_invocable so Copilot invocation metadata can be generated");
         }
 
         String[] lines = normalized.split("\n", -1);
         StringBuilder updated = new StringBuilder(normalized.length() + 64);
         boolean inserted = false;
-        boolean hasUserInvocable = normalized.contains("\nuser-invocable:");
-        boolean hasDisableModelInvocation = normalized.contains("\ndisable-model-invocation:");
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
             updated.append(line);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CopilotGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CopilotGeneratorTest.java
@@ -1,7 +1,10 @@
 package io.github.luigidemasi.camelkit.generator;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentDescriptor;
@@ -18,6 +21,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class CopilotGeneratorTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Set<String> INTERNAL_SKILLS = Set.of(
+            "camel-design",
+            "camel-implement",
+            "camel-test",
+            "camel-verify");
 
     @TempDir
     Path tempDir;
@@ -78,9 +86,12 @@ class CopilotGeneratorTest {
         InitContext ctx = createContext();
         new CopilotGenerator().generate(ctx);
 
-        String implement = Files.readString(tempDir.resolve(".github/skills/camel-implement/SKILL.md"));
-        assertTrue(implement.contains("user-invocable: false"));
-        assertTrue(implement.contains("disable-model-invocation: true"));
+        for (String skillName : INTERNAL_SKILLS) {
+            String skill = Files.readString(tempDir.resolve(".github/skills/" + skillName + "/SKILL.md"));
+            assertTrue(skill.contains("user-invocable: false"), skillName + " must not be user invocable");
+            assertTrue(skill.contains("disable-model-invocation: true"),
+                    skillName + " must not be model invocable");
+        }
 
         String start = Files.readString(tempDir.resolve(".github/skills/camel-start/SKILL.md"));
         assertFalse(start.contains("disable-model-invocation: true"));
@@ -116,6 +127,15 @@ class CopilotGeneratorTest {
         String securityReviewer = Files.readString(tempDir.resolve(".github/agents/camel-security-reviewer.agent.md"));
         assertFalse(securityReviewer.contains("\"edit\""));
         assertFalse(securityReviewer.contains("\"execute\""));
+    }
+
+    @Test
+    void copiesCustomAgentTemplatesVerbatim() throws Exception {
+        InitContext ctx = createContext();
+        new CopilotGenerator().generate(ctx);
+
+        String generated = Files.readString(tempDir.resolve(".github/agents/camel-implementer.agent.md"));
+        assertEquals(resourceText("templates/copilot/agents/camel-implementer.agent.md"), generated);
     }
 
     @Test
@@ -160,5 +180,12 @@ class CopilotGeneratorTest {
 
         String content = Files.readString(ctx.commandsDir().resolve("camel-start.md"));
         assertTrue(content.contains(".github/skills/camel-start/SKILL.md"));
+    }
+
+    private String resourceText(String resourcePath) throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            assertNotNull(in, "Missing test resource " + resourcePath);
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstallerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstallerTest.java
@@ -1,0 +1,36 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SkillResourceInstallerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void copilotMetadataUsesHyphenatedUserInvocableAsValidAnchor() throws Exception {
+        Path skill = tempDir.resolve(".github/skills/camel-implement/SKILL.md");
+        Files.createDirectories(skill.getParent());
+        Files.writeString(skill, """
+                ---
+                name: camel-implement
+                user-invocable: false
+                ---
+
+                Body.
+                """);
+
+        new SkillResourceInstaller().addCopilotReadableInternalSkillMetadata(skill);
+
+        String content = Files.readString(skill);
+        assertTrue(content.contains("user-invocable: false"));
+        assertTrue(content.contains("disable-model-invocation: true"));
+        assertFalse(content.contains("user_invocable:"));
+    }
+}


### PR DESCRIPTION
## Summary
- copy Copilot custom agent templates verbatim so future brace-heavy examples do not pass through Qute rendering
- fail fast when internal Copilot skill metadata cannot be generated, while accepting either `user_invocable` or `user-invocable` as the invocation metadata anchor
- extend generator tests to cover every internal skill annotation, verbatim custom-agent copying, and the hyphenated metadata compatibility case

## Tests
- `./mvnw -pl camel-kit-core -Dtest=SkillResourceInstallerTest,CopilotGeneratorTest test`
- `mvnd clean install`
