### PR TITLE
Add Pi coding agent target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `pi` agent registry descriptor, generator strategy, and `PiGenerator`
   - Generated workspaces include `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.mcp.json`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`
   - Pi MCP config uses `pi-mcp-adapter` with `directTools` allowlists, and `doctor` validates the Pi schema plus guard resources
-  - Internal guide skills are marked with `disable-model-invocation: true` and future-proof `user-invocable: false`
+  - Internal guide skills are marked with `disable-model-invocation: true` and future-proof agent alias `user-invocable: false`
   - Distribution defaults record the tested Pi and adapter versions
 
 - **GitHub Copilot CLI AI target (`--ai copilot`)** — added a first-class Copilot CLI target that generates GitHub-native project assets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pi AI target (`--ai pi`)** — added a first-class Pi target for `@earendil-works/pi-coding-agent`.
+  - New `pi` agent registry descriptor, generator strategy, and `PiGenerator`
+  - Generated workspaces include `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.mcp.json`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`
+  - Pi MCP config uses `pi-mcp-adapter` with `directTools` allowlists, and `doctor` validates the Pi schema plus guard resources
+  - Internal guide skills are marked with `disable-model-invocation: true` and future-proof `user-invocable: false`
+  - Distribution defaults record the tested Pi and adapter versions
+
 - **GitHub Copilot CLI AI target (`--ai copilot`)** — added a first-class Copilot CLI target that generates GitHub-native project assets.
   - New `copilot` agent registry descriptor, generator strategy, and `CopilotGenerator`
   - Generated workspaces include `.github/copilot-instructions.md`, `.github/skills/`, `.github/agents/`, `.github/mcp.json`, and `.github/hooks/camel-kit-safety.json`

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ cd my-integration
 # Run /skills list if you need to inspect available project skills.
 
 # For Pi, install the MCP adapter, trust the project, then run /skill:camel-start.
-# pi install npm:pi-mcp-adapter
+# pi install npm:pi-mcp-adapter@2.11.0
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ camel kit init my-integration
 
 ### Build from Source (development version)
 
-Some features (including `--ai copilot`, `--ai qwen`, and `--ai opencode`) are only available in the development version. To build from source:
+Some features (including `--ai copilot`, `--ai pi`, `--ai qwen`, and `--ai opencode`) are only available in the development version. To build from source:
 
 ```bash
 git clone https://github.com/luigidemasi/camel-kit.git
@@ -134,6 +134,7 @@ camel-kit init my-integration --ai bob      # IBM Bob 1 legacy
 camel-kit init my-integration --ai bob2     # IBM Bob 2
 camel-kit init my-integration --ai gemini   # Google Gemini CLI
 camel-kit init my-integration --ai copilot  # GitHub Copilot CLI
+camel-kit init my-integration --ai pi       # Pi
 camel-kit init my-integration --ai qwen     # Qwen (requires dev build)
 camel-kit init my-integration --ai opencode # OpenCode (requires dev build)
 
@@ -148,6 +149,9 @@ cd my-integration
 
 # For GitHub Copilot CLI, ask Copilot: "Use the /camel-start skill."
 # Run /skills list if you need to inspect available project skills.
+
+# For Pi, install the MCP adapter, trust the project, then run /skill:camel-start.
+# pi install npm:pi-mcp-adapter
 ```
 
 ---
@@ -161,10 +165,11 @@ cd my-integration
 | IBM Bob 2 (default) | `--ai bob2` | `custom_modes.yaml` + rules + skills | `.bob/mcp.json` |
 | Google Gemini CLI | `--ai gemini` | `GEMINI.md` | `.gemini/mcp.json` |
 | GitHub Copilot CLI | `--ai copilot` | `.github/copilot-instructions.md` + `.github/agents/` + `.github/skills/` | `.github/mcp.json` |
+| Pi | `--ai pi` | `AGENTS.md` + `.pi/skills/` + `.pi/prompts/` | `.mcp.json` via `pi-mcp-adapter` |
 | Qwen | `--ai qwen` | `QWEN.md` | `.qwen/mcp.json` |
 | OpenCode | `--ai opencode` | `AGENTS.md` | `.opencode/mcp.json` |
 
