### PR TITLE
Fix #142: add OpenAI Codex CLI target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OpenAI Codex CLI AI target (`--ai codex`)** — added a first-class Codex target with native repository assets.
+  - Generated workspaces include `AGENTS.md`, `.agents/skills/`, `.codex/config.toml`, and seven `.codex/agents/*.toml` roles without an unused command directory
+  - Codex skill references use native `$camel-*` invocation, with `/skills`, `$camel-start`, and `/mcp` guidance
+  - Repository-scoped TOML config preserves unrelated settings and configures Camel, Camel Knowledge, and Citrus with exact tool allowlists and prompt approval defaults
+  - Doctor validates Codex skills, custom-agent TOML, MCP tables, and least-privilege defaults; an isolated Codex CLI smoke verifies instruction, skill, agent, and MCP discovery
+
 - **Pi AI target (`--ai pi`)** — added a first-class Pi target for `@earendil-works/pi-coding-agent`.
   - New `pi` agent registry descriptor, generator strategy, and `PiGenerator`
   - Generated workspaces include `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.mcp.json`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ camel kit init my-integration
 
 ### Build from Source (development version)
 
-Some features (including `--ai copilot`, `--ai pi`, `--ai qwen`, and `--ai opencode`) are only available in the development version. To build from source:
+Some features (including `--ai codex`, `--ai copilot`, `--ai pi`, `--ai qwen`, and `--ai opencode`) are only available in the development version. To build from source:
 
 ```bash
 git clone https://github.com/luigidemasi/camel-kit.git
@@ -133,6 +133,7 @@ camel-kit init my-integration --ai claude   # Anthropic Claude Code
 camel-kit init my-integration --ai bob      # IBM Bob 1 legacy
 camel-kit init my-integration --ai bob2     # IBM Bob 2
 camel-kit init my-integration --ai gemini   # Google Gemini CLI
+camel-kit init my-integration --ai codex    # OpenAI Codex CLI
 camel-kit init my-integration --ai copilot  # GitHub Copilot CLI
 camel-kit init my-integration --ai pi       # Pi
 camel-kit init my-integration --ai qwen     # Qwen (requires dev build)
@@ -150,6 +151,9 @@ cd my-integration
 # For GitHub Copilot CLI, ask Copilot: "Use the /camel-start skill."
 # Run /skills list if you need to inspect available project skills.
 
+# For Codex CLI, trust the repository, then run $camel-start.
+# Use /skills to inspect project skills and /mcp to inspect MCP servers.
+
 # For Pi, install the MCP adapter, trust the project, then run /skill:camel-start.
 # pi install npm:pi-mcp-adapter@2.11.0
 ```
@@ -164,12 +168,13 @@ cd my-integration
 | IBM Bob 1 legacy | `--ai bob` | `custom_modes.yaml` + rules + gates | `.bob/mcp.json` |
 | IBM Bob 2 (default) | `--ai bob2` | `custom_modes.yaml` + rules + skills | `.bob/mcp.json` |
 | Google Gemini CLI | `--ai gemini` | `GEMINI.md` | `.gemini/mcp.json` |
+| OpenAI Codex CLI | `--ai codex` | `AGENTS.md` + `.agents/skills/` + `.codex/agents/` | `.codex/config.toml` |
 | GitHub Copilot CLI | `--ai copilot` | `.github/copilot-instructions.md` + `.github/agents/` + `.github/skills/` | `.github/mcp.json` |
 | Pi | `--ai pi` | `AGENTS.md` + `.pi/skills/` + `.pi/prompts/` | `.mcp.json` via `pi-mcp-adapter` |
 | Qwen | `--ai qwen` | `QWEN.md` | `.qwen/mcp.json` |
 | OpenCode | `--ai opencode` | `AGENTS.md` | `.opencode/mcp.json` |
 
-All agents use the same skills — camel-kit generates agent-specific instruction files with per-agent traits that load the shared skill guides. GitHub Copilot CLI uses native project skills and custom agents instead of Camel-Kit slash commands. Pi uses native project skills and prompt templates, with MCP provided by `pi-mcp-adapter`. The skills are the equalization layer. [Architecture Guide →](docs/architecture.md)
+All agents use the same skills — camel-kit generates agent-specific instruction files with per-agent traits that load the shared skill guides. Codex CLI and GitHub Copilot CLI use native project skills and custom agents instead of Camel-Kit slash commands. Pi uses native project skills and prompt templates, with MCP provided by `pi-mcp-adapter`. The skills are the equalization layer. [Architecture Guide →](docs/architecture.md)
 
 ---
 
@@ -206,7 +211,7 @@ All agents use the same skills — camel-kit generates agent-specific instructio
 
 ### Multi-Agent
 
-- **7 AI targets** — same skills work across Claude Code, IBM Bob 1 legacy, IBM Bob 2, Gemini CLI, GitHub Copilot CLI, Qwen, and OpenCode. Agent-specific traits customize behavior (pacing, approval modes, tool usage) without changing the shared skills. [Learn more →](docs/architecture.md)
+- **9 AI targets** — same skills work across Claude Code, IBM Bob 1 legacy, IBM Bob 2, Gemini CLI, OpenAI Codex CLI, GitHub Copilot CLI, Pi, Qwen, and OpenCode. Agent-specific traits customize behavior (pacing, approval modes, tool usage) without changing the shared skills. [Learn more →](docs/architecture.md)
 
 ---
 

