### PR TITLE
Fix #147: downgrade Citrus MCP to 5.0.0-M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Citrus MCP startup (#147)** — downgraded the generated MCP runner from `5.0.0-M2`, which fails during Quarkus startup with an incompatible JSON Schema Generator dependency, to the verified working `5.0.0-M1` release. Citrus test schemas and dependencies remain on `5.0.0-M2`.
+
 - **Adversarial review findings (#126)** — hardened graph building, init/doctor contracts, generator failure handling, distribution assets, and shipped skill content:
   - Secure XML parsing (XXE/DTD disabled) in `XmlRouteParser` and `MuleXmlFlowParser`; parser failures and warnings now surface through `graph generate`, `doctor`, and `init` instead of producing silently empty graphs
   - `GraphSerializer.read` validates format version and required fields; graph visualizer escapes embedded JSON against `</script>` injection
@@ -77,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Citrus MCP integration for test generation** — generated agent MCP configs now include the published Citrus MCP server (`org.citrusframework:citrus-mcp-server:5.0.0-M2`) so `camel-test` can verify Citrus YAML actions, endpoints, and schemas during test generation.
+- **Citrus MCP integration for test generation** — generated agent MCP configs now include the published Citrus MCP server (`org.citrusframework:citrus-mcp-server:5.0.0-M1`) so `camel-test` can verify Citrus YAML actions, endpoints, and schemas during test generation.
   - Added Citrus distribution properties (`citrus.version`, `citrus.mcp.version`, `citrus.mcp.repos`)
   - `--citrus-version default` now resolves to `5.0.0-M2`
   - Generated project config records `citrus.version`

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 public class DistributionConfig {
 
     private static final String DEFAULT_CITRUS_VERSION = "5.0.0-M2";
-    private static final String DEFAULT_CITRUS_MCP_VERSION = "5.0.0-M2";
+    private static final String DEFAULT_CITRUS_MCP_VERSION = "5.0.0-M1";
     private static final String DEFAULT_PI_VERSION = "0.80.3";
     private static final String DEFAULT_PI_MCP_ADAPTER_VERSION = "2.11.0";
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -83,7 +83,7 @@ class DistributionConfigTest {
         assertEquals("4.21.0", config.camelMcpVersion());
         assertEquals("0.0.1-SNAPSHOT", config.knowledgeMcpVersion());
         assertEquals("5.0.0-M2", config.citrusVersion());
-        assertEquals("5.0.0-M2", config.citrusMcpVersion());
+        assertEquals("5.0.0-M1", config.citrusMcpVersion());
         assertEquals("central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots",
                 config.camelMcpRepos());
         assertEquals("central=https://repo1.maven.org/maven2/", config.knowledgeMcpRepos());
@@ -139,7 +139,7 @@ class DistributionConfigTest {
         DistributionConfig config = DistributionConfig.load(properties);
 
         assertEquals("4.9.2", config.citrusVersion());
-        assertEquals("5.0.0-M2", config.citrusMcpVersion());
+        assertEquals("5.0.0-M1", config.citrusMcpVersion());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CodexCliSmokeTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/CodexCliSmokeTest.java
@@ -51,7 +51,8 @@ class CodexCliSmokeTest {
         generateWorkspace(workspace, environment);
 
         CommandResult prompt = runCodex(
-                List.of("codex", "-C", workspace.toString(), "debug", "prompt-input", "smoke"),
+                List.of("codex", "-C", workspace.toString(), "debug", "prompt-input",
+                        "-c", "mcp_servers.citrus.enabled=false", "smoke"),
                 workspace,
                 environment);
         assertEquals(0, prompt.exitCode(), "Codex did not render the isolated prompt input");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -17,6 +17,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class InitServiceTest {
 
+    private static final String EXPECTED_CITRUS_MCP_VERSION = "5.0.0-M1";
+
     @TempDir
     Path tempDir;
 
@@ -46,7 +48,7 @@ class InitServiceTest {
         assertTrue(config.contains("agent.name=bob"));
         assertTrue(config.contains("project.sourcePlatform=mulesoft"));
         assertTrue(config.contains("citrus.version=5.0.0-M2"));
-        assertTrue(config.contains("citrus.mcp.version=5.0.0-M1"));
+        assertTrue(config.contains("citrus.mcp.version=" + EXPECTED_CITRUS_MCP_VERSION));
 
         assertTrue(progress.events().contains("start:Creating project structure"));
         assertTrue(progress.events().contains("start:Generating IBM Project Bob workspace"));
@@ -177,9 +179,10 @@ class InitServiceTest {
         assertEquals("4.9.2", result.citrusVersion());
         String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
         assertTrue(config.contains("citrus.version=4.9.2"));
-        assertTrue(config.contains("citrus.mcp.version=5.0.0-M1"));
+        assertTrue(config.contains("citrus.mcp.version=" + EXPECTED_CITRUS_MCP_VERSION));
         String mcp = Files.readString(targetDir.resolve(".bob/mcp.json"));
-        assertTrue(mcp.contains("org.citrusframework:citrus-mcp-server:5.0.0-M1:runner"));
+        assertTrue(mcp.contains(
+                "org.citrusframework:citrus-mcp-server:" + EXPECTED_CITRUS_MCP_VERSION + ":runner"));
         assertFalse(mcp.contains("org.citrusframework:citrus-mcp-server:4.9.2:runner"));
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -46,7 +46,7 @@ class InitServiceTest {
         assertTrue(config.contains("agent.name=bob"));
         assertTrue(config.contains("project.sourcePlatform=mulesoft"));
         assertTrue(config.contains("citrus.version=5.0.0-M2"));
-        assertTrue(config.contains("citrus.mcp.version=5.0.0-M2"));
+        assertTrue(config.contains("citrus.mcp.version=5.0.0-M1"));
 
         assertTrue(progress.events().contains("start:Creating project structure"));
         assertTrue(progress.events().contains("start:Generating IBM Project Bob workspace"));
@@ -177,9 +177,9 @@ class InitServiceTest {
         assertEquals("4.9.2", result.citrusVersion());
         String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
         assertTrue(config.contains("citrus.version=4.9.2"));
-        assertTrue(config.contains("citrus.mcp.version=5.0.0-M2"));
+        assertTrue(config.contains("citrus.mcp.version=5.0.0-M1"));
         String mcp = Files.readString(targetDir.resolve(".bob/mcp.json"));
-        assertTrue(mcp.contains("org.citrusframework:citrus-mcp-server:5.0.0-M2:runner"));
+        assertTrue(mcp.contains("org.citrusframework:citrus-mcp-server:5.0.0-M1:runner"));
         assertFalse(mcp.contains("org.citrusframework:citrus-mcp-server:4.9.2:runner"));
     }
 

--- a/distribution.properties
+++ b/distribution.properties
@@ -48,7 +48,7 @@ spring.boot.4.14.7=3.5.12
 camel.mcp.version=4.21.0
 knowledge.mcp.version=0.0.1-SNAPSHOT
 citrus.version=5.0.0-M2
-citrus.mcp.version=5.0.0-M2
+citrus.mcp.version=5.0.0-M1
 
 # ─── Forage (KaotoIO) ────────────────────────────────────────────────────────
 #

--- a/distribution.properties
+++ b/distribution.properties
@@ -48,6 +48,7 @@ spring.boot.4.14.7=3.5.12
 camel.mcp.version=4.21.0
 knowledge.mcp.version=0.0.1-SNAPSHOT
 citrus.version=5.0.0-M2
+# Temporary compatibility pin for #147; revisit after the upstream M2 startup incompatibility is fixed.
 citrus.mcp.version=5.0.0-M1
 
 # ─── Forage (KaotoIO) ────────────────────────────────────────────────────────

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -179,7 +179,7 @@ Any property from `distribution.properties` can be overridden at layers 2 or 3. 
 | `camel.mcp.version` | See `distribution.properties` | Camel MCP server version |
 | `knowledge.mcp.version` | `0.0.1-SNAPSHOT` | Knowledge MCP server version |
 | `citrus.version` | `5.0.0-M2` | Citrus test schema and dependency version |
-| `citrus.mcp.version` | `5.0.0-M2` | Citrus MCP server artifact version |
+| `citrus.mcp.version` | `5.0.0-M1` | Citrus MCP server artifact version |
 
 **Output:**
 


### PR DESCRIPTION
## Summary

- pin the generated Citrus MCP runner to verified working version `5.0.0-M1`
- keep Citrus Framework schemas and generated test dependencies on `5.0.0-M2`
- update generated-coordinate regression expectations and isolate the Codex prompt-render smoke test from the live Citrus process
- document the temporary compatibility pin in the command reference and changelog

Fixes #147.

Website impact is addressed by luigidemasi/camel-kit-web#26 and https://github.com/luigidemasi/camel-kit-web/pull/27.

## Validation

- direct JBang startup smoke for `org.citrusframework:citrus-mcp-server:5.0.0-M1:runner`
- targeted Camel Kit tests: 26 passed
- `./mvnw clean install`: 187 graph tests, 343 core tests, and 3 JBang-plugin tests passed

## Merge order

No strict merge order is required. The website PR documents the version split introduced here.

## Summary by Sourcery

Pin the generated Citrus MCP server runner to a compatible version and update configuration, tests, and docs to reflect the split between Citrus framework and MCP versions.

Bug Fixes:
- Downgraded the generated Citrus MCP server runner from 5.0.0-M2 to the verified working 5.0.0-M1 to avoid Quarkus startup failures caused by an incompatible dependency.

Documentation:
- Documented the Citrus MCP version pin and framework/MCP version split in the changelog and command reference.

Tests:
- Adjusted distribution and init-related tests, including Codex prompt smoke testing, to expect the pinned Citrus MCP server version and to avoid depending on a live Citrus MCP process.

Chores:
- Updated default distribution properties and configuration constants so the Citrus MCP server version defaults to 5.0.0-M1 while keeping Citrus framework artifacts on 5.0.0-M2.