-All agents use the same skills — camel-kit generates agent-specific instruction files with per-agent traits that load the shared skill guides. GitHub Copilot CLI uses native project skills and custom agents instead of Camel-Kit slash commands. The skills are the equalization layer. [Architecture Guide →](docs/architecture.md)
+All agents use the same skills — camel-kit generates agent-specific instruction files with per-agent traits that load the shared skill guides. GitHub Copilot CLI uses native project skills and custom agents instead of Camel-Kit slash commands. Pi uses native project skills and prompt templates, with MCP provided by `pi-mcp-adapter`. The skills are the equalization layer. [Architecture Guide →](docs/architecture.md)
 
 ---
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -34,7 +34,7 @@ public class InitCommand extends CamelKitCommand {
 
     @Option(names = {"-a", "--ai"},
             description = "AI agent: bob2 (IBM Bob 2, default), bob (IBM Bob 1 legacy), "
-                          + "gemini, claude, copilot, qwen, opencode",
+                          + "gemini, claude, copilot, pi, qwen, opencode",
             defaultValue = "bob2")
     public String ai;
 
@@ -191,6 +191,13 @@ public class InitCommand extends CamelKitCommand {
             printer().println("  2  Ask Copilot: " + cyan("\"Use the /camel-start skill.\""));
             printer().println("     Run " + cyan("/skills list") + " to inspect available project skills");
             printer().println("  3  Use " + cyan("/mcp show") + " to verify Camel Kit MCP servers");
+            printer().println();
+            return;
+        }
+        if (AgentGeneratorStrategy.PI.descriptorValue().equalsIgnoreCase(agentId)) {
+            printer().println("  2  Install MCP adapter: " + cyan("pi install npm:pi-mcp-adapter"));
+            printer().println("  3  In Pi, run " + cyan("/trust") + " then " + cyan("/skill:camel-start"));
+            printer().println("     Use " + cyan("/mcp status") + " to verify Camel Kit MCP servers");
             printer().println();
             return;
         }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -195,7 +195,8 @@ public class InitCommand extends CamelKitCommand {
             return;
         }
         if (AgentGeneratorStrategy.PI.descriptorValue().equalsIgnoreCase(agentId)) {
-            printer().println("  2  Install MCP adapter: " + cyan("pi install npm:pi-mcp-adapter"));
+            String adapter = "pi install npm:pi-mcp-adapter@" + CamelKitMain.distribution().piMcpAdapterVersion();
+            printer().println("  2  Install MCP adapter: " + cyan(adapter));
             printer().println("  3  In Pi, run " + cyan("/trust") + " then " + cyan("/skill:camel-start"));
             printer().println("     Use " + cyan("/mcp status") + " to verify Camel Kit MCP servers");
             printer().println();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
@@ -14,6 +14,7 @@ public enum AgentGeneratorStrategy {
     COPILOT("copilot"),
     GEMINI("gemini"),
     OPENCODE("opencode"),
+    PI("pi"),
     QWEN("qwen");
 
     private final String descriptorValue;

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -25,6 +25,8 @@ public class DistributionConfig {
 
     private static final String DEFAULT_CITRUS_VERSION = "5.0.0-M2";
     private static final String DEFAULT_CITRUS_MCP_VERSION = "5.0.0-M2";
+    private static final String DEFAULT_PI_VERSION = "0.80.3";
+    private static final String DEFAULT_PI_MCP_ADAPTER_VERSION = "2.11.0";
 
     private static final Path DEFAULT_USER_CONFIG = Path.of(
             System.getProperty("user.home"), ".camel-kit", "config.properties");
@@ -47,6 +49,8 @@ public class DistributionConfig {
     private final String knowledgeMcpRepos;
     private final String citrusMcpRepos;
     private final String camelCatalogRepos;
+    private final String piVersion;
+    private final String piMcpAdapterVersion;
     private final int overrideCount;
 
     private DistributionConfig(Properties props, int overrideCount) {
@@ -70,6 +74,8 @@ public class DistributionConfig {
         this.citrusMcpRepos = props.getProperty("citrus.mcp.repos", "central=https://repo1.maven.org/maven2/");
         this.camelCatalogRepos = props.getProperty("camel.catalog.repos",
                 "https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots");
+        this.piVersion = props.getProperty("pi.version", DEFAULT_PI_VERSION);
+        this.piMcpAdapterVersion = props.getProperty("pi.mcp.adapter.version", DEFAULT_PI_MCP_ADAPTER_VERSION);
         this.overrideCount = overrideCount;
     }
 
@@ -290,6 +296,14 @@ public class DistributionConfig {
 
     public String camelCatalogRepos() {
         return camelCatalogRepos;
+    }
+
+    public String piVersion() {
+        return piVersion;
+    }
+
+    public String piMcpAdapterVersion() {
+        return piMcpAdapterVersion;
     }
 
     public int overrideCount() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
@@ -17,6 +17,7 @@ public final class AgentGeneratorFactory {
             case COPILOT -> new CopilotGenerator();
             case GEMINI -> new GeminiGenerator();
             case OPENCODE -> new OpenCodeGenerator();
+            case PI -> new PiGenerator();
             case QWEN -> new QwenGenerator();
             case DEFAULT -> new DefaultGenerator();
         };

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
@@ -44,9 +44,7 @@ class McpConfigGenerator {
                         "CAMEL_MCP_REPOS", dist.camelMcpRepos(),
                         "KNOWLEDGE_MCP_REPOS", dist.knowledgeMcpRepos(),
                         "CITRUS_MCP_REPOS", dist.citrusMcpRepos(),
-                        "CAMEL_CATALOG_REPOS", dist.camelCatalogRepos(),
-                        "PI_VERSION", dist.piVersion(),
-                        "PI_MCP_ADAPTER_VERSION", dist.piMcpAdapterVersion()));
+                        "CAMEL_CATALOG_REPOS", dist.camelCatalogRepos()));
 
         WorkflowManifest.WorkflowMcpServer camelServer = workflow.mcpServer("camel");
         data.put("CAMEL_TOOLS_JSON", toJsonArray(camelServer.allowedTools()));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
@@ -44,7 +44,9 @@ class McpConfigGenerator {
                         "CAMEL_MCP_REPOS", dist.camelMcpRepos(),
                         "KNOWLEDGE_MCP_REPOS", dist.knowledgeMcpRepos(),
                         "CITRUS_MCP_REPOS", dist.citrusMcpRepos(),
-                        "CAMEL_CATALOG_REPOS", dist.camelCatalogRepos()));
+                        "CAMEL_CATALOG_REPOS", dist.camelCatalogRepos(),
+                        "PI_VERSION", dist.piVersion(),
+                        "PI_MCP_ADAPTER_VERSION", dist.piMcpAdapterVersion()));
 
         WorkflowManifest.WorkflowMcpServer camelServer = workflow.mcpServer("camel");
         data.put("CAMEL_TOOLS_JSON", toJsonArray(camelServer.allowedTools()));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/PiGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/PiGenerator.java
@@ -1,0 +1,59 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.util.AnsiColors;
+
+public class PiGenerator extends DefaultGenerator {
+
+    private static final Set<String> RENDERED_TEMPLATES = Set.of(
+            "templates/pi/agents-md.md");
+
+    private final QuteTemplateEngine templateEngine = new QuteTemplateEngine();
+
+    @Override
+    public void generate(InitContext ctx) throws Exception {
+        super.generate(ctx);
+
+        Map<String, Object> data = new HashMap<>(
+                Map.of(
+                        "COMMAND_PREFIX", ctx.commandPrefix(),
+                        "PI_VERSION", ctx.distribution().piVersion(),
+                        "PI_MCP_ADAPTER_VERSION", ctx.distribution().piMcpAdapterVersion()));
+        installDescriptorTemplates(ctx, data);
+    }
+
+    private void installDescriptorTemplates(InitContext ctx, Map<String, Object> data) throws Exception {
+        AgentDescriptor descriptor = AgentRegistry.descriptor(ctx.agentName());
+        if (descriptor == null) {
+            throw new IllegalArgumentException("Unsupported agent: " + ctx.agentName());
+        }
+
+        boolean generatedGuard = false;
+        for (AgentDescriptor.TemplateInstall template : descriptor.templates()) {
+            Path target = ctx.projectDir().resolve(template.target());
+            Path parent = target.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            if (RENDERED_TEMPLATES.contains(template.source())) {
+                Files.writeString(target, templateEngine.render(template.source(), data));
+            } else {
+                copyTemplateResource(template.source(), target);
+            }
+            if (template.target().startsWith(".pi/extensions/")) {
+                generatedGuard = true;
+            }
+        }
+
+        if (generatedGuard) {
+            ctx.printer().println(AnsiColors.green("✓") + " Generated Pi safety guard extension");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
@@ -18,7 +18,7 @@ import io.github.luigidemasi.camelkit.util.AnsiColors;
 
 class SkillResourceInstaller {
 
-    private static final Set<String> COPILOT_INTERNAL_SKILLS = Set.of(
+    private static final Set<String> MODEL_HIDDEN_INTERNAL_SKILLS = Set.of(
             "camel-design",
             "camel-implement",
             "camel-test",
@@ -133,6 +133,9 @@ class SkillResourceInstaller {
             if (AgentGeneratorStrategy.COPILOT.descriptorValue().equals(ctx.agentName())) {
                 addCopilotReadableInternalSkillMetadata(destination);
             }
+            if (AgentGeneratorStrategy.PI.descriptorValue().equals(ctx.agentName())) {
+                addPiReadableInternalSkillMetadata(destination);
+            }
             dispatchBlockAppender.append(destination, ctx.agentName());
         }
         if (destination.getFileName().toString().endsWith(".md")) {
@@ -170,8 +173,16 @@ class SkillResourceInstaller {
     }
 
     void addCopilotReadableInternalSkillMetadata(Path skillFile) throws Exception {
+        addInternalSkillInvocationMetadata(skillFile, "Copilot");
+    }
+
+    void addPiReadableInternalSkillMetadata(Path skillFile) throws Exception {
+        addInternalSkillInvocationMetadata(skillFile, "Pi");
+    }
+
+    private void addInternalSkillInvocationMetadata(Path skillFile, String agentName) throws Exception {
         String skillName = skillFile.getParent().getFileName().toString();
-        if (!COPILOT_INTERNAL_SKILLS.contains(skillName)) {
+        if (!MODEL_HIDDEN_INTERNAL_SKILLS.contains(skillName)) {
             return;
         }
 
@@ -179,8 +190,8 @@ class SkillResourceInstaller {
         String normalized = content.replace("\r\n", "\n");
         if (!normalized.startsWith("---\n")) {
             throw new IOException(
-                    "Internal Copilot skill '" + skillName
-                                  + "' must declare frontmatter so Copilot invocation metadata can be generated");
+                    "Internal " + agentName + " skill '" + skillName
+                                  + "' must declare frontmatter so invocation metadata can be generated");
         }
 
         boolean hasUserInvocable = normalized.contains("\nuser-invocable:");
@@ -191,8 +202,8 @@ class SkillResourceInstaller {
         boolean hasCamelKitUserInvocable = normalized.contains("\nuser_invocable:");
         if (!hasCamelKitUserInvocable && !hasUserInvocable) {
             throw new IOException(
-                    "Internal Copilot skill '" + skillName
-                                  + "' must declare user_invocable or user-invocable so Copilot invocation metadata can be generated");
+                    "Internal " + agentName + " skill '" + skillName
+                                  + "' must declare user_invocable or user-invocable so invocation metadata can be generated");
         }
 
         String[] lines = normalized.split("\n", -1);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -195,20 +195,7 @@ public class DoctorService {
                     "Pi safety guard policy is missing",
                     "Run camel-kit init --here --ai pi --force to regenerate Pi guard resources."));
         } else {
-            try {
-                JsonNode rootNode = MAPPER.readTree(policy.toFile());
-                policyOk = rootNode.path("version").asInt() == 1 && rootNode.path("rules").isArray();
-            } catch (IOException e) {
-                findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
-                        "Pi safety guard policy is not valid JSON: " + e.getMessage(),
-                        "Fix the JSON syntax or regenerate Pi guard resources with camel-kit init --here --force."));
-                return;
-            }
-            if (!policyOk) {
-                findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
-                        "Pi safety guard policy must declare version 1 and a rules array",
-                        "Regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
-            }
+            policyOk = checkPiGuardPolicy(root, policy, findings);
         }
 
         if (extensionOk && policyOk) {
@@ -216,6 +203,91 @@ public class DoctorService {
                     "Pi safety guard extension and policy are present",
                     "No action required."));
         }
+    }
+
+    private boolean checkPiGuardPolicy(Path root, Path policy, List<DoctorFinding> findings) {
+        JsonNode rootNode;
+        try {
+            rootNode = MAPPER.readTree(policy.toFile());
+        } catch (IOException e) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                    "Pi safety guard policy is not valid JSON: " + e.getMessage(),
+                    "Fix the JSON syntax or regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
+            return false;
+        }
+
+        boolean valid = true;
+        JsonNode version = rootNode.path("version");
+        if (!version.isInt() || version.asInt() != 1 || !rootNode.path("rules").isArray()) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                    "Pi safety guard policy must declare version 1 and a rules array",
+                    "Regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
+            valid = false;
+        }
+
+        JsonNode rules = rootNode.path("rules");
+        if (rules.isArray()) {
+            for (int i = 0; i < rules.size(); i++) {
+                valid &= checkPiGuardRule(root, policy, rules.get(i), i, findings);
+            }
+        }
+        return valid;
+    }
+
+    private boolean checkPiGuardRule(
+            Path root, Path policy, JsonNode rule, int index, List<DoctorFinding> findings) {
+        boolean valid = true;
+        if (!rule.isObject()) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                    "Pi safety guard policy rule at index " + index + " must be an object",
+                    "Ensure each rule declares inputPattern, reason, and optional toolNames."));
+            return false;
+        }
+
+        if (!isNonBlankText(rule.path("inputPattern"))) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                    "Pi safety guard policy rule at index " + index + " must declare a non-empty inputPattern",
+                    "Regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
+            valid = false;
+        }
+        if (!isNonBlankText(rule.path("reason"))) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                    "Pi safety guard policy rule at index " + index + " must declare a non-empty reason",
+                    "Regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
+            valid = false;
+        }
+
+        JsonNode toolNames = rule.path("toolNames");
+        if (!toolNames.isMissingNode()) {
+            if (!toolNames.isArray()) {
+                addPiGuardPolicyFailure(root, policy, findings,
+                        "Pi safety guard policy rule at index " + index
+                                                                + " has invalid toolNames; expected an array of strings");
+                valid = false;
+            } else {
+                for (int i = 0; i < toolNames.size(); i++) {
+                    if (!isNonBlankText(toolNames.get(i))) {
+                        addPiGuardPolicyFailure(root, policy, findings,
+                                "Pi safety guard policy rule at index " + index
+                                                                        + " has an invalid toolNames entry at index "
+                                                                        + i);
+                        valid = false;
+                    }
+                }
+            }
+        }
+        return valid;
+    }
+
+    private void addPiGuardPolicyFailure(
+            Path root, Path policy, List<DoctorFinding> findings, String message) {
+        findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                message,
+                "Regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
+    }
+
+    private boolean isNonBlankText(JsonNode node) {
+        return node.isTextual() && !node.asText().isBlank();
     }
 
     private void checkCommandFiles(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -169,6 +169,53 @@ public class DoctorService {
                     "Missing SKILL.md for: " + String.join(", ", missingSkills),
                     "Restore the missing skill folders or re-run camel-kit init --here --force."));
         }
