### PR TITLE
Deploy nightly Maven Central snapshots

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,33 @@
+name: Deploy Snapshot
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Deploy snapshot
+        run: ./mvnw -B -Psourcecheck -Dformat.skip=true -DdeployAtEnd=true deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.MVN_CENTRAL_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
         <url>https://github.com/luigidemasi/camel-kit/issues</url>
     </issueManagement>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <repositories>
         <repository>
             <id>central</id>


### PR DESCRIPTION
## Summary
- add a nightly/manual snapshot deployment workflow
- restrict scheduled snapshot deployment to `main` while keeping manual dispatch available
- configure Central Portal snapshots as Maven snapshotRepository
- deploy with Maven deployAtEnd to avoid partial reactor uploads

## Validation
- `./mvnw -B -Psourcecheck -Dformat.skip=true validate`
- `./mvnw clean install -DskipTests -Dformat.skip=true`

Closes #138

Generated by Codex via /oss-address-review