--- a/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/KitInitCommand.java
+++ b/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/KitInitCommand.java
@@ -24,7 +24,7 @@ public class KitInitCommand extends CamelCommand {
 
     @Option(names = {"-a", "--ai"},
             description = "AI agent: bob2 (IBM Bob 2, default), bob (IBM Bob 1 legacy), "
-                          + "gemini, claude, qwen, opencode",
+                          + "gemini, claude, codex, copilot, pi, qwen, opencode",
             defaultValue = "bob2")
     String ai;
 

--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
@@ -19,6 +19,17 @@ class CamelKitPluginTest {
     }
 
     @Test
+    void kitInitAcceptsCodexAndShowsItInHelp() {
+        KitInitCommand command = new KitInitCommand(new CamelJBangMain());
+        CommandLine commandLine = new CommandLine(command);
+
+        commandLine.parseArgs("orders", "--ai", "codex");
+
+        assertEquals("codex", command.ai);
+        assertTrue(commandLine.getUsageMessage().contains("codex"));
+    }
+
+    @Test
     void registersDoctorUnderKitCommand() {
         CamelJBangMain main = new CamelJBangMain();
         CommandLine root = new CommandLine(main);

--- a/camel-kit-core/pom.xml
+++ b/camel-kit-core/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.tomlj</groupId>
+            <artifactId>tomlj</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
         </dependency>

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/InitCommand.java
@@ -34,7 +34,7 @@ public class InitCommand extends CamelKitCommand {
 
     @Option(names = {"-a", "--ai"},
             description = "AI agent: bob2 (IBM Bob 2, default), bob (IBM Bob 1 legacy), "
-                          + "gemini, claude, copilot, pi, qwen, opencode",
+                          + "gemini, claude, codex, copilot, pi, qwen, opencode",
             defaultValue = "bob2")
     public String ai;
 
@@ -187,6 +187,13 @@ public class InitCommand extends CamelKitCommand {
         printer().println("  " + bold("Next steps"));
         printer().println(divider);
         printer().println("  1  Open " + cyan(projectName) + " in " + agentName);
+        if (AgentGeneratorStrategy.CODEX.descriptorValue().equalsIgnoreCase(agentId)) {
+            printer().println("  2  Start Codex from the project root and review the repository before trusting it");
+            printer().println("  3  Run " + cyan("/skills") + ", then invoke " + cyan("$camel-start"));
+            printer().println("     Use " + cyan("/mcp") + " to verify Camel Kit MCP servers");
+            printer().println();
+            return;
+        }
         if (AgentGeneratorStrategy.COPILOT.descriptorValue().equalsIgnoreCase(agentId)) {
             printer().println("  2  Ask Copilot: " + cyan("\"Use the /camel-start skill.\""));
             printer().println("     Run " + cyan("/skills list") + " to inspect available project skills");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentConfig.java
@@ -5,11 +5,21 @@ package io.github.luigidemasi.camelkit.config;
  */
 public record AgentConfig(
         String name,
-        String folder,
+        String commandDirectory,
+        String skillsDirectory,
+        boolean generatesCommandStubs,
         String fileFormat,
         String argPlaceholder,
         String mcpConfigPath,
         String mcpConfigTemplatePath,
+        String mcpConfigFormat,
         String mcpServerContainerKey,
         String description) {
+
+    /**
+     * Primary generated agent directory retained for the persisted workspace contract.
+     */
+    public String folder() {
+        return generatesCommandStubs ? commandDirectory : skillsDirectory;
+    }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptor.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentDescriptor.java
@@ -11,10 +11,13 @@ public record AgentDescriptor(
         String id,
         String displayName,
         String commandDirectory,
+        String skillsDirectory,
+        Boolean generatesCommandStubs,
         String commandFileFormat,
         String argumentPlaceholder,
         String mcpConfigPath,
         String mcpConfigTemplatePath,
+        String mcpConfigFormat,
         String mcpServerContainerKey,
         String description,
         String generatorStrategy,
@@ -25,6 +28,14 @@ public record AgentDescriptor(
         List<String> capabilities) {
 
     public AgentDescriptor {
+        generatesCommandStubs = generatesCommandStubs == null || generatesCommandStubs;
+        if ((skillsDirectory == null || skillsDirectory.isBlank())
+                && commandDirectory != null && commandDirectory.contains("/")) {
+            skillsDirectory = commandDirectory.substring(0, commandDirectory.lastIndexOf('/')) + "/skills";
+        }
+        if (mcpConfigFormat == null || mcpConfigFormat.isBlank()) {
+            mcpConfigFormat = "json";
+        }
         templates = immutableList(templates);
         capabilities = immutableList(capabilities);
     }
@@ -32,11 +43,19 @@ public record AgentDescriptor(
     AgentDescriptor validate(String source) {
         requireText(id, "id", source);
         requireText(displayName, "displayName", source);
-        requireText(commandDirectory, "commandDirectory", source);
-        requireText(commandFileFormat, "commandFileFormat", source);
-        requireText(argumentPlaceholder, "argumentPlaceholder", source);
+        requireText(skillsDirectory, "skillsDirectory", source);
+        requireBoolean(generatesCommandStubs, "generatesCommandStubs", source);
+        if (generatesCommandStubs) {
+            requireText(commandDirectory, "commandDirectory", source);
+            requireText(commandFileFormat, "commandFileFormat", source);
+            requireText(argumentPlaceholder, "argumentPlaceholder", source);
+        }
         requireText(mcpConfigPath, "mcpConfigPath", source);
         requireText(mcpConfigTemplatePath, "mcpConfigTemplatePath", source);
+        requireText(mcpConfigFormat, "mcpConfigFormat", source);
+        if (!mcpConfigFormat.equals("json") && !mcpConfigFormat.equals("toml")) {
+            throw new IllegalStateException(source + " has unsupported mcpConfigFormat '" + mcpConfigFormat + "'");
+        }
         requireText(mcpServerContainerKey, "mcpServerContainerKey", source);
         requireText(description, "description", source);
         requireText(generatorStrategy, "generatorStrategy", source);
@@ -73,10 +92,13 @@ public record AgentDescriptor(
         return new AgentConfig(
                 displayName,
                 commandDirectory,
+                skillsDirectory,
+                generatesCommandStubs,
                 commandFileFormat,
                 argumentPlaceholder,
                 mcpConfigPath,
                 mcpConfigTemplatePath,
+                mcpConfigFormat,
                 mcpServerContainerKey,
                 description);
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/AgentGeneratorStrategy.java
@@ -11,6 +11,7 @@ public enum AgentGeneratorStrategy {
     BOB("bob"),
     BOB2("bob2"),
     CLAUDE("claude"),
+    CODEX("codex"),
     COPILOT("copilot"),
     GEMINI("gemini"),
     OPENCODE("opencode"),

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactory.java
@@ -14,6 +14,7 @@ public final class AgentGeneratorFactory {
             case BOB -> new BobGenerator();
             case BOB2 -> new Bob2Generator();
             case CLAUDE -> new ClaudeGenerator();
+            case CODEX -> new CodexGenerator();
             case COPILOT -> new CopilotGenerator();
             case GEMINI -> new GeminiGenerator();
             case OPENCODE -> new OpenCodeGenerator();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CodexConfigMerger.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CodexConfigMerger.java
@@ -1,0 +1,87 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
+
+final class CodexConfigMerger {
+
+    static final String BEGIN_MARKER = "# BEGIN CAMEL-KIT MANAGED MCP SERVERS";
+    static final String END_MARKER = "# END CAMEL-KIT MANAGED MCP SERVERS";
+
+    private static final List<String> MANAGED_SERVERS = List.of("camel", "camel-knowledge", "citrus");
+
+    void merge(Path configFile, String renderedConfig) throws IOException {
+        validateToml(renderedConfig, "generated Codex MCP configuration");
+
+        String managedBlock = BEGIN_MARKER + System.lineSeparator()
+                              + renderedConfig.strip() + System.lineSeparator()
+                              + END_MARKER;
+        String existing = Files.isRegularFile(configFile) ? Files.readString(configFile) : "";
+        String merged = merge(existing, managedBlock);
+        validateToml(merged, configFile.toString());
+        atomicWrite(configFile, merged + (merged.endsWith(System.lineSeparator()) ? "" : System.lineSeparator()));
+    }
+
+    private String merge(String existing, String managedBlock) throws IOException {
+        if (existing.isBlank()) {
+            return managedBlock;
+        }
+
+        validateToml(existing, "existing .codex/config.toml");
+        int begin = existing.indexOf(BEGIN_MARKER);
+        int end = existing.indexOf(END_MARKER);
+        if (begin >= 0 || end >= 0) {
+            if (begin < 0 || end < begin || existing.indexOf(BEGIN_MARKER, begin + 1) >= 0
+                    || existing.indexOf(END_MARKER, end + 1) >= 0) {
+                throw new IOException("existing .codex/config.toml has invalid Camel-Kit managed block markers");
+            }
+            return existing.substring(0, begin) + managedBlock + existing.substring(end + END_MARKER.length());
+        }
+
+        Object mcpServers = Toml.parse(existing).get("mcp_servers");
+        if (mcpServers instanceof TomlTable servers) {
+            List<String> conflicts = MANAGED_SERVERS.stream()
+                    .filter(server -> servers.get(server) instanceof TomlTable)
+                    .toList();
+            if (!conflicts.isEmpty()) {
+                throw new IOException(
+                        "existing .codex/config.toml already defines Camel-Kit MCP server tables: "
+                                      + String.join(", ", conflicts));
+            }
+        }
+
+        return existing + (existing.endsWith(System.lineSeparator())
+                ? System.lineSeparator()
+                : System.lineSeparator() + System.lineSeparator())
+               + managedBlock;
+    }
+
+    private void validateToml(String content, String source) throws IOException {
+        TomlParseResult parsed = Toml.parse(content);
+        if (parsed.hasErrors()) {
+            throw new IOException(source + " is not valid TOML: " + parsed.errors().get(0));
+        }
+    }
+
+    private void atomicWrite(Path target, String content) throws IOException {
+        Path temp = Files.createTempFile(target.getParent(), target.getFileName().toString(), ".tmp");
+        try {
+            Files.writeString(temp, content);
+            try {
+                Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temp);
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CodexGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CodexGenerator.java
@@ -1,0 +1,70 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.util.AnsiColors;
+
+/**
+ * Generates repository-scoped OpenAI Codex assets.
+ */
+public class CodexGenerator extends DefaultGenerator {
+
+    private static final String AGENTS_TEMPLATE = "templates/codex/agents-md.md";
+
+    private final QuteTemplateEngine templateEngine = new QuteTemplateEngine();
+
+    @Override
+    public void generate(InitContext ctx) throws Exception {
+        rejectSymlinkedManagedPaths(ctx.projectDir());
+        super.generate(ctx);
+        installDescriptorTemplates(ctx);
+    }
+
+    private void rejectSymlinkedManagedPaths(Path projectDir) throws Exception {
+        for (Path managedPath : List.of(
+                projectDir.resolve("AGENTS.md"),
+                projectDir.resolve(".agents"),
+                projectDir.resolve(".codex"))) {
+            if (!Files.exists(managedPath, LinkOption.NOFOLLOW_LINKS)) {
+                continue;
+            }
+            try (var paths = Files.walk(managedPath)) {
+                Path symlink = paths.filter(Files::isSymbolicLink).findFirst().orElse(null);
+                if (symlink != null) {
+                    throw new IllegalStateException(
+                            "Refusing to generate Codex assets through symbolic link: "
+                                                    + projectDir.relativize(symlink));
+                }
+            }
+        }
+    }
+
+    private void installDescriptorTemplates(InitContext ctx) throws Exception {
+        AgentDescriptor descriptor = AgentRegistry.descriptor(ctx.agentName());
+        if (descriptor == null) {
+            throw new IllegalArgumentException("Unsupported agent: " + ctx.agentName());
+        }
+
+        int customAgents = 0;
+        for (AgentDescriptor.TemplateInstall template : descriptor.templates()) {
+            Path target = ctx.projectDir().resolve(template.target());
+            if (AGENTS_TEMPLATE.equals(template.source())) {
+                Files.writeString(target, templateEngine.render(
+                        template.source(), Map.of("COMMAND_PREFIX", ctx.commandPrefix())));
+            } else {
+                copyTemplateResource(template.source(), target);
+            }
+            if (template.target().startsWith(".codex/agents/") && template.target().endsWith(".toml")) {
+                customAgents++;
+            }
+        }
+
+        ctx.printer().println(AnsiColors.green("✓") + " Generated " + customAgents + " Codex custom agents");
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CommandStubGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/CommandStubGenerator.java
@@ -12,10 +12,9 @@ class CommandStubGenerator {
 
     void generate(InitContext ctx, WorkflowManifest workflow) throws Exception {
         List<WorkflowCommand> commands = workflow.generatedCommandStubs();
-        String agentBaseFolder = ctx.agent().folder().substring(0, ctx.agent().folder().lastIndexOf("/"));
 
         for (WorkflowCommand command : commands) {
-            String content = commandContent(ctx, agentBaseFolder, command);
+            String content = commandContent(ctx, command);
             String filename = command.name() + "." + ctx.agent().fileFormat();
             Files.writeString(ctx.commandsDir().resolve(filename), content);
         }
@@ -23,8 +22,8 @@ class CommandStubGenerator {
         ctx.printer().println(AnsiColors.green("✓") + " Created " + commands.size() + " skill reference commands");
     }
 
-    private String commandContent(InitContext ctx, String agentBaseFolder, WorkflowCommand command) {
-        String content = "Read " + agentBaseFolder + "/skills/" + command.skill()
+    private String commandContent(InitContext ctx, WorkflowCommand command) {
+        String content = "Read " + ctx.agent().skillsDirectory() + "/" + command.skill()
                          + "/SKILL.md and follow those instructions";
         if ("toml".equals(ctx.agent().fileFormat())) {
             return wrapInToml(command.shortName(), content);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/DefaultGenerator.java
@@ -55,11 +55,13 @@ public class DefaultGenerator implements AgentGenerator {
     }
 
     protected void generateBaseAssets(InitContext ctx, WorkflowManifest workflow) throws Exception {
-        Files.createDirectories(ctx.commandsDir());
         Files.createDirectories(ctx.skillsDir());
         agentsMdGenerator.generate(ctx);
-        commandStubGenerator.generate(ctx, workflow);
-        skillResourceInstaller.install(ctx);
+        if (ctx.agent().generatesCommandStubs()) {
+            Files.createDirectories(ctx.commandsDir());
+            commandStubGenerator.generate(ctx, workflow);
+        }
+        skillResourceInstaller.install(ctx, workflow);
     }
 
     protected void beforeApplyTraits(InitContext ctx) throws Exception {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
@@ -27,7 +27,11 @@ class McpConfigGenerator {
             QuteTemplateEngine qute = new QuteTemplateEngine();
             String template = TemplateUtils.readTemplate(ctx.agent().mcpConfigTemplatePath());
             String processed = qute.renderString(template, templateData(ctx.distribution(), workflow));
-            Files.writeString(configFile, processed);
+            if ("toml".equals(ctx.agent().mcpConfigFormat())) {
+                new CodexConfigMerger().merge(configFile, processed);
+            } else {
+                Files.writeString(configFile, processed);
+            }
 
             ctx.printer().println(AnsiColors.green("✓") + " MCP config created for " + ctx.agent().name());
         } catch (Exception e) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/SkillResourceInstaller.java
@@ -12,9 +12,12 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.github.luigidemasi.camelkit.config.AgentGeneratorStrategy;
 import io.github.luigidemasi.camelkit.util.AnsiColors;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
 
 class SkillResourceInstaller {
 
@@ -38,7 +41,7 @@ class SkillResourceInstaller {
         this.versionPlaceholderResolver = versionPlaceholderResolver;
     }
 
-    void install(InitContext ctx) throws Exception {
+    void install(InitContext ctx, WorkflowManifest workflow) throws Exception {
         Files.createDirectories(ctx.skillsDir());
 
         var skillsResource = getClass().getClassLoader().getResource("skills");
@@ -60,7 +63,7 @@ class SkillResourceInstaller {
                 skillsSourceDir = Path.of(uri);
             }
 
-            int filesCopied = copySkills(ctx, skillsSourceDir);
+            int filesCopied = copySkills(ctx, skillsSourceDir, workflow);
             int skillCount;
             try (var stream = Files.list(ctx.skillsDir())) {
                 skillCount = (int) stream.filter(Files::isDirectory).count();
@@ -92,7 +95,7 @@ class SkillResourceInstaller {
         }
     }
 
-    private int copySkills(InitContext ctx, Path skillsSourceDir) throws Exception {
+    private int copySkills(InitContext ctx, Path skillsSourceDir, WorkflowManifest workflow) throws Exception {
         int filesCopied = 0;
         List<String> failures = new ArrayList<>();
         try (var stream = Files.walk(skillsSourceDir)) {
@@ -107,7 +110,7 @@ class SkillResourceInstaller {
                     if (Files.isDirectory(source)) {
                         Files.createDirectories(destination);
                     } else {
-                        copySkillFile(ctx, source, destination);
+                        copySkillFile(ctx, source, destination, workflow);
                         filesCopied++;
                     }
                 } catch (Exception e) {
@@ -121,7 +124,9 @@ class SkillResourceInstaller {
         return filesCopied;
     }
 
-    private void copySkillFile(InitContext ctx, Path source, Path destination) throws Exception {
+    private void copySkillFile(
+            InitContext ctx, Path source, Path destination, WorkflowManifest workflow)
+            throws Exception {
         Files.createDirectories(destination.getParent());
         try (InputStream in = Files.newInputStream(source)) {
             Files.copy(in, destination, StandardCopyOption.REPLACE_EXISTING);
@@ -140,6 +145,23 @@ class SkillResourceInstaller {
         }
         if (destination.getFileName().toString().endsWith(".md")) {
             versionPlaceholderResolver.substitute(destination, ctx.distribution());
+            if (AgentGeneratorStrategy.CODEX.descriptorValue().equals(ctx.agentName())) {
+                useCodexSkillInvocations(destination, workflow);
+            }
+        }
+    }
+
+    private void useCodexSkillInvocations(Path markdown, WorkflowManifest workflow) throws IOException {
+        String content = Files.readString(markdown);
+        String adapted = content;
+        for (WorkflowManifest.WorkflowSkill skill : workflow.skills()) {
+            Pattern invocation = Pattern.compile(
+                    "(?<![A-Za-z0-9._/-])/" + Pattern.quote(skill.name()) + "(?![A-Za-z0-9-])");
+            adapted = invocation.matcher(adapted)
+                    .replaceAll(Matcher.quoteReplacement("$" + skill.name()));
+        }
+        if (!adapted.equals(content)) {
+            Files.writeString(markdown, adapted);
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorExpectations.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorExpectations.java
@@ -19,16 +19,19 @@ public final class DoctorExpectations {
     private final List<String> requiredSkills;
     private final Set<String> camelMcpTools;
     private final Set<String> knowledgeMcpTools;
+    private final Set<String> citrusMcpTools;
 
     private DoctorExpectations(
                                List<String> userCommands,
                                List<String> requiredSkills,
                                Set<String> camelMcpTools,
-                               Set<String> knowledgeMcpTools) {
+                               Set<String> knowledgeMcpTools,
+                               Set<String> citrusMcpTools) {
         this.userCommands = List.copyOf(userCommands);
         this.requiredSkills = List.copyOf(requiredSkills);
         this.camelMcpTools = Collections.unmodifiableSet(new LinkedHashSet<>(camelMcpTools));
         this.knowledgeMcpTools = Collections.unmodifiableSet(new LinkedHashSet<>(knowledgeMcpTools));
+        this.citrusMcpTools = Collections.unmodifiableSet(new LinkedHashSet<>(citrusMcpTools));
     }
 
     public static DoctorExpectations loadDefault() {
@@ -48,7 +51,8 @@ public final class DoctorExpectations {
                         .map(WorkflowManifest.WorkflowSkill::name)
                         .toList(),
                 orderedSet(workflow.mcpServer("camel").allowedTools()),
-                orderedSet(workflow.mcpServer("camel-knowledge").allowedTools()));
+                orderedSet(workflow.mcpServer("camel-knowledge").allowedTools()),
+                orderedSet(workflow.mcpServer("citrus").allowedTools()));
     }
 
     public List<String> userCommands() {
@@ -65,6 +69,10 @@ public final class DoctorExpectations {
 
     public Set<String> knowledgeMcpTools() {
         return knowledgeMcpTools;
+    }
+
+    public Set<String> citrusMcpTools() {
+        return citrusMcpTools;
     }
 
     private static Set<String> orderedSet(List<String> values) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
 import io.github.luigidemasi.camelkit.config.AgentGeneratorStrategy;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
 import io.github.luigidemasi.camelkit.graph.GraphBuildResult;
@@ -27,6 +28,10 @@ import io.github.luigidemasi.camelkit.util.ProcessRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
 
 /**
  * Validates generated Camel-Kit workspaces.
@@ -140,16 +145,18 @@ public class DoctorService {
             return;
         }
 
-        Path commandsDir = root.resolve(agent.folder());
-        if (!Files.isDirectory(commandsDir)) {
-            findings.add(DoctorFinding.fail("workspace", relativize(root, commandsDir),
-                    "Generated command directory is missing",
-                    "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate commands."));
-        } else {
-            checkCommandFiles(root, commandsDir, agent, findings);
+        if (agent.generatesCommandStubs()) {
+            Path commandsDir = root.resolve(agent.commandDirectory());
+            if (!Files.isDirectory(commandsDir)) {
+                findings.add(DoctorFinding.fail("workspace", relativize(root, commandsDir),
+                        "Generated command directory is missing",
+                        "Run camel-kit init --here --ai " + agentKey(agent) + " --force to regenerate commands."));
+            } else {
+                checkCommandFiles(root, commandsDir, agent, findings);
+            }
         }
 
-        Path skillsDir = root.resolve(agent.folder()).getParent().resolve("skills");
+        Path skillsDir = root.resolve(agent.skillsDirectory());
         if (!Files.isDirectory(skillsDir)) {
             findings.add(DoctorFinding.fail("skills", relativize(root, skillsDir),
                     "Generated skills directory is missing",
@@ -176,6 +183,71 @@ public class DoctorService {
         if (AgentGeneratorStrategy.PI.descriptorValue().equals(agentKey(agent))) {
             checkPiGuard(root, findings);
         }
+        if (AgentGeneratorStrategy.CODEX.descriptorValue().equals(agentKey(agent))) {
+            checkCodexAgents(root, findings);
+        }
+    }
+
+    private void checkCodexAgents(Path root, List<DoctorFinding> findings) {
+        AgentDescriptor descriptor = AgentRegistry.descriptor(AgentGeneratorStrategy.CODEX.descriptorValue());
+        boolean valid = true;
+        for (AgentDescriptor.TemplateInstall template : descriptor.templates()) {
+            if (!template.target().startsWith(".codex/agents/") || !template.target().endsWith(".toml")) {
+                continue;
+            }
+
+            Path agentFile = root.resolve(template.target());
+            if (!Files.isRegularFile(agentFile)) {
+                findings.add(DoctorFinding.fail("workspace", relativize(root, agentFile),
+                        "Codex custom agent is missing",
+                        "Run camel-kit init --here --ai codex --force to regenerate Codex agents."));
+                valid = false;
+                continue;
+            }
+
+            try {
+                TomlParseResult parsed = Toml.parse(agentFile);
+                if (parsed.hasErrors()) {
+                    findings.add(DoctorFinding.fail("workspace", relativize(root, agentFile),
+                            "Codex custom agent is not valid TOML: " + parsed.errors().get(0),
+                            "Fix the TOML syntax or regenerate Codex agents with camel-kit init --here --ai codex --force."));
+                    valid = false;
+                    continue;
+                }
+                List<String> missing = List.of("name", "description", "developer_instructions").stream()
+                        .filter(key -> !(parsed.get(key) instanceof String value) || value.isBlank())
+                        .toList();
+                if (!missing.isEmpty()) {
+                    findings.add(DoctorFinding.fail("workspace", relativize(root, agentFile),
+                            "Codex custom agent is missing required fields: " + String.join(", ", missing),
+                            "Restore the required fields or regenerate Codex agents with camel-kit init --here --ai codex --force."));
+                    valid = false;
+                }
+                if (isReadOnlyCodexAgent(template.target())
+                        && !"read-only".equals(parsed.get("sandbox_mode"))) {
+                    findings.add(DoctorFinding.fail("workspace", relativize(root, agentFile),
+                            "Codex research or security agent must declare sandbox_mode = 'read-only'",
+                            "Restore sandbox_mode = \"read-only\" or regenerate Codex agents with camel-kit init --here --ai codex --force."));
+                    valid = false;
+                }
+            } catch (IOException e) {
+                findings.add(DoctorFinding.fail("workspace", relativize(root, agentFile),
+                        "Could not read Codex custom agent: " + e.getMessage(),
+                        "Check filesystem permissions and re-run camel-kit doctor."));
+                valid = false;
+            }
+        }
+
+        if (valid) {
+            findings.add(DoctorFinding.pass("workspace", ".codex/agents",
+                    "Codex custom agents are valid TOML and declare the required fields",
+                    "No action required."));
+        }
+    }
+
+    private boolean isReadOnlyCodexAgent(String target) {
+        return target.endsWith("camel-catalog-researcher.toml")
+                || target.endsWith("camel-security-reviewer.toml");
     }
 
     private void checkPiGuard(Path root, List<DoctorFinding> findings) {
@@ -352,6 +424,12 @@ public class DoctorService {
             return;
         }
 
+        AgentConfig configuredAgent = AgentRegistry.get(normalizedAgentName);
+        if (configuredAgent != null && "toml".equals(configuredAgent.mcpConfigFormat())) {
+            checkCodexMcp(root, mcpFile, findings);
+            return;
+        }
+
         JsonNode rootNode;
         try {
             rootNode = MAPPER.readTree(mcpFile.toFile());
@@ -381,6 +459,107 @@ public class DoctorService {
                     "MCP config exists and tool allowlists match Camel-Kit expectations",
                     "No action required."));
         }
+    }
+
+    private void checkCodexMcp(Path root, Path mcpFile, List<DoctorFinding> findings) {
+        TomlParseResult parsed;
+        try {
+            parsed = Toml.parse(mcpFile);
+        } catch (IOException e) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Could not read Codex MCP config: " + e.getMessage(),
+                    "Check filesystem permissions and re-run camel-kit doctor."));
+            return;
+        }
+        if (parsed.hasErrors()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP config is not valid TOML: " + parsed.errors().get(0),
+                    "Fix the TOML syntax or regenerate it with camel-kit init --here --ai codex --force."));
+            return;
+        }
+
+        if (!(parsed.get("mcp_servers") instanceof TomlTable servers)) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP config does not contain an mcp_servers table",
+                    "Regenerate it with camel-kit init --here --ai codex --force."));
+            return;
+        }
+
+        boolean camelOk = checkCodexMcpServer(
+                root, mcpFile, servers, "camel", expectations.camelMcpTools(), findings);
+        boolean knowledgeOk = checkCodexMcpServer(
+                root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), findings);
+        boolean citrusOk = checkCodexMcpServer(
+                root, mcpFile, servers, "citrus", expectations.citrusMcpTools(), findings);
+        if (camelOk && knowledgeOk && citrusOk) {
+            findings.add(DoctorFinding.pass("mcp", relativize(root, mcpFile),
+                    "Codex MCP config is valid TOML and all tool allowlists match Camel-Kit expectations",
+                    "No action required."));
+        }
+    }
+
+    private boolean checkCodexMcpServer(
+            Path root, Path mcpFile, TomlTable servers, String serverName, Set<String> expected,
+            List<DoctorFinding> findings) {
+        if (!(servers.get(serverName) instanceof TomlTable server)) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP server '" + serverName + "' is missing",
+                    "Regenerate the Codex MCP config with camel-kit init --here --ai codex --force."));
+            return false;
+        }
+
+        boolean valid = true;
+        if (!(server.get("command") instanceof String command) || command.isBlank()) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP server '" + serverName + "' must declare a non-empty command",
+                    "Regenerate the Codex MCP config with camel-kit init --here --ai codex --force."));
+            valid = false;
+        }
+
+        TomlArray args = server.get("args") instanceof TomlArray value ? value : null;
+        if (!isStringArray(args)) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP server '" + serverName + "' args must be an array of strings",
+                    "Regenerate the Codex MCP config with camel-kit init --here --ai codex --force."));
+            valid = false;
+        }
+
+        TomlArray enabledTools = server.get("enabled_tools") instanceof TomlArray value ? value : null;
+        if (!isStringArray(enabledTools)) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP server '" + serverName + "' enabled_tools must be an array of strings",
+                    "Regenerate the Codex MCP config with camel-kit init --here --ai codex --force."));
+            valid = false;
+        } else {
+            Set<String> actual = new LinkedHashSet<>();
+            for (int i = 0; i < enabledTools.size(); i++) {
+                actual.add((String) enabledTools.get(i));
+            }
+            valid &= checkToolSet(
+                    root, mcpFile, serverName, "enabled_tools", actual, expected, false, findings);
+        }
+
+        Object approvalMode = server.get("default_tools_approval_mode");
+        if (!"prompt".equals(approvalMode)) {
+            findings.add(DoctorFinding.fail("mcp", relativize(root, mcpFile),
+                    "Codex MCP server '" + serverName
+                                                                              + "' default_tools_approval_mode must be 'prompt' for least privilege",
+                    "Set default_tools_approval_mode = \"prompt\" or regenerate the Codex MCP config."));
+            valid = false;
+        }
+        return valid;
+    }
+
+    private boolean isStringArray(TomlArray array) {
+        if (array == null) {
+            return false;
+        }
+        for (int i = 0; i < array.size(); i++) {
+            if (!(array.get(i) instanceof String)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean checkMcpServer(
@@ -634,8 +813,8 @@ public class DoctorService {
         addIfExists(activeFiles, root.resolve("QWEN.md"));
         addIfExists(activeFiles, root.resolve("opencode.json"));
         if (agent != null) {
-            Path commandsDir = root.resolve(agent.folder());
-            if (Files.isDirectory(commandsDir)) {
+            Path commandsDir = agent.generatesCommandStubs() ? root.resolve(agent.commandDirectory()) : null;
+            if (commandsDir != null && Files.isDirectory(commandsDir)) {
                 try (Stream<Path> stream = Files.list(commandsDir)) {
                     stream.filter(Files::isRegularFile).forEach(activeFiles::add);
                 } catch (IOException e) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
@@ -44,9 +44,11 @@ public class InitService {
 
         Path targetDir = request.targetDir();
         Path camelKitDir = targetDir.resolve(".camel-kit");
-        Path commandsDir = targetDir.resolve(agent.folder());
+        Path skillsDir = targetDir.resolve(agent.skillsDirectory());
+        Path commandsDir = agent.generatesCommandStubs()
+                ? targetDir.resolve(agent.commandDirectory())
+                : skillsDir;
         Path docsDir = targetDir.resolve("docs");
-        Path skillsDir = commandsDir.getParent().resolve("skills");
         String citrusVersion = request.resolvedCitrusVersion();
 
         List<Path> createdPaths = new ArrayList<>();
@@ -57,7 +59,12 @@ public class InitService {
         }
 
         progress.startTask("\uD83D\uDCC1", "Creating project structure");
-        createProjectStructure(targetDir, commandsDir, camelKitDir, docsDir, createdPaths);
+        createProjectStructure(
+                targetDir,
+                agent.generatesCommandStubs() ? commandsDir : null,
+                camelKitDir,
+                docsDir,
+                createdPaths);
         progress.finishTask();
 
         progress.startTask("\uD83D\uDCDD", "Writing configuration");
@@ -67,10 +74,9 @@ public class InitService {
         progress.finishTask();
 
         progress.startTask("\uD83E\uDD16", "Generating " + agent.name() + " workspace");
-        Path agentBaseDir = targetDir.resolve(agent.folder()).getParent();
         InitContext genCtx = new InitContext(
                 agent, request.agentName(), commandsDir,
-                agentBaseDir.resolve("skills"), targetDir,
+                skillsDir, targetDir,
                 request.commandPrefix(), request.distribution(), request.printer());
         AgentGeneratorFactory.create(request.agentName()).generate(genCtx);
         progress.finishTask();
@@ -102,7 +108,9 @@ public class InitService {
             Path targetDir, Path commandsDir, Path camelKitDir, Path docsDir, List<Path> createdPaths)
             throws Exception {
         createDirectory(targetDir, createdPaths);
-        createDirectory(commandsDir, createdPaths);
+        if (commandsDir != null) {
+            createDirectory(commandsDir, createdPaths);
+        }
         createDirectory(camelKitDir, createdPaths);
         createDirectory(docsDir.resolve("flows"), createdPaths);
         createDirectory(camelKitDir.resolve("templates"), createdPaths);

--- a/camel-kit-core/src/main/resources/agents/registry/bob.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/bob.yaml
@@ -1,10 +1,13 @@
 id: bob
 displayName: IBM Project Bob
 commandDirectory: .bob/commands
+skillsDirectory: .bob/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: .bob/mcp.json
 mcpConfigTemplatePath: templates/mcp-configs/bob-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: IBM's AI-powered development assistant
 generatorStrategy: bob

--- a/camel-kit-core/src/main/resources/agents/registry/bob2.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/bob2.yaml
@@ -1,10 +1,13 @@
 id: bob2
 displayName: IBM Bob 2
 commandDirectory: .bob/commands
+skillsDirectory: .bob/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: .bob/mcp.json
 mcpConfigTemplatePath: templates/mcp-configs/bob-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: IBM Bob 2 with native skills and subagents
 generatorStrategy: bob2

--- a/camel-kit-core/src/main/resources/agents/registry/claude.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/claude.yaml
@@ -1,10 +1,13 @@
 id: claude
 displayName: Claude Code
 commandDirectory: .claude/commands
+skillsDirectory: .claude/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: .mcp.json
 mcpConfigTemplatePath: templates/mcp-configs/claude-code-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: Anthropic's Claude Code CLI
 generatorStrategy: claude

--- a/camel-kit-core/src/main/resources/agents/registry/codex.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/codex.yaml
@@ -1,0 +1,38 @@
+id: codex
+displayName: OpenAI Codex CLI
+skillsDirectory: .agents/skills
+generatesCommandStubs: false
+mcpConfigPath: .codex/config.toml
+mcpConfigTemplatePath: templates/mcp-configs/codex-mcp.toml
+mcpConfigFormat: toml
+mcpServerContainerKey: mcp_servers
+description: OpenAI's coding agent for the terminal
+generatorStrategy: codex
+dispatchTemplatePath: templates/dispatch/codex.md
+templates:
+  - source: templates/codex/agents-md.md
+    target: AGENTS.md
+  - source: templates/codex/agents/camel-planner.toml
+    target: .codex/agents/camel-planner.toml
+  - source: templates/codex/agents/camel-implementer.toml
+    target: .codex/agents/camel-implementer.toml
+  - source: templates/codex/agents/camel-tester.toml
+    target: .codex/agents/camel-tester.toml
+  - source: templates/codex/agents/camel-validator.toml
+    target: .codex/agents/camel-validator.toml
+  - source: templates/codex/agents/camel-migrator.toml
+    target: .codex/agents/camel-migrator.toml
+  - source: templates/codex/agents/camel-catalog-researcher.toml
+    target: .codex/agents/camel-catalog-researcher.toml
+  - source: templates/codex/agents/camel-security-reviewer.toml
+    target: .codex/agents/camel-security-reviewer.toml
+supportsSubagents: true
+supportsTraits: true
+capabilities:
+  - project-skills
+  - custom-agents
+  - parallel-subagent-dispatch
+  - mcp
+  - approvals
+  - sandbox
+  - repository-trust

--- a/camel-kit-core/src/main/resources/agents/registry/copilot.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/copilot.yaml
@@ -1,10 +1,13 @@
 id: copilot
 displayName: GitHub Copilot CLI
 commandDirectory: .github/commands
+skillsDirectory: .github/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: .github/mcp.json
 mcpConfigTemplatePath: templates/mcp-configs/copilot-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: GitHub Copilot CLI terminal agent
 generatorStrategy: copilot

--- a/camel-kit-core/src/main/resources/agents/registry/gemini.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/gemini.yaml
@@ -1,10 +1,13 @@
 id: gemini
 displayName: Gemini CLI
 commandDirectory: .gemini/commands
+skillsDirectory: .gemini/skills
+generatesCommandStubs: true
 commandFileFormat: toml
 argumentPlaceholder: "{{args}}"
 mcpConfigPath: .gemini/settings.json
 mcpConfigTemplatePath: templates/mcp-configs/gemini-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: Google's Gemini CLI
 generatorStrategy: gemini

--- a/camel-kit-core/src/main/resources/agents/registry/opencode.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/opencode.yaml
@@ -1,10 +1,13 @@
 id: opencode
 displayName: OpenCode
 commandDirectory: .opencode/commands
+skillsDirectory: .opencode/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: opencode.json
 mcpConfigTemplatePath: templates/mcp-configs/opencode-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcp
 description: AI coding agent for the terminal
 generatorStrategy: opencode

--- a/camel-kit-core/src/main/resources/agents/registry/pi.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/pi.yaml
@@ -1,10 +1,13 @@
 id: pi
 displayName: Pi
 commandDirectory: .pi/prompts
+skillsDirectory: .pi/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: .mcp.json
 mcpConfigTemplatePath: templates/mcp-configs/pi-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: Pi terminal coding agent
 generatorStrategy: pi

--- a/camel-kit-core/src/main/resources/agents/registry/qwen.yaml
+++ b/camel-kit-core/src/main/resources/agents/registry/qwen.yaml
@@ -1,10 +1,13 @@
 id: qwen
 displayName: Qwen Code
 commandDirectory: .qwen/commands
+skillsDirectory: .qwen/skills
+generatesCommandStubs: true
 commandFileFormat: md
 argumentPlaceholder: $ARGUMENTS
 mcpConfigPath: .qwen/settings.json
 mcpConfigTemplatePath: templates/mcp-configs/qwen-mcp.json
+mcpConfigFormat: json
 mcpServerContainerKey: mcpServers
 description: Alibaba's Qwen Code CLI
 generatorStrategy: qwen

--- a/camel-kit-core/src/main/resources/templates/codex/agents-md.md
+++ b/camel-kit-core/src/main/resources/templates/codex/agents-md.md
@@ -1,0 +1,26 @@
+# Camel-Kit Project
+
+Start integration work with `$camel-start`. Use `/skills` to inspect or select any Camel-Kit skill explicitly.
+
+## Laws (NEVER violate)
+
+1. Verify all Camel components, EIPs, and data formats through the configured MCP servers before use.
+2. Read and follow `docs/constitution.md`.
+3. Do not implement without a user-approved design specification.
+4. Read the Camel version only from `.camel-kit/config.properties`.
+5. Run the application after implementation and report the verification evidence.
+
+## Codex project resources
+
+- Skills: `.agents/skills/`
+- Custom agents: `.codex/agents/`
+- MCP configuration: `.codex/config.toml`
+- MCP status: `/mcp`
+
+Codex loads project `.codex/` configuration and any project hooks only after the repository is trusted. Camel-Kit
+does not generate hooks. Keep the active sandbox and approval policy in place; request the narrowest approval that
+lets blocked work continue.
+
+## CLI
+
+Use `{COMMAND_PREFIX}` for Camel-Kit CLI commands (for example, `{COMMAND_PREFIX} graph stats`).

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-catalog-researcher.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-catalog-researcher.toml
@@ -1,0 +1,7 @@
+name = "camel_catalog_researcher"
+description = "Performs read-only Camel catalog and documentation research through configured MCP servers."
+sandbox_mode = "read-only"
+developer_instructions = """
+Use the Camel, Camel Knowledge, and Citrus MCP servers as the source of truth.
+Return concise findings with exact tool evidence. Do not edit project files or infer catalog facts from memory.
+"""

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-implementer.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-implementer.toml
@@ -1,0 +1,6 @@
+name = "camel_implementer"
+description = "Implements one approved Camel task and leaves focused verification evidence."
+developer_instructions = """
+Read .agents/skills/camel-implement/SKILL.md and the task's referenced guides before editing.
+Implement only the assigned task, verify every Camel element through MCP, and run the requested checks.
+"""

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-migrator.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-migrator.toml
@@ -1,0 +1,6 @@
+name = "camel_migrator"
+description = "Analyzes source integrations and designs evidence-backed migrations to Apache Camel."
+developer_instructions = """
+Read .agents/skills/camel-migrate/SKILL.md and follow its no-code design workflow.
+Preserve source behavior, verify target capabilities through MCP, and write only the requested migration artifacts.
+"""

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-planner.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-planner.toml
@@ -1,0 +1,6 @@
+name = "camel_planner"
+description = "Plans approved Camel designs as ordered, verifiable implementation tasks."
+developer_instructions = """
+Read .agents/skills/camel-plan/SKILL.md and follow it exactly.
+Write only planning artifacts. Use MCP evidence and preserve every approved design constraint.
+"""

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-security-reviewer.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-security-reviewer.toml
@@ -1,0 +1,7 @@
+name = "camel_security_reviewer"
+description = "Performs a read-only security review of Camel routes and configuration."
+sandbox_mode = "read-only"
+developer_instructions = """
+Review trust boundaries, secret handling, endpoint exposure, unsafe expressions, and dependency risk.
+Use MCP evidence, cite concrete paths, and return findings only. Do not modify the implementation.
+"""

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-tester.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-tester.toml
@@ -1,0 +1,6 @@
+name = "camel_tester"
+description = "Creates and runs focused Camel and Citrus tests for an approved implementation task."
+developer_instructions = """
+Read .agents/skills/camel-test/SKILL.md and the relevant test guides.
+Test observable behavior, use the configured Citrus MCP evidence, and report exact commands and results.
+"""

--- a/camel-kit-core/src/main/resources/templates/codex/agents/camel-validator.toml
+++ b/camel-kit-core/src/main/resources/templates/codex/agents/camel-validator.toml
@@ -1,0 +1,6 @@
+name = "camel_validator"
+description = "Validates Camel routes for correctness, security, and constitution compliance."
+developer_instructions = """
+Read .agents/skills/camel-validate/SKILL.md and follow its evidence requirements.
+Validate independently from implementation and return actionable findings with paths and MCP evidence.
+"""

--- a/camel-kit-core/src/main/resources/templates/dispatch/codex.md
+++ b/camel-kit-core/src/main/resources/templates/dispatch/codex.md
@@ -1,0 +1,18 @@
+## Dispatch
+
+Use Codex subagents for self-contained work that benefits from an isolated context:
+
+- Use the built-in `explorer` or `camel_catalog_researcher` for read-only project and MCP research.
+- Use the generated `camel_planner`, `camel_implementer`, `camel_tester`, `camel_validator`,
+  `camel_migrator`, and `camel_security_reviewer` roles for their named responsibilities.
+- Spawn independent tasks from the same implementation wave in parallel. Keep dependent waves sequential.
+- The parent remains the orchestrator, supplies exact input and output paths, and verifies returned work.
+- Delegated agents must not spawn more agents; they return a concise result to the parent.
+
+Include the Camel version from `.camel-kit/config.properties`, relevant user decisions, the guide paths to read,
+prior artifact paths, and verification commands in each delegated task.
+
+### Fallback
+
+If subagent dispatch or a generated role is unavailable, read the guide directly and execute it in the current
+session. This uses more context but preserves the workflow.

--- a/camel-kit-core/src/main/resources/templates/mcp-configs/codex-mcp.toml
+++ b/camel-kit-core/src/main/resources/templates/mcp-configs/codex-mcp.toml
@@ -1,0 +1,32 @@
+[mcp_servers.camel]
+command = "jbang"
+args = [
+  "--repos", "{CAMEL_MCP_REPOS}",
+  "-Dcamel.catalog.repos={CAMEL_CATALOG_REPOS}",
+  "-Dquarkus.log.level=WARN",
+  "-Dquarkus.http.port=-1",
+  "org.apache.camel:camel-jbang-mcp:{CAMEL_MCP_VERSION}:runner"
+]
+enabled_tools = {CAMEL_TOOLS_JSON}
+default_tools_approval_mode = "prompt"
+
+[mcp_servers.camel-knowledge]
+command = "jbang"
+args = [
+  "--repos", "{KNOWLEDGE_MCP_REPOS}",
+  "-Dquarkus.log.level=WARN",
+  "io.github.luigidemasi:camel-kit-knowledge-mcp:{KNOWLEDGE_VERSION}:runner"
+]
+enabled_tools = {KNOWLEDGE_TOOLS_JSON}
+default_tools_approval_mode = "prompt"
+
+[mcp_servers.citrus]
+command = "jbang"
+args = [
+  "--repos", "{CITRUS_MCP_REPOS}",
+  "-Dquarkus.log.level=WARN",
+  "-Dquarkus.http.port=-1",
+  "org.citrusframework:citrus-mcp-server:{CITRUS_MCP_VERSION}:runner"
+]
+enabled_tools = {CITRUS_TOOLS_JSON}
+default_tools_approval_mode = "prompt"

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/DoctorCommandTest.java
@@ -163,7 +163,8 @@ class DoctorCommandTest {
 
     @Test
     void generatedWorkspacesMatchDoctorExpectations() throws Exception {
-        for (String agentName : List.of("bob", "bob2", "claude", "copilot", "gemini", "qwen", "opencode", "pi")) {
+        for (String agentName : List.of(
+                "bob", "bob2", "claude", "copilot", "codex", "gemini", "qwen", "opencode", "pi")) {
             Path root = tempDir.resolve(agentName);
             createGeneratedWorkspace(root, agentName);
 
@@ -171,14 +172,20 @@ class DoctorCommandTest {
 
             assertEquals(0, result.exitCode(), agentName + System.lineSeparator() + result.output());
             AgentConfig agent = AgentRegistry.get(agentName);
-            String extension = "." + agent.fileFormat();
-            Path commandsDir = root.resolve(agent.folder());
-            for (String internalCommand : List.of("camel-design", "camel-implement", "camel-test", "camel-verify")) {
-                assertFalse(Files.exists(commandsDir.resolve(internalCommand + extension)),
-                        agentName + " should not expose " + internalCommand + " as a command");
+            if (agent.generatesCommandStubs()) {
+                String extension = "." + agent.fileFormat();
+                Path commandsDir = root.resolve(agent.commandDirectory());
+                for (String internalCommand : List.of(
+                        "camel-design", "camel-implement", "camel-test", "camel-verify")) {
+                    assertFalse(Files.exists(commandsDir.resolve(internalCommand + extension)),
+                            agentName + " should not expose " + internalCommand + " as a command");
+                }
+            } else {
+                assertFalse(Files.exists(root.resolve(".codex/commands")),
+                        agentName + " should not generate command stubs");
             }
 
-            Path skillsDir = commandsDir.getParent().resolve("skills");
+            Path skillsDir = root.resolve(agent.skillsDirectory());
             for (String internalSkill : List.of("camel-design", "camel-implement", "camel-test", "camel-verify")) {
                 assertTrue(Files.isRegularFile(skillsDir.resolve(internalSkill).resolve("SKILL.md")),
                         agentName + " should keep " + internalSkill + " as a skill");
@@ -249,8 +256,10 @@ class DoctorCommandTest {
         Files.writeString(root.resolve(".camel-kit/project-graph.json"), "{}");
         Files.writeString(root.resolve("mvnw"), "#!/bin/sh\n");
 
-        Path commandsDir = root.resolve(agent.folder());
-        Path skillsDir = commandsDir.getParent().resolve("skills");
+        Path commandsDir = agent.generatesCommandStubs()
+                ? root.resolve(agent.commandDirectory())
+                : root.resolve(".codex/commands");
+        Path skillsDir = root.resolve(agent.skillsDirectory());
         InitContext ctx = new InitContext(
                 agent, agentName, commandsDir, skillsDir, root, "camel-kit", Printer.noop());
         AgentGeneratorFactory.create(agentName).generate(ctx);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/InitCommandTest.java
@@ -71,6 +71,34 @@ class InitCommandTest {
         assertFalse(output.contains("/camel-start  "));
     }
 
+    @Test
+    void codexOptionIsAcceptedAndShownInHelp() {
+        InitCommand command = new InitCommand(new CamelKitMain());
+        CommandLine commandLine = new CommandLine(command);
+
+        commandLine.parseArgs("orders", "--ai", "codex");
+
+        assertEquals("codex", command.ai);
+        assertTrue(commandLine.getUsageMessage().contains("codex"));
+    }
+
+    @Test
+    void codexNextStepsUseTrustSkillsAndMcpDiscovery() {
+        CapturingPrinter printer = new CapturingPrinter();
+        CamelKitMain main = new CamelKitMain();
+        main.setOut(printer);
+
+        InitCommand command = new InitCommand(main);
+        command.printNextSteps("orders", "OpenAI Codex CLI", "codex");
+
+        String output = printer.output();
+        assertTrue(output.contains("trust"));
+        assertTrue(output.contains("/skills"));
+        assertTrue(output.contains("$camel-start"));
+        assertTrue(output.contains("/mcp"));
+        assertFalse(output.contains("/camel-start"));
+    }
+
     private static final class CapturingPrinter implements Printer {
         private final StringBuilder output = new StringBuilder();
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/AgentRegistryTest.java
@@ -23,7 +23,7 @@ class AgentRegistryTest {
 
     @Test
     void builtInAgentsAreLoadedFromResourceDescriptors() {
-        assertEquals(Set.of("bob", "bob2", "claude", "copilot", "gemini", "opencode", "pi", "qwen"),
+        assertEquals(Set.of("bob", "bob2", "claude", "codex", "copilot", "gemini", "opencode", "pi", "qwen"),
                 AgentRegistry.names());
 
         AgentConfig claude = AgentRegistry.get("claude");
@@ -46,6 +46,28 @@ class AgentRegistryTest {
         assertTrue(descriptor.supportsSubagents());
         assertTrue(descriptor.supportsTraits());
         assertTrue(descriptor.capabilities().contains("parallel-subagent-dispatch"));
+    }
+
+    @Test
+    void codexDescriptorUsesNativeProjectLocationsWithoutCommands() {
+        AgentConfig codex = AgentRegistry.get("codex");
+        assertNotNull(codex);
+        assertEquals("OpenAI Codex CLI", codex.name());
+        assertNull(codex.commandDirectory());
+        assertEquals(".agents/skills", codex.skillsDirectory());
+        assertFalse(codex.generatesCommandStubs());
+        assertEquals(".agents/skills", codex.folder());
+        assertEquals(".codex/config.toml", codex.mcpConfigPath());
+        assertEquals("toml", codex.mcpConfigFormat());
+        assertEquals("mcp_servers", codex.mcpServerContainerKey());
+
+        AgentDescriptor descriptor = AgentRegistry.descriptor("codex");
+        assertNotNull(descriptor);
+        assertEquals(AgentGeneratorStrategy.CODEX, descriptor.generatorStrategyType());
+        assertTrue(descriptor.supportsSubagents());
+        assertTrue(descriptor.capabilities().contains("project-skills"));
+        assertTrue(descriptor.capabilities().contains("custom-agents"));
+        assertTrue(descriptor.capabilities().contains("repository-trust"));
     }
 
     @Test
@@ -185,6 +207,35 @@ class AgentRegistryTest {
     }
 
     @Test
+    void legacyJsonDescriptorDefaultsNewPathAndFormatFields() throws IOException {
+        Files.writeString(tempDir.resolve("legacy.yaml"), """
+                id: legacy
+                displayName: Legacy Agent
+                commandDirectory: .legacy/commands
+                commandFileFormat: md
+                argumentPlaceholder: $ARGUMENTS
+                mcpConfigPath: .legacy/mcp.json
+                mcpConfigTemplatePath: templates/mcp-configs/legacy-mcp.json
+                mcpServerContainerKey: mcpServers
+                description: Legacy descriptor shape
+                generatorStrategy: default
+                dispatchTemplatePath: templates/dispatch/legacy.md
+                supportsSubagents: false
+                supportsTraits: false
+                """);
+
+        AgentDescriptor descriptor = AgentDescriptorLoader.load(tempDir).get("legacy");
+        AgentConfig config = descriptor.toAgentConfig();
+
+        assertTrue(descriptor.generatesCommandStubs());
+        assertEquals(".legacy/skills", descriptor.skillsDirectory());
+        assertEquals("json", descriptor.mcpConfigFormat());
+        assertTrue(config.generatesCommandStubs());
+        assertEquals(".legacy/skills", config.skillsDirectory());
+        assertEquals("json", config.mcpConfigFormat());
+    }
+
+    @Test
     void jarBackedRegistryLoadsDescriptors() throws Exception {
         Path jarFile = tempDir.resolve("agents.jar");
         try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarFile))) {
@@ -219,10 +270,13 @@ class AgentRegistryTest {
                 id: %1$s
                 displayName: Test Agent
                 commandDirectory: .%1$s/commands
+                skillsDirectory: .%1$s/skills
+                generatesCommandStubs: true
                 commandFileFormat: md
                 argumentPlaceholder: $ARGUMENTS
                 mcpConfigPath: .%1$s/mcp.json
                 mcpConfigTemplatePath: templates/mcp-configs/%1$s-mcp.json
+                mcpConfigFormat: json
                 mcpServerContainerKey: mcpServers
                 description: Test agent
                 generatorStrategy: default

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/AgentGeneratorFactoryTest.java
@@ -22,6 +22,11 @@ class AgentGeneratorFactoryTest {
     }
 
     @Test
+    void codexReturnsCodexGenerator() {
+        assertInstanceOf(CodexGenerator.class, AgentGeneratorFactory.create("codex"));
+    }
+
+    @Test
     void copilotReturnsCopilotGenerator() {
         assertInstanceOf(CopilotGenerator.class, AgentGeneratorFactory.create("copilot"));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CodexCliSmokeTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CodexCliSmokeTest.java
@@ -1,0 +1,302 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CodexCliSmokeTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void installedCodexDiscoversGeneratedInstructionsSkillsAgentsAndMcpServers() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path codexHome = configureIsolatedCodexHome(workspace);
+        Map<String, String> environment = isolatedEnvironment(codexHome);
+        CommandResult version = tryRunCodex(List.of("codex", "--version"), workspace, environment);
+        Assumptions.assumeTrue(version != null && version.exitCode() == 0,
+                "Codex CLI is not installed; skipping local discovery smoke test");
+        generateWorkspace(workspace, environment);
+
+        CommandResult prompt = runCodex(
+                List.of("codex", "-C", workspace.toString(), "debug", "prompt-input", "smoke"),
+                workspace,
+                environment);
+        assertEquals(0, prompt.exitCode(), "Codex did not render the isolated prompt input");
+        assertTrue(prompt.stdout().contains("# Camel-Kit Project"), "Codex did not load the generated AGENTS.md");
+        assertTrue(prompt.stdout().contains("camel-start"), "Codex did not expose the generated skills");
+        assertFalse(prompt.combined().contains("Ignoring malformed agent role definition"),
+                "Codex rejected a generated custom agent definition");
+
+        CommandResult mcp = runCodex(
+                List.of("codex", "-C", workspace.toString(), "mcp", "list", "--json"),
+                workspace,
+                environment);
+        assertEquals(0, mcp.exitCode(), "Codex did not load the generated MCP configuration");
+        JsonNode mcpServers = MAPPER.readTree(mcp.stdout());
+        assertEquals(List.of("camel", "camel-knowledge", "citrus"),
+                mcpServers.findValuesAsText("name"), "Codex discovered an unexpected MCP server set");
+
+        JsonNode skills = discoverSkills(workspace, environment, false);
+        Set<String> discoveredSkills = new LinkedHashSet<>(skills.findValuesAsText("name"));
+        Set<String> expectedSkills = new LinkedHashSet<>(
+                WorkflowManifestLoader.loadDefault().skills().stream()
+                        .map(skill -> skill.name())
+                        .toList());
+        assertTrue(discoveredSkills.containsAll(expectedSkills),
+                "Missing skills: " + difference(expectedSkills, discoveredSkills) + "\n" + skills.toPrettyString());
+        assertTrue(skills.findValuesAsText("scope").contains("repo"), skills.toPrettyString());
+
+        Files.copy(
+                workspace.resolve(".codex/agents/camel-implementer.toml"),
+                workspace.resolve(".codex/agents/duplicate-implementer.toml"));
+        // The app-server has no role-list endpoint, so a duplicate-valid control proves that thread startup
+        // parsed the generated role name while every other generated role remained valid.
+        discoverSkills(workspace, environment, true);
+    }
+
+    private void generateWorkspace(Path workspace, Map<String, String> environment) throws Exception {
+        AgentConfig agent = AgentRegistry.get("codex");
+        InitContext context = new InitContext(
+                agent,
+                "codex",
+                workspace.resolve(".codex/commands"),
+                workspace.resolve(agent.skillsDirectory()),
+                workspace,
+                "camel-kit",
+                Printer.noop());
+        AgentGeneratorFactory.create("codex").generate(context);
+
+        CommandResult gitInit = runCodex(List.of("git", "init", "--quiet"), workspace, environment);
+        assertEquals(0, gitInit.exitCode(), "Unable to initialize isolated smoke-test repository");
+    }
+
+    private Path configureIsolatedCodexHome(Path workspace) throws IOException {
+        Path home = Files.createDirectories(tempDir.resolve("home"));
+        Path codexHome = Files.createDirectories(home.resolve(".codex"));
+        String trustedPath = workspace.toAbsolutePath().normalize().toString().replace("\\", "\\\\");
+        Files.writeString(codexHome.resolve("config.toml"), String.format(Locale.ROOT, """
+                [projects."%s"]
+                trust_level = "trusted"
+                """, trustedPath));
+        return codexHome;
+    }
+
+    private Map<String, String> isolatedEnvironment(Path codexHome) throws IOException {
+        return Map.of(
+                "HOME", tempDir.resolve("home").toString(),
+                "CODEX_HOME", codexHome.toString(),
+                "CODEX_SQLITE_HOME", Files.createDirectories(tempDir.resolve("sqlite")).toString(),
+                "XDG_CACHE_HOME", Files.createDirectories(tempDir.resolve("cache")).toString(),
+                "XDG_CONFIG_HOME", Files.createDirectories(tempDir.resolve("config")).toString(),
+                "TMPDIR", Files.createDirectories(tempDir.resolve("tmp")).toString(),
+                "NO_COLOR", "1",
+                "TERM", "dumb");
+    }
+
+    private JsonNode discoverSkills(
+            Path workspace, Map<String, String> environment, boolean expectMalformedAgentWarning)
+            throws Exception {
+        ProcessBuilder builder = isolatedProcessBuilder(
+                List.of("codex", "app-server", "--strict-config", "--listen", "stdio://"),
+                workspace,
+                environment);
+        Process process = builder.start();
+        StringBuffer stdout = new StringBuffer();
+        LinkedBlockingQueue<String> lines = new LinkedBlockingQueue<>();
+        CompletableFuture<Void> stdoutReader = CompletableFuture.runAsync(() -> readLines(process, stdout, lines));
+        CompletableFuture<String> stderrReader = readAsync(process.getErrorStream());
+
+        try (OutputStreamWriter writer = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8)) {
+            writeRequest(writer,
+                    "{\"id\":1,\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"name\":\"camel-kit-smoke\",\"version\":\"1\"}}}");
+            awaitResponse(lines, 1, stdout, stderrReader, process);
+
+            writeRequest(writer, "{\"method\":\"initialized\"}");
+            writeRequest(writer,
+                    "{\"id\":2,\"method\":\"thread/start\",\"params\":{\"cwd\":\""
+                                 + jsonEscape(workspace.toString()) + "\",\"ephemeral\":true}}");
+            JsonNode thread = awaitResponse(lines, 2, stdout, stderrReader, process);
+            assertFalse(thread.has("error"), "Codex app-server could not start an isolated thread");
+
+            writeRequest(writer,
+                    "{\"id\":3,\"method\":\"skills/list\",\"params\":{\"cwds\":[\""
+                                 + jsonEscape(workspace.toString()) + "\"],\"forceReload\":true}}");
+            JsonNode response = awaitResponse(lines, 3, stdout, stderrReader, process);
+            assertFalse(response.has("error"), "Codex app-server could not list repository skills");
+
+            writer.close();
+            assertTrue(process.waitFor(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                    "Codex app-server did not exit after stdin closed");
+            stdoutReader.join();
+            String stderr = stderrReader.join();
+            assertEquals(0, process.exitValue(), "Codex app-server exited unsuccessfully");
+            assertEquals(expectMalformedAgentWarning,
+                    stderr.contains("Ignoring malformed agent role definition"),
+                    expectMalformedAgentWarning
+                            ? "Codex did not inspect project custom-agent definitions"
+                            : "Codex rejected a generated custom agent definition");
+            if (expectMalformedAgentWarning) {
+                assertTrue(stderr.contains("duplicate agent role name `camel_implementer`"),
+                        "Codex did not parse the generated custom-agent role name");
+                assertEquals(1,
+                        stderr.lines()
+                                .filter(line -> line.contains("Ignoring malformed agent role definition"))
+                                .count(),
+                        "Codex rejected another generated custom-agent definition");
+            }
+            return response.path("result");
+        }
+    }
+
+    private JsonNode awaitResponse(
+            LinkedBlockingQueue<String> lines,
+            int expectedId,
+            StringBuffer stdout,
+            CompletableFuture<String> stderr,
+            Process process)
+            throws Exception {
+        long deadline = System.nanoTime() + TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            long remaining = deadline - System.nanoTime();
+            String line = lines.poll(remaining, TimeUnit.NANOSECONDS);
+            if (line == null) {
+                break;
+            }
+            JsonNode response = MAPPER.readTree(line);
+            if (response.path("id").asInt(-1) == expectedId) {
+                return response;
+            }
+        }
+        process.destroyForcibly();
+        fail("Codex app-server returned no response for id " + expectedId + ":\n" + stdout + stderr.join());
+        return MAPPER.nullNode();
+    }
+
+    private void writeRequest(OutputStreamWriter writer, String request) throws IOException {
+        writer.write(request);
+        writer.write(System.lineSeparator());
+        writer.flush();
+    }
+
+    private void readLines(Process process, StringBuffer output, LinkedBlockingQueue<String> lines) {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append(System.lineSeparator());
+                lines.add(line);
+            }
+        } catch (IOException e) {
+            if (process.isAlive()) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private CommandResult tryRunCodex(List<String> command, Path directory, Map<String, String> environment)
+            throws InterruptedException {
+        try {
+            return runCodex(command, directory, environment);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private CommandResult runCodex(List<String> command, Path directory, Map<String, String> environment)
+            throws IOException, InterruptedException {
+        ProcessBuilder builder = isolatedProcessBuilder(command, directory, environment);
+        Process process = builder.start();
+        CompletableFuture<String> stdout = readAsync(process.getInputStream());
+        CompletableFuture<String> stderr = readAsync(process.getErrorStream());
+        process.getOutputStream().close();
+
+        if (!process.waitFor(TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            fail("Command timed out after " + TIMEOUT + ": " + String.join(" ", command));
+        }
+        return new CommandResult(process.exitValue(), stdout.join(), stderr.join());
+    }
+
+    private ProcessBuilder isolatedProcessBuilder(
+            List<String> command, Path directory, Map<String, String> environment) {
+        ProcessBuilder builder = new ProcessBuilder(new ArrayList<>(command));
+        builder.directory(directory.toFile());
+        Map<String, String> childEnvironment = builder.environment();
+        childEnvironment.clear();
+        copyHostEnvironment(childEnvironment, "PATH");
+        copyHostEnvironment(childEnvironment, "SHELL");
+        copyHostEnvironment(childEnvironment, "CODEX_MANAGED_BY_NPM");
+        copyHostEnvironment(childEnvironment, "CODEX_MANAGED_PACKAGE_ROOT");
+        childEnvironment.put("LANG", "C.UTF-8");
+        childEnvironment.put("CODEX_SANDBOX_NETWORK_DISABLED", "1");
+        childEnvironment.putAll(environment);
+        return builder;
+    }
+
+    private void copyHostEnvironment(Map<String, String> target, String name) {
+        String value = System.getenv(name);
+        if (value != null && !value.isBlank()) {
+            target.put(name, value);
+        }
+    }
+
+    private CompletableFuture<String> readAsync(InputStream input) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (input) {
+                return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        });
+    }
+
+    private String jsonEscape(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private Set<String> difference(Set<String> expected, Set<String> actual) {
+        Set<String> missing = new LinkedHashSet<>(expected);
+        missing.removeAll(actual);
+        return missing;
+    }
+
+    private record CommandResult(int exitCode, String stdout, String stderr) {
+
+        private String combined() {
+            return stdout + stderr;
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CodexGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CodexGeneratorTest.java
@@ -1,0 +1,303 @@
+package io.github.luigidemasi.camelkit.generator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import io.github.luigidemasi.camelkit.config.AgentConfig;
+import io.github.luigidemasi.camelkit.config.AgentDescriptor;
+import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.output.Printer;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
+import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CodexGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void generatesCodexNativeAssetsWithoutCommandScaffolding() throws Exception {
+        InitContext ctx = createContext(tempDir);
+
+        new CodexGenerator().generate(ctx);
+
+        assertFalse(Files.exists(tempDir.resolve(".codex/commands")));
+        assertFalse(Files.exists(tempDir.resolve(".agents/commands")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("AGENTS.md")));
+        String agentsMd = Files.readString(tempDir.resolve("AGENTS.md"));
+        assertTrue(agentsMd.contains("$camel-start"));
+        assertTrue(agentsMd.contains("/skills"));
+        assertTrue(agentsMd.contains("/mcp"));
+        assertTrue(agentsMd.contains("configuration and any project hooks only after the repository is trusted"));
+        assertFalse(agentsMd.contains("/camel-start"));
+
+        String executeSkill = Files.readString(tempDir.resolve(".agents/skills/camel-execute/SKILL.md"));
+        assertTrue(executeSkill.contains("Spawn independent tasks from the same implementation wave in parallel"));
+        assertTrue(executeSkill.contains("Delegated agents must not spawn more agents"));
+
+        String startSkill = Files.readString(tempDir.resolve(".agents/skills/camel-start/SKILL.md"));
+        assertTrue(startSkill.contains("$camel-plan"));
+        assertTrue(startSkill.contains("$camel-execute"));
+        assertFalse(startSkill.contains("/camel-plan"));
+        assertFalse(startSkill.contains("/camel-execute"));
+
+        String planSkill = Files.readString(tempDir.resolve(".agents/skills/camel-plan/SKILL.md"));
+        assertTrue(planSkill.contains("$camel-brainstorm"));
+        assertTrue(planSkill.contains("$camel-execute"));
+        assertTrue(planSkill.contains("docs/camel-kit/<PIPELINE_ID>/implementation-plan.md"));
+        assertFalse(planSkill.contains("/camel-brainstorm"));
+        assertFalse(planSkill.contains("/camel-execute"));
+
+        WorkflowManifest workflow = WorkflowManifestLoader.loadDefault();
+        assertNoUnsupportedSlashSkillInvocations(workflow, tempDir.resolve(".agents/skills"));
+        for (WorkflowManifest.WorkflowSkill skill : workflow.skills()) {
+            assertTrue(Files.isRegularFile(
+                    tempDir.resolve(".agents/skills").resolve(skill.name()).resolve("SKILL.md")), skill.name());
+        }
+        assertEquals(workflow.skills().size(), countSkillDirectories(tempDir.resolve(".agents/skills")));
+
+        AgentDescriptor descriptor = AgentRegistry.descriptor("codex");
+        long customAgentCount = descriptor.templates().stream()
+                .filter(template -> template.target().startsWith(".codex/agents/"))
+                .count();
+        assertEquals(7, customAgentCount);
+        for (AgentDescriptor.TemplateInstall template : descriptor.templates()) {
+            if (!template.target().startsWith(".codex/agents/")) {
+                continue;
+            }
+            TomlParseResult agent = Toml.parse(tempDir.resolve(template.target()));
+            assertFalse(agent.hasErrors(), agent.errors().toString());
+            assertNonBlankString(agent, "name");
+            assertNonBlankString(agent, "description");
+            assertNonBlankString(agent, "developer_instructions");
+            if (template.target().endsWith("camel-catalog-researcher.toml")
+                    || template.target().endsWith("camel-security-reviewer.toml")) {
+                assertEquals("read-only", agent.getString("sandbox_mode"), template.target());
+            }
+        }
+        assertFalse(Files.exists(tempDir.resolve(".codex/hooks")));
+    }
+
+    @Test
+    void generatesResolvedLeastPrivilegeMcpConfiguration() throws Exception {
+        InitContext ctx = createContext(tempDir);
+
+        new CodexGenerator().generate(ctx);
+
+        Path configFile = tempDir.resolve(".codex/config.toml");
+        String configText = Files.readString(configFile);
+        assertFalse(configText.contains("{CAMEL_"));
+        assertFalse(configText.contains("{KNOWLEDGE_"));
+        assertFalse(configText.contains("{CITRUS_"));
+        assertEquals(1, occurrences(configText, CodexConfigMerger.BEGIN_MARKER));
+        assertEquals(1, occurrences(configText, CodexConfigMerger.END_MARKER));
+
+        TomlParseResult config = Toml.parse(configFile);
+        assertFalse(config.hasErrors(), config.errors().toString());
+        TomlTable servers = (TomlTable) config.get("mcp_servers");
+        assertNotNull(servers);
+
+        WorkflowManifest workflow = WorkflowManifestLoader.loadDefault();
+        assertServer(servers, "camel", workflow.mcpServer("camel").allowedTools(),
+                ctx.distribution().camelMcpVersion());
+        assertServer(servers, "camel-knowledge", workflow.mcpServer("camel-knowledge").allowedTools(),
+                ctx.distribution().knowledgeMcpVersion());
+        assertServer(servers, "citrus", workflow.mcpServer("citrus").allowedTools(),
+                ctx.distribution().citrusMcpVersion());
+    }
+
+    @Test
+    void preservesUnrelatedValidCodexConfiguration() throws Exception {
+        Path codexDir = Files.createDirectories(tempDir.resolve(".codex"));
+        Files.writeString(codexDir.resolve("config.toml"), """
+                model_reasoning_effort = "high"
+
+                [mcp_servers.other]
+                command = "other-mcp"
+                enabled_tools = ["read"]
+                """);
+
+        new CodexGenerator().generate(createContext(tempDir));
+
+        TomlParseResult config = Toml.parse(codexDir.resolve("config.toml"));
+        assertFalse(config.hasErrors(), config.errors().toString());
+        assertEquals("high", config.getString("model_reasoning_effort"));
+        TomlTable servers = config.getTable("mcp_servers");
+        assertEquals("other-mcp", servers.getTable("other").getString("command"));
+        assertNotNull(servers.getTable("camel"));
+        assertNotNull(servers.getTable("camel-knowledge"));
+        assertNotNull(servers.getTable("citrus"));
+    }
+
+    @Test
+    void invalidExistingCodexConfigurationFailsWithoutChangingIt() throws Exception {
+        Path configFile = Files.createDirectories(tempDir.resolve(".codex")).resolve("config.toml");
+        String invalid = "model = [\n";
+        Files.writeString(configFile, invalid);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> new CodexGenerator().generate(createContext(tempDir)));
+
+        assertTrue(error.getMessage().contains("not valid TOML"));
+        assertEquals(invalid, Files.readString(configFile));
+    }
+
+    @Test
+    void conflictingCodexMcpTableFailsWithoutChangingIt() throws Exception {
+        Path configFile = Files.createDirectories(tempDir.resolve(".codex")).resolve("config.toml");
+        String existing = """
+                [mcp_servers.camel]
+                command = "custom"
+                """;
+        Files.writeString(configFile, existing);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> new CodexGenerator().generate(createContext(tempDir)));
+
+        assertTrue(error.getMessage().contains("already defines Camel-Kit MCP server tables"));
+        assertEquals(existing, Files.readString(configFile));
+    }
+
+    @Test
+    void repeatedGenerationReplacesManagedBlockWithoutDuplicates() throws Exception {
+        CodexGenerator generator = new CodexGenerator();
+        InitContext ctx = createContext(tempDir);
+        generator.generate(ctx);
+        String first = Files.readString(tempDir.resolve(".codex/config.toml"));
+
+        generator.generate(ctx);
+
+        String second = Files.readString(tempDir.resolve(".codex/config.toml"));
+        assertEquals(first, second);
+        assertEquals(1, occurrences(second, CodexConfigMerger.BEGIN_MARKER));
+    }
+
+    @Test
+    void refusesSymlinkedCodexDirectoryWithoutChangingExternalConfig() throws Exception {
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Path externalCodex = Files.createDirectories(tempDir.resolve("external-codex"));
+        Path externalConfig = externalCodex.resolve("config.toml");
+        String original = "model_reasoning_effort = \"high\"\n";
+        Files.writeString(externalConfig, original);
+        createSymlinkOrSkip(project.resolve(".codex"), externalCodex);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> new CodexGenerator().generate(createContext(project)));
+
+        assertTrue(error.getMessage().contains("symbolic link: .codex"));
+        assertEquals(original, Files.readString(externalConfig));
+        assertFalse(Files.exists(externalCodex.resolve("agents")));
+    }
+
+    @Test
+    void refusesNestedSymlinkedSkillsDirectoryWithoutWritingOutsideProject() throws Exception {
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Path agents = Files.createDirectories(project.resolve(".agents"));
+        Path externalSkills = Files.createDirectories(tempDir.resolve("external-skills"));
+        Path marker = externalSkills.resolve("keep.txt");
+        Files.writeString(marker, "unchanged");
+        createSymlinkOrSkip(agents.resolve("skills"), externalSkills);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> new CodexGenerator().generate(createContext(project)));
+
+        assertTrue(error.getMessage().contains("symbolic link: .agents/skills"));
+        assertEquals("unchanged", Files.readString(marker));
+        try (var files = Files.list(externalSkills)) {
+            assertEquals(List.of(marker), files.toList());
+        }
+    }
+
+    private InitContext createContext(Path projectDir) {
+        AgentConfig agent = AgentRegistry.get("codex");
+        return new InitContext(
+                agent,
+                "codex",
+                projectDir.resolve(".codex/commands"),
+                projectDir.resolve(agent.skillsDirectory()),
+                projectDir,
+                "camel-kit",
+                Printer.noop());
+    }
+
+    private void createSymlinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            Files.createSymbolicLink(link, target.toAbsolutePath());
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            org.junit.jupiter.api.Assumptions.assumeTrue(false,
+                    "Symbolic links are unavailable on this test platform: " + e.getMessage());
+        }
+    }
+
+    private long countSkillDirectories(Path skillsDir) throws Exception {
+        try (var paths = Files.list(skillsDir)) {
+            return paths.filter(Files::isDirectory)
+                    .filter(path -> !"shared".equals(path.getFileName().toString()))
+                    .count();
+        }
+    }
+
+    private void assertNoUnsupportedSlashSkillInvocations(WorkflowManifest workflow, Path skillsDir)
+            throws Exception {
+        String skillNames = workflow.skills().stream()
+                .map(skill -> Pattern.quote(skill.name()))
+                .collect(Collectors.joining("|"));
+        Pattern unsupported = Pattern.compile(
+                "(?<![A-Za-z0-9._/-])/(?:" + skillNames + ")(?![A-Za-z0-9-])");
+        try (var files = Files.walk(skillsDir)) {
+            for (Path markdown : files.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".md"))
+                    .toList()) {
+                var match = unsupported.matcher(Files.readString(markdown));
+                if (match.find()) {
+                    fail(markdown + " contains unsupported Codex invocation " + match.group());
+                }
+            }
+        }
+    }
+
+    private void assertServer(TomlTable servers, String name, List<String> expectedTools, String version) {
+        TomlTable server = (TomlTable) servers.get(name);
+        assertNotNull(server, name);
+        assertEquals("jbang", server.getString("command"));
+        assertEquals("prompt", server.getString("default_tools_approval_mode"));
+
+        Set<String> actualTools = new LinkedHashSet<>(strings(server.getArray("enabled_tools")));
+        assertEquals(new LinkedHashSet<>(expectedTools), actualTools);
+        assertTrue(strings(server.getArray("args")).stream().anyMatch(argument -> argument.contains(version)), name);
+    }
+
+    private List<String> strings(TomlArray values) {
+        return java.util.stream.IntStream.range(0, values.size())
+                .mapToObj(values::getString)
+                .toList();
+    }
+
+    private void assertNonBlankString(TomlParseResult parsed, String key) {
+        assertInstanceOf(String.class, parsed.get(key), key);
+        assertFalse(((String) parsed.get(key)).isBlank(), key);
+    }
+
+    private int occurrences(String content, String token) {
+        return content.split(java.util.regex.Pattern.quote(token), -1).length - 1;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -23,12 +23,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlTable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ResourceConsistencyTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String CODEX = AgentGeneratorStrategy.CODEX.descriptorValue();
     private static final String COPILOT = AgentGeneratorStrategy.COPILOT.descriptorValue();
     private static final String PI = AgentGeneratorStrategy.PI.descriptorValue();
 
@@ -133,6 +137,11 @@ class ResourceConsistencyTest {
 
             new DefaultGenerator().generate(ctx);
 
+            if (!ctx.agent().generatesCommandStubs()) {
+                assertFalse(Files.exists(ctx.commandsDir()), agentName + " must not generate command scaffolding");
+                continue;
+            }
+
             Set<String> generatedCommands;
             try (Stream<Path> files = Files.list(ctx.commandsDir())) {
                 generatedCommands = files
@@ -161,6 +170,14 @@ class ResourceConsistencyTest {
             InitContext ctx = createContext(agentName, projectDir);
 
             new DefaultGenerator().generate(ctx);
+
+            if (CODEX.equals(agentName)) {
+                TomlTable knowledgeServer = tomlServerConfig(agentName, projectDir, "camel-knowledge");
+                assertTomlTools(agentName, "enabled_tools", knowledgeServer, "camel-knowledge");
+                TomlTable citrusServer = tomlServerConfig(agentName, projectDir, "citrus");
+                assertTomlTools(agentName, "enabled_tools", citrusServer, "citrus");
+                continue;
+            }
 
             JsonNode knowledgeServer = serverConfig(agentName, projectDir, "camel-knowledge");
             if (COPILOT.equals(agentName)) {
@@ -276,6 +293,30 @@ class ResourceConsistencyTest {
         return server;
     }
 
+    private TomlTable tomlServerConfig(String agentName, Path projectDir, String serverId) throws IOException {
+        AgentConfig agent = AgentRegistry.get(agentName);
+        var config = Toml.parse(projectDir.resolve(agent.mcpConfigPath()));
+        assertFalse(config.hasErrors(), config.errors().toString());
+        TomlTable servers = config.getTable(agent.mcpServerContainerKey());
+        assertNotNull(servers, "Missing MCP server config for " + agentName);
+        TomlTable server = servers.getTable(serverId);
+        assertNotNull(server, "Missing " + serverId + " MCP server config for " + agentName);
+        return server;
+    }
+
+    private static void assertTomlTools(
+            String agentName, String field, TomlTable server, String workflowServer)
+            throws IOException {
+        TomlArray allowlist = server.getArray(field);
+        assertNotNull(allowlist, "Missing " + field + " allowlist for " + agentName);
+        Set<String> actual = java.util.stream.IntStream.range(0, allowlist.size())
+                .mapToObj(allowlist::getString)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        assertEquals(new LinkedHashSet<>(
+                WorkflowManifestLoader.loadDefault().mcpServer(workflowServer).allowedTools()), actual,
+                field + " allowlist for " + agentName + " must match " + workflowServer + " tools");
+    }
+
     private static List<Path> activeResourceFiles(Path root) throws IOException {
         List<Path> scanRoots = List.of(
                 root.resolve("camel-kit-core/src/main/resources/skills"),
@@ -328,9 +369,10 @@ class ResourceConsistencyTest {
 
     private static InitContext createContext(String agentName, Path projectDir) {
         AgentConfig agent = AgentRegistry.get(agentName);
-        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
-        Path commandsDir = projectDir.resolve(agent.folder());
-        Path skillsDir = projectDir.resolve(agentBaseFolder + "/skills");
+        Path commandsDir = agent.generatesCommandStubs()
+                ? projectDir.resolve(agent.commandDirectory())
+                : projectDir.resolve(".codex/commands");
+        Path skillsDir = projectDir.resolve(agent.skillsDirectory());
         return new InitContext(
                 agent, agentName, commandsDir, skillsDir, projectDir,
                 "camel-kit", Printer.noop());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ShippedAssetStructureTest.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.tomlj.Toml;
+import org.tomlj.TomlTable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -212,8 +214,12 @@ class ShippedAssetStructureTest {
             InitContext ctx = createContext(agentName, tempDir.resolve(agentName));
             AgentGeneratorFactory.create(agentName).generate(ctx);
 
-            assertGeneratedCommandFiles(agentName, ctx, generatedCommands);
-            assertGeneratedSkillReferencesResolve(agentName, ctx, generatedCommands);
+            if (ctx.agent().generatesCommandStubs()) {
+                assertGeneratedCommandFiles(agentName, ctx, generatedCommands);
+                assertGeneratedSkillReferencesResolve(agentName, ctx, generatedCommands);
+            } else {
+                assertFalse(Files.exists(ctx.commandsDir()), agentName + " must not generate command scaffolding");
+            }
             assertGeneratedMcpConfigIsValid(agentName, ctx);
         }
     }
@@ -471,19 +477,34 @@ class ShippedAssetStructureTest {
         Path configPath = ctx.projectDir().resolve(ctx.agent().mcpConfigPath());
         assertTrue(Files.isRegularFile(configPath), agentName + " MCP config must be generated at " + configPath);
 
+        if ("toml".equals(ctx.agent().mcpConfigFormat())) {
+            var root = Toml.parse(configPath);
+            assertFalse(root.hasErrors(), root.errors().toString());
+            TomlTable servers = root.getTable(ctx.agent().mcpServerContainerKey());
+            assertNotNull(servers, agentName + " MCP config missing " + ctx.agent().mcpServerContainerKey());
+            assertInstanceOf(TomlTable.class, servers.get("camel"), agentName + " MCP config missing camel server");
+            assertInstanceOf(TomlTable.class, servers.get("camel-knowledge"),
+                    agentName + " MCP config missing camel-knowledge server");
+            assertInstanceOf(TomlTable.class, servers.get("citrus"),
+                    agentName + " MCP config missing citrus server");
+            return;
+        }
+
         JsonNode root = MAPPER.readTree(configPath.toFile());
         JsonNode servers = root.get(ctx.agent().mcpServerContainerKey());
         assertNotNull(servers, agentName + " MCP config missing " + ctx.agent().mcpServerContainerKey());
         assertTrue(servers.has("camel"), agentName + " MCP config missing camel server");
         assertTrue(servers.has("camel-knowledge"), agentName + " MCP config missing camel-knowledge server");
+        assertTrue(servers.has("citrus"), agentName + " MCP config missing citrus server");
     }
 
     private static InitContext createContext(String agentName, Path projectDir) {
         AgentConfig agent = AgentRegistry.get(agentName);
         assertNotNull(agent, "Unexpected agent: " + agentName);
-        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
-        Path commandsDir = projectDir.resolve(agent.folder());
-        Path skillsDir = projectDir.resolve(agentBaseFolder + "/skills");
+        Path commandsDir = agent.generatesCommandStubs()
+                ? projectDir.resolve(agent.commandDirectory())
+                : projectDir.resolve(".codex/commands");
+        Path skillsDir = projectDir.resolve(agent.skillsDirectory());
         return new InitContext(
                 agent, agentName, commandsDir, skillsDir, projectDir,
                 "camel-kit", Printer.noop());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -9,6 +9,9 @@ import java.util.Locale;
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentGeneratorStrategy;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
+import io.github.luigidemasi.camelkit.generator.InitContext;
+import io.github.luigidemasi.camelkit.output.Printer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,6 +22,7 @@ class DoctorServiceTest {
 
     private static final DoctorExpectations EXPECTATIONS = DoctorExpectations.loadDefault();
     private static final String COPILOT = AgentGeneratorStrategy.COPILOT.descriptorValue();
+    private static final String CODEX = AgentGeneratorStrategy.CODEX.descriptorValue();
     private static final String PI = AgentGeneratorStrategy.PI.descriptorValue();
 
     @TempDir
@@ -75,6 +79,110 @@ class DoctorServiceTest {
         assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "workspace",
                 "Pi safety guard extension and policy are present",
                 "No action required."));
+    }
+
+    @Test
+    void healthyCodexWorkspaceValidatesTomlAgentsAndDoesNotRequireCommands() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertFalse(result.hasFailures(), result.findings().toString());
+        assertFalse(Files.exists(tempDir.resolve(".codex/commands")));
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
+                "Codex MCP config is valid TOML and all tool allowlists match Camel-Kit expectations",
+                "No action required."));
+        assertTrue(hasFinding(result, DoctorFinding.Status.PASS, "workspace",
+                "Codex custom agents are valid TOML and declare the required fields",
+                "No action required."));
+    }
+
+    @Test
+    void malformedCodexConfigProducesActionableFailure() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+        Files.writeString(tempDir.resolve(".codex/config.toml"), "[mcp_servers.camel\n");
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                "Codex MCP config is not valid TOML",
+                "camel-kit init --here --ai codex --force"));
+    }
+
+    @Test
+    void codexMcpApprovalModeMustRemainPrompt() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+        Path config = tempDir.resolve(".codex/config.toml");
+        Files.writeString(config, Files.readString(config)
+                .replace("default_tools_approval_mode = \"prompt\"",
+                        "default_tools_approval_mode = \"never\""));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                "default_tools_approval_mode must be 'prompt' for least privilege",
+                "default_tools_approval_mode = \"prompt\""));
+    }
+
+    @Test
+    void codexMcpEnabledToolsMustMatchTheGeneratedAllowlist() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+        Path config = tempDir.resolve(".codex/config.toml");
+        String firstTool = EXPECTATIONS.camelMcpTools().iterator().next();
+        Files.writeString(config, Files.readString(config)
+                .replace("\"" + firstTool + "\"", "\"" + firstTool + "\", \"unexpected_tool\""));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                "enabled_tools has extra unexpected_tool",
+                "update the allowlist"));
+    }
+
+    @Test
+    void missingCodexCustomAgentProducesActionableFailure() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+        Files.delete(tempDir.resolve(".codex/agents/camel-implementer.toml"));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "Codex custom agent is missing",
+                "camel-kit init --here --ai codex --force"));
+    }
+
+    @Test
+    void codexCustomAgentRequiresDocumentedFields() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+        Path agentFile = tempDir.resolve(".codex/agents/camel-implementer.toml");
+        Files.writeString(agentFile, Files.readString(agentFile)
+                .replace("name = \"camel_implementer\"", "name = \"\""));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "Codex custom agent is missing required fields: name",
+                "regenerate Codex agents"));
+    }
+
+    @Test
+    void codexResearchAgentsMustRemainReadOnly() throws Exception {
+        createHealthyWorkspace(tempDir, CODEX);
+        Path agentFile = tempDir.resolve(".codex/agents/camel-security-reviewer.toml");
+        Files.writeString(agentFile, Files.readString(agentFile)
+                .replace("sandbox_mode = \"read-only\"\n", ""));
+
+        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(result.hasFailures(), result.findings().toString());
+        assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "workspace",
+                "must declare sandbox_mode = 'read-only'",
+                "sandbox_mode = \"read-only\""));
     }
 
     @Test
@@ -341,6 +449,19 @@ class DoctorServiceTest {
         Files.writeString(root.resolve(".camel-kit/project-graph.json"), "{}");
         Files.writeString(root.resolve("AGENTS.md"), "Integration work -> /camel-start\n");
         Files.writeString(root.resolve("mvnw"), "#!/bin/sh\n");
+
+        if (CODEX.equals(agentName)) {
+            InitContext context = new InitContext(
+                    agent,
+                    agentName,
+                    root.resolve(".codex/commands"),
+                    root.resolve(agent.skillsDirectory()),
+                    root,
+                    "camel-kit",
+                    Printer.noop());
+            AgentGeneratorFactory.create(agentName).generate(context);
+            return;
+        }
 
         Path commands = root.resolve(agent.folder());
         String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf('/'));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -116,6 +116,28 @@ class InitServiceTest {
     }
 
     @Test
+    void initializesCodexWorkspaceWithNativeAssetsWithoutCommandStubs() throws Exception {
+        RecordingProgress progress = new RecordingProgress();
+        Path targetDir = tempDir.resolve("orders");
+
+        InitResult result = new InitService().initialize(
+                request(targetDir, "codex", progress, InitReporter.noop()));
+
+        assertEquals("codex", result.agentName());
+        assertTrue(Files.isRegularFile(targetDir.resolve("AGENTS.md")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".codex/config.toml")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".agents/skills/camel-start/SKILL.md")));
+        assertTrue(Files.isRegularFile(targetDir.resolve(".codex/agents/camel-implementer.toml")));
+        assertFalse(Files.exists(targetDir.resolve(".codex/commands")));
+        assertFalse(Files.exists(targetDir.resolve(".agents/commands")));
+        assertTrue(progress.events().contains("start:Generating OpenAI Codex CLI workspace"));
+
+        String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
+        assertTrue(config.contains("agent.name=codex"));
+        assertTrue(config.contains("agent.folder=.agents/skills"));
+    }
+
+    @Test
     void initPersistsRuntimeAndVersionConfig() throws Exception {
         Path targetDir = tempDir.resolve("orders");
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/workflow/WorkflowManifestTest.java
@@ -133,6 +133,11 @@ class WorkflowManifestTest {
             InitContext ctx = createContext(agentName);
             AgentGeneratorFactory.create(agentName).generate(ctx);
 
+            if (!ctx.agent().generatesCommandStubs()) {
+                assertFalse(Files.exists(ctx.commandsDir()), agentName + " must not generate a command directory");
+                continue;
+            }
+
             Set<String> expected = manifest.generatedCommandStubs().stream()
                     .map(command -> command.name() + "." + ctx.agent().fileFormat())
                     .collect(Collectors.toCollection(java.util.TreeSet::new));
@@ -337,9 +342,10 @@ class WorkflowManifestTest {
 
     private InitContext createContext(String agentName) {
         AgentConfig agent = AgentRegistry.get(agentName);
-        String agentBaseFolder = agent.folder().substring(0, agent.folder().lastIndexOf("/"));
-        Path commandsDir = tempDir.resolve(agent.folder());
-        Path skillsDir = tempDir.resolve(agentBaseFolder + "/skills");
+        Path commandsDir = agent.generatesCommandStubs()
+                ? tempDir.resolve(agent.commandDirectory())
+                : tempDir.resolve(".codex/commands");
+        Path skillsDir = tempDir.resolve(agent.skillsDirectory());
         return new InitContext(
                 agent, agentName, commandsDir, skillsDir, tempDir,
                 "camel-kit", Printer.noop());

--- a/docs/agent-architectures.md
+++ b/docs/agent-architectures.md
@@ -551,6 +551,61 @@ The generated safety hook is deliberately narrow. It denies `git push`, broad `r
 
 ---
 
+## OpenAI Codex CLI -- Project Skills + Native Custom Agents
+
+### Dispatch Model
+
+Codex reads repository instructions from `AGENTS.md`, discovers project skills under `.agents/skills/`, and loads
+custom roles from `.codex/agents/*.toml`. Camel-Kit generates planner, implementer, tester, validator, migrator,
+catalog researcher, and security reviewer roles. The parent session remains the orchestrator, dispatches independent
+tasks from the same implementation wave in parallel, and keeps dependent waves sequential. Delegated agents return
+results to the parent and do not spawn another layer. If delegation is unavailable, the skill runs inline.
+
+Codex does not use generated slash-command files, so Camel-Kit does not create `.codex/commands/`. Project config and
+any user-added project hooks are skipped until repository trust; Camel-Kit itself generates no hooks. After trusting
+the repository, users start with `$camel-start`, inspect skills with `/skills`, and inspect MCP servers with `/mcp`.
+
+### Template Files
+
+| File | Purpose |
+|------|---------|
+| `templates/codex/agents-md.md` | `AGENTS.md` -- entry point, laws, trust, sandbox, and approval guidance |
+| `templates/codex/agents/*.toml` | 7 custom-agent role definitions |
+| `templates/mcp-configs/codex-mcp.toml` | Three project MCP servers in `.codex/config.toml` |
+| `templates/dispatch/codex.md` | Parent-owned dispatch, parallel-wave, and inline-fallback guidance |
+
+### How It Works
+
+```text
+User: $camel-start
+  └── Codex loads AGENTS.md and .agents/skills/camel-start/SKILL.md
+      ├── Parent selects a generated .codex/agents role for isolated work
+      ├── Independent tasks in one plan wave may run in parallel
+      ├── Child roles return concise evidence to the parent orchestrator
+      └── MCP tools come from .codex/config.toml after repository trust
+```
+
+### Tool Restriction Model
+
+Camel-Kit leaves the user's Codex sandbox and approval policy in force. The catalog researcher and security reviewer
+declare `sandbox_mode = "read-only"`; other roles inherit the active policy. Each generated MCP server uses an exact
+`enabled_tools` list and `default_tools_approval_mode = "prompt"`. Camel-Kit writes only repository-scoped files: it
+does not change global Codex configuration or authentication and does not generate executable hooks.
+
+When `.codex/config.toml` already exists, init preserves unrelated valid settings and replaces only Camel-Kit's
+marked MCP block. Invalid TOML or conflicting managed server tables fail clearly without changing the existing file.
+
+### Unique Capabilities
+
+- **Native repository skills:** all shared Camel-Kit skills use Codex's `.agents/skills/` discovery path.
+- **Seven custom roles:** pipeline work maps to explicit Codex custom-agent definitions.
+- **Parent-owned parallel dispatch:** independent implementation-wave tasks can run together without recursive delegation.
+- **Trust-gated project config:** MCP configuration loads only for a trusted repository.
+- **Least-privilege MCP:** exact allowlists and per-call prompt approval for Camel, knowledge, and Citrus tools.
+- **Safe config composition:** managed-block replacement is idempotent and preserves unrelated project settings.
+
+---
+
 ## Pi -- Native Skills + Prompt Templates + Guard Extension
 
 ### Dispatch Model
@@ -601,14 +656,14 @@ container or VM concern.
 
 ## Agent Comparison
 
-| Aspect | Claude | Bob 1 legacy | Bob 2 | Gemini | Copilot | Pi | Qwen | OpenCode |
-|--------|--------|--------------|-------|--------|---------|----|------|----------|
-| Dispatch model | Parallel subagents | Mode switching | `spawn_subagent` (`explore`, `general`) | `invoke_subagent` unified tool (local/remote/browser) | Project skills + custom agents | Project skills + prompt templates | Dual: named subagent + fork | `task` tool creating child sessions |
-| Template files | 3 | 17+ | Bob 2 modes + traits + rules | 12 | 11 | 5 | 9 | 8 |
-| Tool restriction | Instruction-based | Mode tool groups | Mode tool groups + `allowedSubagents` | Allowlist + TOML policy + server-scoped wildcards | Custom-agent `tools` plus hooks | Guard extension + external sandbox | Allowlist + blocklist | 3-state permissions + bash glob patterns |
-| Path-scoped edits | No | `.md` only (via fileRegex) | Mode-dependent `fileRegex` | Yes (Policy Engine) | Tool-level, not path-scoped | No | No | Yes (glob patterns) |
-| MCP auto-approval | No (manual) | No (manual) | No (manual) | Yes (TOML policy) | No (permission prompts) | Adapter `directTools` | No (manual) | No (manual) |
-| Parallel execution | Yes (graph-based) | No | Yes (same-turn `spawn_subagent`) | Yes (scheduler `Promise.all()`) | Unknown | No native subagents | Partial (read-only tools concurrent; fork background) | Partial (LLM-level parallel tool calls) |
-| Subagent recursion | Yes (no limit) | N/A | No (subagents must not spawn subagents) | No (hardcoded `Kind.Agent` filter) | Unknown | N/A | No (fork-of-fork blocked) | Opt-in configurable depth |
-| Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Parent task orchestrates subagents | Main agent (recursion prevention) | Project skill delegates when available | Main Pi session | Sub-agent with `task` tool | Agent with `task` permission |
-| Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | Shared skills + Bob 2 traits + modes | `@file.md` modular imports | `.github/copilot-instructions.md` + project skills | `AGENTS.md` + `.pi/skills` | Single `QWEN.md` | Ultra-minimal `AGENTS.md` |
+| Aspect | Claude | Bob 1 legacy | Bob 2 | Gemini | Codex | Copilot | Pi | Qwen | OpenCode |
+|--------|--------|--------------|-------|--------|-------|---------|----|------|----------|
+| Dispatch model | Parallel subagents | Mode switching | `spawn_subagent` (`explore`, `general`) | `invoke_subagent` unified tool (local/remote/browser) | Project skills + custom agents | Project skills + custom agents | Project skills + prompt templates | Dual: named subagent + fork | `task` tool creating child sessions |
+| Template files | 3 | 17+ | Bob 2 modes + traits + rules | 12 | 10 | 11 | 5 | 9 | 8 |
+| Tool restriction | Instruction-based | Mode tool groups | Mode tool groups + `allowedSubagents` | Allowlist + TOML policy + server-scoped wildcards | Inherited sandbox/approvals + read-only research roles | Custom-agent `tools` plus hooks | Guard extension + external sandbox | Allowlist + blocklist | 3-state permissions + bash glob patterns |
+| Path-scoped edits | No | `.md` only (via fileRegex) | Mode-dependent `fileRegex` | Yes (Policy Engine) | No | Tool-level, not path-scoped | No | No | Yes (glob patterns) |
+| MCP auto-approval | No (manual) | No (manual) | No (manual) | Yes (TOML policy) | No (`prompt`) | No (permission prompts) | Adapter `directTools` | No (manual) | No (manual) |
+| Parallel execution | Yes (graph-based) | No | Yes (same-turn `spawn_subagent`) | Yes (scheduler `Promise.all()`) | Yes (independent waves) | Unknown | No native subagents | Partial (read-only tools concurrent; fork background) | Partial (LLM-level parallel tool calls) |
+| Subagent recursion | Yes (no limit) | N/A | No (subagents must not spawn subagents) | No (hardcoded `Kind.Agent` filter) | No (parent-owned) | Unknown | N/A | No (fork-of-fork blocked) | Opt-in configurable depth |
+| Execute phase | Subagent with parallel dispatch | Gate file with mode switch | Parent task orchestrates subagents | Main agent (recursion prevention) | Parent dispatches custom roles with inline fallback | Project skill delegates when available | Main Pi session | Sub-agent with `task` tool | Agent with `task` permission |
+| Instruction composition | Single `CLAUDE.md` | Modes + gates + rules | Shared skills + Bob 2 traits + modes | `@file.md` modular imports | `AGENTS.md` + `.agents/skills` | `.github/copilot-instructions.md` + project skills | `AGENTS.md` + `.pi/skills` | Single `QWEN.md` | Ultra-minimal `AGENTS.md` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,15 +48,16 @@ user_invocable: false
 | `guides/optional-guide.md` | When condition X | Supplementary guide |
 ```
 
-**Note:** Only `camel-start` sets `user_invocable: true` — it is the single auto-discovered entry point (meta-router). Pipeline and standalone skills (Tier 1/2) are invoked through generated command stubs on slash-command agents and through project skill selection on GitHub Copilot CLI. Internal skills are dispatched only by pipeline skills.
+**Note:** Only `camel-start` sets `user_invocable: true` — it is the single auto-discovered entry point (meta-router). Pipeline and standalone skills (Tier 1/2) are invoked through generated command stubs on slash-command agents and through native project skill selection on Codex CLI and GitHub Copilot CLI. Internal skills are dispatched only by pipeline skills.
 
 The frontmatter fields:
 - `name` -- skill identifier, used in cross-references
 - `description` -- trigger keywords that help agents match user intent to the correct skill
-- `user_invocable` -- `true` for `camel-start` (meta-router) only. Pipeline and standalone skills (Tier 1/2) still have generated entry points despite `user_invocable: false`: slash-command stubs for most agents and project skills for GitHub Copilot CLI. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills
+- `user_invocable` -- `true` for `camel-start` (meta-router) only. Pipeline and standalone skills (Tier 1/2) still have generated entry points despite `user_invocable: false`: slash-command stubs for most agents and project skills for Codex CLI and GitHub Copilot CLI. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills
 
 Agent-specific generators may add runtime aliases to copied skill files. For example, Copilot and Pi generated
-copies add `user-invocable: false` alongside Camel-Kit's source `user_invocable` metadata.
+copies add `user-invocable: false` alongside Camel-Kit's source `user_invocable` metadata. Codex generated copies
+adapt exact `/camel-*` skill invocations to native `$camel-*` mentions while leaving file paths unchanged.
 
 ### All Skills
 
@@ -76,7 +77,7 @@ copies add `user-invocable: false` alongside Camel-Kit's source `user_invocable`
 | `camel-knowledge` | No | `camel-brainstorm`, `camel-execute` | Routes questions to knowledge MCP tools |
 | `camel-debug` | No | `camel-start` (ad-hoc troubleshooting) | Standalone debugging: STOP → PRESERVE → DIAGNOSE → FIX → GUARD workflow |
 
-**Note:** Only `camel-start` has `user_invocable: true` in its skill metadata. Pipeline and standalone skills still have generated entry points despite `user_invocable: false`: slash-command stubs for most agents and project skills for GitHub Copilot CLI. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills.
+**Note:** Only `camel-start` has `user_invocable: true` in its skill metadata. Pipeline and standalone skills still have generated entry points despite `user_invocable: false`: slash-command stubs for most agents and project skills for Codex CLI and GitHub Copilot CLI. Internal skills (`camel-verify`, `camel-design`, `camel-implement`, `camel-test`) are dispatched only by pipeline skills.
 
 ### Shared Guides
 
@@ -344,11 +345,11 @@ Built-in agent metadata lives in `camel-kit-core/src/main/resources/agents/regis
 `AgentRegistry` loads these descriptors at startup and maps them into the public `AgentConfig` model used by
 commands and generators.
 
-Each descriptor defines the agent id, display name, command directory, command file format, argument placeholder,
-MCP config path, MCP config template path, MCP server container key, description, generator strategy, dispatch
-template path, templates installed by the agent-specific generator, and whether the agent supports sub-agents or
-traits. Missing required fields, duplicate ids, unsupported generator strategies, or malformed YAML fail during
-registry loading with a descriptor-specific error.
+Each descriptor defines the agent id, display name, skills directory, whether it generates command stubs, optional
+command directory and command syntax, MCP config path, template and format, MCP server container key, description,
+generator strategy, dispatch template path, templates installed by the agent-specific generator, and whether the
+agent supports sub-agents or traits. Missing required fields, duplicate ids, unsupported generator strategies, or
+malformed YAML fail during registry loading with a descriptor-specific error.
 
 ### What `camel-kit init` Generates
 
@@ -358,6 +359,7 @@ registry loading with a descriptor-specific error.
 | IBM Bob 1 legacy | `templates/bob/` | `custom_modes.yaml` + rules + gates | `.bob/mcp.json` | `.bob/skills/` |
 | IBM Bob 2 | `templates/bob2/` | `custom_modes.yaml` + rules + shared skills | `.bob/mcp.json` | `.bob/skills/` |
 | Gemini CLI | `templates/gemini/` | `GEMINI.md` + `@file.md` imports + policies | `.gemini/settings.json` | `.gemini/skills/` |
+| OpenAI Codex CLI | `templates/codex/` | `AGENTS.md` + `.codex/agents/*.toml` | `.codex/config.toml` | `.agents/skills/` |
 | GitHub Copilot CLI | `templates/copilot/` | `.github/copilot-instructions.md` + `.github/agents/` + hooks | `.github/mcp.json` | `.github/skills/` |
 | Pi | `templates/pi/` | `AGENTS.md` + `.pi/prompts/` + guard extension | `.mcp.json` | `.pi/skills/` |
 | Qwen | `templates/qwen/` | `QWEN.md` + sub-agent definitions | `.qwen/settings.json` | `.qwen/skills/` |
@@ -371,7 +373,7 @@ The active scan covers `camel-kit-core/src/main/resources/skills`, `camel-kit-co
 
 Docs subdirectories are intentionally out of scope; this keeps ignored archives such as `docs/plans/` and `docs/superpowers/`, image assets, and generated planning material out of the contract check.
 
-`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent descriptor has dispatch and MCP config templates, descriptor template sources exist, trait files target existing skills or guides, every shipped trait appears in generated output for its production agent generator, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as JSON with the expected server containers.
+`ShippedAssetStructureTest` covers structural coherence for shipped assets. It verifies that workflow manifest skills have `skills/<name>/SKILL.md`, guide tables in `SKILL.md` point to existing bundled files, shared guide references in shipped skills and templates resolve, every supported agent descriptor has dispatch and MCP config templates, descriptor template sources exist, trait files target existing skills or guides, every shipped trait appears in generated output for its production agent generator, generated command files match manifest command names, generated command skill references resolve to copied skills, and generated MCP configs parse as their declared JSON or TOML format with the expected server containers.
 
 Historical release notes, old planning material, and archived ADR-style documents are outside the active contract unless they are copied into generated projects or used as live instructions. Keep historical context in those files as history; do not exclude an active shipped instruction just because it is inconvenient to update.
 
@@ -441,6 +443,8 @@ Most supported agents use native **sub-agent dispatch** or custom-agent isolatio
 
 - **GitHub Copilot CLI** -- project skills live under `.github/skills/` and custom agents live under `.github/agents/`. Camel-Kit generates planner, implementer, tester, validator, migrator, catalog researcher, and security reviewer agents with Copilot tool aliases and MCP server prefixes. Internal guide skills copied for custom-agent use are marked `user-invocable: false` and `disable-model-invocation: true` using Copilot-readable metadata. MCP servers are committed in `.github/mcp.json` using Copilot's `tools` schema. Repository hooks under `.github/hooks/` provide a lightweight safety harness for destructive shell commands while keeping Copilot's normal permission prompts active.
 
+- **OpenAI Codex CLI** -- native project skills live under `.agents/skills/`, project instructions live in `AGENTS.md`, and seven custom roles live under `.codex/agents/`. Codex receives no command-stub directory; `$camel-start` and `/skills` are the entry points. The generated `.codex/config.toml` preserves unrelated valid project settings while adding three version-pinned MCP servers with exact `enabled_tools` lists and prompt approval. Repository trust controls whether project config loads, while the user's sandbox and approval settings remain authoritative. The parent Codex agent owns orchestration, dispatches independent wave work in parallel when supported, and falls back to inline execution when delegation is unavailable.
+
 - **Pi** -- project skills live under `.pi/skills/` and command stubs are generated as `.pi/prompts/` prompt templates. Pi reads `AGENTS.md` natively. MCP servers are committed in `.mcp.json` for `pi-mcp-adapter` using the adapter's `directTools` allowlist schema. Internal guide skills are marked `user-invocable: false` and `disable-model-invocation: true`; Pi currently honors only the model-invocation flag. A static `.pi/extensions/camel-kit-guard.ts` extension interprets `.pi/camel-kit-guard-policy.json` to block destructive or secret-sensitive tool calls. Pi has no native subagents, so custom-agent parity is deferred.
 
 **IBM Bob 2** uses Bob's native `spawn_subagent` tool. Camel-Kit exposes this as `--ai bob2`, but generated project files still live under `.bob/` because Bob reads `.bob/commands`, `.bob/skills`, `.bob/custom_modes.yaml`, and `.bob/mcp.json`.
@@ -468,7 +472,7 @@ The trade-off table:
 | Context isolation | Per-task (fresh sub-agent) | Per-session (accumulated) |
 | Reviewer independence | Separate sub-agent | Same session self-reviews |
 | Tool restriction mechanism | Instruction-based / tool whitelists / policies | Platform-enforced mode tool groups |
-| Parallel execution | Claude (graph topology), Bob 2 (`spawn_subagent` in one turn), Gemini (scheduler `Promise.all()`), Qwen (fork), OpenCode (LLM-level) | Not possible |
+| Parallel execution | Claude (graph topology), Bob 2 (`spawn_subagent` in one turn), Gemini (scheduler `Promise.all()`), Codex (independent waves), Qwen (fork), OpenCode (LLM-level) | Not possible |
 | Skill loading | Loaded into sub-agent context on dispatch | Inlined in monolithic gate files |
 | Template complexity | 3-12 files per agent | 17+ files (gates + rules + modes) |
 | Failure isolation | Sub-agent failure doesn't affect other tasks | Phase failure affects entire session |
@@ -481,6 +485,7 @@ The trade-off table:
 | IBM Bob 1 legacy | B+A hybrid with custom modes | Monolithic gate files, 3 checkpoint types |
 | IBM Bob 2 | Native `spawn_subagent` plus custom modes | `explore`/`general` subagents, parallel same-turn dispatch, shared skills |
 | Gemini CLI | `invoke_subagent` + parallel scheduler | Default-parallel `Promise.all()`, TOML policy, MCP wildcards, A2A remote agents |
+| OpenAI Codex CLI | Native custom-agent dispatch | `.agents/skills`, `.codex/agents`, prompt-gated MCP tools, inherited sandbox and approvals |
 | GitHub Copilot CLI | Project skills + custom agents + hooks | `.github/skills`, `.github/agents`, `.github/mcp.json`, safety hooks |
 | Pi | Project skills + prompt templates + guard extension | `.pi/skills`, `.pi/prompts`, `.mcp.json`, `pi-mcp-adapter`, trust-gated resources |
 | Qwen | Dual dispatch (named + fork) | Fork background tasks, DashScope cache sharing, auto-delegation |
@@ -492,8 +497,8 @@ For full per-agent deep dives (template files, tool restriction models, configur
 
 To add support for a new AI coding assistant:
 
-1. Add `agents/registry/{agent-name}.yaml` with command paths, MCP config path, generator strategy,
-   dispatch template, and capabilities.
+1. Add `agents/registry/{agent-name}.yaml` with the skills path, optional command-stub contract, MCP config path and
+   format, generator strategy, dispatch template, and capabilities.
 2. Create a template directory: `templates/{agent-name}/`
 3. Implement `{Agent}Generator extends DefaultGenerator` in `io.github.luigidemasi.camelkit.generator`
 4. Register the generator strategy in `AgentGeneratorStrategy` and `AgentGeneratorFactory`
@@ -796,7 +801,7 @@ user_invocable: false
 | `guides/main-guide.md` | Always | Primary instruction guide |
 ```
 
-**Note:** Only `camel-start` should have `user_invocable: true`. All other skills have `user_invocable: false`. Generated command stubs and Copilot project skills still work independently of this metadata.
+**Note:** Only `camel-start` should have `user_invocable: true`. All other skills have `user_invocable: false`. Generated command stubs and Codex/Copilot project skills still work independently of this metadata.
 
 3. **Write guide files** in `guides/`. Each guide is a self-contained markdown instruction file loaded by the agent when the skill is active.
 
@@ -807,14 +812,15 @@ user_invocable: false
    - IBM Bob 1 legacy: update `templates/bob/custom_modes.yaml`, gate files, and rules directories
    - IBM Bob 2: update `templates/bob2/custom_modes.yaml`, `templates/traits/bob2/`, and rules directories
    - Gemini CLI: update `templates/gemini/gemini-md.md`
+   - OpenAI Codex CLI: update `templates/codex/`, `templates/dispatch/codex.md`, and custom-agent TOML templates
    - GitHub Copilot CLI: update `templates/copilot/copilot-instructions.md`, `templates/copilot/agents-md.md`, and any affected `.github/agents` templates
    - Pi: update `templates/pi/agents-md.md`, `templates/dispatch/pi.md`, and guard policy templates when relevant
    - Qwen: update `templates/qwen/qwen-md.md`
    - OpenCode: update `templates/opencode/agents-md.md`
 
-6. **If changing an agent capability:** update `agents/registry/{agent}.yaml` when command directories,
-   file formats, MCP config paths, generator strategy, dispatch templates, installed templates, sub-agent support,
-   trait support, or capability labels change.
+6. **If changing an agent capability:** update `agents/registry/{agent}.yaml` when skills or command directories,
+   command-generation behavior, file formats, MCP config paths or formats, generator strategy, dispatch templates,
+   installed templates, sub-agent support, trait support, or capability labels change.
 
 7. **If internal:** update the loading skill's `SKILL.md` to reference the new guides (e.g., add a guide reference to `camel-execute`'s guide manifest).
 

--- a/docs/camel-kit-overview.md
+++ b/docs/camel-kit-overview.md
@@ -334,8 +334,11 @@ Camel-Kit works across multiple AI coding assistants. The same design-plan-execu
 | Agent | Provider |
 |-------|----------|
 | Claude Code | Anthropic |
-| Project Bob | IBM |
+| Project Bob 1 legacy / Bob 2 | IBM |
 | Gemini CLI | Google |
+| Codex CLI | OpenAI |
+| GitHub Copilot CLI | GitHub |
+| Pi | Community |
 | Qwen | Alibaba |
 | OpenCode | Community |
 
@@ -358,6 +361,9 @@ flowchart TB
         claude["CLAUDE.md\n(Claude)"]
         bob["custom_modes.yaml\n(Bob 1/Bob 2)"]
         gemini["GEMINI.md\n(Gemini)"]
+        codex["AGENTS.md + .codex/\n(Codex)"]
+        copilot[".github/ skills + agents\n(Copilot)"]
+        pi["AGENTS.md + .pi/\n(Pi)"]
         qwen["QWEN.md\n(Qwen)"]
         opencode["AGENTS.md\n(OpenCode)"]
     end
@@ -430,7 +436,7 @@ flowchart TB
 | Documentation | Knowledge MCP server (Apache Camel docs -- hybrid semantic search) |
 | Testing | Citrus MCP + Citrus YAML + Testcontainers |
 | IDE support | Kaoto (visual route and DataMapper editing) |
-| AI agents | Claude Code, IBM Bob 1 legacy, IBM Bob 2, Gemini CLI, Qwen, OpenCode |
+| AI agents | Claude Code, IBM Bob 1 legacy, IBM Bob 2, Gemini CLI, OpenAI Codex CLI, GitHub Copilot CLI, Pi, Qwen, OpenCode |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Camel-Kit Command Reference
 
-This document is the reference for all Camel-Kit commands: the `camel-kit` CLI, slash commands used inside most AI coding assistants, and GitHub Copilot CLI project skills.
+This document is the reference for all Camel-Kit commands: the `camel-kit` CLI, slash commands used inside most AI coding assistants, and native project skills used by Codex CLI and GitHub Copilot CLI.
 
 ## Table of Contents
 
@@ -36,6 +36,8 @@ Initialize a new Camel-Kit project.
 ```bash
 camel-kit init <project-name> [options]
 camel-kit init --here [options]
+camel kit init <project-name> [options]
+camel kit init --here [options]
 ```
 
 **Arguments:**
@@ -48,7 +50,7 @@ camel-kit init --here [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--ai`, `-a` | `bob2` | AI coding assistant to configure (`bob2` for IBM Bob 2, `bob` for IBM Bob 1 legacy, `gemini`, `claude`, `copilot`, `pi`, `qwen`, `opencode`) |
+| `--ai`, `-a` | `bob2` | AI coding assistant to configure (`bob2` for IBM Bob 2, `bob` for IBM Bob 1 legacy, `gemini`, `claude`, `codex`, `copilot`, `pi`, `qwen`, `opencode`) |
 | `--citrus-version` | `5.0.0-M2` | Citrus Framework version for test schemas and generated test dependencies |
 | `--here` | `false` | Initialize in current directory |
 | `--no-fetch` | `false` | Skip external catalog fetching |
@@ -76,6 +78,10 @@ camel-kit init my-integration --ai gemini
 
 # Create new project for Claude Code
 camel-kit init my-integration --ai claude
+
+# Create new project for OpenAI Codex CLI
+camel-kit init my-integration --ai codex
+camel kit init my-integration --ai codex
 
 # Create new project for GitHub Copilot CLI
 camel-kit init my-integration --ai copilot
@@ -201,6 +207,10 @@ my-integration/
 ├── .mcp.json                    # Claude Code or Pi MCP configuration
 ├── .bob/mcp.json                # IBM Bob MCP configuration
 ├── .gemini/mcp.json             # Gemini CLI MCP configuration
+├── AGENTS.md                    # Codex CLI, Pi, or OpenCode project instructions
+├── .agents/skills/              # Codex CLI project skills
+├── .codex/config.toml           # Codex CLI project MCP configuration
+├── .codex/agents/               # Codex CLI custom agents
 ├── .github/mcp.json             # GitHub Copilot CLI MCP configuration
 ├── .github/copilot-instructions.md
 ├── .github/agents/              # GitHub Copilot CLI custom agents
@@ -212,6 +222,8 @@ my-integration/
 ```
 
 The MCP configuration file created depends on the `--ai` option chosen.
+
+For OpenAI Codex CLI, Camel-Kit generates `AGENTS.md`, native project skills under `.agents/skills/`, seven custom agents under `.codex/agents/`, and the `camel`, `camel-knowledge`, and `citrus` MCP servers in `.codex/config.toml`. It does not create `.codex/commands/`; after trusting the repository, start with `$camel-start`, use `/skills` to inspect skills, and use `/mcp` to inspect servers. Codex skips project config and any project hooks until the repository is trusted. The three generated MCP servers use exact tool allowlists and `default_tools_approval_mode = "prompt"`. Existing valid, unrelated project configuration is preserved; invalid TOML or conflicting managed server tables cause init to fail without changing the existing config file. Camel-Kit does not change global Codex configuration or authentication and does not install project hooks.
 
 For GitHub Copilot CLI, Camel-Kit also generates `.github/copilot-instructions.md`, project skills under `.github/skills/`, custom agents under `.github/agents/`, and a conservative `.github/hooks/camel-kit-safety.json` hook that denies destructive or secret-sensitive shell commands while leaving normal Copilot permission prompts intact. Copilot users should start by asking Copilot to "Use the `/camel-start` skill." Run `/skills list` to inspect available project skills.
 
@@ -254,7 +266,7 @@ camel kit doctor --json
 
 **Checks:**
 
-`doctor` validates `.camel-kit/config.properties`, selected agent command stubs, skill directories and `SKILL.md` files, user-invocable command exposure, agent MCP config, MCP tool allowlists, graph availability, command prefix configuration, Java/Maven/JBang prerequisites, and common stale references in active generated files. Internal skills such as `camel-verify` must exist as skills, but must not be exposed as user command stubs.
+`doctor` validates `.camel-kit/config.properties`, selected agent command stubs when that target uses them, skill directories and `SKILL.md` files, user-invocable command exposure, agent MCP config, MCP tool allowlists, graph availability, command prefix configuration, Java/Maven/JBang prerequisites, and common stale references in active generated files. For Codex, it parses `.codex/config.toml`, checks all three exact MCP allowlists and prompt approval modes, and verifies that every generated custom-agent TOML file declares `name`, `description`, and `developer_instructions`. Internal skills such as `camel-verify` must exist as skills, but must not be exposed as user command stubs.
 
 Findings are printed as `PASS`, `WARN`, or `FAIL`. Missing external prerequisites are warnings so automated checks do not depend on the local machine having every optional tool installed. Broken generated workspace artifacts are failures and produce a non-zero exit code.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -143,6 +143,7 @@ camel-kit init order-processing --ai claude
 camel-kit init order-processing --ai bob      # IBM Bob 1 legacy
 camel-kit init order-processing --ai bob2     # IBM Bob 2
 camel-kit init order-processing --ai gemini
+camel-kit init order-processing --ai codex
 camel-kit init order-processing --ai copilot
 camel-kit init order-processing --ai pi
 camel-kit init order-processing --ai qwen
@@ -153,6 +154,7 @@ To initialize inside an existing directory:
 
 ```bash
 camel-kit init --here --ai claude
+camel kit init --here --ai codex
 ```
 
 ### Customizing Configuration
@@ -194,6 +196,11 @@ order-processing/
   docs/
     constitution.md          # 8 route quality rules
   .mcp.json                  # MCP server config (agent-specific location)
+  AGENTS.md                  # Codex, Pi, or OpenCode project instructions
+  .agents/skills/            # Codex project skills when --ai codex is selected
+  .codex/
+    config.toml              # Codex project MCP servers
+    agents/                  # Codex custom agents
   .github/                   # GitHub Copilot CLI assets when --ai copilot is selected
   .pi/                       # Pi skills, prompt templates, and guard extension when --ai pi is selected
   pom.xml                    # Maven project with Camel BOM
@@ -201,6 +208,8 @@ order-processing/
 ```
 
 The init command checks prerequisites (Java, JBang, Camel JBang, test plugin), copies skill files, configures MCP, and sets up the Maven wrapper so you can start designing immediately. If the target directory already contains a camel-kit project (`AGENTS.md` or `.camel-kit/`), init warns and exits — use `--force` to overwrite.
+
+With `--ai codex`, both `camel-kit init` and the Camel JBang plugin form `camel kit init` generate repository-scoped Codex resources. Trust the repository so Codex can load `.codex/config.toml`; Codex also skips any user-added project hooks until trust. Then start with `$camel-start`; `/skills` lists project skills and `/mcp` shows the three configured servers. Camel-Kit preserves unrelated valid project config, does not create `.codex/commands/`, and does not change global Codex settings, authentication, or hooks.
 
 ### Validating the Workspace
 
@@ -212,7 +221,7 @@ camel-kit doctor
 camel kit doctor
 ```
 
-`doctor` checks the generated configuration, command stubs, skill files, MCP config and allowlists, project graph, command prefix, prerequisites, and common stale generated references. It also verifies that internal skills such as `camel-verify` are present as skills but not exposed as user command stubs. It prints `PASS`, `WARN`, and `FAIL` findings with remediation text. External tools such as JBang and Camel JBang are reported as warnings when unavailable; broken generated workspace files are failures.
+`doctor` checks the generated configuration, command stubs where applicable, skill files, MCP config and allowlists, project graph, command prefix, prerequisites, and common stale generated references. It also verifies that internal skills such as `camel-verify` are present as skills but not exposed as user command stubs. For Codex, it validates the TOML config, the `camel`, `camel-knowledge`, and `citrus` server allowlists and prompt approval modes, plus required fields in all custom-agent files. It prints `PASS`, `WARN`, and `FAIL` findings with remediation text. External tools such as JBang and Camel JBang are reported as warnings when unavailable; broken generated workspace files are failures.
 
 For automation:
 
@@ -724,6 +733,7 @@ The same skills work across all supported AI coding assistants. Camel-Kit uses m
 | **Bob 1 legacy** (IBM Bob) | `--ai bob` | Switches between custom modes and monolithic gate files |
 | **Bob 2** (IBM Bob, default) | `--ai bob2` | Uses native `spawn_subagent` plus Bob custom modes and shared skills |
 | **Gemini** (Google Gemini CLI) | `--ai gemini` | Dispatches to 6 subagents; execute phase runs in main agent |
+| **OpenAI Codex CLI** | `--ai codex` | Uses `AGENTS.md`, `.agents/skills`, seven `.codex/agents`, and `.codex/config.toml` |
 | **GitHub Copilot CLI** | `--ai copilot` | Uses `.github/skills`, `.github/agents`, `.github/mcp.json`, and repository safety hooks |
 | **Pi** | `--ai pi` | Uses `.pi/skills`, `.pi/prompts`, `.mcp.json` through `pi-mcp-adapter`, and a project guard extension |
 | **Qwen** (Alibaba Qwen CLI) | `--ai qwen` | Auto-delegates to 7 sub-agents based on intent matching |
@@ -735,28 +745,29 @@ All agents produce the same output (YAML routes, properties files, tests). The d
 
 | If you value... | Consider |
 |-----------------|----------|
-| **Speed** (parallel implementation of independent flows) | Claude or Bob 2 |
+| **Speed** (parallel implementation of independent flows) | Claude, Bob 2, or Codex CLI |
 | **Safety** (strictest tool restrictions per phase) | Bob 1 legacy, Bob 2, or OpenCode |
 | **Automatic routing** (say what you want, agent picks the right phase) | Qwen |
 | **Customizability** (override policies, compose instructions) | Gemini or GitHub Copilot CLI |
 | **GitHub-native agent workflows** (skills, custom agents, hooks, MCP) | GitHub Copilot CLI |
+| **Codex-native repository workflows** (skills, custom agents, sandbox, approvals, MCP) | OpenAI Codex CLI |
 | **Fine-grained file permissions** (auto-allow test dirs, ask for source) | OpenCode |
 
 ### What Differs Between Agents
 
 | Aspect | What You'll Notice |
 |--------|-------------------|
-| **Dispatch transparency** | Claude and Bob 2 show subagent dispatch; Bob 1 legacy shows mode switching; Gemini/Qwen/OpenCode/Copilot delegate to specialized agents; Pi runs in the main session |
-| **Tool restrictions** | During brainstorm, Bob modes can physically prevent code edits. Claude and Qwen rely on skill instructions. OpenCode uses glob-pattern permissions. Copilot uses tool allow/deny permissions and generated safety hooks. Pi uses a generated guard extension plus external sandboxing when needed. |
-| **Parallel execution** | Claude and Bob 2 can dispatch independent tasks in the same wave; other agents have more limited parallelism |
-| **MCP approval prompts** | Gemini auto-approves MCP tool calls via its policy engine. Copilot uses `.github/mcp.json` plus Copilot's permission system. Pi uses `pi-mcp-adapter` `directTools`. Other agents may prompt you for each MCP call. |
+| **Dispatch transparency** | Claude, Bob 2, and Codex show subagent dispatch; Bob 1 legacy shows mode switching; Gemini/Qwen/OpenCode/Copilot delegate to specialized agents; Pi runs in the main session |
+| **Tool restrictions** | During brainstorm, Bob modes can physically prevent code edits. Claude and Qwen rely on skill instructions. Codex keeps the active sandbox and approval policy. OpenCode uses glob-pattern permissions. Copilot uses tool allow/deny permissions and generated safety hooks. Pi uses a generated guard extension plus external sandboxing when needed. |
+| **Parallel execution** | Claude, Bob 2, and Codex can dispatch independent tasks in the same wave; other agents have more limited parallelism |
+| **MCP approval prompts** | Codex uses exact `enabled_tools` allowlists with prompt approval. Gemini auto-approves MCP tool calls via its policy engine. Copilot uses `.github/mcp.json` plus Copilot's permission system. Pi uses `pi-mcp-adapter` `directTools`. Other agents may prompt you for each MCP call. |
 | **Execution limits** | OpenCode and Gemini enforce step/turn limits per phase. Other agents have no hard limits. |
 
 ### How Execution Works: Subagents vs. Mode Switching
 
 During `/camel-execute`, the AI must implement multiple tasks, review each one, and fix issues -- all autonomously. How it manages this work internally depends on the agent's native capabilities.
 
-**Agents with subagent support (Claude, Bob 2, Gemini, GitHub Copilot CLI, Qwen, OpenCode)** dispatch each pipeline task to a fresh, isolated subagent. The subagent receives only the information it needs -- the task description, the relevant design spec section, and the skill guides -- and works in its own context window. When it finishes, a separate reviewer subagent checks the output. This isolation prevents cross-contamination: a mistake in one task cannot leak into the next, and the reviewer has no bias from having written the code.
+**Agents with subagent support (Claude, Bob 2, Gemini, OpenAI Codex CLI, GitHub Copilot CLI, Qwen, OpenCode)** dispatch each pipeline task to a fresh, isolated subagent. The subagent receives only the information it needs -- the task description, the relevant design spec section, and the skill guides -- and works in its own context window. When it finishes, a separate reviewer subagent checks the output. This isolation prevents cross-contamination: a mistake in one task cannot leak into the next, and the reviewer has no bias from having written the code.
 
 The execution loop for these agents:
 
@@ -773,11 +784,11 @@ The execution loop for these agents:
 
 The Bob 1 trade-off is that work stays in a single session and reviewer checks are not isolated. The compensation is strict platform-enforced mode restrictions. Bob 2 keeps those mode restrictions where useful and adds native isolated subagents.
 
-| Capability | Subagent Agents (Claude, Bob 2, Gemini, Copilot, Qwen, OpenCode) | Bob 1 Legacy Mode Switching |
+| Capability | Subagent Agents (Claude, Bob 2, Gemini, Codex, Copilot, Qwen, OpenCode) | Bob 1 Legacy Mode Switching |
 |-----------|----------------------------------------------------------|-----------------------------|
 | Context isolation per task | Fresh subagent with clean context | Same session, accumulated context |
 | Reviewer independence | Separate subagent reviews the work | Same session reviews its own work |
-| Parallel execution | Claude and Bob 2 for implementation waves; other agents vary | Not possible |
+| Parallel execution | Claude, Bob 2, and Codex for implementation waves; other agents vary | Not possible |
 | Tool restriction enforcement | Varies by agent; Bob 2 combines modes with subagent restrictions | Platform-enforced mode restrictions |
 | Phase transition | Dispatch subagent or switch mode depending on agent | Switch custom mode |
 
@@ -792,7 +803,7 @@ Skills are markdown instruction files that the AI agent loads and follows. Becau
 - The same MCP tools are called
 - The same output formats are produced
 
-The dispatch model is internal to the agent. For most agents, you run the same commands (`/camel-brainstorm`, `/camel-execute`, etc.) and get the same artifacts. For GitHub Copilot CLI, use the same skill names through Copilot project skills; start with a direct instruction such as "Use the `/camel-start` skill." Run `/skills list` to inspect available project skills.
+The dispatch model is internal to the agent. For most agents, you run the same commands (`/camel-brainstorm`, `/camel-execute`, etc.) and get the same artifacts. For Codex CLI, start with `$camel-start` and inspect project skills with `/skills`. For GitHub Copilot CLI, use the same skill names through Copilot project skills; start with a direct instruction such as "Use the `/camel-start` skill." Run `/skills list` to inspect available project skills.
 
 For contributor-level details on each agent's architecture (template files, permission models, dispatch internals), see [Agent Architectures](agent-architectures.md).
 
@@ -820,11 +831,14 @@ MCP is auto-configured during `camel-kit init`. The init command creates agent-s
 - **Claude:** `.mcp.json`
 - **Bob:** `.bob/mcp.json`
 - **Gemini:** `.gemini/mcp.json`
+- **OpenAI Codex CLI:** `.codex/config.toml`
 - **GitHub Copilot CLI:** `.github/mcp.json`
 - **Pi:** `.mcp.json` via `pi-mcp-adapter`
 - **Qwen/OpenCode:** agent-specific config locations
 
 GitHub Copilot CLI workspaces also get `.github/copilot-instructions.md`, `.github/skills/`, `.github/agents/`, and `.github/hooks/camel-kit-safety.json`. Internal guide skills copied for custom-agent use are marked so Copilot does not directly or automatically invoke them. The generated hook denies obvious destructive or secret-sensitive shell commands such as `git push`, broad `rm -rf`, `chmod 777`, and reads of common secret files, while leaving normal Copilot permissions in place. Workspace MCP servers from `.github/mcp.json` load only after the repository folder is trusted.
+
+Codex CLI workspaces get `AGENTS.md`, `.agents/skills/`, seven `.codex/agents/*.toml` role definitions, and `.codex/config.toml`. Project config and any user-added project hooks load only after repository trust; Camel-Kit itself generates no hooks. Camel-Kit configures the Camel catalog, Camel knowledge, and Citrus servers with their pinned distribution versions, exact `enabled_tools` lists, and `default_tools_approval_mode = "prompt"`; it leaves global Codex config, authentication, approvals, and sandbox settings alone.
 
 Pi workspaces also get `AGENTS.md`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/camel-kit-guard.ts`, and `.pi/camel-kit-guard-policy.json`. Install `pi-mcp-adapter` with `pi install npm:pi-mcp-adapter@2.11.0`, run `/trust`, then invoke `/skill:camel-start`. For headless validation, use `pi -a` so Pi loads project resources.
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <jackson.version>2.19.2</jackson.version>
         <jline.version>3.30.6</jline.version>
         <tamboui.version>0.1.0</tamboui.version>
+        <tomlj.version>1.1.1</tomlj.version>
         <quarkus.version>3.20.2.2</quarkus.version>
         <quarkus-mcp.version>1.6.1</quarkus-mcp.version>
         <camel.version>4.21.0</camel.version>
@@ -192,6 +193,12 @@
                 <groupId>io.quarkus.qute</groupId>
                 <artifactId>qute-core</artifactId>
                 <version>${quarkus.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.tomlj</groupId>
+                <artifactId>tomlj</artifactId>
+                <version>${tomlj.version}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
## Summary

- add `--ai codex` to both Camel-Kit init entry points and registry diagnostics
- generate Codex-native `AGENTS.md`, `.agents/skills/`, repository TOML, and seven custom-agent roles without command scaffolding
- preserve unrelated `.codex/config.toml` settings through validated, atomic managed-block updates
- add Codex-aware doctor checks, least-privilege MCP defaults, supported subagent guidance, and inline fallback
- document the target in the CLI guides and Unreleased changelog

## Testing

- `./mvnw clean install` (full five-module reactor with all tests)
- isolated Codex CLI 0.144.1 smoke for instruction, skill, custom-agent, and MCP discovery
- `git diff --check`
- companion website: `npm ci --offline --ignore-scripts` and `npm run build` (40 pages)

## Website impact

Required. Companion documentation: https://github.com/luigidemasi/camel-kit-web/pull/21

The website PR is stacked on https://github.com/luigidemasi/camel-kit-web/pull/20, which establishes the current site baseline.

Closes #142

Generated by Codex via /oss-fix-issue