+        checkAgentSpecificWorkspace(root, agent, findings);
+    }
+
+    private void checkAgentSpecificWorkspace(Path root, AgentConfig agent, List<DoctorFinding> findings) {
+        if (AgentGeneratorStrategy.PI.descriptorValue().equals(agentKey(agent))) {
+            checkPiGuard(root, findings);
+        }
+    }
+
+    private void checkPiGuard(Path root, List<DoctorFinding> findings) {
+        Path extension = root.resolve(".pi/extensions/camel-kit-guard.ts");
+        Path policy = root.resolve(".pi/camel-kit-guard-policy.json");
+        boolean extensionOk = Files.isRegularFile(extension);
+        boolean policyOk = false;
+
+        if (!extensionOk) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, extension),
+                    "Pi safety guard extension is missing",
+                    "Run camel-kit init --here --ai pi --force to regenerate Pi guard resources."));
+        }
+
+        if (!Files.isRegularFile(policy)) {
+            findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                    "Pi safety guard policy is missing",
+                    "Run camel-kit init --here --ai pi --force to regenerate Pi guard resources."));
+        } else {
+            try {
+                JsonNode rootNode = MAPPER.readTree(policy.toFile());
+                policyOk = rootNode.path("version").asInt() == 1 && rootNode.path("rules").isArray();
+            } catch (IOException e) {
+                findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                        "Pi safety guard policy is not valid JSON: " + e.getMessage(),
+                        "Fix the JSON syntax or regenerate Pi guard resources with camel-kit init --here --force."));
+                return;
+            }
+            if (!policyOk) {
+                findings.add(DoctorFinding.fail("workspace", relativize(root, policy),
+                        "Pi safety guard policy must declare version 1 and a rules array",
+                        "Regenerate Pi guard resources with camel-kit init --here --ai pi --force."));
+            }
+        }
+
+        if (extensionOk && policyOk) {
+            findings.add(DoctorFinding.pass("workspace", relativize(root, extension),
+                    "Pi safety guard extension and policy are present",
+                    "No action required."));
+        }
     }
 
     private void checkCommandFiles(
@@ -214,8 +261,11 @@ public class DoctorService {
 
     private void checkMcp(Path root, Properties config, List<DoctorFinding> findings) {
         String agentName = config.getProperty("agent.name", "").trim();
+        String normalizedAgentName = agentName.toLowerCase(Locale.ROOT);
         boolean copilotToolsSchema = AgentGeneratorStrategy.COPILOT.descriptorValue()
-                .equals(agentName.toLowerCase(Locale.ROOT));
+                .equals(normalizedAgentName);
+        boolean piDirectToolsSchema = AgentGeneratorStrategy.PI.descriptorValue()
+                .equals(normalizedAgentName);
         Path mcpFile = mcpConfigPath(root, agentName);
         if (mcpFile == null) {
             findings.add(DoctorFinding.fail("mcp", null,
@@ -249,10 +299,11 @@ public class DoctorService {
         }
 
         boolean camelOk = checkMcpServer(
-                root, mcpFile, servers, "camel", expectations.camelMcpTools(), copilotToolsSchema, findings);
+                root, mcpFile, servers, "camel", expectations.camelMcpTools(), copilotToolsSchema,
+                piDirectToolsSchema, findings);
         boolean knowledgeOk = checkMcpServer(
                 root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), copilotToolsSchema,
-                findings);
+                piDirectToolsSchema, findings);
         if (camelOk && knowledgeOk) {
             findings.add(DoctorFinding.pass("mcp", relativize(root, mcpFile),
                     "MCP config exists and tool allowlists match Camel-Kit expectations",
@@ -262,7 +313,7 @@ public class DoctorService {
 
     private boolean checkMcpServer(
             Path root, Path mcpFile, JsonNode servers, String serverName, Set<String> expected,
-            boolean copilotToolsSchema, List<DoctorFinding> findings) {
+            boolean copilotToolsSchema, boolean piDirectToolsSchema, List<DoctorFinding> findings) {
         JsonNode server = servers.path(serverName);
         if (!server.isObject()) {
             findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
@@ -273,6 +324,9 @@ public class DoctorService {
 
         if (copilotToolsSchema) {
             return checkCopilotTools(root, mcpFile, serverName, server, expected, findings);
+        }
+        if (piDirectToolsSchema) {
+            return checkPiDirectTools(root, mcpFile, serverName, server, expected, findings);
         }
 
         boolean autoApproveOk = checkAllowlist(root, mcpFile, serverName, "autoApprove", server, expected, findings);
@@ -310,6 +364,42 @@ public class DoctorService {
                 "MCP server '" + serverName + "' tools must be an array or comma-separated string",
                 "Set tools to [\"*\"] or the generated Camel-Kit tool list, then re-run camel-kit doctor."));
         return false;
+    }
+
+    private boolean checkPiDirectTools(
+            Path root, Path mcpFile, String serverName, JsonNode server, Set<String> expected,
+            List<DoctorFinding> findings) {
+        JsonNode directTools = server.path("directTools");
+        if (directTools.isMissingNode() || directTools.isNull()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' is missing directTools",
+                    "Regenerate the Pi MCP config with camel-kit init --here --ai pi --force."));
+            return false;
+        }
+
+        if (directTools.isBoolean()) {
+            if (directTools.asBoolean()) {
+                findings.add(DoctorFinding.warn("mcp", relativize(root, mcpFile),
+                        "MCP server '" + serverName + "' directTools promotes all tools",
+                        "Prefer the generated Camel-Kit tool allowlist for least privilege unless broader access is intentional."));
+                return true;
+            }
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' directTools disables first-class tools",
+                    "Set directTools to the generated Camel-Kit tool allowlist and re-run camel-kit doctor."));
+            return false;
+        }
+
+        if (!directTools.isArray()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "MCP server '" + serverName + "' directTools must be an array or true",
+                    "Set directTools to true or the generated Camel-Kit tool list, then re-run camel-kit doctor."));
+            return false;
+        }
+
+        Set<String> actual = new LinkedHashSet<>();
+        directTools.forEach(value -> actual.add(value.asText()));
+        return checkToolSet(root, mcpFile, serverName, "directTools", actual, expected, false, findings);
     }
 
     private boolean checkAllowlist(

--- a/camel-kit-core/src/main/resources/agents/registry/pi.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/pi.yaml
@@ -1,0 +1,26 @@
+id: pi
+displayName: Pi
+commandDirectory: .pi/prompts
+commandFileFormat: md
+argumentPlaceholder: $ARGUMENTS
+mcpConfigPath: .mcp.json
+mcpConfigTemplatePath: templates/mcp-configs/pi-mcp.json
+mcpServerContainerKey: mcpServers
+description: Pi terminal coding agent
+generatorStrategy: pi
+dispatchTemplatePath: templates/dispatch/pi.md
+templates:
+  - source: templates/pi/agents-md.md
+    target: AGENTS.md
+  - source: templates/pi/extensions/camel-kit-guard.ts
+    target: .pi/extensions/camel-kit-guard.ts
+  - source: templates/pi/extensions/camel-kit-guard-policy.json
+    target: .pi/camel-kit-guard-policy.json
+supportsSubagents: false
+supportsTraits: true
+capabilities:
+  - project-skills
+  - prompt-templates
+  - instruction-files
+  - mcp
+  - hooks

--- a/camel-kit-core/src/main/resources/templates/dispatch/pi.md
+++ b/camel-kit-core/src/main/resources/templates/dispatch/pi.md
@@ -1,0 +1,13 @@
+## Dispatch
+
+Pi has no native subagent surface. Execute each guide step in the current Pi session, keeping the active plan,
+artifact paths, Camel version from `.camel-kit/config.properties`, and verification evidence in view.
+
+For large tasks, the user may launch separate Pi sessions manually, for example with `pi --tools read,grep,find,ls`
+for read-only research. Treat those sessions as external helpers and bring their findings back into the main task
+before changing project files.
+
+### Fallback
+
+If prompt templates or MCP adapter resources are unavailable, read the guide directly and continue with the same
+workflow. Missing MCP evidence must be called out in the final verification notes.

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/pi-mcp.json
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/pi-mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "camel": {
+      "command": "jbang",
+      "args": [
+        "--repos", "{CAMEL_MCP_REPOS}",
+        "-Dcamel.catalog.repos={CAMEL_CATALOG_REPOS}",
+        "-Dquarkus.log.level=WARN",
+        "-Dquarkus.http.port=-1",
+        "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
+      ],
+      "description": "Apache Camel MCP Server - Component catalog, validation, and security analysis",
+      "directTools": {CAMEL_TOOLS_JSON},
+      "excludeTools": []
+    },
+    "camel-knowledge": {
+      "command": "jbang",
+      "args": [
+        "--repos", "{KNOWLEDGE_MCP_REPOS}",
+        "-Dquarkus.log.level=WARN",
+        "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
+      ],
+      "description": "{KNOWLEDGE_DESCRIPTION}",
+      "directTools": {KNOWLEDGE_TOOLS_JSON},
+      "excludeTools": []
+    },
+    "citrus": {
+      "command": "jbang",
+      "args": [
+        "--repos", "{CITRUS_MCP_REPOS}",
+        "-Dquarkus.log.level=WARN",
+        "-Dquarkus.http.port=-1",
+        "org.citrusframework:citrus-mcp-server:{CITRUS_MCP_VERSION}:runner"
+      ],
+      "description": "{CITRUS_DESCRIPTION}",
+      "directTools": {CITRUS_TOOLS_JSON},
+      "excludeTools": []
+    }
+  }
+}

--- a/camel-kit-core/src/main/resources/templates/pi/agents-md.md
+++ b/camel-kit-core/src/main/resources/templates/pi/agents-md.md
@@ -1,0 +1,44 @@
+# Camel Kit Project
+
+This repository is initialized for Pi.
+
+For integration work, trust the project first, then invoke the entry skill:
+
+```text
+/trust
+/skill:camel-start
+```
+
+`/skill:camel-start` routes to the correct Camel Kit workflow skill for greenfield design, migration, planning,
+execution, validation, debugging, or Camel documentation questions.
+
+## Pi Assets
+
+- Project skills live in `.pi/skills/`.
+- Prompt templates live in `.pi/prompts/`.
+- MCP servers are configured in `.mcp.json` through `pi-mcp-adapter`.
+- Safety guardrails are configured by `.pi/extensions/camel-kit-guard.ts` and `.pi/camel-kit-guard-policy.json`.
+
+Install the MCP adapter with:
+
+```text
+pi install npm:pi-mcp-adapter@{PI_MCP_ADAPTER_VERSION}
+```
+
+The tested Pi baseline is `{PI_VERSION}`. Headless checks must approve project trust explicitly, for example:
+
+```text
+pi -a -p "/skill:camel-start"
+```
+
+## Laws
+
+1. Verify all Camel components, EIPs, data formats, and endpoint options through MCP before use.
+2. Read and follow `docs/constitution.md`.
+3. Do not implement without a user-approved spec or plan.
+4. Read Camel version values only from `.camel-kit/config.properties`.
+5. Run the generated application or equivalent verification loop after implementation.
+
+## CLI
+
+Use `{COMMAND_PREFIX}` for Camel Kit commands, for example `{COMMAND_PREFIX} graph stats`.

--- a/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard-policy.json
+++ b/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard-policy.json
@@ -11,7 +11,7 @@
     {
       "id": "deny-recursive-force-delete",
       "toolNames": ["bash"],
-      "inputPattern": "\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*r[a-z]*f\\b|\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*f[a-z]*r\\b|\\brm\\s+[^\\n]*-[a-z]*r\\b[^\\n]*-[a-z]*f\\b|\\brm\\s+[^\\n]*-[a-z]*f\\b[^\\n]*-[a-z]*r\\b",
+      "inputPattern": "\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*r[a-z]*f\\b|\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*f[a-z]*r\\b|\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*r\\b[^\\n]*\\s-[a-z]*f\\b|\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*f\\b[^\\n]*\\s-[a-z]*r\\b",
       "flags": "i",
       "reason": "Camel Kit safety guard blocked a broad recursive force delete command."
     },

--- a/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard-policy.json
+++ b/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard-policy.json
@@ -11,7 +11,7 @@
     {
       "id": "deny-recursive-force-delete",
       "toolNames": ["bash"],
-      "inputPattern": "\\brm\\s+[^\\n]*-[^\\n]*r[^\\n]*f|\\brm\\s+[^\\n]*-[^\\n]*f[^\\n]*r",
+      "inputPattern": "\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*r[a-z]*f\\b|\\brm\\s+(?:[^\\n]*\\s+)?-[a-z]*f[a-z]*r\\b|\\brm\\s+[^\\n]*-[a-z]*r\\b[^\\n]*-[a-z]*f\\b|\\brm\\s+[^\\n]*-[a-z]*f\\b[^\\n]*-[a-z]*r\\b",
       "flags": "i",
       "reason": "Camel Kit safety guard blocked a broad recursive force delete command."
     },

--- a/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard-policy.json
+++ b/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard-policy.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "id": "deny-git-push",
+      "toolNames": ["bash"],
+      "inputPattern": "\\bgit\\s+push\\b",
+      "flags": "i",
+      "reason": "Camel Kit safety guard blocked git push from an automated Pi session."
+    },
+    {
+      "id": "deny-recursive-force-delete",
+      "toolNames": ["bash"],
+      "inputPattern": "\\brm\\s+[^\\n]*-[^\\n]*r[^\\n]*f|\\brm\\s+[^\\n]*-[^\\n]*f[^\\n]*r",
+      "flags": "i",
+      "reason": "Camel Kit safety guard blocked a broad recursive force delete command."
+    },
+    {
+      "id": "deny-world-writable-chmod",
+      "toolNames": ["bash"],
+      "inputPattern": "\\bchmod\\s+777\\b",
+      "flags": "i",
+      "reason": "Camel Kit safety guard blocked chmod 777."
+    },
+    {
+      "id": "deny-common-secret-read",
+      "toolNames": ["bash", "read"],
+      "inputPattern": "(^|[\\s/])(?:\\.env|id_rsa|\\.npmrc|credentials|\\.aws/config|\\.aws/credentials)\\b",
+      "flags": "i",
+      "reason": "Camel Kit safety guard blocked access to a common secret or credential file."
+    }
+  ]
+}

