### PR TITLE
Harden Ship foundation capability boundaries

### DIFF
--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
@@ -3,15 +3,19 @@ package io.github.luigidemasi.camelkit.ship;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.nio.channels.Channel;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,6 +25,8 @@ import io.github.luigidemasi.camelkit.ship.context.ContextFilesystemPolicy;
 import io.github.luigidemasi.camelkit.ship.context.ContextResolution;
 import io.github.luigidemasi.camelkit.ship.context.InitialContext;
 import io.github.luigidemasi.camelkit.ship.security.ProjectContextFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 
 import org.junit.jupiter.api.Test;
 
@@ -178,6 +184,7 @@ class ShipFoundationBoundaryTest {
             "java/util/ServiceLoader",
             "java/util/jar/",
             "java/util/zip/");
+    // javap -v instruction, constant-pool, and bootstrap output is checked by JavapFormatCanary below.
     private static final String METHOD_REFERENCE_PREFIX
             = "(?:REF_(?:invoke[A-Za-z]+|newInvokeSpecial)\\s+"
               + "|(?:Interface)?Methodref\\s+#[^\\r\\n]*//\\s+"
@@ -373,15 +380,19 @@ class ShipFoundationBoundaryTest {
         Path testClasses = Path.of(ShipFoundationBoundaryTest.class.getProtectionDomain()
                 .getCodeSource().getLocation().toURI());
         ToolProvider javap = ToolProvider.findFirst("javap").orElseThrow();
-        String methodReference = jdeps(
+        String javapCanary = jdeps(
                 javap,
                 "-classpath", testClasses.toString(),
                 "-v",
                 "-p",
-                ForbiddenMethodReference.class.getName());
+                JavapFormatCanary.class.getName());
+        assertJavapFormatCanary(javapCanary);
         assertThrows(
                 AssertionError.class,
-                () -> assertMetadataOnlyContextIo(CONTEXT_FILESYSTEM_POLICY, methodReference));
+                () -> assertMetadataOnlyContextIo(CONTEXT_FILESYSTEM_POLICY, javapCanary));
+        assertThrows(
+                AssertionError.class,
+                () -> assertFixedUnixAttributeRead(CONTEXT_FILESYSTEM_POLICY + "$Canary", javapCanary));
     }
 
     private static void assertCompiledBoundary() throws Exception {
@@ -408,6 +419,7 @@ class ShipFoundationBoundaryTest {
                 "-filter:none",
                 "--class-path", classes.toString(),
                 context.toString(), security.toString());
+        Set<String> observedContextDependencies = new HashSet<>();
         for (String line : dependencies.lines().toList()) {
             int arrow = line.indexOf(" -> ");
             if (arrow < 0) {
@@ -420,6 +432,7 @@ class ShipFoundationBoundaryTest {
             String dependency = line.substring(arrow + 4).trim().split("\\s+", 2)[0];
             assertFalse(isForbidden(dependency), line.trim() + " crosses a forbidden Ship boundary");
             if (source.startsWith(CONTEXT_PACKAGE)) {
+                observedContextDependencies.add(source + " -> " + dependency);
                 assertMetadataOnlyContextDependency(source, dependency);
             }
             assertTrue(
@@ -429,6 +442,14 @@ class ShipFoundationBoundaryTest {
                             || dependency.startsWith(SECURITY_PACKAGE),
                     line.trim() + " is outside the java.base-only Ship foundation");
         }
+        // These known edges are parser tripwires, not dependencies that production must retain.
+        Set<String> expectedContextDependencies = Set.of(
+                CONTEXT_FILESYSTEM_POLICY + " -> java.nio.file.Files",
+                CONTEXT_FILESYSTEM_POLICY + " -> " + SECURITY_PACKAGE + "ProjectContextFiles");
+        assertTrue(
+                observedContextDependencies.containsAll(expectedContextDependencies),
+                () -> "jdeps no longer exposes the known Ship context dependency edges; expected "
+                      + expectedContextDependencies + " but found " + observedContextDependencies);
 
         ToolProvider javap = ToolProvider.findFirst("javap").orElseThrow(
                 () -> new AssertionError("Ship foundation boundary test requires a JDK with javap"));
@@ -565,6 +586,65 @@ class ShipFoundationBoundaryTest {
         return List.copyOf(instructions);
     }
 
+    private static void assertJavapFormatCanary(String bytecode) {
+        Set<String> fileMethods = new HashSet<>();
+        Matcher fileReferences = FILE_METHOD_REFERENCE.matcher(bytecode);
+        while (fileReferences.find()) {
+            fileMethods.add(fileReferences.group(1) + '.' + fileReferences.group(2));
+        }
+        Set<String> expectedFileMethods = Set.of(
+                "java/nio/file/Files.exists",
+                "java/nio/file/Files.readAttributes",
+                "java/nio/file/Files.readString",
+                "java/nio/file/Path.normalize");
+        assertTrue(
+                fileMethods.containsAll(expectedFileMethods),
+                () -> "javap no longer exposes the known filesystem references; expected "
+                      + expectedFileMethods + " but found " + fileMethods);
+
+        Set<String> securityMethods = new HashSet<>();
+        Matcher securityReferences = SECURITY_METHOD_REFERENCE.matcher(bytecode);
+        while (securityReferences.find()) {
+            securityMethods.add(securityReferences.group(1));
+        }
+        Set<String> expectedSecurityMethods = Set.of(
+                "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.maxFileCount:()I",
+                "io/github/luigidemasi/camelkit/ship/security/ProjectSnapshot$DirectoryEntry.\"<init>\":"
+                                                                                                + "(Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification;IJJ)V");
+        assertTrue(
+                securityMethods.containsAll(expectedSecurityMethods),
+                () -> "javap no longer exposes the known security method references; expected "
+                      + expectedSecurityMethods + " but found " + securityMethods);
+
+        Set<String> securityFields = new HashSet<>();
+        Matcher fieldReferences = SECURITY_FIELD_REFERENCE.matcher(bytecode);
+        while (fieldReferences.find()) {
+            securityFields.add(fieldReferences.group(1));
+        }
+        String expectedSecurityField
+                = "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification.DENIED:"
+                  + "Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification;";
+        assertTrue(
+                securityFields.contains(expectedSecurityField),
+                () -> "javap no longer exposes the known security field reference; found " + securityFields);
+
+        assertTrue(
+                DIRECT_METHOD_HANDLE_REFERENCE.matcher(bytecode).find(),
+                "javap no longer exposes the explicit MethodHandles reference");
+        assertTrue(
+                DIRECT_CLASS_REFLECTION_REFERENCE.matcher(bytecode).find(),
+                "javap no longer exposes the direct Class reflection reference");
+        assertTrue(
+                NATIVE_LOAD_REFERENCE.matcher(bytecode).find(),
+                "javap no longer exposes the native-library loading reference");
+        assertTrue(
+                NATIVE_METHOD.matcher(bytecode).find(),
+                "javap no longer exposes ACC_NATIVE");
+        assertTrue(
+                STRING_ATTRIBUTE_READ_METHOD_HANDLE.matcher(bytecode).find(),
+                "javap no longer exposes the string-attribute method handle");
+    }
+
     private static boolean isForbidden(String dependency) {
         if (dependency.startsWith("java.net.")
                 || dependency.startsWith("javax.net.")
@@ -695,10 +775,41 @@ class ShipFoundationBoundaryTest {
         String read(Path path) throws IOException;
     }
 
-    private static final class ForbiddenMethodReference {
-        private static final PathReader READ = Files::readString;
+    @FunctionalInterface
+    private interface StringAttributeReader {
+        Map<String, Object> read(Path path, String attributes, LinkOption... options) throws IOException;
+    }
 
-        private ForbiddenMethodReference() {
+    @FunctionalInterface
+    private interface DirectoryEntryFactory {
+        ProjectSnapshot.DirectoryEntry create(
+                ShipTreePolicy.Classification classification, int unixMode, long userId, long groupId);
+    }
+
+    // Replace canary targets when APIs change; this fixture does not require those APIs to remain public.
+    private static final class JavapFormatCanary {
+        private static final PathReader READ = Files::readString;
+        private static final StringAttributeReader ATTRIBUTES = Files::readAttributes;
+        private static final DirectoryEntryFactory DIRECTORY_ENTRY = ProjectSnapshot.DirectoryEntry::new;
+
+        private JavapFormatCanary() {
         }
+
+        private static Object[] directReferences(Path path, ShipTreePolicy policy) throws ClassNotFoundException {
+            return new Object[]{
+                    Files.exists(path),
+                    path.normalize(),
+                    policy.maxFileCount(),
+                    ShipTreePolicy.Classification.DENIED,
+                    MethodHandles.lookup(),
+                    Class.forName(path.toString())
+            };
+        }
+
+        private static void loadNative(String library) {
+            System.load(library);
+        }
+
+        private static native void nativeCapability();
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
@@ -1,5 +1,6 @@
 package io.github.luigidemasi.camelkit.ship;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Modifier;
@@ -8,6 +9,7 @@ import java.net.URI;
 import java.nio.channels.Channel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -22,14 +24,17 @@ import io.github.luigidemasi.camelkit.ship.security.ProjectContextFiles;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShipFoundationBoundaryTest {
 
     private static final String CONTEXT_PACKAGE = "io.github.luigidemasi.camelkit.ship.context.";
     private static final String SECURITY_PACKAGE = "io.github.luigidemasi.camelkit.ship.security.";
+    private static final String CONTEXT_FILESYSTEM_POLICY = CONTEXT_PACKAGE + "ContextFilesystemPolicy";
     private static final List<String> FORBIDDEN_REFERENCES = List.of(
             "io.github.luigidemasi.camelkit.ship.controller.",
             "io.github.luigidemasi.camelkit.ship.protocol.",
@@ -81,37 +86,302 @@ class ShipFoundationBoundaryTest {
     private static final Set<String> HELD_ROOT_METHODS = Set.of(
             "close()->void throws java.io.IOException",
             "toString()->java.lang.String");
-    private static final List<String> FORBIDDEN_CONTENT_OPEN_REFERENCES = List.of(
-            "FileInputStream",
-            "RandomAccessFile",
-            "newInputStream",
-            "newByteChannel",
-            "newBufferedReader",
-            "readAllBytes",
-            "readString",
-            "readAllLines",
-            "Files.lines",
-            "Files.copy",
-            "FileChannel.open",
-            "AsynchronousFileChannel.open");
-    private static final Set<String> ALLOWED_CONTEXT_FILES_METHODS = Set.of(
-            "exists",
-            "isDirectory",
-            "isSymbolicLink",
-            "newDirectoryStream",
-            "readAttributes");
-    private static final Set<String> ALLOWED_CONTEXT_JAVA_IO_TYPES = Set.of(
-            "FileNotFoundException", "IOException");
-    private static final Pattern FILES_METHOD_REFERENCE = Pattern.compile(
-            "java/nio/file/Files\\.([A-Za-z0-9_$]+)");
-    private static final Pattern JAVA_IO_TYPE_REFERENCE = Pattern.compile(
-            "java/io/([A-Za-z0-9_$]+)");
+    private static final Set<String> ALLOWED_CONTEXT_FILE_DEPENDENCIES = Set.of(
+            "java.io.FileNotFoundException",
+            "java.io.IOException",
+            "java.nio.file.AccessDeniedException",
+            "java.nio.file.DirectoryStream",
+            "java.nio.file.FileSystem",
+            "java.nio.file.Files",
+            "java.nio.file.InvalidPathException",
+            "java.nio.file.LinkOption",
+            "java.nio.file.NoSuchFileException",
+            "java.nio.file.Path",
+            "java.nio.file.ProviderMismatchException",
+            "java.nio.file.SecureDirectoryStream",
+            "java.nio.file.attribute.BasicFileAttributeView",
+            "java.nio.file.attribute.BasicFileAttributes",
+            "java.nio.file.attribute.FileAttributeView",
+            "java.nio.file.attribute.FileTime",
+            "java.nio.file.attribute.PosixFileAttributes",
+            "java.nio.file.attribute.PosixFilePermissions");
+    private static final Set<String> ALLOWED_CONTEXT_SECURITY_DEPENDENCIES = Set.of(
+            SECURITY_PACKAGE + "ProjectContextFiles",
+            SECURITY_PACKAGE + "ProjectContextFiles$HeldRoot",
+            SECURITY_PACKAGE + "ShipFilesystemException",
+            SECURITY_PACKAGE + "ShipTreePolicy",
+            SECURITY_PACKAGE + "ShipTreePolicy$Classification");
+    private static final Set<String> CONTEXT_WIDE_FILE_METHODS = Set.of(
+            "java/nio/file/FileSystem.getSeparator",
+            "java/nio/file/Path.equals",
+            "java/nio/file/Path.getFileName",
+            "java/nio/file/Path.getFileSystem",
+            "java/nio/file/Path.getNameCount",
+            "java/nio/file/Path.getParent",
+            "java/nio/file/Path.getRoot",
+            "java/nio/file/Path.isAbsolute",
+            "java/nio/file/Path.iterator",
+            "java/nio/file/Path.normalize",
+            "java/nio/file/Path.of",
+            "java/nio/file/Path.relativize",
+            "java/nio/file/Path.resolve",
+            "java/nio/file/Path.startsWith",
+            "java/nio/file/Path.toAbsolutePath",
+            "java/nio/file/Path.toString");
+    private static final Set<String> POLICY_ONLY_FILE_METHODS = Set.of(
+            "java/nio/file/DirectoryStream.close",
+            "java/nio/file/Files.exists",
+            "java/nio/file/Files.isDirectory",
+            "java/nio/file/Files.isSymbolicLink",
+            "java/nio/file/Files.newDirectoryStream",
+            "java/nio/file/Files.readAttributes",
+            "java/nio/file/Path.toRealPath",
+            "java/nio/file/SecureDirectoryStream.close",
+            "java/nio/file/SecureDirectoryStream.getFileAttributeView",
+            "java/nio/file/attribute/BasicFileAttributeView.readAttributes",
+            "java/nio/file/attribute/BasicFileAttributes.fileKey",
+            "java/nio/file/attribute/BasicFileAttributes.isDirectory",
+            "java/nio/file/attribute/BasicFileAttributes.isRegularFile",
+            "java/nio/file/attribute/BasicFileAttributes.isSymbolicLink",
+            "java/nio/file/attribute/BasicFileAttributes.lastModifiedTime",
+            "java/nio/file/attribute/BasicFileAttributes.size",
+            "java/nio/file/attribute/FileTime.equals",
+            "java/nio/file/attribute/FileTime.to",
+            "java/nio/file/attribute/PosixFileAttributes.lastModifiedTime",
+            "java/nio/file/attribute/PosixFileAttributes.permissions",
+            "java/nio/file/attribute/PosixFileAttributes.size",
+            "java/nio/file/attribute/PosixFilePermissions.toString");
+    private static final List<String> FORBIDDEN_CONTEXT_DEPENDENCY_PREFIXES = List.of(
+            "java.lang.foreign.",
+            "java.lang.module.",
+            "java.lang.reflect.",
+            "java.nio.channels.",
+            "java.nio.file.spi.",
+            "java.util.jar.",
+            "java.util.zip.");
+    private static final Set<String> FORBIDDEN_CONTEXT_DEPENDENCIES = Set.of(
+            "java.lang.ClassLoader",
+            "java.util.Formatter",
+            "java.util.ResourceBundle",
+            "java.util.Scanner",
+            "java.util.ServiceLoader");
+    private static final List<String> FORBIDDEN_CONTEXT_BYTECODE_REFERENCES = List.of(
+            "java/lang/ClassLoader",
+            "java/lang/foreign/",
+            "java/lang/module/",
+            "java/lang/reflect/",
+            "java/nio/channels/",
+            "java/nio/file/spi/",
+            "java/util/Formatter",
+            "java/util/ResourceBundle",
+            "java/util/Scanner",
+            "java/util/ServiceLoader",
+            "java/util/jar/",
+            "java/util/zip/");
+    private static final String METHOD_REFERENCE_PREFIX
+            = "(?:REF_(?:invoke[A-Za-z]+|newInvokeSpecial)\\s+"
+              + "|(?:Interface)?Methodref\\s+#[^\\r\\n]*//\\s+"
+              + "|// (?:InterfaceMethod|Method)\\s+)";
+    private static final Pattern FILE_METHOD_REFERENCE = Pattern.compile(
+            METHOD_REFERENCE_PREFIX
+                                                                         + "(java/nio/file(?:/attribute)?/[A-Za-z0-9_$]+)\\.([A-Za-z0-9_$]+):");
+    private static final Set<String> ALLOWED_CONTEXT_SECURITY_METHODS = Set.of(
+            "io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles$HeldRoot.close:()V",
+            "io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.close:()V",
+            "io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.hold:"
+                                                                                          + "(Lio/github/luigidemasi/camelkit/ship/context/ContextFilesystemPolicy$ProjectRootAdmission;)"
+                                                                                          + "Lio/github/luigidemasi/camelkit/ship/security/ProjectContextFiles$HeldRoot;",
+            "io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.open:"
+                                                                                                                                                                           + "(Lio/github/luigidemasi/camelkit/ship/context/ContextFilesystemPolicy$ProjectAccess;)"
+                                                                                                                                                                           + "Lio/github/luigidemasi/camelkit/ship/security/ProjectContextFiles;",
+            "io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.readDocument:(Ljava/lang/String;I)[B",
+            "io/github/luigidemasi/camelkit/ship/security/ShipFilesystemException.code:()Ljava/lang/String;",
+            "io/github/luigidemasi/camelkit/ship/security/ShipFilesystemException.getCause:()Ljava/lang/Throwable;",
+            "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.classify:"
+                                                                                                                     + "(Ljava/lang/String;)"
+                                                                                                                     + "Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification;",
+            "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.current:"
+                                                                                                                                                                                                       + "()Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy;",
+            "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.isAllowedAbsolutePath:(Ljava/nio/file/Path;)Z",
+            "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.requireCanonicalRelativePath:"
+                                                                                                                         + "(Ljava/lang/String;)Ljava/lang/String;");
+    private static final Set<String> ALLOWED_CONTEXT_SECURITY_FIELDS = Set.of(
+            "io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification.MATERIAL:"
+                                                                              + "Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification;");
+    private static final Pattern SECURITY_METHOD_REFERENCE = Pattern.compile(
+            METHOD_REFERENCE_PREFIX
+                                                                             + "(io/github/luigidemasi/camelkit/ship/security/[A-Za-z0-9_$]+\\."
+                                                                             + "(?:[A-Za-z0-9_$]+|\"<init>\"):[^\\s]+)");
+    private static final String FIELD_REFERENCE_PREFIX
+            = "(?:REF_(?:get|put)(?:Field|Static)\\s+|Fieldref\\s+#[^\\r\\n]*//\\s+|// Field\\s+)";
+    private static final Pattern SECURITY_FIELD_REFERENCE = Pattern.compile(
+            FIELD_REFERENCE_PREFIX
+                                                                            + "(io/github/luigidemasi/camelkit/ship/security/[A-Za-z0-9_$]+\\.[A-Za-z0-9_$]+:[^\\s]+)");
+    private static final Pattern DIRECT_METHOD_HANDLE_REFERENCE = Pattern.compile(
+            METHOD_REFERENCE_PREFIX + "java/lang/invoke/"
+                                                                                  + "(?:MethodHandle|MethodHandles(?:\\$Lookup)?)\\.[A-Za-z0-9_$]+:");
+    private static final Pattern DIRECT_CLASS_REFLECTION_REFERENCE = Pattern.compile(
+            METHOD_REFERENCE_PREFIX + "java/lang/(?:Class|ClassLoader)\\."
+                                                                                     + "(?:forName|loadClass|getMethods?|getDeclaredMethods?|getConstructors?|"
+                                                                                     + "getDeclaredConstructors?|getFields?|getDeclaredFields?|newInstance):");
+    private static final Pattern NATIVE_LOAD_REFERENCE = Pattern.compile(
+            METHOD_REFERENCE_PREFIX + "java/lang/(?:Runtime|System)\\.load(?:Library)?:");
+    private static final Pattern NATIVE_METHOD = Pattern.compile(
+            "(?m)^\\s*flags:.*\\bACC_NATIVE\\b");
+    private static final String STRING_ATTRIBUTE_READ_TARGET
+            = "java/nio/file/Files\\.readAttributes:"
+              + "\\(Ljava/nio/file/Path;Ljava/lang/String;\\[Ljava/nio/file/LinkOption;\\)Ljava/util/Map;";
+    private static final Pattern STRING_ATTRIBUTE_READ_INSTRUCTION = Pattern.compile(
+            "// Method " + STRING_ATTRIBUTE_READ_TARGET);
+    private static final Pattern STRING_ATTRIBUTE_READ_METHOD_HANDLE = Pattern.compile(
+            "REF_invoke[A-Za-z]+\\s+" + STRING_ATTRIBUTE_READ_TARGET);
+    private static final Pattern BYTECODE_INSTRUCTION = Pattern.compile(
+            "^\\s*[0-9]+:\\s+(.*)$");
+    private static final List<Pattern> FIXED_UNIX_ATTRIBUTE_OPERANDS = List.of(
+            Pattern.compile("ldc(?:_w)?\\s+#[0-9]+\\s+// String "
+                            + Pattern.quote("unix:dev,ino,nlink,mode,ctime,size,lastModifiedTime")),
+            Pattern.compile("iconst_1"),
+            Pattern.compile("anewarray\\s+#[0-9]+\\s+// class java/nio/file/LinkOption"),
+            Pattern.compile("dup"),
+            Pattern.compile("iconst_0"),
+            Pattern.compile("getstatic\\s+#[0-9]+\\s+// Field java/nio/file/LinkOption\\.NOFOLLOW_LINKS:"
+                            + "Ljava/nio/file/LinkOption;"),
+            Pattern.compile("aastore"));
 
     @Test
     void foundationRemainsJavaBaseOnlyAndPurposeBound() throws Exception {
         assertCompiledBoundary();
         assertPublicFilesystemSurface();
         assertResolvedContextHasNoHostLocationSurface();
+    }
+
+    @Test
+    void metadataOnlyGuardRejectsUnapprovedFilesystemCapabilities() throws Exception {
+        assertDoesNotThrow(() -> assertMetadataOnlyContextIo(
+                CONTEXT_FILESYSTEM_POLICY,
+                "// Method java/nio/file/Files.readAttributes:(Ljava/nio/file/Path;)Ljava/lang/Object;"));
+        assertDoesNotThrow(() -> assertMetadataOnlyContextIo(
+                CONTEXT_PACKAGE + "InitialContextResolver",
+                "// InterfaceMethod java/nio/file/Path.normalize:()Ljava/nio/file/Path;"));
+        assertDoesNotThrow(() -> assertMetadataOnlyContextDependency(
+                CONTEXT_FILESYSTEM_POLICY, SECURITY_PACKAGE + "ShipTreePolicy"));
+        assertDoesNotThrow(() -> assertMetadataOnlyContextIo(
+                CONTEXT_FILESYSTEM_POLICY,
+                "// Method io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.current:"
+                                           + "()Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy;\n"
+                                           + "// Field io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification.MATERIAL:"
+                                           + "Lio/github/luigidemasi/camelkit/ship/security/ShipTreePolicy$Classification;"));
+        String fixedAttributes = "90: ldc_w #1 // String unix:dev,ino,nlink,mode,ctime,size,lastModifiedTime\n"
+                                 + "93: iconst_1\n"
+                                 + "94: anewarray #2 // class java/nio/file/LinkOption\n"
+                                 + "97: dup\n"
+                                 + "98: iconst_0\n"
+                                 + "99: getstatic #3 // Field java/nio/file/LinkOption.NOFOLLOW_LINKS:"
+                                 + "Ljava/nio/file/LinkOption;\n"
+                                 + "102: aastore\n"
+                                 + "103: invokestatic #4 // Method java/nio/file/Files.readAttributes:"
+                                 + "(Ljava/nio/file/Path;Ljava/lang/String;"
+                                 + "[Ljava/nio/file/LinkOption;)Ljava/util/Map;";
+        assertDoesNotThrow(() -> assertFixedUnixAttributeRead(CONTEXT_FILESYSTEM_POLICY, fixedAttributes));
+        assertThrows(
+                AssertionError.class,
+                () -> assertFixedUnixAttributeRead(CONTEXT_FILESYSTEM_POLICY, fixedAttributes.replace(
+                        "unix:dev,ino,nlink,mode,ctime,size,lastModifiedTime", "user:*")));
+        assertThrows(
+                AssertionError.class,
+                () -> assertFixedUnixAttributeRead(
+                        CONTEXT_FILESYSTEM_POLICY,
+                        fixedAttributes.replace("93: iconst_1", "91: pop\n92: aload_2\n93: iconst_1")));
+        assertThrows(
+                AssertionError.class,
+                () -> assertFixedUnixAttributeRead(CONTEXT_FILESYSTEM_POLICY + "$Nested", fixedAttributes));
+
+        for (String bytecode : List.of(
+                "// InterfaceMethod java/nio/file/SecureDirectoryStream.deleteFile:(Ljava/nio/file/Path;)V",
+                "// InterfaceMethod java/nio/file/attribute/BasicFileAttributeView.setTimes:()V",
+                "// Method java/nio/file/spi/FileSystemProvider.newByteChannel:()V",
+                "// Method java/util/zip/ZipFile.\"<init>\":(Ljava/lang/String;)V",
+                "// Method java/util/jar/JarFile.\"<init>\":(Ljava/lang/String;)V",
+                "// Method java/util/Formatter.\"<init>\":(Ljava/lang/String;)V",
+                "// Method java/util/ResourceBundle.getBundle:(Ljava/lang/String;)Ljava/util/ResourceBundle;",
+                "// Method java/util/ServiceLoader.load:(Ljava/lang/Class;)Ljava/util/ServiceLoader;",
+                "// Method java/lang/reflect/Method.invoke:()Ljava/lang/Object;",
+                "// Method java/lang/Class.forName:(Ljava/lang/String;)Ljava/lang/Class;",
+                "// Method java/lang/invoke/MethodHandles$Lookup.findStatic:()Ljava/lang/invoke/MethodHandle;",
+                "// Method java/lang/ClassLoader.defineClass:()[B",
+                "// Method java/lang/Runtime.load:(Ljava/lang/String;)V",
+                "// Method java/lang/System.load:(Ljava/lang/String;)V",
+                "flags: (0x0100) ACC_NATIVE")) {
+            assertThrows(
+                    AssertionError.class,
+                    () -> assertMetadataOnlyContextIo(CONTEXT_FILESYSTEM_POLICY, bytecode));
+        }
+
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextIo(
+                        CONTEXT_PACKAGE + "InitialContextResolver",
+                        "// Method java/nio/file/Files.readAttributes:()Ljava/lang/Object;"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextIo(
+                        CONTEXT_PACKAGE + "InitialContextResolver",
+                        "// InterfaceMethod java/nio/file/Path.toRealPath:()Ljava/nio/file/Path;"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextDependency(
+                        CONTEXT_FILESYSTEM_POLICY, "java.io.FileReader"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextDependency(
+                        CONTEXT_FILESYSTEM_POLICY, "java.nio.file.spi.FileSystemProvider"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextDependency(
+                        CONTEXT_FILESYSTEM_POLICY, "java.lang.module.ModuleFinder"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextDependency(
+                        CONTEXT_FILESYSTEM_POLICY, "java.lang.ClassLoader"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextDependency(
+                        CONTEXT_FILESYSTEM_POLICY, "java.util.ResourceBundle"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextDependency(
+                        CONTEXT_FILESYSTEM_POLICY, SECURITY_PACKAGE + "ExternalDocumentReader"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextIo(
+                        CONTEXT_FILESYSTEM_POLICY,
+                        "// Method io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.readExternal:"
+                                                   + "(Ljava/nio/file/Path;)[B"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextIo(
+                        CONTEXT_FILESYSTEM_POLICY,
+                        "REF_newInvokeSpecial "
+                                                   + "io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.\"<init>\":()V"));
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextIo(
+                        CONTEXT_FILESYSTEM_POLICY,
+                        "// Field io/github/luigidemasi/camelkit/ship/security/ProjectContextFiles.READER:"
+                                                   + "Ljava/util/function/Function;"));
+
+        Path testClasses = Path.of(ShipFoundationBoundaryTest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI());
+        ToolProvider javap = ToolProvider.findFirst("javap").orElseThrow();
+        String methodReference = jdeps(
+                javap,
+                "-classpath", testClasses.toString(),
+                "-v",
+                "-p",
+                ForbiddenMethodReference.class.getName());
+        assertThrows(
+                AssertionError.class,
+                () -> assertMetadataOnlyContextIo(CONTEXT_FILESYSTEM_POLICY, methodReference));
     }
 
     private static void assertCompiledBoundary() throws Exception {
@@ -149,6 +419,9 @@ class ShipFoundationBoundaryTest {
             }
             String dependency = line.substring(arrow + 4).trim().split("\\s+", 2)[0];
             assertFalse(isForbidden(dependency), line.trim() + " crosses a forbidden Ship boundary");
+            if (source.startsWith(CONTEXT_PACKAGE)) {
+                assertMetadataOnlyContextDependency(source, dependency);
+            }
             assertTrue(
                     dependency.startsWith("java.")
                             || dependency.startsWith("javax.")
@@ -171,39 +444,125 @@ class ShipFoundationBoundaryTest {
             String bytecode = jdeps(
                     javap,
                     "-classpath", classes.toString(),
-                    "-c",
+                    "-v",
                     "-p",
                     className);
-            for (String forbidden : FORBIDDEN_CONTENT_OPEN_REFERENCES) {
-                assertFalse(
-                        bytecode.contains(forbidden),
-                        () -> className + " gained a content-opening reference: " + forbidden);
-            }
             assertMetadataOnlyContextIo(className, bytecode);
+            if (className.equals(CONTEXT_FILESYSTEM_POLICY)
+                    || className.startsWith(CONTEXT_FILESYSTEM_POLICY + '$')) {
+                assertFixedUnixAttributeRead(className, bytecode);
+            }
         }
     }
 
+    private static void assertMetadataOnlyContextDependency(String className, String dependency) {
+        if (dependency.startsWith("java.io.") || dependency.startsWith("java.nio.file.")) {
+            assertTrue(
+                    ALLOWED_CONTEXT_FILE_DEPENDENCIES.contains(dependency),
+                    () -> className + " gained an unreviewed filesystem dependency: " + dependency);
+        }
+        if (dependency.startsWith(SECURITY_PACKAGE)) {
+            assertTrue(
+                    ALLOWED_CONTEXT_SECURITY_DEPENDENCIES.contains(dependency),
+                    () -> className + " gained an unreviewed security dependency: " + dependency);
+        }
+        assertFalse(
+                FORBIDDEN_CONTEXT_DEPENDENCIES.contains(dependency)
+                        || FORBIDDEN_CONTEXT_DEPENDENCY_PREFIXES.stream().anyMatch(dependency::startsWith),
+                () -> className + " gained an indirect filesystem capability: " + dependency);
+    }
+
     private static void assertMetadataOnlyContextIo(String className, String bytecode) {
-        Matcher filesMethods = FILES_METHOD_REFERENCE.matcher(bytecode);
-        while (filesMethods.find()) {
-            String method = filesMethods.group(1);
+        Matcher fileMethods = FILE_METHOD_REFERENCE.matcher(bytecode);
+        while (fileMethods.find()) {
+            String method = fileMethods.group(1) + '.' + fileMethods.group(2);
             assertTrue(
-                    ALLOWED_CONTEXT_FILES_METHODS.contains(method),
-                    () -> className + " gained an unreviewed Files method: " + method);
+                    CONTEXT_WIDE_FILE_METHODS.contains(method) || POLICY_ONLY_FILE_METHODS.contains(method),
+                    () -> className + " gained an unreviewed filesystem method: " + method);
+            if (POLICY_ONLY_FILE_METHODS.contains(method)) {
+                assertTrue(
+                        className.equals(CONTEXT_FILESYSTEM_POLICY)
+                                || className.startsWith(CONTEXT_FILESYSTEM_POLICY + '$'),
+                        () -> className + " used a policy-only filesystem method outside ContextFilesystemPolicy: "
+                              + method);
+            }
         }
-        Matcher javaIoTypes = JAVA_IO_TYPE_REFERENCE.matcher(bytecode);
-        while (javaIoTypes.find()) {
-            String type = javaIoTypes.group(1);
+        Matcher securityMethods = SECURITY_METHOD_REFERENCE.matcher(bytecode);
+        while (securityMethods.find()) {
+            String method = securityMethods.group(1);
             assertTrue(
-                    ALLOWED_CONTEXT_JAVA_IO_TYPES.contains(type),
-                    () -> className + " gained an unreviewed java.io type: " + type);
+                    ALLOWED_CONTEXT_SECURITY_METHODS.contains(method),
+                    () -> className + " gained an unreviewed security method: " + method);
+        }
+        Matcher securityFields = SECURITY_FIELD_REFERENCE.matcher(bytecode);
+        while (securityFields.find()) {
+            String field = securityFields.group(1);
+            assertTrue(
+                    ALLOWED_CONTEXT_SECURITY_FIELDS.contains(field),
+                    () -> className + " gained an unreviewed security field: " + field);
+        }
+        for (String forbidden : FORBIDDEN_CONTEXT_BYTECODE_REFERENCES) {
+            assertFalse(
+                    bytecode.contains(forbidden),
+                    () -> className + " gained an indirect filesystem capability: " + forbidden);
         }
         assertFalse(
-                bytecode.contains("java/nio/channels/"),
-                () -> className + " gained a java.nio.channels capability");
+                DIRECT_METHOD_HANDLE_REFERENCE.matcher(bytecode).find(),
+                () -> className + " gained an explicit MethodHandle capability");
         assertFalse(
-                bytecode.contains("java/util/Scanner"),
-                () -> className + " gained a path-capable Scanner");
+                DIRECT_CLASS_REFLECTION_REFERENCE.matcher(bytecode).find(),
+                () -> className + " gained an explicit reflective lookup capability");
+        assertFalse(
+                NATIVE_LOAD_REFERENCE.matcher(bytecode).find(),
+                () -> className + " gained a native-library loading capability");
+        assertFalse(
+                NATIVE_METHOD.matcher(bytecode).find(),
+                () -> className + " gained a native method");
+    }
+
+    private static void assertFixedUnixAttributeRead(String className, String bytecode) {
+        List<String> instructions = bytecodeInstructions(bytecode);
+        List<Integer> stringAttributeReads = new ArrayList<>();
+        for (int index = 0; index < instructions.size(); index++) {
+            if (STRING_ATTRIBUTE_READ_INSTRUCTION.matcher(instructions.get(index)).find()) {
+                stringAttributeReads.add(index);
+            }
+        }
+        int expectedReads = className.equals(CONTEXT_FILESYSTEM_POLICY) ? 1 : 0;
+        assertEquals(
+                expectedReads,
+                stringAttributeReads.size(),
+                () -> className + " must have " + expectedReads + " fixed string-based attribute reads");
+        assertFalse(
+                STRING_ATTRIBUTE_READ_METHOD_HANDLE.matcher(bytecode).find(),
+                () -> className + " must not delegate its attribute selector through a method handle");
+        if (expectedReads == 0) {
+            return;
+        }
+
+        int readIndex = stringAttributeReads.get(0);
+        assertTrue(
+                readIndex >= FIXED_UNIX_ATTRIBUTE_OPERANDS.size(),
+                "ContextFilesystemPolicy string-based attribute read is missing fixed operands");
+        for (int offset = 0; offset < FIXED_UNIX_ATTRIBUTE_OPERANDS.size(); offset++) {
+            String instruction = instructions.get(readIndex - FIXED_UNIX_ATTRIBUTE_OPERANDS.size() + offset);
+            Pattern expected = FIXED_UNIX_ATTRIBUTE_OPERANDS.get(offset);
+            assertTrue(
+                    expected.matcher(instruction).matches(),
+                    () -> "ContextFilesystemPolicy string-based attribute read gained a dynamic or unapproved operand: "
+                          + instruction);
+        }
+    }
+
+    private static List<String> bytecodeInstructions(String bytecode) {
+        List<String> instructions = new ArrayList<>();
+        for (String line : bytecode.lines().toList()) {
+            Matcher instruction = BYTECODE_INSTRUCTION.matcher(line);
+            if (instruction.matches()) {
+                instructions.add(instruction.group(1));
+            }
+        }
+        return List.copyOf(instructions);
     }
 
     private static boolean isForbidden(String dependency) {
@@ -329,5 +688,17 @@ class ShipFoundationBoundaryTest {
         int result = tool.run(new PrintWriter(output), new PrintWriter(errors), arguments);
         assertEquals(0, result, () -> errors + System.lineSeparator() + output);
         return output.toString();
+    }
+
+    @FunctionalInterface
+    private interface PathReader {
+        String read(Path path) throws IOException;
+    }
+
+    private static final class ForbiddenMethodReference {
+        private static final PathReader READ = Files::readString;
+
+        private ForbiddenMethodReference() {
+        }
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
@@ -469,8 +469,7 @@ class ShipFoundationBoundaryTest {
                     "-p",
                     className);
             assertMetadataOnlyContextIo(className, bytecode);
-            if (className.equals(CONTEXT_FILESYSTEM_POLICY)
-                    || className.startsWith(CONTEXT_FILESYSTEM_POLICY + '$')) {
+            if (isFilesystemPolicyClass(className)) {
                 assertFixedUnixAttributeRead(className, bytecode);
             }
         }
@@ -502,8 +501,7 @@ class ShipFoundationBoundaryTest {
                     () -> className + " gained an unreviewed filesystem method: " + method);
             if (POLICY_ONLY_FILE_METHODS.contains(method)) {
                 assertTrue(
-                        className.equals(CONTEXT_FILESYSTEM_POLICY)
-                                || className.startsWith(CONTEXT_FILESYSTEM_POLICY + '$'),
+                        isFilesystemPolicyClass(className),
                         () -> className + " used a policy-only filesystem method outside ContextFilesystemPolicy: "
                               + method);
             }
@@ -539,6 +537,10 @@ class ShipFoundationBoundaryTest {
         assertFalse(
                 NATIVE_METHOD.matcher(bytecode).find(),
                 () -> className + " gained a native method");
+    }
+
+    private static boolean isFilesystemPolicyClass(String className) {
+        return className.equals(CONTEXT_FILESYSTEM_POLICY) || className.startsWith(CONTEXT_FILESYSTEM_POLICY + '$');
     }
 
     private static void assertFixedUnixAttributeRead(String className, String bytecode) {


### PR DESCRIPTION
## Summary

- Replace the coarse context-filesystem bytecode checks with exact fail-closed dependency and method allowlists.
- Pin every permitted context-to-security type, full method descriptor, constructor, and field reference.
- Inspect verbose bytecode and bootstrap targets so direct calls and method references cross the same boundary.
- Bind the sole string-based Unix metadata read to its exact selector operands and `NOFOLLOW_LINKS`, while forbidding that overload in nested policy classes.
- Add adversarial controls for dynamic selectors, providers, archives, modules, reflection, method handles, native loading, class loaders, resource/provider loading, and a compiled `Files::readString` reference.

## Scope

This changes one test file only. The merged production implementation remains unchanged.

The strengthened check is a compiled-code regression boundary over declared dependencies, constant-pool/bootstrap capabilities, and the exact metadata-selector call. It is not a runtime sandbox; trusted security-package semantics remain covered by behavioral and later protection-boundary tests.

Website impact: not required. This is an internal test-only hardening follow-up; the parent issue still requires website work at the eventual public cutover.

## Validation

- Focused `ShipFoundationBoundaryTest` on Java 21 and Java 25
- `./mvnw -B -Psourcecheck validate`
- `./mvnw -B clean install`
- Independent API, security, and test reviews with no blockers

Part of #149

## Summary by Sourcery

Strengthen Ship foundation boundary tests to assert precise, fail-closed filesystem and security capabilities at the bytecode level.

Tests:
- Add comprehensive metadata-only filesystem capability tests with explicit allowlists for context and security dependencies, methods, and fields.
- Verify fixed Unix attribute read call shape and operands, rejecting dynamic selectors, method-handle indirection, and nested policy usage.
- Add adversarial test coverage for forbidden IO, reflection, modules, method handles, native loading, class loaders, and Files::readString references within context classes.