### PR TITLE
Fix #98: make snapshot installation self-contained

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,3 +32,48 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.MVN_CENTRAL_USER }}
           MAVEN_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
+
+  smoke-install:
+    name: Verify snapshot installation
+    needs: deploy
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install snapshot in a clean JBang container
+        run: |
+          snapshot_version=$(awk -F'[<>]' '/^[[:space:]]*<version>/{print $3; exit}' pom.xml)
+          [[ "$snapshot_version" == *-SNAPSHOT ]]
+
+          for attempt in {1..10}; do
+            if docker run --rm \
+              --entrypoint /bin/bash \
+              -e SNAPSHOT_VERSION="$snapshot_version" \
+              docker.io/jbangdev/jbang-action:0.139.3@sha256:f5d2d51955d4b6c8ed005b880e6b5f48f0322585298d7e3c146f8241e2d44b01 -lc '
+                set -euo pipefail
+                export HOME=/tmp/camel-kit-smoke
+                export JBANG_DIR="$HOME/.jbang"
+                export JBANG_REPO="$HOME/.m2/repository"
+                export JAVA_TOOL_OPTIONS="-Duser.home=$HOME -Dmaven.repo.local=$JBANG_REPO"
+                export JBANG_NO_VERSION_CHECK=1
+                export PATH="$JBANG_DIR/bin:/jbang/bin:$PATH"
+
+                mkdir -p "$HOME" "$JBANG_REPO"
+                jbang trust add https://github.com/luigidemasi/camel-kit/
+                jbang app install camel-kit@luigidemasi/camel-kit
+                test "$(camel-kit --version)" = "$SNAPSHOT_VERSION"
+              '; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 10 ]; then
+              exit 1
+            fi
+
+            echo "Snapshot not visible yet; retrying in 30 seconds"
+            sleep 30
+          done

--- a/camel-kit-main/dist/CamelKit.java
+++ b/camel-kit-main/dist/CamelKit.java
@@ -3,6 +3,7 @@
 //JAVA 17+
 
 //REPOS central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots
+//REPOS central_snap=https://central.sonatype.com/repository/maven-snapshots/
 //DEPS io.github.luigidemasi:camel-kit-core:${camel.kit.version:0.3.2-SNAPSHOT}
 
 package main;

--- a/camel-kit-main/src/main/jbang/main/CamelKit.java
+++ b/camel-kit-main/src/main/jbang/main/CamelKit.java
@@ -3,6 +3,7 @@
 //JAVA 17+
 
 //REPOS central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots
+//REPOS central_snap=https://central.sonatype.com/repository/maven-snapshots/
 //DEPS io.github.luigidemasi:camel-kit-core:${camel.kit.version:0.3.2-SNAPSHOT}
 
 package main;


### PR DESCRIPTION
## Summary

- add Central Portal Snapshots to the standalone JBang launcher
- verify every successful main-branch snapshot deployment with an isolated, digest-pinned JBang container
- retry whole containers during publication propagation and assert the exact snapshot version

## Validation

- `./mvnw clean install`
- `./mvnw -pl camel-kit-main -am test`
- clean digest-pinned JBang container local catalog installation (`0.3.2-SNAPSHOT`)
- workflow YAML and shell parsing
- `git diff --check`

Closes #98

Website impact: not required — this restores the already-documented installation behavior.