--- a/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard.ts
+++ b/camel-kit-core/src/main/resources/templates/pi/extensions/camel-kit-guard.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type GuardRule = {
+  id: string;
+  toolNames?: string[];
+  inputPattern: string;
+  flags?: string;
+  reason: string;
+};
+
+type GuardPolicy = {
+  version: number;
+  rules: GuardRule[];
+};
+
+function policyPath(): string {
+  let current = process.cwd();
+  while (true) {
+    const candidate = path.join(current, ".pi", "camel-kit-guard-policy.json");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return path.join(process.cwd(), ".pi", "camel-kit-guard-policy.json");
+    }
+    current = parent;
+  }
+}
+
+function loadPolicy(): GuardPolicy {
+  const raw = fs.readFileSync(policyPath(), "utf8");
+  const parsed = JSON.parse(raw) as GuardPolicy;
+  if (parsed.version !== 1 || !Array.isArray(parsed.rules)) {
+    throw new Error("Unsupported Camel Kit guard policy format");
+  }
+  return parsed;
+}
+
+function inputText(input: unknown): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input && typeof input === "object") {
+    const value = input as Record<string, unknown>;
+    for (const key of ["command", "cmd", "path", "file", "content"]) {
+      if (typeof value[key] === "string") {
+        return value[key] as string;
+      }
+    }
+  }
+  return JSON.stringify(input ?? "");
+}
+
+function appliesTo(rule: GuardRule, toolName: string): boolean {
+  return !rule.toolNames || rule.toolNames.length === 0 || rule.toolNames.includes(toolName);
+}
+
+export default function camelKitGuard(pi: any) {
+  const policy = loadPolicy();
+
+  pi.on("tool_call", (event: any) => {
+    const toolName = String(event.toolName ?? event.name ?? "");
+    const text = inputText(event.input ?? event.args ?? event);
+
+    for (const rule of policy.rules) {
+      if (!appliesTo(rule, toolName)) {
+        continue;
+      }
+      const pattern = new RegExp(rule.inputPattern, rule.flags ?? "i");
+      if (pattern.test(text)) {
+        return {
+          block: true,
+          reason: rule.reason
+        };
+      }
+    }
+    return undefined;
+  });
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
@@ -163,7 +163,7 @@ class DoctorCommandTest {
 
     @Test
     void generatedWorkspacesMatchDoctorExpectations() throws Exception {
-        for (String agentName : List.of("bob", "bob2", "claude", "copilot", "gemini", "qwen", "opencode")) {
+        for (String agentName : List.of("bob", "bob2", "claude", "copilot", "gemini", "qwen", "opencode", "pi")) {
             Path root = tempDir.resolve(agentName);
             createGeneratedWorkspace(root, agentName);
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
@@ -54,6 +54,23 @@ class InitCommandTest {
         assertFalse(output.contains("select camel-start"));
     }
 
+    @Test
+    void piNextStepsUseTrustAndSkillInvocation() {
+        CapturingPrinter printer = new CapturingPrinter();
+        CamelKitMain main = new CamelKitMain();
+        main.setOut(printer);
+
+        InitCommand command = new InitCommand(main);
+        command.printNextSteps("orders", "Pi", "pi");
+
+        String output = printer.output();
+        assertTrue(output.contains("pi install npm:pi-mcp-adapter"));
+        assertTrue(output.contains("/trust"));
+        assertTrue(output.contains("/skill:camel-start"));
+        assertTrue(output.contains("/mcp status"));
+        assertFalse(output.contains("/camel-start  "));
+    }
+
     private static final class CapturingPrinter implements Printer {
         private final StringBuilder output = new StringBuilder();
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
@@ -64,7 +64,7 @@ class InitCommandTest {
         command.printNextSteps("orders", "Pi", "pi");
 
         String output = printer.output();
-        assertTrue(output.contains("pi install npm:pi-mcp-adapter"));
+        assertTrue(output.contains("pi install npm:pi-mcp-adapter@2.11.0"));
         assertTrue(output.contains("/trust"));
         assertTrue(output.contains("/skill:camel-start"));
         assertTrue(output.contains("/mcp status"));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
@@ -23,7 +23,7 @@ class AgentRegistryTest {
 
     @Test
     void builtInAgentsAreLoadedFromResourceDescriptors() {
-        assertEquals(Set.of("bob", "bob2", "claude", "copilot", "gemini", "opencode", "qwen"),
+        assertEquals(Set.of("bob", "bob2", "claude", "copilot", "gemini", "opencode", "pi", "qwen"),
                 AgentRegistry.names());
 
         AgentConfig claude = AgentRegistry.get("claude");
@@ -69,6 +69,30 @@ class AgentRegistryTest {
         assertTrue(descriptor.capabilities().contains("custom-agents"));
         assertTrue(descriptor.capabilities().contains("project-skills"));
         assertTrue(descriptor.capabilities().contains("hooks"));
+    }
+
+    @Test
+    void piDescriptorUsesNativeProjectLocations() {
+        AgentConfig pi = AgentRegistry.get("pi");
+        assertNotNull(pi);
+        assertEquals("Pi", pi.name());
+        assertEquals(".pi/prompts", pi.folder());
+        assertEquals("md", pi.fileFormat());
+        assertEquals(".mcp.json", pi.mcpConfigPath());
+        assertEquals("templates/mcp-configs/pi-mcp.json", pi.mcpConfigTemplatePath());
+        assertEquals("mcpServers", pi.mcpServerContainerKey());
+
+        AgentDescriptor descriptor = AgentRegistry.descriptor("pi");
+        assertNotNull(descriptor);
+        assertEquals("pi", descriptor.generatorStrategy());
+        assertEquals(AgentGeneratorStrategy.PI, descriptor.generatorStrategyType());
+        assertEquals("templates/dispatch/pi.md", descriptor.dispatchTemplatePath());
+        assertFalse(descriptor.supportsSubagents());
+        assertTrue(descriptor.supportsTraits());
+        assertTrue(descriptor.capabilities().contains("project-skills"));
+        assertTrue(descriptor.capabilities().contains("prompt-templates"));
+        assertTrue(descriptor.capabilities().contains("hooks"));
+        assertFalse(descriptor.capabilities().contains("custom-agents"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -90,6 +90,8 @@ class DistributionConfigTest {
         assertEquals("central=https://repo1.maven.org/maven2/", config.citrusMcpRepos());
         assertEquals("https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots",
                 config.camelCatalogRepos());
+        assertEquals("0.80.3", config.piVersion());
+        assertEquals("2.11.0", config.piMcpAdapterVersion());
     }
 
     @Test
@@ -103,6 +105,18 @@ class DistributionConfigTest {
 
         DistributionConfig overriddenConfig = DistributionConfig.load(properties);
         assertEquals("9.9.9-TEST", overriddenConfig.camelMcpVersion());
+    }
+
+    @Test
+    void piVersionsCanBeOverriddenViaProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("pi.version", "9.9.9-test");
+        properties.setProperty("pi.mcp.adapter.version", "8.8.8-test");
+
+        DistributionConfig config = DistributionConfig.load(properties);
+
+        assertEquals("9.9.9-test", config.piVersion());
+        assertEquals("8.8.8-test", config.piMcpAdapterVersion());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
@@ -42,6 +42,11 @@ class AgentGeneratorFactoryTest {
     }
 
     @Test
+    void piReturnsPiGenerator() {
+        assertInstanceOf(PiGenerator.class, AgentGeneratorFactory.create("pi"));
+    }
+
+    @Test
     void unknownAgentFailsFast() {
         IllegalArgumentException thrown = assertThrows(
                 IllegalArgumentException.class,

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class DefaultGeneratorTest {
 
     private static final String COPILOT = AgentGeneratorStrategy.COPILOT.descriptorValue();
+    private static final String PI = AgentGeneratorStrategy.PI.descriptorValue();
 
     @TempDir
     Path tempDir;
@@ -95,7 +96,7 @@ class DefaultGeneratorTest {
                 .allowedTools());
 
         ObjectMapper mapper = new ObjectMapper();
-        for (String agentName : List.of("bob", "claude", COPILOT, "gemini", "qwen", "opencode")) {
+        for (String agentName : List.of("bob", "claude", COPILOT, "gemini", "qwen", "opencode", PI)) {
             InitContext ctx = createContext(agentName);
             new DefaultGenerator().generate(ctx);
 
@@ -103,6 +104,9 @@ class DefaultGeneratorTest {
             if (COPILOT.equals(agentName)) {
                 assertEquals(implementedKnowledgeTools, jsonArrayToList(knowledgeServer.path("tools")),
                         agentName + " tools must only include implemented Knowledge MCP tools");
+            } else if (PI.equals(agentName)) {
+                assertEquals(implementedKnowledgeTools, jsonArrayToList(knowledgeServer.path("directTools")),
+                        agentName + " directTools must only include implemented Knowledge MCP tools");
             } else {
                 assertEquals(implementedKnowledgeTools, jsonArrayToList(knowledgeServer.path("autoApprove")),
                         agentName + " autoApprove must only include implemented Knowledge MCP tools");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/PiGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/PiGeneratorTest.java
@@ -1,0 +1,137 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.output.Printer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PiGeneratorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Set<String> INTERNAL_SKILLS = Set.of(
+            "camel-design",
+            "camel-implement",
+            "camel-test",
+            "camel-verify");
+
+    @TempDir
+    Path tempDir;
+
+    private InitContext createContext() {
+        AgentConfig agent = AgentRegistry.get("pi");
+        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
+        Path commandsDir = tempDir.resolve(agent.folder());
+        Path skillsDir = tempDir.resolve(agentBaseFolder + "/skills");
+        return new InitContext(
+                agent, "pi", commandsDir, skillsDir, tempDir,
+                "camel-kit", Printer.noop());
+    }
+
+    @Test
+    void generatesPiAgentsMdAndNativeProjectAssets() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        String agentsMd = Files.readString(tempDir.resolve("AGENTS.md"));
+        assertTrue(agentsMd.contains("initialized for Pi"));
+        assertTrue(agentsMd.contains("/skill:camel-start"));
+        assertTrue(agentsMd.contains(".pi/skills"));
+        assertTrue(agentsMd.contains(".mcp.json"));
+        assertTrue(agentsMd.contains("pi install npm:pi-mcp-adapter@2.11.0"));
+        assertTrue(agentsMd.contains("pi -a -p"));
+        assertFalse(agentsMd.contains("{COMMAND_PREFIX}"));
+        assertFalse(agentsMd.contains("{PI_MCP_ADAPTER_VERSION}"));
+
+        assertTrue(Files.isRegularFile(tempDir.resolve(".pi/extensions/camel-kit-guard.ts")));
+        JsonNode policy = MAPPER.readTree(tempDir.resolve(".pi/camel-kit-guard-policy.json").toFile());
+        assertEquals(1, policy.path("version").asInt());
+        assertTrue(policy.path("rules").isArray());
+    }
+
+    @Test
+    void installsEveryTemplateDeclaredByPiDescriptor() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        AgentDescriptor descriptor = AgentRegistry.descriptor("pi");
+        for (AgentDescriptor.TemplateInstall template : descriptor.templates()) {
+            assertTrue(Files.isRegularFile(tempDir.resolve(template.target())),
+                    "Missing generated Pi template target " + template.target());
+        }
+    }
+
+    @Test
+    void generatesProjectSkillsInPiSkillsDirectory() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        assertTrue(Files.exists(tempDir.resolve(".pi/skills/camel-start/SKILL.md")));
+        assertTrue(Files.exists(tempDir.resolve(".pi/skills/camel-execute/SKILL.md")));
+        assertTrue(Files.exists(tempDir.resolve(".pi/skills/shared/iron-laws.md")));
+    }
+
+    @Test
+    void marksInternalSkillsAsNotUserOrModelInvocableForPi() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        for (String skillName : INTERNAL_SKILLS) {
+            String skill = Files.readString(tempDir.resolve(".pi/skills/" + skillName + "/SKILL.md"));
+            assertTrue(skill.contains("user-invocable: false"), skillName + " must declare future user hiding");
+            assertTrue(skill.contains("disable-model-invocation: true"),
+                    skillName + " must not be model invocable");
+        }
+
+        String start = Files.readString(tempDir.resolve(".pi/skills/camel-start/SKILL.md"));
+        assertFalse(start.contains("disable-model-invocation: true"));
+    }
+
+    @Test
+    void generatesPiMcpConfigWithDirectToolsSchema() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        Path mcp = tempDir.resolve(".mcp.json");
+        assertTrue(Files.exists(mcp));
+        JsonNode root = MAPPER.readTree(mcp.toFile());
+        JsonNode camel = root.path("mcpServers").path("camel");
+        assertEquals("jbang", camel.path("command").asText());
+        assertTrue(camel.path("directTools").isArray());
+        assertTrue(camel.path("excludeTools").isArray());
+        assertFalse(camel.has("autoApprove"));
+        assertFalse(camel.has("alwaysAllow"));
+        assertFalse(camel.has("tools"));
+
+        JsonNode citrus = root.path("mcpServers").path("citrus");
+        assertTrue(citrus.path("directTools").isArray());
+    }
+
+    @Test
+    void generatedPromptTemplatesReferencePiSkills() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        String content = Files.readString(ctx.commandsDir().resolve("camel-start.md"));
+        assertTrue(content.contains(".pi/skills/camel-start/SKILL.md"));
+    }
+
+    @Test
+    void doesNotGenerateCustomAgentsForPiV1() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        assertFalse(Files.exists(tempDir.resolve(".pi/agents")));
+        assertFalse(Files.exists(tempDir.resolve(".github/agents")));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/PiGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/PiGeneratorTest.java
@@ -142,6 +142,9 @@ class PiGeneratorTest {
         assertTrue(pattern.matcher("rm -f -r target").find());
         assertFalse(pattern.matcher("rm -f README.md").find());
         assertFalse(pattern.matcher("rm -f target/output.txt").find());
+        assertFalse(pattern.matcher("rm -f foo-bar.txt").find());
+        assertFalse(pattern.matcher("rm -f my-runner.log").find());
+        assertFalse(pattern.matcher("rm -r some-conf").find());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/PiGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/PiGeneratorTest.java
@@ -3,6 +3,7 @@ package io.github.luigidemasi.camelkit.generator;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentDescriptor;
@@ -115,6 +116,32 @@ class PiGeneratorTest {
 
         JsonNode citrus = root.path("mcpServers").path("citrus");
         assertTrue(citrus.path("directTools").isArray());
+    }
+
+    @Test
+    void guardPolicyBlocksRecursiveForceDeleteWithoutBlockingForceDeleteOfRegularFiles() throws Exception {
+        InitContext ctx = createContext();
+        new PiGenerator().generate(ctx);
+
+        JsonNode rules = MAPPER.readTree(tempDir.resolve(".pi/camel-kit-guard-policy.json").toFile()).path("rules");
+        JsonNode rmRule = null;
+        for (JsonNode rule : rules) {
+            if ("deny-recursive-force-delete".equals(rule.path("id").asText())) {
+                rmRule = rule;
+                break;
+            }
+        }
+        assertNotNull(rmRule);
+        Pattern pattern = Pattern.compile(rmRule.path("inputPattern").asText(), Pattern.CASE_INSENSITIVE);
+
+        assertTrue(pattern.matcher("rm -rf target").find());
+        assertTrue(pattern.matcher("rm -fr target").find());
+        assertTrue(pattern.matcher("rm -vrf target").find());
+        assertTrue(pattern.matcher("rm --one-file-system -Rf target").find());
+        assertTrue(pattern.matcher("rm -r -f target").find());
+        assertTrue(pattern.matcher("rm -f -r target").find());
+        assertFalse(pattern.matcher("rm -f README.md").find());
+        assertFalse(pattern.matcher("rm -f target/output.txt").find());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -30,6 +30,7 @@ class ResourceConsistencyTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String COPILOT = AgentGeneratorStrategy.COPILOT.descriptorValue();
+    private static final String PI = AgentGeneratorStrategy.PI.descriptorValue();
 
     private static final List<StalePattern> STALE_PATTERNS = List.of(
             new StalePattern(".camel-kit/config.yaml", Pattern.compile(Pattern.quote(".camel-kit/config.yaml"))),
@@ -164,6 +165,8 @@ class ResourceConsistencyTest {
             JsonNode knowledgeServer = serverConfig(agentName, projectDir, "camel-knowledge");
             if (COPILOT.equals(agentName)) {
                 assertKnowledgeTools(agentName, "tools", knowledgeServer.get("tools"));
+            } else if (PI.equals(agentName)) {
+                assertKnowledgeTools(agentName, "directTools", knowledgeServer.get("directTools"));
             } else {
                 assertKnowledgeTools(agentName, "autoApprove", knowledgeServer.get("autoApprove"));
                 assertKnowledgeTools(agentName, "alwaysAllow", knowledgeServer.get("alwaysAllow"));
@@ -172,6 +175,8 @@ class ResourceConsistencyTest {
             JsonNode citrusServer = serverConfig(agentName, projectDir, "citrus");
             if (COPILOT.equals(agentName)) {
                 assertCitrusTools(agentName, "tools", citrusServer.get("tools"));
+            } else if (PI.equals(agentName)) {
+                assertCitrusTools(agentName, "directTools", citrusServer.get("directTools"));
             } else {
                 assertCitrusTools(agentName, "autoApprove", citrusServer.get("autoApprove"));
                 assertCitrusTools(agentName, "alwaysAllow", citrusServer.get("alwaysAllow"));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstallerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstallerTest.java
@@ -33,4 +33,24 @@ class SkillResourceInstallerTest {
         assertTrue(content.contains("disable-model-invocation: true"));
         assertFalse(content.contains("user_invocable:"));
     }
+
+    @Test
+    void piMetadataMarksInternalSkillsAsHiddenFromModel() throws Exception {
+        Path skill = tempDir.resolve(".pi/skills/camel-test/SKILL.md");
+        Files.createDirectories(skill.getParent());
+        Files.writeString(skill, """
+                ---
+                name: camel-test
+                user_invocable: false
+                ---
+
+                Body.
+                """);
+
+        new SkillResourceInstaller().addPiReadableInternalSkillMetadata(skill);
+
+        String content = Files.readString(skill);
+        assertTrue(content.contains("user-invocable: false"));
+        assertTrue(content.contains("disable-model-invocation: true"));
+    }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -19,6 +19,7 @@ class DoctorServiceTest {
 
     private static final DoctorExpectations EXPECTATIONS = DoctorExpectations.loadDefault();
     private static final String COPILOT = AgentGeneratorStrategy.COPILOT.descriptorValue();
+    private static final String PI = AgentGeneratorStrategy.PI.descriptorValue();
 
     @TempDir
     Path tempDir;
@@ -58,6 +59,21 @@ class DoctorServiceTest {
         assertFalse(result.hasFailures(), result.findings().toString());
         assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
                 "MCP config exists and tool allowlists match Camel-Kit expectations",
+                "No action required."));
+    }
+
+    @Test
+    void healthyPiWorkspaceUsesDirectToolsSchemaAndGuardResources() throws Exception {
+        createHealthyWorkspace(tempDir, "pi");
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertFalse(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
+                "MCP config exists and tool allowlists match Camel-Kit expectations",
+                "No action required."));
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "workspace",
+                "Pi safety guard extension and policy are present",
                 "No action required."));
     }
 
@@ -147,6 +163,71 @@ class DoctorServiceTest {
     }
 
     @Test
+    void piDirectToolsTrueWarnsWithoutFailing() throws Exception {
+        createHealthyWorkspace(tempDir, "pi");
+        writeMcpConfig(tempDir, "pi", """
+                {
+                  "mcpServers": {
+                    "camel": {
+                      "command": "jbang",
+                      "directTools": true
+                    },
+                    "camel-knowledge": {
+                      "command": "jbang",
+                      "directTools": true
+                    }
+                  }
+                }
+                """);
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertFalse(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.WARN, "mcp",
+                "MCP server 'camel' directTools promotes all tools",
+                "Prefer the generated Camel-Kit tool allowlist"));
+    }
+
+    @Test
+    void invalidPiDirectToolsScalarProducesClearFailure() throws Exception {
+        createHealthyWorkspace(tempDir, "pi");
+        writeMcpConfig(tempDir, "pi", """
+                {
+                  "mcpServers": {
+                    "camel": {
+                      "command": "jbang",
+                      "directTools": "camel_catalog_components"
+                    },
+                    "camel-knowledge": {
+                      "command": "jbang",
+                      "directTools": []
+                    }
+                  }
+                }
+                """);
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                "MCP server 'camel' directTools must be an array or true",
+                "Set directTools"));
+    }
+
+    @Test
+    void missingPiGuardPolicyProducesClearFailure() throws Exception {
+        createHealthyWorkspace(tempDir, "pi");
+        Files.delete(tempDir.resolve(".pi/camel-kit-guard-policy.json"));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "Pi safety guard policy is missing",
+                "Run camel-kit init --here --ai pi --force"));
+    }
+
+    @Test
     void nonCopilotToolsKeyDoesNotBypassLegacyAllowlistValidation() throws Exception {
         createHealthyWorkspace(tempDir, "bob");
         writeMcpConfig(tempDir, "bob", """
@@ -233,6 +314,18 @@ class DoctorServiceTest {
         Files.createDirectories(mcpFile.getParent());
         Files.writeString(mcpFile,
                 mcpJson(agentName, EXPECTATIONS.camelMcpTools(), EXPECTATIONS.knowledgeMcpTools()));
+
+        if (PI.equals(agentName)) {
+            Files.createDirectories(root.resolve(".pi/extensions"));
+            Files.writeString(root.resolve(".pi/extensions/camel-kit-guard.ts"),
+                    "export default function camelKitGuard(pi: any) {}\n");
+            Files.writeString(root.resolve(".pi/camel-kit-guard-policy.json"), """
+                    {
+                      "version": 1,
+                      "rules": []
+                    }
+                    """);
+        }
     }
 
     private void writeMcpConfig(Path root, String agentName, String content) throws Exception {
@@ -256,6 +349,22 @@ class DoctorServiceTest {
                           "type": "stdio",
                           "command": "jbang",
                           "tools": [%s]
+                        }
+                      }
+                    }
+                    """, jsonArray(camelTools), jsonArray(knowledgeTools));
+        }
+        if (PI.equals(agentName)) {
+            return String.format(Locale.ROOT, """
+                    {
+                      "mcpServers": {
+                        "camel": {
+                          "command": "jbang",
+                          "directTools": [%s]
+                        },
+                        "camel-knowledge": {
+                          "command": "jbang",
+                          "directTools": [%s]
                         }
                       }
                     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -228,6 +228,53 @@ class DoctorServiceTest {
     }
 
     @Test
+    void invalidPiGuardPolicyJsonUsesPiRegenerationCommand() throws Exception {
+        createHealthyWorkspace(tempDir, "pi");
+        writePiGuardPolicy("""
+                {
+                  "version": 1,
+                  "rules": [
+                }
+                """);
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "Pi safety guard policy is not valid JSON",
+                "camel-kit init --here --ai pi --force"));
+    }
+
+    @Test
+    void malformedPiGuardPolicyRuleProducesClearFailure() throws Exception {
+        createHealthyWorkspace(tempDir, "pi");
+        writePiGuardPolicy("""
+                {
+                  "version": 1,
+                  "rules": [
+                    {
+                      "toolNames": "bash",
+                      "reason": ""
+                    }
+                  ]
+                }
+                """);
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "must declare a non-empty inputPattern",
+                "camel-kit init --here --ai pi --force"));
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "must declare a non-empty reason",
+                "camel-kit init --here --ai pi --force"));
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "has invalid toolNames; expected an array of strings",
+                "camel-kit init --here --ai pi --force"));
+    }
+
+    @Test
     void nonCopilotToolsKeyDoesNotBypassLegacyAllowlistValidation() throws Exception {
         createHealthyWorkspace(tempDir, "bob");
         writeMcpConfig(tempDir, "bob", """
@@ -333,6 +380,10 @@ class DoctorServiceTest {
         Path mcpFile = root.resolve(agent.mcpConfigPath());
         Files.createDirectories(mcpFile.getParent());
         Files.writeString(mcpFile, content);
+    }
+
+    private void writePiGuardPolicy(String content) throws Exception {
+        Files.writeString(tempDir.resolve(".pi/camel-kit-guard-policy.json"), content);
     }
 
     private String mcpJson(String agentName, Collection<String> camelTools, Collection<String> knowledgeTools) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -94,6 +94,28 @@ class InitServiceTest {
     }
 
     @Test
+    void initializesPiWorkspaceWithNativeAssets() throws Exception {
+        RecordingProgress progress = new RecordingProgress();
+        Path targetDir = tempDir.resolve("orders");
+
+        InitResult result = new InitService().initialize(
+                request(targetDir, "pi", progress, InitReporter.noop()));
+
+        assertEquals("pi", result.agentName());
+        assertTrue(Files.isRegularFile(targetDir.resolve("AGENTS.md")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".mcp.json")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".pi/skills/camel-start/SKILL.md")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".pi/prompts/camel-start.md")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".pi/extensions/camel-kit-guard.ts")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".pi/camel-kit-guard-policy.json")));
+        assertTrue(progress.events().contains("start:Generating Pi workspace"));
+
+        String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
+        assertTrue(config.contains("agent.name=pi"));
+        assertTrue(config.contains("agent.folder=.pi/prompts"));
+    }
+
+    @Test
     void initPersistsRuntimeAndVersionConfig() throws Exception {
         Path targetDir = tempDir.resolve("orders");
 

--- a/distribution.properties
+++ b/distribution.properties
@@ -50,6 +50,10 @@ knowledge.mcp.version=0.0.1-SNAPSHOT
 citrus.version=5.0.0-M2
 citrus.mcp.version=5.0.0-M2
 
+# ─── Pi Agent Versions ─────────────────────────────────────────────────────
+pi.version=0.80.3
+pi.mcp.adapter.version=2.11.0
+
 # ─── MCP Repos ─────────────────────────────────────────────────────────────
 camel.mcp.repos=central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots
 knowledge.mcp.repos=central=https://repo1.maven.org/maven2/

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -551,16 +551,64 @@ The generated safety hook is deliberately narrow. It denies `git push`, broad `r
 
 ---
 
+## Pi -- Native Skills + Prompt Templates + Guard Extension
+
+### Dispatch Model
+
+Pi reads `AGENTS.md` and native project skills from `.pi/skills/`. Camel-Kit also writes command stubs to `.pi/prompts/`
+so users can launch prompt templates, but the primary entry remains `/skill:camel-start`.
+
+Pi has no native subagents. `/camel-execute` keeps orchestration in the main Pi session. For isolated read-only
+research, users can launch separate Pi sessions manually with tool constraints such as `pi --tools read,grep,find,ls`
+and bring the findings back to the main task.
+
+### Template Files
+
+| File | Purpose |
+|------|---------|
+| `templates/pi/agents-md.md` | `AGENTS.md` -- Pi entry point, trust guidance, laws, and adapter setup |
+| `templates/pi/extensions/camel-kit-guard.ts` | Static `tool_call` guard extension |
+| `templates/pi/extensions/camel-kit-guard-policy.json` | Declarative policy interpreted by the guard extension |
+| `templates/mcp-configs/pi-mcp.json` | `.mcp.json` for `pi-mcp-adapter` using `directTools` |
+| `templates/dispatch/pi.md` | Shared dispatch block for Pi skill copies |
+
+### How It Works
+
+```text
+User: /trust
+User: /skill:camel-start
+  └── Pi loads AGENTS.md after project trust
+      ├── Skill retrieval selects .pi/skills/camel-start/SKILL.md
+      ├── Prompt templates are available from .pi/prompts/
+      ├── MCP tools come from .mcp.json through pi-mcp-adapter
+      └── .pi/extensions/camel-kit-guard.ts blocks policy-matched tool calls
+```
+
+### Tool Restriction Model
+
+Pi has no built-in permission prompt model. Camel-Kit provides a project guard extension that blocks obvious
+destructive or secret-sensitive tool calls and keeps the policy in JSON. Broader sandboxing remains an external
+container or VM concern.
+
+### Unique Capabilities
+
+- **Native skills:** Camel Kit skills use Pi's `.pi/skills/` discovery path.
+- **Trust-gated project resources:** post-init guidance and doctor checks use `pi -a` for headless validation.
+- **Adapter-backed MCP:** `.mcp.json` uses `pi-mcp-adapter` and `directTools` allowlists.
+- **Static guard extension:** generated policy is declarative JSON; executable TypeScript stays fixed.
+
+---
+
 ## Agent Comparison
 
-| Aspect | Claude | Bob 1 legacy | Bob 2 | Gemini | Copilot | Qwen | OpenCode |
-|--------|--------|--------------|-------|--------|---------|------|----------|
-| Dispatch model | Parallel subagents | Mode switching | `spawn_subagent` (`explore`, `general`) | `invoke_subagent` unified tool (local/remote/browser) | Project skills + custom agents | Dual: named subagent + fork | `task` tool creating child sessions |
-| Template files | 3 | 17+ | Bob 2 modes + traits + rules | 12 | 11 | 9 | 8 |
-| Tool restriction | Instruction-based | Mode tool groups | Mode tool groups + `allowedSubagents` | Allowlist + TOML policy + server-scoped wildcards | Custom-agent `tools` plus hooks | Allowlist + blocklist | 3-state permissions + bash glob patterns |
-| Path-scoped edits | No | `.md` only (via fileRegex) | Mode-dependent `fileRegex` | Yes (Policy Engine) | Tool-level, not path-scoped | No | Yes (glob patterns) |
-| MCP auto-approval | No (manual) | No (manual) | No (manual) | Yes (TOML policy) | No (permission prompts) | No (manual) | No (manual) |
-| Parallel execution | Yes (graph-based) | No | Yes (same-turn `spawn_subagent`) | Yes (scheduler `Promise.all()`) | Unknown | Partial (read-only tools concurrent; fork background) | Partial (LLM-level parallel tool calls) |
-| Subagent recursion | Yes (no limit) | N/A | No (subagents must not spawn subagents) | No (hardcoded `Kind.Agent` filter) | Unknown | No (fork-of-fork blocked) | Opt-in configurable depth |
-| Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Parent task orchestrates subagents | Main agent (recursion prevention) | Project skill delegates when available | Sub-agent with `task` tool | Agent with `task` permission |
-| Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | Shared skills + Bob 2 traits + modes | `@file.md` modular imports | `.github/copilot-instructions.md` + project skills | Single `QWEN.md` | Ultra-minimal `AGENTS.md` |
+| Aspect | Claude | Bob 1 legacy | Bob 2 | Gemini | Copilot | Pi | Qwen | OpenCode |
+|--------|--------|--------------|-------|--------|---------|----|------|----------|
+| Dispatch model | Parallel subagents | Mode switching | `spawn_subagent` (`explore`, `general`) | `invoke_subagent` unified tool (local/remote/browser) | Project skills + custom agents | Project skills + prompt templates | Dual: named subagent + fork | `task` tool creating child sessions |
+| Template files | 3 | 17+ | Bob 2 modes + traits + rules | 12 | 11 | 5 | 9 | 8 |
+| Tool restriction | Instruction-based | Mode tool groups | Mode tool groups + `allowedSubagents` | Allowlist + TOML policy + server-scoped wildcards | Custom-agent `tools` plus hooks | Guard extension + external sandbox | Allowlist + blocklist | 3-state permissions + bash glob patterns |
+| Path-scoped edits | No | `.md` only (via fileRegex) | Mode-dependent `fileRegex` | Yes (Policy Engine) | Tool-level, not path-scoped | No | No | Yes (glob patterns) |
+| MCP auto-approval | No (manual) | No (manual) | No (manual) | Yes (TOML policy) | No (permission prompts) | Adapter `directTools` | No (manual) | No (manual) |
+| Parallel execution | Yes (graph-based) | No | Yes (same-turn `spawn_subagent`) | Yes (scheduler `Promise.all()`) | Unknown | No native subagents | Partial (read-only tools concurrent; fork background) | Partial (LLM-level parallel tool calls) |
+| Subagent recursion | Yes (no limit) | N/A | No (subagents must not spawn subagents) | No (hardcoded `Kind.Agent` filter) | Unknown | N/A | No (fork-of-fork blocked) | Opt-in configurable depth |
+| Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Parent task orchestrates subagents | Main agent (recursion prevention) | Project skill delegates when available | Main Pi session | Sub-agent with `task` tool | Agent with `task` permission |
+| Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | Shared skills + Bob 2 traits + modes | `@file.md` modular imports | `.github/copilot-instructions.md` + project skills | `AGENTS.md` + `.pi/skills` | Single `QWEN.md` | Ultra-minimal `AGENTS.md` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,9 @@ The frontmatter fields:
 - `description` -- trigger keywords that help agents match user intent to the correct skill
 - `user_invocable` -- `true` for `camel-start` (meta-router) only. Pipeline and standalone skills (Tier 1/2) still have generated entry points despite `user_invocable: false`: slash-command stubs for most agents and project skills for GitHub Copilot CLI. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills
 
+Agent-specific generators may add runtime aliases to copied skill files. For example, Copilot and Pi generated
+copies add `user-invocable: false` alongside Camel-Kit's source `user_invocable` metadata.
+
 ### All Skills
 
 | Skill | User-Invocable | Loaded By | Purpose |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,6 +356,7 @@ registry loading with a descriptor-specific error.
 | IBM Bob 2 | `templates/bob2/` | `custom_modes.yaml` + rules + shared skills | `.bob/mcp.json` | `.bob/skills/` |
 | Gemini CLI | `templates/gemini/` | `GEMINI.md` + `@file.md` imports + policies | `.gemini/settings.json` | `.gemini/skills/` |
 | GitHub Copilot CLI | `templates/copilot/` | `.github/copilot-instructions.md` + `.github/agents/` + hooks | `.github/mcp.json` | `.github/skills/` |
+| Pi | `templates/pi/` | `AGENTS.md` + `.pi/prompts/` + guard extension | `.mcp.json` | `.pi/skills/` |
 | Qwen | `templates/qwen/` | `QWEN.md` + sub-agent definitions | `.qwen/settings.json` | `.qwen/skills/` |
 | OpenCode | `templates/opencode/` | `AGENTS.md` + permission-based agents | `opencode.json` | `.opencode/skills/` |
 
@@ -437,6 +438,8 @@ Most supported agents use native **sub-agent dispatch** or custom-agent isolatio
 
 - **GitHub Copilot CLI** -- project skills live under `.github/skills/` and custom agents live under `.github/agents/`. Camel-Kit generates planner, implementer, tester, validator, migrator, catalog researcher, and security reviewer agents with Copilot tool aliases and MCP server prefixes. Internal guide skills copied for custom-agent use are marked `user-invocable: false` and `disable-model-invocation: true` using Copilot-readable metadata. MCP servers are committed in `.github/mcp.json` using Copilot's `tools` schema. Repository hooks under `.github/hooks/` provide a lightweight safety harness for destructive shell commands while keeping Copilot's normal permission prompts active.
 
+- **Pi** -- project skills live under `.pi/skills/` and command stubs are generated as `.pi/prompts/` prompt templates. Pi reads `AGENTS.md` natively. MCP servers are committed in `.mcp.json` for `pi-mcp-adapter` using the adapter's `directTools` allowlist schema. Internal guide skills are marked `user-invocable: false` and `disable-model-invocation: true`; Pi currently honors only the model-invocation flag. A static `.pi/extensions/camel-kit-guard.ts` extension interprets `.pi/camel-kit-guard-policy.json` to block destructive or secret-sensitive tool calls. Pi has no native subagents, so custom-agent parity is deferred.
+
 **IBM Bob 2** uses Bob's native `spawn_subagent` tool. Camel-Kit exposes this as `--ai bob2`, but generated project files still live under `.bob/` because Bob reads `.bob/commands`, `.bob/skills`, `.bob/custom_modes.yaml`, and `.bob/mcp.json`.
 
 - `explore` is used for read-only research, route inspection, spec review, quality review, and MCP verification summaries.
@@ -476,6 +479,7 @@ The trade-off table:
 | IBM Bob 2 | Native `spawn_subagent` plus custom modes | `explore`/`general` subagents, parallel same-turn dispatch, shared skills |
 | Gemini CLI | `invoke_subagent` + parallel scheduler | Default-parallel `Promise.all()`, TOML policy, MCP wildcards, A2A remote agents |
 | GitHub Copilot CLI | Project skills + custom agents + hooks | `.github/skills`, `.github/agents`, `.github/mcp.json`, safety hooks |
+| Pi | Project skills + prompt templates + guard extension | `.pi/skills`, `.pi/prompts`, `.mcp.json`, `pi-mcp-adapter`, trust-gated resources |
 | Qwen | Dual dispatch (named + fork) | Fork background tasks, DashScope cache sharing, auto-delegation |
 | OpenCode | `task` child sessions + opt-in delegation | 14 permission types, glob patterns, configurable depth limits |
 
@@ -801,6 +805,7 @@ user_invocable: false
    - IBM Bob 2: update `templates/bob2/custom_modes.yaml`, `templates/traits/bob2/`, and rules directories
    - Gemini CLI: update `templates/gemini/gemini-md.md`
    - GitHub Copilot CLI: update `templates/copilot/copilot-instructions.md`, `templates/copilot/agents-md.md`, and any affected `.github/agents` templates
+   - Pi: update `templates/pi/agents-md.md`, `templates/dispatch/pi.md`, and guard policy templates when relevant
    - Qwen: update `templates/qwen/qwen-md.md`
    - OpenCode: update `templates/opencode/agents-md.md`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,7 +48,7 @@ camel-kit init --here [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--ai`, `-a` | `bob2` | AI coding assistant to configure (`bob2` for IBM Bob 2, `bob` for IBM Bob 1 legacy, `gemini`, `claude`, `copilot`, `qwen`, `opencode`) |
+| `--ai`, `-a` | `bob2` | AI coding assistant to configure (`bob2` for IBM Bob 2, `bob` for IBM Bob 1 legacy, `gemini`, `claude`, `copilot`, `pi`, `qwen`, `opencode`) |
 | `--citrus-version` | `5.0.0-M2` | Citrus Framework version for test schemas and generated test dependencies |
 | `--here` | `false` | Initialize in current directory |
 | `--no-fetch` | `false` | Skip external catalog fetching |
@@ -79,6 +79,9 @@ camel-kit init my-integration --ai claude
 
 # Create new project for GitHub Copilot CLI
 camel-kit init my-integration --ai copilot
+
+# Create new project for Pi
+camel-kit init my-integration --ai pi
 
 # Create new project for Qwen
 camel-kit init my-integration --ai qwen
@@ -195,7 +198,7 @@ my-integration/
 │   │   ├── camelYamlDsl-{version}.json
 │   │   └── citrus/{version}/    # Citrus JSON schemas
 │   └── templates/               # Reference templates
-├── .mcp.json                    # Claude Code MCP configuration
+├── .mcp.json                    # Claude Code or Pi MCP configuration
 ├── .bob/mcp.json                # IBM Bob MCP configuration
 ├── .gemini/mcp.json             # Gemini CLI MCP configuration
 ├── .github/mcp.json             # GitHub Copilot CLI MCP configuration
@@ -203,6 +206,7 @@ my-integration/
 ├── .github/agents/              # GitHub Copilot CLI custom agents
 ├── .github/skills/              # GitHub Copilot CLI project skills
 ├── .github/hooks/               # GitHub Copilot CLI safety hooks
+├── .pi/                         # Pi skills, prompt templates, and guard extension
 ├── .qwen/mcp.json               # Qwen MCP configuration
 └── .opencode/mcp.json           # OpenCode MCP configuration
 ```
@@ -210,6 +214,8 @@ my-integration/
 The MCP configuration file created depends on the `--ai` option chosen.
 
 For GitHub Copilot CLI, Camel-Kit also generates `.github/copilot-instructions.md`, project skills under `.github/skills/`, custom agents under `.github/agents/`, and a conservative `.github/hooks/camel-kit-safety.json` hook that denies destructive or secret-sensitive shell commands while leaving normal Copilot permission prompts intact. Copilot users should start by asking Copilot to "Use the `/camel-start` skill." Run `/skills list` to inspect available project skills.
+
+For Pi, Camel-Kit generates `AGENTS.md`, project skills under `.pi/skills/`, prompt templates under `.pi/prompts/`, `.mcp.json` for `pi-mcp-adapter`, and `.pi/extensions/camel-kit-guard.ts` plus a JSON guard policy. Install the adapter with `pi install npm:pi-mcp-adapter`, trust the project with `/trust`, then run `/skill:camel-start`. Headless checks must use `pi -a`.
 
 ### camel-kit doctor
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -215,7 +215,7 @@ The MCP configuration file created depends on the `--ai` option chosen.
 
 For GitHub Copilot CLI, Camel-Kit also generates `.github/copilot-instructions.md`, project skills under `.github/skills/`, custom agents under `.github/agents/`, and a conservative `.github/hooks/camel-kit-safety.json` hook that denies destructive or secret-sensitive shell commands while leaving normal Copilot permission prompts intact. Copilot users should start by asking Copilot to "Use the `/camel-start` skill." Run `/skills list` to inspect available project skills.
 
-For Pi, Camel-Kit generates `AGENTS.md`, project skills under `.pi/skills/`, prompt templates under `.pi/prompts/`, `.mcp.json` for `pi-mcp-adapter`, and `.pi/extensions/camel-kit-guard.ts` plus a JSON guard policy. Install the adapter with `pi install npm:pi-mcp-adapter`, trust the project with `/trust`, then run `/skill:camel-start`. Headless checks must use `pi -a`.
+For Pi, Camel-Kit generates `AGENTS.md`, project skills under `.pi/skills/`, prompt templates under `.pi/prompts/`, `.mcp.json` for `pi-mcp-adapter`, and `.pi/extensions/camel-kit-guard.ts` plus a JSON guard policy. Install the adapter with `pi install npm:pi-mcp-adapter@2.11.0`, trust the project with `/trust`, then run `/skill:camel-start`. Headless checks must use `pi -a`.
 
 ### camel-kit doctor
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -144,6 +144,7 @@ camel-kit init order-processing --ai bob      # IBM Bob 1 legacy
 camel-kit init order-processing --ai bob2     # IBM Bob 2
 camel-kit init order-processing --ai gemini
 camel-kit init order-processing --ai copilot
+camel-kit init order-processing --ai pi
 camel-kit init order-processing --ai qwen
 camel-kit init order-processing --ai opencode
 ```
@@ -194,6 +195,7 @@ order-processing/
     constitution.md          # 7 route quality rules
   .mcp.json                  # MCP server config (agent-specific location)
   .github/                   # GitHub Copilot CLI assets when --ai copilot is selected
+  .pi/                       # Pi skills, prompt templates, and guard extension when --ai pi is selected
   pom.xml                    # Maven project with Camel BOM
   mvnw / mvnw.cmd            # Maven wrapper
 ```
@@ -723,6 +725,7 @@ The same skills work across all supported AI coding assistants. Camel-Kit uses m
 | **Bob 2** (IBM Bob, default) | `--ai bob2` | Uses native `spawn_subagent` plus Bob custom modes and shared skills |
 | **Gemini** (Google Gemini CLI) | `--ai gemini` | Dispatches to 6 subagents; execute phase runs in main agent |
 | **GitHub Copilot CLI** | `--ai copilot` | Uses `.github/skills`, `.github/agents`, `.github/mcp.json`, and repository safety hooks |
+| **Pi** | `--ai pi` | Uses `.pi/skills`, `.pi/prompts`, `.mcp.json` through `pi-mcp-adapter`, and a project guard extension |
 | **Qwen** (Alibaba Qwen CLI) | `--ai qwen` | Auto-delegates to 7 sub-agents based on intent matching |
 | **OpenCode** | `--ai opencode` | Dispatches to 7 agents with granular permission control |
 
@@ -743,10 +746,10 @@ All agents produce the same output (YAML routes, properties files, tests). The d
 
 | Aspect | What You'll Notice |
 |--------|-------------------|
-| **Dispatch transparency** | Claude and Bob 2 show subagent dispatch; Bob 1 legacy shows mode switching; Gemini/Qwen/OpenCode/Copilot delegate to specialized agents |
-| **Tool restrictions** | During brainstorm, Bob modes can physically prevent code edits. Claude and Qwen rely on skill instructions. OpenCode uses glob-pattern permissions. Copilot uses tool allow/deny permissions and generated safety hooks. |
+| **Dispatch transparency** | Claude and Bob 2 show subagent dispatch; Bob 1 legacy shows mode switching; Gemini/Qwen/OpenCode/Copilot delegate to specialized agents; Pi runs in the main session |
+| **Tool restrictions** | During brainstorm, Bob modes can physically prevent code edits. Claude and Qwen rely on skill instructions. OpenCode uses glob-pattern permissions. Copilot uses tool allow/deny permissions and generated safety hooks. Pi uses a generated guard extension plus external sandboxing when needed. |
 | **Parallel execution** | Claude and Bob 2 can dispatch independent tasks in the same wave; other agents have more limited parallelism |
-| **MCP approval prompts** | Gemini auto-approves MCP tool calls via its policy engine. Copilot uses `.github/mcp.json` plus Copilot's permission system. Other agents may prompt you for each MCP call. |
+| **MCP approval prompts** | Gemini auto-approves MCP tool calls via its policy engine. Copilot uses `.github/mcp.json` plus Copilot's permission system. Pi uses `pi-mcp-adapter` `directTools`. Other agents may prompt you for each MCP call. |
 | **Execution limits** | OpenCode and Gemini enforce step/turn limits per phase. Other agents have no hard limits. |
 
 ### How Execution Works: Subagents vs. Mode Switching
@@ -818,11 +821,14 @@ MCP is auto-configured during `camel-kit init`. The init command creates agent-s
 - **Bob:** `.bob/mcp.json`
 - **Gemini:** `.gemini/mcp.json`
 - **GitHub Copilot CLI:** `.github/mcp.json`
+- **Pi:** `.mcp.json` via `pi-mcp-adapter`
 - **Qwen/OpenCode:** agent-specific config locations
 
 GitHub Copilot CLI workspaces also get `.github/copilot-instructions.md`, `.github/skills/`, `.github/agents/`, and `.github/hooks/camel-kit-safety.json`. Internal guide skills copied for custom-agent use are marked so Copilot does not directly or automatically invoke them. The generated hook denies obvious destructive or secret-sensitive shell commands such as `git push`, broad `rm -rf`, `chmod 777`, and reads of common secret files, while leaving normal Copilot permissions in place. Workspace MCP servers from `.github/mcp.json` load only after the repository folder is trusted.
 
-No additional configuration is needed. The AI assistant automatically uses MCP tools when available.
+Pi workspaces also get `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`. Install `pi-mcp-adapter` with `pi install npm:pi-mcp-adapter`, run `/trust`, then invoke `/skill:camel-start`. For headless validation, use `pi -a` so Pi loads project resources.
+
+After the agent-specific setup above, the AI assistant automatically uses MCP tools when available.
 
 ### Knowledge and Citrus MCP
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -826,7 +826,7 @@ MCP is auto-configured during `camel-kit init`. The init command creates agent-s
 
 GitHub Copilot CLI workspaces also get `.github/copilot-instructions.md`, `.github/skills/`, `.github/agents/`, and `.github/hooks/camel-kit-safety.json`. Internal guide skills copied for custom-agent use are marked so Copilot does not directly or automatically invoke them. The generated hook denies obvious destructive or secret-sensitive shell commands such as `git push`, broad `rm -rf`, `chmod 777`, and reads of common secret files, while leaving normal Copilot permissions in place. Workspace MCP servers from `.github/mcp.json` load only after the repository folder is trusted.
 
-Pi workspaces also get `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`. Install `pi-mcp-adapter` with `pi install npm:pi-mcp-adapter`, run `/trust`, then invoke `/skill:camel-start`. For headless validation, use `pi -a` so Pi loads project resources.
+Pi workspaces also get `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`. Install `pi-mcp-adapter` with `pi install npm:pi-mcp-adapter@2.11.0`, run `/trust`, then invoke `/skill:camel-start`. For headless validation, use `pi -a` so Pi loads project resources.
 
 After the agent-specific setup above, the AI assistant automatically uses MCP tools when available.
 


### PR DESCRIPTION
Fixes #132.

## Summary

- Add `--ai pi` as a first-class agent target with Pi-native `AGENTS.md`, `.pi/skills`, `.pi/prompts`, `.mcp.json`, and guard extension assets.
- Map Pi MCP config to `pi-mcp-adapter` `directTools` allowlists plus `excludeTools`, with tested version pins in `distribution.properties`.
- Extend doctor validation, init UX, docs, and tests for Pi workspaces.

## Verification

- `./mvnw -pl camel-kit-core test`
- `mvnd clean install`

## Summary by Sourcery

Add Pi as a first-class AI coding agent target with native workspace assets, MCP configuration, and safety guardrails, and extend validation, initialization, and docs accordingly.

New Features:
- Introduce Pi (`--ai pi`) as a built-in agent with registry descriptor, generator strategy, and dedicated PiGenerator.
- Generate Pi-native project assets including AGENTS.md, `.pi/skills`, `.pi/prompts`, `.mcp.json`, and `.pi` guard extension resources.
- Provide a Pi-specific MCP config using `pi-mcp-adapter` with `directTools`/`excludeTools` allowlists, parameterized by distribution properties.

Enhancements:
- Extend doctor checks to validate Pi MCP `directTools` schema and presence/structure of Pi guard extension and policy.
- Generalize internal skill metadata so both Copilot and Pi mark guide skills as non-user-invocable and disable model invocation.
- Update init UX, next-steps messaging, and resource consistency tests to cover Pi workspaces and MCP expectations.

Build:
- Add Pi version and `pi-mcp-adapter` version defaults to distribution properties and expose them via DistributionConfig for templating.

Documentation:
- Document the Pi agent architecture, dispatch model, guard extension, MCP integration, and update user guide, commands, and README to include `--ai pi` usage and workspace layout.

Tests:
- Add comprehensive tests for Pi agent registry, generator, init/doctor behavior, MCP config generation, skill metadata, and CLI messaging, and include Pi in existing multi-agent doctor and MCP consistency suites.