### PR TITLE
chore: drop stale errata wording from knowledge tool docs

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: camel-knowledge
-description: Look up Camel documentation, components, CVEs, errata, and versions.
+description: Look up Camel documentation, components, CVEs/security advisories, and versions.
 user_invocable: false
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
@@ -24,7 +24,7 @@
 
 **MCP catalog tools — MANDATORY when MCP is configured (same rules as the design assembly guide):**
 
-Before every MCP catalog call, translate `CAMEL_VERSION` + `RUNTIME` to the correct `camelVersion` parameter using the version mapping table in `skills/shared/mcp-setup.md`. Never pass the raw `CAMEL_VERSION` or a stripped minor version (e.g., `4.14`) directly — always use the translated Red Hat artifact version from the table. Never use a Camel component name, EIP name, data format name, or expression language name from training data or the mapping guide without first verifying it in the catalog.
+Before every MCP catalog call, translate `CAMEL_VERSION` + `RUNTIME` to the correct `platformBom` GAV using Rule 1 in `skills/shared/mcp-setup.md`. Never pass a stripped minor version (e.g., `4.14`) as `camelVersion` — always pass the full runtime-specific `platformBom` coordinate. Never use a Camel component name, EIP name, data format name, or expression language name from training data or the mapping guide without first verifying it in the catalog.
 
 → **For MCP setup, version mapping, and fallback policy:** see `skills/shared/mcp-setup.md`
 

--- a/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-start/SKILL.md
@@ -78,5 +78,5 @@ These standalone utilities are not part of the main pipelines but are accessible
 | Slash Command | Purpose |
 |---|---|
 | `/camel-ship` | Run the full pipeline autonomously with configurable oversight (`--ask always\|smart\|never`) |
-| `/camel-knowledge` | Look up Apache Camel documentation, components, CVEs, errata, versions |
+| `/camel-knowledge` | Look up Apache Camel documentation, components, CVEs/security advisories, versions |
 | `/camel-debug` | Ad-hoc troubleshooting for broken routes outside of a pipeline run |

--- a/camel-kit-core/src/main/resources/templates/copilot/agents/camel-catalog-researcher.agent.md
+++ b/camel-kit-core/src/main/resources/templates/copilot/agents/camel-catalog-researcher.agent.md
@@ -1,10 +1,10 @@
 ---
 name: camel-catalog-researcher
-description: Researches Apache Camel components, EIPs, data formats, versions, CVEs, errata, and documentation through Camel Kit MCP servers.
+description: Researches Apache Camel components, EIPs, data formats, versions, CVEs/security advisories, and documentation through Camel Kit MCP servers.
 target: github-copilot
 tools: ["read", "search", "web", "camel/*", "camel-knowledge/*"]
 ---
 
 You are the Camel catalog and documentation researcher.
 
-Use MCP tools before answering Camel-specific questions. Prefer `camel-knowledge` for documentation, release, CVE, errata, and issue lookup. Prefer `camel` for component catalog, EIP, data format, route validation, and hardening metadata. Mark anything not verified as unknown.
+Use MCP tools before answering Camel-specific questions. Prefer `camel-knowledge` for documentation, release, CVE/security-advisory, and issue lookup. Prefer `camel` for component catalog, EIP, data format, route validation, and hardening metadata. Mark anything not verified as unknown.

--- a/camel-kit-core/src/main/resources/templates/copilot/copilot-instructions.md
+++ b/camel-kit-core/src/main/resources/templates/copilot/copilot-instructions.md
@@ -12,7 +12,7 @@ For integration work, use the `/camel-start` project skill first. It routes to t
 - `camel-execute` for approved plans that need implementation and verification.
 - `camel-validate` for route quality, correctness, security, and anti-pattern checks.
 - `camel-debug` for ad-hoc build, startup, or runtime failures.
-- `camel-knowledge` for Apache Camel documentation, component, CVE, errata, and version questions.
+- `camel-knowledge` for Apache Camel documentation, component, CVE/security-advisory, and version questions.
 
 Use `/skills list` if you need to inspect project skills.
 
@@ -40,7 +40,7 @@ Use `{COMMAND_PREFIX}` for Camel Kit CLI commands, for example `{COMMAND_PREFIX}
 Use the configured MCP servers before relying on model memory:
 
 - `camel` for Camel catalog, route validation, hardening, and error diagnosis.
-- `camel-knowledge` for Camel documentation, CVEs, release notes, errata, and issue lookup.
+- `camel-knowledge` for Camel documentation, CVEs/security advisories, release notes, and issue lookup.
 - `citrus` for Citrus action, endpoint, schema, and documentation lookups during test generation.
 
 If Copilot CLI does not show the workspace servers immediately, first ensure this repository folder is trusted, then run `/mcp show` or `copilot mcp list --json`. If needed, run `/mcp reload` and continue.

--- a/camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml
+++ b/camel-kit-core/src/main/resources/workflow/camel-kit-workflow.yaml
@@ -71,7 +71,7 @@ commands:
     generated_stub: true
     user_facing: true
     tier: utility
-    description: "Look up Camel documentation, components, CVEs, errata, and versions."
+    description: "Look up Camel documentation, components, CVEs/security advisories, and versions."
     standalone: true
     chained: false
   - name: camel-debug


### PR DESCRIPTION
## Summary

Removes stale Red Hat–era wording left over from the RH-build → upstream pivot of the knowledge layer.

- `"CVEs, errata"` → `"CVEs/security advisories"` in the `camel-knowledge` and `camel-start` skills, both copilot templates, and the workflow manifest — the knowledge MCP indexes Apache security advisories; there is no errata concept upstream, so agents were being promised a lookup that returns nothing.
- `camel-migrate/guides/biztalk-phase2.md`: the instruction *"always use the translated Red Hat artifact version from the table in mcp-setup.md"* pointed at a table that does not exist in this variant — a dangling reference that invites an LLM to invent a version mapping mid-migration. Rewritten to the actual contract (`mcp-setup.md` Rule 1: runtime-specific `platformBom` GAV, never a stripped minor as `camelVersion`).

Deliberately untouched: the `redhat-*`/`fuse-*` detection in `camel-migrate` and `InitService` — that identifies the *source platform* of applications being migrated and is a feature, not debris.

## Test plan

Docs/resources-only change (8 lines changed across 6 files); no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Summary by Sourcery

Clarify Camel knowledge tool documentation to reflect upstream Apache security advisory lookups and correct MCP catalog version mapping guidance for BizTalk migrations.

Documentation:
- Update Camel copilot agent and skill descriptions to reference CVEs/security advisories instead of errata.
- Revise BizTalk Phase 2 migration guide to align MCP catalog usage with platformBom-based version mapping rather than outdated Red Hat artifact references.