### PR TITLE
Add bounded Ship catalog evidence snapshots

### DIFF
--- a/camel-kit-core/pom.xml
+++ b/camel-kit-core/pom.xml
@@ -68,6 +68,19 @@
             <artifactId>tamboui-jline3-backend</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.github.luigidemasi</groupId>
+            <artifactId>camel-kit-ship-resolver</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <!-- The published module contains relocated internals; keep the source reactor equally isolated. -->
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- No camel-catalog or citrus-catalog-schema dependency - JSON downloaded at runtime -->
 
         <!-- Graph builder for project code analysis -->
@@ -86,6 +99,32 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- The reactor substitutes the resolver's unshaded target/classes for its packaged JAR. -->
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-supplier</artifactId>
+            <version>${maven.resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${maven.resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${maven.provider.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model-builder</artifactId>
+            <version>${maven.provider.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogArtifactReader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogArtifactReader.java
@@ -1,0 +1,447 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Reads one bounded catalog artifact through descriptor-relative, no-follow handles. This is a descriptive snapshot,
+ * not a certifying filesystem capability: Java 17 cannot query the identity of the final opened byte channel.
+ */
+final class CatalogArtifactReader {
+
+    private static final String UNIX_ATTRIBUTES = "unix:dev,ino,nlink,size,lastModifiedTime,ctime,mode,uid,gid";
+    private static final int FILE_TYPE_MASK = 0170000;
+    private static final int DIRECTORY_TYPE = 0040000;
+    private static final int REGULAR_FILE_TYPE = 0100000;
+    private static final Set<OpenOption> READ_OPTIONS = Set.of(
+            StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+
+    private CatalogArtifactReader() {
+    }
+
+    static byte[] read(Path requestedRoot, Path requestedFile, long maximumBytes) throws IOException {
+        if (maximumBytes < 1 || maximumBytes > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Catalog artifact byte limit is invalid");
+        }
+        Path root = Objects.requireNonNull(requestedRoot, "requestedRoot must not be null")
+                .toAbsolutePath().normalize();
+        Path file = Objects.requireNonNull(requestedFile, "requestedFile must not be null")
+                .toAbsolutePath().normalize();
+        if (!file.startsWith(root) || file.equals(root)) {
+            throw new IOException("Catalog artifact is outside its repository root");
+        }
+        Path relative = root.relativize(file);
+        int count = relative.getNameCount();
+        if (count < 2) {
+            throw new IOException("Catalog artifact path lacks a parent directory");
+        }
+        try (BoundRoot boundRoot = openRoot(root)) {
+            byte[] result = readFrom(
+                    boundRoot.stream(), root, relative, 0, boundRoot.identity().device(), maximumBytes);
+            boundRoot.validate();
+            return result;
+        }
+    }
+
+    private static byte[] readFrom(
+            SecureDirectoryStream<Path> directory,
+            Path lexicalDirectory,
+            Path relative,
+            int index,
+            long rootDevice,
+            long maximumBytes)
+            throws IOException {
+        Path name = singleName(relative.getName(index));
+        if (index == relative.getNameCount() - 1) {
+            return readFile(directory, name, lexicalDirectory.resolve(name), rootDevice, maximumBytes);
+        }
+        Path lexicalChild = lexicalDirectory.resolve(name);
+        try (BoundDirectory child = openDirectory(directory, name, lexicalChild, rootDevice)) {
+            return readFrom(child.stream(), lexicalChild, relative, index + 1, rootDevice, maximumBytes);
+        }
+    }
+
+    private static BoundRoot openRoot(Path root) throws IOException {
+        rejectSymbolicComponents(root);
+        if (!root.equals(root.toRealPath())) {
+            throw new IOException("Catalog repository root is not a canonical real directory");
+        }
+        DirectoryStream<Path> opened = Files.newDirectoryStream(root);
+        if (!(opened instanceof SecureDirectoryStream<?>)) {
+            opened.close();
+            throw new IOException("Catalog repository filesystem lacks descriptor-relative directory access");
+        }
+        @SuppressWarnings("unchecked")
+        SecureDirectoryStream<Path> secure = (SecureDirectoryStream<Path>) opened;
+        try {
+            BasicFileAttributes held = attributes(secure, null);
+            UnixIdentity identity = sampleUnix(root, held.fileKey());
+            requireDirectory(held, identity, identity.device());
+            return new BoundRoot(root, secure, identity);
+        } catch (IOException | RuntimeException e) {
+            try {
+                secure.close();
+            } catch (IOException closeFailure) {
+                e.addSuppressed(closeFailure);
+            }
+            throw e;
+        }
+    }
+
+    private static BoundDirectory openDirectory(
+            SecureDirectoryStream<Path> parent,
+            Path name,
+            Path lexicalPath,
+            long rootDevice)
+            throws IOException {
+        BasicFileAttributes named = attributes(parent, name);
+        UnixIdentity expected = sampleUnix(lexicalPath, named.fileKey());
+        requireDirectory(named, expected, rootDevice);
+        SecureDirectoryStream<Path> opened = null;
+        try {
+            opened = parent.newDirectoryStream(name, LinkOption.NOFOLLOW_LINKS);
+            requireDirectory(attributes(opened, null), expected, rootDevice);
+            UnixIdentity rebound = sampleUnix(lexicalPath, expected.fileKey());
+            if (!expected.equals(rebound)) {
+                throw new IOException("Catalog repository directory changed while it was opened");
+            }
+            return new BoundDirectory(parent, name, lexicalPath, opened, expected, rootDevice);
+        } catch (IOException | RuntimeException e) {
+            if (opened != null) {
+                try {
+                    opened.close();
+                } catch (IOException closeFailure) {
+                    e.addSuppressed(closeFailure);
+                }
+            }
+            throw e;
+        }
+    }
+
+    private static byte[] readFile(
+            SecureDirectoryStream<Path> parent,
+            Path name,
+            Path lexicalPath,
+            long rootDevice,
+            long maximumBytes)
+            throws IOException {
+        BasicFileAttributes basicBefore = attributes(parent, name);
+        UnixIdentity before = sampleUnix(lexicalPath, basicBefore.fileKey());
+        requireRegularFile(basicBefore, before, rootDevice);
+        if (before.size() <= 0 || before.size() > maximumBytes) {
+            throw new IOException("Catalog artifact has an unsafe size");
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.toIntExact(before.size()));
+        try (SeekableByteChannel channel = parent.newByteChannel(name, READ_OPTIONS)) {
+            ByteBuffer buffer = ByteBuffer.allocate(16_384);
+            long total = 0;
+            int read;
+            while ((read = channel.read(buffer)) != -1) {
+                if (read == 0) {
+                    continue;
+                }
+                total = Math.addExact(total, read);
+                if (total > before.size() || total > maximumBytes) {
+                    throw new IOException("Catalog artifact changed size while it was read");
+                }
+                output.write(buffer.array(), 0, read);
+                buffer.clear();
+            }
+        } catch (ArithmeticException e) {
+            throw new IOException("Catalog artifact size accounting overflowed", e);
+        }
+
+        BasicFileAttributes basicAfter = attributes(parent, name);
+        UnixIdentity after = sampleUnix(lexicalPath, before.fileKey());
+        requireRegularFile(basicAfter, after, rootDevice);
+        if (!before.equals(after) || output.size() != before.size()) {
+            throw new IOException("Catalog artifact changed while it was read");
+        }
+        return output.toByteArray();
+    }
+
+    private static BasicFileAttributes attributes(SecureDirectoryStream<Path> directory, Path name)
+            throws IOException {
+        BasicFileAttributeView view = name == null
+                ? directory.getFileAttributeView(BasicFileAttributeView.class)
+                : directory.getFileAttributeView(
+                        name, BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        if (view == null) {
+            throw new IOException("Catalog repository lacks descriptor-relative basic attributes");
+        }
+        return view.readAttributes();
+    }
+
+    private static UnixIdentity sampleUnix(Path path, Object expectedKey) throws IOException {
+        if (expectedKey == null) {
+            throw new IOException("Catalog repository entry lacks a stable file key");
+        }
+        try {
+            BasicFileAttributes before = Files.readAttributes(
+                    path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!expectedKey.equals(before.fileKey())) {
+                throw new IOException("Catalog repository entry changed before Unix metadata sampling");
+            }
+            Map<String, Object> values = Files.readAttributes(
+                    path, UNIX_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
+            BasicFileAttributes after = Files.readAttributes(
+                    path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!expectedKey.equals(after.fileKey())) {
+                throw new IOException("Catalog repository entry changed during Unix metadata sampling");
+            }
+            UnixIdentity identity = new UnixIdentity(
+                    expectedKey,
+                    requiredLong(values, "dev"),
+                    requiredLong(values, "ino"),
+                    requiredLong(values, "nlink"),
+                    requiredLong(values, "size"),
+                    requiredTime(values, "lastModifiedTime").to(TimeUnit.NANOSECONDS),
+                    requiredTime(values, "ctime").to(TimeUnit.NANOSECONDS),
+                    before.creationTime().to(TimeUnit.NANOSECONDS),
+                    requiredInt(values, "mode"),
+                    requiredUnixId(values, "uid"),
+                    requiredUnixId(values, "gid"));
+            requireBasicBinding(before, identity);
+            requireBasicBinding(after, identity);
+            return identity;
+        } catch (UnsupportedOperationException | IllegalArgumentException e) {
+            throw new IOException("Catalog repository lacks stable Unix identity metadata", e);
+        }
+    }
+
+    private static void requireDirectory(
+            BasicFileAttributes basic, UnixIdentity unix, long rootDevice)
+            throws IOException {
+        if (!basic.isDirectory() || basic.isSymbolicLink()
+                || (unix.mode() & FILE_TYPE_MASK) != DIRECTORY_TYPE) {
+            throw new IOException("Catalog repository path contains a non-directory entry");
+        }
+        requireBasicBinding(basic, unix);
+        requireSameDevice(unix, rootDevice);
+    }
+
+    private static void requireRegularFile(
+            BasicFileAttributes basic, UnixIdentity unix, long rootDevice)
+            throws IOException {
+        if (!basic.isRegularFile() || basic.isSymbolicLink()
+                || (unix.mode() & FILE_TYPE_MASK) != REGULAR_FILE_TYPE) {
+            throw new IOException("Catalog artifact is not a stable regular file");
+        }
+        requireBasicBinding(basic, unix);
+        requireSameDevice(unix, rootDevice);
+        if (unix.linkCount() != 1) {
+            throw new IOException("Catalog artifact is hard-linked");
+        }
+    }
+
+    private static void requireBasicBinding(BasicFileAttributes basic, UnixIdentity unix)
+            throws IOException {
+        if (basic.fileKey() == null
+                || !unix.fileKey().equals(basic.fileKey())
+                || basic.size() != unix.size()
+                || basic.lastModifiedTime().to(TimeUnit.NANOSECONDS) != unix.modifiedNanos()
+                || basic.creationTime().to(TimeUnit.NANOSECONDS) != unix.createdNanos()) {
+            throw new IOException("Catalog repository entry changed across its identity sample");
+        }
+    }
+
+    private static void requireSameDevice(UnixIdentity unix, long rootDevice) throws IOException {
+        if (unix.device() != rootDevice) {
+            throw new IOException("Catalog artifact path crosses its repository filesystem device");
+        }
+    }
+
+    private static long requiredLong(Map<String, Object> values, String name) throws IOException {
+        Object value = values.get(name);
+        if (!(value instanceof Number number)) {
+            throw new IOException("Catalog repository lacks a required Unix attribute");
+        }
+        return number.longValue();
+    }
+
+    private static int requiredInt(Map<String, Object> values, String name) throws IOException {
+        long value = requiredLong(values, name);
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new IOException("Catalog repository returned an invalid Unix attribute");
+        }
+        return (int) value;
+    }
+
+    private static long requiredUnixId(Map<String, Object> values, String name) throws IOException {
+        Object value = values.get(name);
+        if (!(value instanceof Number number)) {
+            throw new IOException("Catalog repository lacks a required Unix identity attribute");
+        }
+        long result = value instanceof Integer integer
+                ? Integer.toUnsignedLong(integer)
+                : number.longValue();
+        if (result < 0 || result > 0xffff_ffffL) {
+            throw new IOException("Catalog repository returned an invalid Unix identity attribute");
+        }
+        return result;
+    }
+
+    private static FileTime requiredTime(Map<String, Object> values, String name) throws IOException {
+        Object value = values.get(name);
+        if (!(value instanceof FileTime time)) {
+            throw new IOException("Catalog repository lacks a required Unix time attribute");
+        }
+        return time;
+    }
+
+    private static Path singleName(Path name) throws IOException {
+        if (name == null || name.getNameCount() != 1 || name.toString().isBlank()
+                || ".".equals(name.toString()) || "..".equals(name.toString())) {
+            throw new IOException("Catalog artifact path contains an unsafe segment");
+        }
+        return name;
+    }
+
+    private static void rejectSymbolicComponents(Path path) throws IOException {
+        Path current = path.getRoot();
+        for (Path component : path) {
+            current = current == null ? component : current.resolve(component);
+            if (Files.isSymbolicLink(current)) {
+                throw new IOException("Catalog repository path contains a symbolic link");
+            }
+        }
+    }
+
+    private record UnixIdentity(
+            Object fileKey,
+            long device,
+            long inode,
+            long linkCount,
+            long size,
+            long modifiedNanos,
+            long changedNanos,
+            long createdNanos,
+            int mode,
+            long userId,
+            long groupId) {
+    }
+
+    private static final class BoundRoot implements AutoCloseable {
+        private final Path path;
+        private final SecureDirectoryStream<Path> stream;
+        private final UnixIdentity identity;
+
+        private BoundRoot(Path path, SecureDirectoryStream<Path> stream, UnixIdentity identity) {
+            this.path = path;
+            this.stream = stream;
+            this.identity = identity;
+        }
+
+        private SecureDirectoryStream<Path> stream() {
+            return stream;
+        }
+
+        private UnixIdentity identity() {
+            return identity;
+        }
+
+        private void validate() throws IOException {
+            requireDirectory(attributes(stream, null), identity, identity.device());
+            if (!identity.equals(sampleUnix(path, identity.fileKey()))) {
+                throw new IOException("Catalog repository root changed while an artifact was read");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOException failure = null;
+            try {
+                validate();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                stream.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    private static final class BoundDirectory implements AutoCloseable {
+        private final SecureDirectoryStream<Path> parent;
+        private final Path name;
+        private final Path lexicalPath;
+        private final SecureDirectoryStream<Path> stream;
+        private final UnixIdentity identity;
+        private final long rootDevice;
+
+        private BoundDirectory(
+                               SecureDirectoryStream<Path> parent,
+                               Path name,
+                               Path lexicalPath,
+                               SecureDirectoryStream<Path> stream,
+                               UnixIdentity identity,
+                               long rootDevice) {
+            this.parent = parent;
+            this.name = name;
+            this.lexicalPath = lexicalPath;
+            this.stream = stream;
+            this.identity = identity;
+            this.rootDevice = rootDevice;
+        }
+
+        private SecureDirectoryStream<Path> stream() {
+            return stream;
+        }
+
+        private void validate() throws IOException {
+            requireDirectory(attributes(stream, null), identity, rootDevice);
+            requireDirectory(attributes(parent, name), identity, rootDevice);
+            if (!identity.equals(sampleUnix(lexicalPath, identity.fileKey()))) {
+                throw new IOException("Catalog repository directory changed while it was used");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOException failure = null;
+            try {
+                validate();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                stream.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogComponentModel.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogComponentModel.java
@@ -1,0 +1,153 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+
+/**
+ * Bounded, descriptive option metadata. This caller-constructible record is not proof of provenance; only an opaque
+ * {@link ShipCatalogService.Snapshot} binds models to the artifact bytes it verified and froze.
+ */
+public record CatalogComponentModel(
+        SubjectEvidence evidence,
+        String syntax,
+        boolean lenientProperties,
+        List<Option> options) {
+
+    static final int MAX_OPTIONS = 4_096;
+    static final int MAX_ENUM_VALUES = 4_096;
+
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
+    private static final Comparator<Option> OPTION_ORDER = Comparator.comparing(Option::scope)
+            .thenComparing(Option::kind)
+            .thenComparingInt(Option::index)
+            .thenComparing(Option::name);
+
+    public CatalogComponentModel {
+        Objects.requireNonNull(evidence, "evidence must not be null");
+        if (evidence.subject().kind() != CatalogSubject.Kind.COMPONENT) {
+            throw new IllegalArgumentException("Component metadata requires component evidence");
+        }
+        if (!safeText(syntax, 1_024) || !syntax.startsWith(evidence.subject().name() + ':')) {
+            throw new IllegalArgumentException("Component syntax is invalid");
+        }
+        options = boundedCopy(options);
+        Set<String> normalized = new HashSet<>();
+        for (int index = 0; index < options.size(); index++) {
+            Option option = options.get(index);
+            if (index > 0 && OPTION_ORDER.compare(options.get(index - 1), option) >= 0) {
+                throw new IllegalArgumentException("Component options are not canonical and unique");
+            }
+            String key = option.scope() + ":" + option.name().replace("-", "").replace("_", "")
+                    .toLowerCase(Locale.ROOT);
+            if (!normalized.add(key)) {
+                throw new IllegalArgumentException("Component options have ambiguous normalized names");
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CatalogComponentModel[evidence=" + evidence
+               + ", syntax=<redacted>, lenientProperties=" + lenientProperties
+               + ", options=<" + options.size() + " entries>]";
+    }
+
+    public record Option(
+            String name,
+            Scope scope,
+            Kind kind,
+            int index,
+            String type,
+            String javaType,
+            boolean required,
+            boolean multiValue,
+            String prefix,
+            String optionalPrefix,
+            List<String> enumValues) {
+
+        public Option {
+            if (name == null || !SAFE_NAME.matcher(name).matches()) {
+                throw new IllegalArgumentException("Component option name is invalid");
+            }
+            Objects.requireNonNull(scope, "scope must not be null");
+            Objects.requireNonNull(kind, "kind must not be null");
+            if (scope == Scope.COMPONENT ? kind != Kind.PROPERTY : kind == Kind.PROPERTY) {
+                throw new IllegalArgumentException("Component option kind is inconsistent with its scope");
+            }
+            if (index < 0 || !safeText(type, 512) || !safeText(javaType, 512)) {
+                throw new IllegalArgumentException("Component option metadata is invalid");
+            }
+            if (prefix != null && !SAFE_NAME.matcher(prefix).matches()) {
+                throw new IllegalArgumentException("Component option prefix is invalid");
+            }
+            if (optionalPrefix != null && !SAFE_NAME.matcher(optionalPrefix).matches()) {
+                throw new IllegalArgumentException("Component option optional prefix is invalid");
+            }
+            enumValues = boundedEnums(enumValues);
+        }
+
+        @Override
+        public String toString() {
+            return "Option[name=" + name
+                   + ", scope=" + scope
+                   + ", kind=" + kind
+                   + ", index=" + index
+                   + ", type=" + type
+                   + ", javaType=" + javaType
+                   + ", required=" + required
+                   + ", multiValue=" + multiValue
+                   + ", prefix=" + prefix
+                   + ", optionalPrefix=" + optionalPrefix
+                   + ", enumValues=<" + enumValues.size() + " entries>]";
+        }
+    }
+
+    public enum Scope {
+        COMPONENT,
+        ENDPOINT
+    }
+
+    public enum Kind {
+        PROPERTY,
+        PATH,
+        PARAMETER
+    }
+
+    private static List<Option> boundedCopy(List<Option> values) {
+        Objects.requireNonNull(values, "options must not be null");
+        List<Option> copy = new ArrayList<>();
+        for (Option value : values) {
+            if (copy.size() == MAX_OPTIONS) {
+                throw new IllegalArgumentException("Component options exceed their fixed bound");
+            }
+            copy.add(Objects.requireNonNull(value, "options must not contain null"));
+        }
+        return List.copyOf(copy);
+    }
+
+    private static List<String> boundedEnums(List<String> values) {
+        Objects.requireNonNull(values, "enumValues must not be null");
+        List<String> copy = new ArrayList<>();
+        Set<String> unique = new HashSet<>();
+        for (String value : values) {
+            if (copy.size() == MAX_ENUM_VALUES || !safeText(value, 512) || !unique.add(value)) {
+                throw new IllegalArgumentException("Component option enum is invalid or excessive");
+            }
+            copy.add(value);
+        }
+        return List.copyOf(copy);
+    }
+
+    private static boolean safeText(String value, int maximum) {
+        return value != null && !value.isBlank() && value.length() <= maximum
+                && value.chars().noneMatch(Character::isISOControl);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogEvidenceSet.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogEvidenceSet.java
@@ -1,0 +1,381 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+
+/** Immutable descriptive snapshot of exact catalog artifacts and resources. */
+public record CatalogEvidenceSet(
+        int schemaVersion,
+        CatalogTarget target,
+        MavenCoordinate platformCoordinate,
+        List<ArtifactEvidence> artifacts,
+        List<SubjectEvidence> subjects,
+        String digest) {
+
+    public static final int SCHEMA_VERSION = 1;
+    static final int MAX_ARTIFACTS = 5;
+    static final int MAX_SUBJECTS = 512;
+
+    private static final long MAX_JAR_BYTES = 128L * 1024 * 1024;
+    private static final long MAX_POM_BYTES = 4L * 1024 * 1024;
+    private static final Pattern DIGEST = Pattern.compile("sha256:[0-9a-f]{64}");
+    private static final Pattern SAFE_IDENTITY = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
+    private static final Comparator<ArtifactEvidence> ARTIFACT_ORDER
+            = Comparator.comparing(value -> value.coordinate().resolverString());
+    private static final Comparator<SubjectEvidence> SUBJECT_ORDER
+            = Comparator.comparing(SubjectEvidence::subject)
+                    .thenComparing(SubjectEvidence::resource);
+
+    public CatalogEvidenceSet {
+        if (schemaVersion != SCHEMA_VERSION) {
+            throw new IllegalArgumentException("Unsupported catalog snapshot schema version");
+        }
+        Objects.requireNonNull(target, "target must not be null");
+        Objects.requireNonNull(platformCoordinate, "platformCoordinate must not be null");
+        artifacts = boundedCopy(artifacts, 1, MAX_ARTIFACTS, "artifacts");
+        subjects = boundedCopy(subjects, 1, MAX_SUBJECTS, "subjects");
+        requireCanonical(artifacts, ARTIFACT_ORDER, "artifacts");
+        requireCanonical(subjects, SUBJECT_ORDER, "subjects");
+        validateSnapshot(target, platformCoordinate, artifacts, subjects);
+        String expected = digestFor(schemaVersion, target, platformCoordinate, artifacts, subjects);
+        if (!expected.equals(digest)) {
+            throw new IllegalArgumentException("Catalog snapshot digest does not match its contents");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CatalogEvidenceSet[schemaVersion=" + schemaVersion
+               + ", target=" + target
+               + ", platformCoordinate=" + platformCoordinate
+               + ", artifacts=<" + artifacts.size() + " entries>"
+               + ", subjects=<" + subjects.size() + " entries>"
+               + ", digest=" + digest + ']';
+    }
+
+    /** Creates a canonically ordered snapshot and derives its content digest. */
+    static CatalogEvidenceSet create(
+            CatalogTarget target,
+            MavenCoordinate platformCoordinate,
+            List<ArtifactEvidence> artifacts,
+            List<SubjectEvidence> subjects) {
+        List<ArtifactEvidence> canonicalArtifacts = sortedCopy(
+                artifacts, MAX_ARTIFACTS, ARTIFACT_ORDER, "artifacts");
+        List<SubjectEvidence> canonicalSubjects = sortedCopy(
+                subjects, MAX_SUBJECTS, SUBJECT_ORDER, "subjects");
+        String digest = digestFor(
+                SCHEMA_VERSION, target, platformCoordinate, canonicalArtifacts, canonicalSubjects);
+        return new CatalogEvidenceSet(
+                SCHEMA_VERSION, target, platformCoordinate, canonicalArtifacts, canonicalSubjects, digest);
+    }
+
+    /** Exact Maven artifact bytes included in this descriptive snapshot. */
+    public record ArtifactEvidence(MavenCoordinate coordinate, String sha256, long size) {
+        public ArtifactEvidence {
+            Objects.requireNonNull(coordinate, "coordinate must not be null");
+            if (!coordinate.classifier().isEmpty()
+                    || !("jar".equals(coordinate.extension()) || "pom".equals(coordinate.extension()))) {
+                throw new IllegalArgumentException("Catalog artifact must be an unclassified JAR or POM");
+            }
+            requireDigest(sha256, "artifact");
+            long limit = "pom".equals(coordinate.extension()) ? MAX_POM_BYTES : MAX_JAR_BYTES;
+            if (size <= 0 || size > limit) {
+                throw new IllegalArgumentException("Catalog artifact size is outside its fixed bound");
+            }
+        }
+    }
+
+    /** Exact catalog resource and source-artifact binding for one requested subject. */
+    public record SubjectEvidence(
+            CatalogSubject subject,
+            MavenCoordinate catalogCoordinate,
+            String catalogSha256,
+            String resource,
+            String resourceSha256,
+            String groupId,
+            String artifactId,
+            String artifactVersion,
+            boolean deprecated) {
+
+        public SubjectEvidence {
+            Objects.requireNonNull(subject, "subject must not be null");
+            Objects.requireNonNull(catalogCoordinate, "catalogCoordinate must not be null");
+            if (!"jar".equals(catalogCoordinate.extension()) || !catalogCoordinate.classifier().isEmpty()) {
+                throw new IllegalArgumentException("Catalog resource source must be an unclassified JAR");
+            }
+            requireDigest(catalogSha256, "catalog");
+            requireResource(resource);
+            requireDigest(resourceSha256, "resource");
+            boolean absentIdentity = groupId == null && artifactId == null && artifactVersion == null;
+            boolean completeIdentity = safeIdentity(groupId) && safeIdentity(artifactId)
+                    && safeIdentity(artifactVersion);
+            if (subject.kind() == CatalogSubject.Kind.EIP ? !absentIdentity : !completeIdentity) {
+                throw new IllegalArgumentException("Catalog resource Maven identity is incomplete or unexpected");
+            }
+        }
+    }
+
+    private static void validateSnapshot(
+            CatalogTarget target,
+            MavenCoordinate platform,
+            List<ArtifactEvidence> artifacts,
+            List<SubjectEvidence> subjects) {
+        Map<MavenCoordinate, ArtifactEvidence> byCoordinate = new HashMap<>();
+        for (ArtifactEvidence artifact : artifacts) {
+            if (byCoordinate.put(artifact.coordinate(), artifact) != null) {
+                throw new IllegalArgumentException("Catalog snapshot contains duplicate artifact coordinates");
+            }
+        }
+        MavenCoordinate main = MavenCoordinate.jar(
+                "org.apache.camel", "camel-catalog", target.camelVersion());
+        requireArtifact(byCoordinate, main);
+        Set<MavenCoordinate> subjectSources = new HashSet<>();
+        subjectSources.add(main);
+        switch (target.runtime()) {
+            case "main" -> {
+                requireExactArtifacts(artifacts, 1);
+                requireCoordinate(platform, main);
+            }
+            case "spring-boot" -> {
+                MavenCoordinate provider = MavenCoordinate.jar(
+                        "org.apache.camel.springboot", "camel-catalog-provider-springboot",
+                        target.platformVersion());
+                requireCoordinate(platform, provider);
+                requireArtifact(byCoordinate, provider);
+                requireArtifact(byCoordinate, provider.withExtension("pom"));
+                requireArtifact(byCoordinate, MavenCoordinate.of(
+                        "org.apache.camel.springboot", "spring-boot",
+                        target.platformVersion(), "pom"));
+                requireArtifact(byCoordinate, MavenCoordinate.of(
+                        "org.apache.camel", "camel-dependencies",
+                        target.camelVersion(), "pom"));
+                requireExactArtifacts(artifacts, 5);
+                subjectSources.add(provider);
+            }
+            case "quarkus" -> {
+                MavenCoordinate bom = MavenCoordinate.of(
+                        "io.quarkus.platform", "quarkus-camel-bom", target.platformVersion(), "pom");
+                requireCoordinate(platform, bom);
+                requireArtifact(byCoordinate, bom);
+                ArtifactEvidence provider = artifacts.stream()
+                        .filter(value -> "org.apache.camel.quarkus".equals(value.coordinate().groupId()))
+                        .filter(value -> "camel-quarkus-catalog".equals(value.coordinate().artifactId()))
+                        .filter(value -> "jar".equals(value.coordinate().extension()))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "Quarkus catalog snapshot lacks its provider artifact"));
+                requireExactArtifacts(artifacts, 3);
+                subjectSources.add(provider.coordinate());
+            }
+            default -> throw new IllegalStateException("Unexpected catalog runtime");
+        }
+
+        Set<CatalogSubject> uniqueSubjects = new HashSet<>();
+        Set<String> uniqueResources = new HashSet<>();
+        for (SubjectEvidence subject : subjects) {
+            if (!uniqueSubjects.add(subject.subject()) || !uniqueResources.add(subject.resource())) {
+                throw new IllegalArgumentException("Catalog snapshot contains duplicate subjects or resources");
+            }
+            if (!subjectSources.contains(subject.catalogCoordinate())) {
+                throw new IllegalArgumentException("Catalog subject references an artifact outside the snapshot");
+            }
+            ArtifactEvidence source = requireArtifact(byCoordinate, subject.catalogCoordinate());
+            if (!source.sha256().equals(subject.catalogSha256())) {
+                throw new IllegalArgumentException("Catalog subject source digest does not match its artifact");
+            }
+            validateSubjectBinding(target, main, subject);
+        }
+    }
+
+    private static void validateSubjectBinding(
+            CatalogTarget target, MavenCoordinate main, SubjectEvidence evidence) {
+        CatalogSubject subject = evidence.subject();
+        boolean mainSource = evidence.catalogCoordinate().equals(main);
+        if (subject.kind() == CatalogSubject.Kind.EIP && !mainSource) {
+            throw new IllegalArgumentException("EIP catalog subjects must come from the main catalog artifact");
+        }
+        if (subject.kind() != CatalogSubject.Kind.EIP && "main".equals(target.runtime()) != mainSource) {
+            throw new IllegalArgumentException("Catalog subject comes from the wrong runtime artifact");
+        }
+        String root = mainSource
+                ? "org/apache/camel/catalog"
+                : "spring-boot".equals(target.runtime())
+                        ? "org/apache/camel/springboot/catalog"
+                : "org/apache/camel/catalog/quarkus";
+        String expectedResource = root + '/' + directory(subject.kind()) + '/' + subject.name() + ".json";
+        if (!expectedResource.equals(evidence.resource())) {
+            throw new IllegalArgumentException("Catalog subject resource does not match its canonical identity");
+        }
+        if (subject.kind() != CatalogSubject.Kind.EIP) {
+            String expectedGroup = mainSource
+                    ? "org.apache.camel"
+                    : "spring-boot".equals(target.runtime())
+                            ? "org.apache.camel.springboot"
+                    : "org.apache.camel.quarkus";
+            if (!expectedGroup.equals(evidence.groupId())
+                    || !evidence.catalogCoordinate().version().equals(evidence.artifactVersion())) {
+                throw new IllegalArgumentException("Catalog subject Maven identity does not match its source artifact");
+            }
+        }
+    }
+
+    private static ArtifactEvidence requireArtifact(
+            Map<MavenCoordinate, ArtifactEvidence> artifacts, MavenCoordinate coordinate) {
+        ArtifactEvidence result = artifacts.get(coordinate);
+        if (result == null) {
+            throw new IllegalArgumentException("Catalog snapshot lacks a required artifact");
+        }
+        return result;
+    }
+
+    private static void requireCoordinate(MavenCoordinate actual, MavenCoordinate expected) {
+        if (!expected.equals(actual)) {
+            throw new IllegalArgumentException("Catalog snapshot platform coordinate is inconsistent");
+        }
+    }
+
+    private static void requireExactArtifacts(List<ArtifactEvidence> artifacts, int expected) {
+        if (artifacts.size() != expected) {
+            throw new IllegalArgumentException("Catalog snapshot artifact set is incomplete or excessive");
+        }
+    }
+
+    private static <T> void requireCanonical(List<T> values, Comparator<? super T> comparator, String label) {
+        for (int index = 1; index < values.size(); index++) {
+            if (comparator.compare(values.get(index - 1), values.get(index)) >= 0) {
+                throw new IllegalArgumentException("Catalog snapshot " + label + " are not canonical and unique");
+            }
+        }
+    }
+
+    private static <T> List<T> sortedCopy(
+            List<T> values, int maximum, Comparator<? super T> order, String label) {
+        List<T> copy = new ArrayList<>(boundedCopy(values, 1, maximum, label));
+        copy.sort(order);
+        return List.copyOf(copy);
+    }
+
+    private static <T> List<T> boundedCopy(List<T> values, int minimum, int maximum, String label) {
+        Objects.requireNonNull(values, label + " must not be null");
+        List<T> copy = new ArrayList<>();
+        for (T value : values) {
+            if (copy.size() == maximum) {
+                throw new IllegalArgumentException("Catalog snapshot " + label + " exceed their fixed bound");
+            }
+            copy.add(Objects.requireNonNull(value, label + " must not contain null"));
+        }
+        if (copy.size() < minimum) {
+            throw new IllegalArgumentException("Catalog snapshot " + label + " are empty");
+        }
+        return List.copyOf(copy);
+    }
+
+    private static void requireDigest(String value, String label) {
+        if (value == null || !DIGEST.matcher(value).matches()) {
+            throw new IllegalArgumentException("Catalog " + label + " digest is invalid");
+        }
+    }
+
+    private static void requireResource(String resource) {
+        if (resource == null || resource.length() > 512 || resource.startsWith("/")
+                || resource.indexOf('\\') >= 0 || resource.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("Catalog resource path is invalid");
+        }
+        for (String segment : resource.split("/", -1)) {
+            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+                throw new IllegalArgumentException("Catalog resource path is invalid");
+            }
+        }
+    }
+
+    private static boolean safeIdentity(String value) {
+        return value != null && SAFE_IDENTITY.matcher(value).matches();
+    }
+
+    private static String directory(CatalogSubject.Kind kind) {
+        return switch (kind) {
+            case COMPONENT -> "components";
+            case EIP -> "models";
+            case DATAFORMAT -> "dataformats";
+            case LANGUAGE -> "languages";
+        };
+    }
+
+    private static String digestFor(
+            int schemaVersion,
+            CatalogTarget target,
+            MavenCoordinate platform,
+            List<ArtifactEvidence> artifacts,
+            List<SubjectEvidence> subjects) {
+        MessageDigest digest = sha256();
+        put(digest, "camel-kit.ship.catalog-snapshot.v1");
+        putInt(digest, schemaVersion);
+        put(digest, target.runtime());
+        put(digest, target.camelVersion());
+        putNullable(digest, target.platformVersion());
+        putNullable(digest, target.springBootVersion());
+        put(digest, platform.resolverString());
+        putInt(digest, artifacts.size());
+        for (ArtifactEvidence artifact : artifacts) {
+            put(digest, artifact.coordinate().resolverString());
+            put(digest, artifact.sha256());
+            putLong(digest, artifact.size());
+        }
+        putInt(digest, subjects.size());
+        for (SubjectEvidence subject : subjects) {
+            put(digest, subject.subject().kind().name());
+            put(digest, subject.subject().name());
+            put(digest, subject.catalogCoordinate().resolverString());
+            put(digest, subject.catalogSha256());
+            put(digest, subject.resource());
+            put(digest, subject.resourceSha256());
+            putNullable(digest, subject.groupId());
+            putNullable(digest, subject.artifactId());
+            putNullable(digest, subject.artifactVersion());
+            digest.update((byte) (subject.deprecated() ? 1 : 0));
+        }
+        return "sha256:" + java.util.HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static void putNullable(MessageDigest digest, String value) {
+        digest.update((byte) (value == null ? 0 : 1));
+        if (value != null) {
+            put(digest, value);
+        }
+    }
+
+    private static void put(MessageDigest digest, String value) {
+        byte[] bytes = Objects.requireNonNull(value, "digest value").getBytes(StandardCharsets.UTF_8);
+        putInt(digest, bytes.length);
+        digest.update(bytes);
+    }
+
+    private static void putInt(MessageDigest digest, int value) {
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(value).array());
+    }
+
+    private static void putLong(MessageDigest digest, long value) {
+        digest.update(ByteBuffer.allocate(Long.BYTES).putLong(value).array());
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogSubject.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogSubject.java
@@ -1,0 +1,30 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/** A named Camel catalog item that a design or generated route intends to use. */
+public record CatalogSubject(Kind kind, String name) implements Comparable<CatalogSubject> {
+
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
+
+    public CatalogSubject {
+        Objects.requireNonNull(kind, "kind must not be null");
+        if (name == null || !SAFE_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Catalog subject name is invalid");
+        }
+    }
+
+    @Override
+    public int compareTo(CatalogSubject other) {
+        int kindOrder = kind.compareTo(other.kind);
+        return kindOrder != 0 ? kindOrder : name.compareTo(other.name);
+    }
+
+    public enum Kind {
+        COMPONENT,
+        EIP,
+        DATAFORMAT,
+        LANGUAGE
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTarget.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTarget.java
@@ -1,0 +1,61 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Exact immutable runtime tuple whose catalog bytes are being snapshotted. */
+public record CatalogTarget(
+        String runtime,
+        String camelVersion,
+        String platformVersion,
+        String springBootVersion) {
+
+    private static final Pattern SAFE_VERSION = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}");
+    private static final Pattern TIMESTAMPED_SNAPSHOT = Pattern.compile(".*-\\d{8}\\.\\d{6}-\\d+$");
+
+    public CatalogTarget {
+        if (runtime == null || !Set.of("main", "spring-boot", "quarkus").contains(runtime)) {
+            throw new IllegalArgumentException("Unsupported catalog runtime");
+        }
+        requireRelease(camelVersion, "Camel");
+        if (platformVersion != null) {
+            requireRelease(platformVersion, "platform");
+        }
+        if (springBootVersion != null) {
+            requireRelease(springBootVersion, "Spring Boot");
+        }
+        switch (runtime) {
+            case "main" -> {
+                if (platformVersion != null || springBootVersion != null) {
+                    throw new IllegalArgumentException("Camel Main catalog target accepts only camelVersion");
+                }
+            }
+            case "spring-boot" -> {
+                if (platformVersion == null || springBootVersion == null) {
+                    throw new IllegalArgumentException(
+                            "Spring Boot catalog target requires platformVersion and springBootVersion");
+                }
+            }
+            case "quarkus" -> {
+                if (platformVersion == null || springBootVersion != null) {
+                    throw new IllegalArgumentException(
+                            "Quarkus catalog target requires platformVersion and forbids springBootVersion");
+                }
+            }
+            default -> throw new IllegalStateException("Unexpected catalog runtime");
+        }
+    }
+
+    private static void requireRelease(String version, String label) {
+        if (version == null || !SAFE_VERSION.matcher(version).matches()
+                || version.startsWith(".") || version.endsWith(".") || version.contains("..")) {
+            throw new IllegalArgumentException(label + " catalog version is invalid");
+        }
+        String normalized = version.toUpperCase(Locale.ROOT);
+        if (normalized.contains("SNAPSHOT") || "LATEST".equals(normalized) || "RELEASE".equals(normalized)
+                || TIMESTAMPED_SNAPSHOT.matcher(version).matches()) {
+            throw new IllegalArgumentException(label + " catalog version must be an immutable release");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
@@ -1,0 +1,1295 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.ArtifactEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+import io.github.luigidemasi.camelkit.ship.resolver.ResolvedExactMavenArtifact;
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver;
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver.ResolutionMode;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Resolves and snapshots version-specific Camel catalog artifacts without loading their classes. */
+public final class ShipCatalogService {
+
+    private static final long MAX_ARTIFACT_BYTES = 128L * 1024 * 1024;
+    private static final long MAX_POM_BYTES = 4L * 1024 * 1024;
+    private static final int MAX_POM_DEPTH = 64;
+    private static final int MAX_POM_ELEMENTS = 16_384;
+    private static final int MAX_POM_ATTRIBUTES = 512;
+    private static final int MAX_POM_NODES = 65_536;
+    private static final int MAX_POM_VALUE_CHARS = 1_024;
+    private static final int MAX_ZIP_ENTRIES = 8_192;
+    private static final long MAX_ZIP_UNCOMPRESSED_BYTES = 256L * 1024 * 1024;
+    private static final int MAX_RESOURCE_BYTES = 2 * 1024 * 1024;
+    private static final int MAX_SUBJECTS = 512;
+    private static final int MAX_NAMES_PER_KIND = 8_192;
+    private static final String MAIN_ROOT = "org/apache/camel/catalog";
+    private static final String SPRING_ROOT = "org/apache/camel/springboot/catalog";
+    private static final String QUARKUS_ROOT = "org/apache/camel/catalog/quarkus";
+    private static final String POM_NAMESPACE = "http://maven.apache.org/POM/4.0.0";
+    private static final Pattern SAFE_COORDINATE = Pattern.compile("[A-Za-z0-9_.-]+");
+    private static final Pattern TIMESTAMPED_SNAPSHOT = Pattern.compile(".*-\\d{8}\\.\\d{6}-\\d+$");
+    private static final Pattern PROPERTY = Pattern.compile("\\$\\{([^}]+)}");
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(100)
+                            .maxStringLength(MAX_RESOURCE_BYTES)
+                            .build())
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+    private final Path localRepository;
+    private final ResolutionMode resolutionMode;
+    private final ArtifactResolver artifactResolver;
+
+    /**
+     * Uses an explicit caller-supplied local repository and the fixed Maven Central release source. The controlling
+     * process remains responsible for creating and protecting that repository from other writers.
+     */
+    public ShipCatalogService(Path localRepository) {
+        this(localRepository, ResolutionMode.ONLINE, ShipMavenResolver::resolveArtifacts);
+    }
+
+    ShipCatalogService(
+                       Path localRepository, ResolutionMode resolutionMode, ArtifactResolver artifactResolver) {
+        this.localRepository = Objects.requireNonNull(localRepository, "localRepository must not be null")
+                .toAbsolutePath().normalize();
+        this.resolutionMode = Objects.requireNonNull(resolutionMode, "resolutionMode must not be null");
+        this.artifactResolver = Objects.requireNonNull(artifactResolver, "artifactResolver must not be null");
+    }
+
+    /** Acquires one exact artifact generation and freezes its bytes for every subsequent catalog query. */
+    public Snapshot snapshot(CatalogTarget target) throws IOException {
+        Objects.requireNonNull(target, "target must not be null");
+        prepareLocalRepository();
+        return new Snapshot(resolve(target));
+    }
+
+    private static CatalogEvidenceSet evidenceFor(
+            ResolvedCatalog resolved, Collection<CatalogSubject> requested)
+            throws IOException {
+        List<CatalogSubject> subjects = boundedSubjects(requested, null, "Catalog evidence");
+        Set<String> mainResources = new HashSet<>();
+        Set<String> providerResources = new HashSet<>();
+        for (CatalogSubject subject : subjects) {
+            String resource = resourceName(subject.kind(), subject.name(),
+                    subject.kind() == Kind.EIP || resolved.provider() == null ? MAIN_ROOT : resolved.providerRoot());
+            (subject.kind() == Kind.EIP || resolved.provider() == null
+                    ? mainResources : providerResources).add(resource);
+        }
+        CatalogArchive main = new CatalogArchive(
+                resolved.main(), MAIN_ROOT, resolved.target().camelVersion(), mainResources);
+        CatalogArchive provider = resolved.provider() == null
+                ? null
+                : new CatalogArchive(
+                        resolved.provider(), resolved.providerRoot(), resolved.providerVersion(), providerResources);
+        List<SubjectEvidence> evidence = new ArrayList<>();
+        for (CatalogSubject subject : subjects) {
+            CatalogArchive archive = subject.kind() == Kind.EIP || provider == null ? main : provider;
+            if (!archive.names(subject.kind()).contains(subject.name())) {
+                throw new IOException(
+                        "Catalog subject is unavailable for " + resolved.target().runtime() + ": " + subject);
+            }
+            evidence.add(archive.verify(subject, resolved.target(), archive == provider));
+        }
+        try {
+            return CatalogEvidenceSet.create(
+                    resolved.target(),
+                    resolved.platformCoordinate(),
+                    resolved.artifacts().stream()
+                            .map(ResolvedArtifactSnapshot::evidence)
+                            .sorted(Comparator.comparing(value -> value.coordinate().resolverString()))
+                            .toList(),
+                    List.copyOf(evidence));
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Resolved catalog data violates the bounded snapshot model", e);
+        }
+    }
+
+    private static List<CatalogSubject> availableSubjects(ResolvedCatalog resolved) throws IOException {
+        CatalogArchive main = new CatalogArchive(
+                resolved.main(), MAIN_ROOT, resolved.target().camelVersion(), Set.of());
+        CatalogArchive provider = resolved.provider() == null
+                ? null
+                : new CatalogArchive(
+                        resolved.provider(), resolved.providerRoot(), resolved.providerVersion(), Set.of());
+        TreeSet<CatalogSubject> result = new TreeSet<>();
+        for (Kind kind : Kind.values()) {
+            CatalogArchive archive = kind == Kind.EIP || provider == null ? main : provider;
+            for (String name : archive.names(kind)) {
+                if (result.size() == MAX_ZIP_ENTRIES) {
+                    throw new IOException("Catalog exposes more than " + MAX_ZIP_ENTRIES + " subjects");
+                }
+                result.add(new CatalogSubject(kind, name));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<CatalogComponentModel> componentModelsFor(
+            ResolvedCatalog resolved, Collection<CatalogSubject> components)
+            throws IOException {
+        List<CatalogSubject> subjects = boundedSubjects(components, Kind.COMPONENT, "Component metadata");
+        String root = resolved.provider() == null ? MAIN_ROOT : resolved.providerRoot();
+        Set<String> resources = new HashSet<>();
+        for (CatalogSubject subject : subjects) {
+            resources.add(resourceName(Kind.COMPONENT, subject.name(), root));
+        }
+        CatalogArchive archive = new CatalogArchive(
+                resolved.provider() == null ? resolved.main() : resolved.provider(),
+                root,
+                resolved.provider() == null ? resolved.target().camelVersion() : resolved.providerVersion(),
+                resources);
+        List<CatalogComponentModel> models = new ArrayList<>();
+        for (CatalogSubject subject : subjects) {
+            if (!archive.names(Kind.COMPONENT).contains(subject.name())) {
+                throw new IOException(
+                        "Catalog component is unavailable for " + resolved.target().runtime() + ": " + subject);
+            }
+            models.add(archive.componentModel(subject, resolved.target(), resolved.provider() != null));
+        }
+        return List.copyOf(models);
+    }
+
+    private static List<CatalogSubject> boundedSubjects(
+            Collection<CatalogSubject> values, Kind requiredKind, String label)
+            throws IOException {
+        Objects.requireNonNull(values, label + " subjects must not be null");
+        TreeSet<CatalogSubject> result = new TreeSet<>();
+        for (CatalogSubject subject : values) {
+            if (result.size() == MAX_SUBJECTS || subject == null
+                    || requiredKind != null && subject.kind() != requiredKind) {
+                throw new IOException(
+                        label + " requires between 1 and " + MAX_SUBJECTS + " valid subjects");
+            }
+            if (!result.add(subject)) {
+                throw new IOException(label + " request contains duplicate subjects");
+            }
+        }
+        if (result.isEmpty()) {
+            throw new IOException(
+                    label + " requires between 1 and " + MAX_SUBJECTS + " valid subjects");
+        }
+        return List.copyOf(result);
+    }
+
+    /** Opaque view over one frozen set of exact catalog artifact bytes. */
+    public static final class Snapshot {
+
+        private final ResolvedCatalog resolved;
+
+        private Snapshot(ResolvedCatalog resolved) {
+            this.resolved = Objects.requireNonNull(resolved, "resolved catalog must not be null");
+        }
+
+        public CatalogTarget target() {
+            return resolved.target();
+        }
+
+        /** Produces descriptive evidence for subjects from this snapshot only. */
+        public CatalogEvidenceSet evidenceFor(Collection<CatalogSubject> subjects) throws IOException {
+            return ShipCatalogService.evidenceFor(resolved, subjects);
+        }
+
+        /** Returns the complete runtime-filtered inventory from this snapshot only. */
+        public List<CatalogSubject> availableSubjects() throws IOException {
+            return ShipCatalogService.availableSubjects(resolved);
+        }
+
+        /** Parses exact component option metadata from this snapshot only. */
+        public List<CatalogComponentModel> componentModelsFor(Collection<CatalogSubject> components)
+                throws IOException {
+            return ShipCatalogService.componentModelsFor(resolved, components);
+        }
+
+        @Override
+        public String toString() {
+            return "CatalogSnapshot[target=" + resolved.target() + ']';
+        }
+    }
+
+    private ResolvedCatalog resolve(CatalogTarget target) throws IOException {
+        MavenCoordinate mainGav = gav("org.apache.camel", "camel-catalog", target.camelVersion(), "jar");
+        ResolvedArtifactSnapshot main = resolveArtifact(mainGav);
+        List<ResolvedArtifactSnapshot> artifacts = new ArrayList<>();
+        artifacts.add(main);
+
+        return switch (target.runtime()) {
+            case "main" -> {
+                yield new ResolvedCatalog(
+                        target, mainGav, main, null, null, null,
+                        List.copyOf(artifacts));
+            }
+            case "spring-boot" -> resolveSpring(target, main, artifacts);
+            case "quarkus" -> resolveQuarkus(target, main, artifacts);
+            default -> throw new IOException("Unsupported catalog runtime: " + target.runtime());
+        };
+    }
+
+    private ResolvedCatalog resolveSpring(
+            CatalogTarget target, ResolvedArtifactSnapshot main, List<ResolvedArtifactSnapshot> artifacts)
+            throws IOException {
+        MavenCoordinate providerGav = gav(
+                "org.apache.camel.springboot", "camel-catalog-provider-springboot",
+                target.platformVersion(), "jar");
+
+        MavenCoordinate providerPomGav = gav(
+                providerGav.groupId(), providerGav.artifactId(), providerGav.version(), "pom");
+        ResolvedArtifactSnapshot providerPom = resolveArtifact(providerPomGav);
+        MavenCoordinate springRootGav = gav(
+                "org.apache.camel.springboot", "spring-boot", providerGav.version(), "pom");
+        ResolvedArtifactSnapshot springRoot = resolveArtifact(springRootGav);
+        MavenCoordinate dependenciesGav = pomParentCoordinate(springRoot.bytes());
+        MavenCoordinate expectedDependencies = gav(
+                "org.apache.camel", "camel-dependencies", target.camelVersion(), "pom");
+        if (!expectedDependencies.equals(dependenciesGav)) {
+            throw new IOException("Spring Boot catalog root has an unexpected parent POM");
+        }
+        ResolvedArtifactSnapshot dependencies = resolveArtifact(dependenciesGav);
+        Map<String, String> inheritedProperties = new HashMap<>(pomProperties(dependencies.bytes()));
+        inheritedProperties.putAll(pomProperties(springRoot.bytes()));
+        String springBootVersion = resolvePomValue(
+                inheritedProperties.get("spring-boot-version"), inheritedProperties);
+        if (!safe(springBootVersion) || !immutableRelease(springBootVersion)) {
+            throw new IOException("Spring Boot catalog metadata lacks an immutable Spring Boot version");
+        }
+        if (!target.springBootVersion().equals(springBootVersion)) {
+            throw new IOException(
+                    "Spring Boot catalog metadata does not match the approved Spring Boot version");
+        }
+        String providerCamelVersion = pomVersion(
+                providerPom.bytes(), false, "org.apache.camel", "camel-catalog", inheritedProperties);
+        if (!target.camelVersion().equals(providerCamelVersion)) {
+            throw new IOException(
+                    "Spring Boot catalog provider does not match the approved Camel version");
+        }
+
+        ResolvedArtifactSnapshot provider = resolveArtifact(providerGav);
+        artifacts.add(providerPom);
+        artifacts.add(springRoot);
+        artifacts.add(dependencies);
+        artifacts.add(provider);
+        return new ResolvedCatalog(
+                target, providerGav, main, provider, SPRING_ROOT,
+                providerGav.version(), List.copyOf(artifacts));
+    }
+
+    private ResolvedCatalog resolveQuarkus(
+            CatalogTarget target, ResolvedArtifactSnapshot main, List<ResolvedArtifactSnapshot> artifacts)
+            throws IOException {
+        if (target.platformVersion() == null) {
+            throw new IOException("Quarkus catalog verification requires platformVersion");
+        }
+        MavenCoordinate bomGav = gav(
+                "io.quarkus.platform", "quarkus-camel-bom", target.platformVersion(), "pom");
+        ResolvedArtifactSnapshot bom = resolveArtifact(bomGav);
+
+        String managedCamelVersion = pomVersion(
+                bom.bytes(), true, "org.apache.camel", "camel-catalog");
+        if (!target.camelVersion().equals(managedCamelVersion)) {
+            throw new IOException("Quarkus platform does not match the approved Camel version");
+        }
+        String quarkusCatalogVersion = pomVersion(
+                bom.bytes(), true, "org.apache.camel.quarkus", "camel-quarkus-catalog");
+        if (quarkusCatalogVersion == null) {
+            throw new IOException("Quarkus platform BOM does not manage camel-quarkus-catalog");
+        }
+        MavenCoordinate providerGav = gav(
+                "org.apache.camel.quarkus", "camel-quarkus-catalog", quarkusCatalogVersion, "jar");
+        ResolvedArtifactSnapshot provider = resolveArtifact(providerGav);
+        artifacts.add(bom);
+        artifacts.add(provider);
+        return new ResolvedCatalog(
+                target, bomGav, main, provider, QUARKUS_ROOT,
+                quarkusCatalogVersion, List.copyOf(artifacts));
+    }
+
+    private ResolvedArtifactSnapshot resolveArtifact(MavenCoordinate coordinate) throws IOException {
+        List<ResolvedExactMavenArtifact> resolved;
+        try {
+            resolved = artifactResolver.resolve(localRepository, List.of(coordinate), resolutionMode);
+        } catch (IOException e) {
+            throw new IOException(
+                    "Could not acquire the exact catalog artifact in "
+                                  + resolutionMode.name().toLowerCase(Locale.ROOT) + " mode",
+                    e);
+        }
+        if (resolved == null) {
+            throw new IOException("Ship resolver returned an unexpected catalog artifact");
+        }
+        ResolvedExactMavenArtifact artifact = null;
+        for (ResolvedExactMavenArtifact value : resolved) {
+            if (artifact != null || value == null) {
+                throw new IOException("Ship resolver returned an unexpected catalog artifact");
+            }
+            artifact = value;
+        }
+        if (artifact == null || !coordinate.equals(artifact.coordinate())) {
+            throw new IOException("Ship resolver returned an unexpected catalog artifact");
+        }
+        return snapshotArtifact(coordinate, artifact);
+    }
+
+    private ResolvedArtifactSnapshot snapshotArtifact(
+            MavenCoordinate coordinate, ResolvedExactMavenArtifact artifact)
+            throws IOException {
+        Path file = artifact.path();
+        if (file == null) {
+            throw new IOException("Ship resolver returned an artifact without a path");
+        }
+        Path normalized = file.toAbsolutePath().normalize();
+        requireInsideRepository(normalized);
+        if (!normalized.equals(exactArtifactPath(coordinate))) {
+            throw new IOException("Resolved catalog artifact is not at its exact repository path");
+        }
+        long limit = "pom".equals(coordinate.extension()) ? MAX_POM_BYTES : MAX_ARTIFACT_BYTES;
+        byte[] bytes;
+        try {
+            bytes = CatalogArtifactReader.read(localRepository, normalized, limit);
+        } catch (IOException e) {
+            throw new IOException(
+                    "Could not securely snapshot the exact catalog artifact "
+                                  + resolverString(coordinate),
+                    e);
+        }
+        String digest = sha256(bytes);
+        if (bytes.length != artifact.contentLength() || !digest.equals(artifact.contentSha256())) {
+            throw new IOException("Catalog artifact does not match its acquired content identity");
+        }
+        if ("pom".equals(coordinate.extension())) {
+            requirePomCoordinate(bytes, coordinate);
+        }
+        return new ResolvedArtifactSnapshot(coordinate, bytes, digest);
+    }
+
+    private Path exactArtifactPath(MavenCoordinate coordinate) {
+        return localRepository.resolve(coordinate.groupId().replace('.', '/'))
+                .resolve(coordinate.artifactId())
+                .resolve(coordinate.version())
+                .resolve(coordinate.fileName())
+                .normalize();
+    }
+
+    private void prepareLocalRepository() throws IOException {
+        Path parent = localRepository.getParent();
+        if (parent == null || Files.isSymbolicLink(parent)
+                || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Catalog repository parent must be a real directory");
+        }
+        if (!Files.exists(localRepository, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createDirectory(localRepository);
+        }
+        if (Files.isSymbolicLink(localRepository)
+                || !Files.isDirectory(localRepository, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Catalog repository must be a real directory without symbolic links");
+        }
+    }
+
+    private void requireInsideRepository(Path path) throws IOException {
+        if (!path.startsWith(localRepository)) {
+            throw new IOException("Resolved catalog artifact escaped its private repository");
+        }
+    }
+
+    private static String pomVersion(byte[] pom, boolean managed, String groupId, String artifactId)
+            throws IOException {
+        return pomVersion(pom, managed, groupId, artifactId, Map.of());
+    }
+
+    private static String pomVersion(
+            byte[] pom,
+            boolean managed,
+            String groupId,
+            String artifactId,
+            Map<String, String> inheritedProperties)
+            throws IOException {
+        Document document = parsePom(pom);
+        Element project = document.getDocumentElement();
+        Map<String, String> properties = new HashMap<>(inheritedProperties);
+        Set<String> localProperties = new HashSet<>();
+        Element propertiesElement = child(project, "properties");
+        if (propertiesElement != null) {
+            for (Node node = propertiesElement.getFirstChild(); node != null; node = node.getNextSibling()) {
+                if (node instanceof Element property) {
+                    String name = localName(property);
+                    if (!localProperties.add(name)) {
+                        throw new IOException("Catalog POM contains a duplicate Maven property");
+                    }
+                    requirePomNamespace(property);
+                    properties.put(name, elementText(property));
+                }
+            }
+        }
+        String projectVersion = childText(project, "version");
+        if (projectVersion == null) {
+            projectVersion = childText(child(project, "parent"), "version");
+        }
+        if (projectVersion != null) {
+            properties.putIfAbsent("project.version", projectVersion);
+            properties.putIfAbsent("pom.version", projectVersion);
+        }
+
+        Element dependencies = managed
+                ? child(child(project, "dependencyManagement"), "dependencies")
+                : child(project, "dependencies");
+        String result = null;
+        if (dependencies != null) {
+            for (Node node = dependencies.getFirstChild(); node != null; node = node.getNextSibling()) {
+                if (!(node instanceof Element dependency) || !"dependency".equals(localName(dependency))) {
+                    continue;
+                }
+                requirePomNamespace(dependency);
+                if (groupId.equals(childText(dependency, "groupId"))
+                        && artifactId.equals(childText(dependency, "artifactId"))) {
+                    if (result != null) {
+                        throw new IOException(
+                                "Catalog POM declares duplicate dependency " + groupId + ':' + artifactId);
+                    }
+                    result = resolvePomValue(childText(dependency, "version"), properties);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, String> pomProperties(byte[] pom) throws IOException {
+        Element project = parsePom(pom).getDocumentElement();
+        Map<String, String> properties = new HashMap<>();
+        Element propertiesElement = child(project, "properties");
+        if (propertiesElement != null) {
+            for (Node node = propertiesElement.getFirstChild(); node != null; node = node.getNextSibling()) {
+                if (node instanceof Element property) {
+                    String name = localName(property);
+                    requirePomNamespace(property);
+                    if (properties.putIfAbsent(name, elementText(property)) != null) {
+                        throw new IOException("Catalog POM contains a duplicate Maven property");
+                    }
+                }
+            }
+        }
+        return Map.copyOf(properties);
+    }
+
+    private static void requirePomCoordinate(byte[] pom, MavenCoordinate expected) throws IOException {
+        Element project = parsePom(pom).getDocumentElement();
+        Element parent = child(project, "parent");
+        Map<String, String> properties = pomProperties(pom);
+        String groupId = resolvePomValue(childText(project, "groupId"), properties);
+        if (groupId == null) {
+            groupId = resolvePomValue(childText(parent, "groupId"), properties);
+        }
+        String artifactId = resolvePomValue(childText(project, "artifactId"), properties);
+        String version = resolvePomValue(childText(project, "version"), properties);
+        if (version == null) {
+            version = resolvePomValue(childText(parent, "version"), properties);
+        }
+        if (!expected.groupId().equals(groupId)
+                || !expected.artifactId().equals(artifactId)
+                || !expected.version().equals(version)) {
+            throw new IOException("Catalog POM identity does not match its exact artifact coordinate");
+        }
+    }
+
+    private static MavenCoordinate pomParentCoordinate(byte[] pom) throws IOException {
+        Element parent = child(parsePom(pom).getDocumentElement(), "parent");
+        if (parent == null) {
+            throw new IOException("Spring Boot catalog root lacks its required parent POM");
+        }
+        return gav(
+                childText(parent, "groupId"),
+                childText(parent, "artifactId"),
+                childText(parent, "version"),
+                "pom");
+    }
+
+    private static Document parsePom(byte[] pom) throws IOException {
+        if (pom.length == 0 || pom.length > MAX_POM_BYTES) {
+            throw new IOException("Catalog POM has an unsafe size");
+        }
+        requireBoundedPomStructure(pom);
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newDefaultInstance();
+        try {
+            factory.setNamespaceAware(true);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setCoalescing(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            var builder = factory.newDocumentBuilder();
+            builder.setErrorHandler(new StrictXmlErrorHandler());
+            try (InputStream input = new ByteArrayInputStream(pom)) {
+                Document document = builder.parse(input);
+                Element project = document.getDocumentElement();
+                if (!"project".equals(localName(project))
+                        || !POM_NAMESPACE.equals(project.getNamespaceURI())) {
+                    throw new IOException("Catalog POM root is not project");
+                }
+                if (!"4.0.0".equals(childText(project, "modelVersion"))) {
+                    throw new IOException("Catalog POM has an unsupported model version");
+                }
+                return document;
+            }
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new IOException("Could not securely parse catalog POM", e);
+        }
+    }
+
+    private static void requireBoundedPomStructure(byte[] pom) throws IOException {
+        XMLInputFactory factory = XMLInputFactory.newDefaultFactory();
+        try {
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Could not securely configure catalog POM preflight", e);
+        }
+        factory.setXMLResolver((publicId, systemId, baseUri, namespace) -> {
+            throw new XMLStreamException("External XML references are forbidden");
+        });
+
+        XMLStreamReader reader = null;
+        try (InputStream input = new ByteArrayInputStream(pom)) {
+            reader = factory.createXMLStreamReader(input);
+            int depth = 0;
+            int elements = 0;
+            int attributes = 0;
+            int nodes = 0;
+            while (reader.hasNext()) {
+                int event = reader.next();
+                if (event == XMLStreamConstants.DTD || event == XMLStreamConstants.ENTITY_REFERENCE
+                        || event == XMLStreamConstants.PROCESSING_INSTRUCTION) {
+                    throw new IOException("Catalog POM contains forbidden XML declarations");
+                }
+                if (event == XMLStreamConstants.START_ELEMENT) {
+                    depth = Math.addExact(depth, 1);
+                    elements = Math.addExact(elements, 1);
+                    attributes = Math.addExact(attributes,
+                            Math.addExact(reader.getAttributeCount(), reader.getNamespaceCount()));
+                    nodes = Math.addExact(nodes, 1);
+                    if (depth > MAX_POM_DEPTH || elements > MAX_POM_ELEMENTS
+                            || attributes > MAX_POM_ATTRIBUTES || nodes > MAX_POM_NODES) {
+                        throw new IOException("Catalog POM exceeds its structural limits");
+                    }
+                } else if (event == XMLStreamConstants.END_ELEMENT) {
+                    depth--;
+                } else if (event == XMLStreamConstants.CHARACTERS
+                        || event == XMLStreamConstants.CDATA
+                        || event == XMLStreamConstants.SPACE
+                        || event == XMLStreamConstants.COMMENT) {
+                    nodes = Math.addExact(nodes, 1);
+                    if (nodes > MAX_POM_NODES) {
+                        throw new IOException("Catalog POM exceeds its structural limits");
+                    }
+                }
+            }
+            if (depth != 0 || elements == 0) {
+                throw new IOException("Catalog POM has an invalid XML structure");
+            }
+        } catch (ArithmeticException e) {
+            throw new IOException("Catalog POM structure accounting overflowed", e);
+        } catch (XMLStreamException e) {
+            throw new IOException("Could not securely preflight catalog POM", e);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (XMLStreamException ignored) {
+                    // The in-memory source is already closed; parsing failures remain authoritative.
+                }
+            }
+        }
+    }
+
+    private static String resolvePomValue(String value, Map<String, String> properties) throws IOException {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return expandPomValue(value.trim(), properties, new HashSet<>(), 0);
+    }
+
+    private static String expandPomValue(
+            String value, Map<String, String> properties, Set<String> active, int depth)
+            throws IOException {
+        if (depth > 16) {
+            throw new IOException("Maven property expansion is too deep");
+        }
+        Matcher matcher = PROPERTY.matcher(value);
+        StringBuilder result = new StringBuilder(Math.min(value.length(), MAX_POM_VALUE_CHARS));
+        int cursor = 0;
+        while (matcher.find()) {
+            appendPomValue(result, value, cursor, matcher.start());
+            String key = matcher.group(1);
+            String replacement = properties.get(key);
+            if (replacement == null) {
+                return null;
+            }
+            if (!active.add(key)) {
+                throw new IOException("Catalog POM contains cyclic Maven property expansion");
+            }
+            try {
+                appendPomValue(result, expandPomValue(replacement, properties, active, depth + 1));
+            } finally {
+                active.remove(key);
+            }
+            cursor = matcher.end();
+        }
+        appendPomValue(result, value, cursor, value.length());
+        return result.toString();
+    }
+
+    private static void appendPomValue(StringBuilder target, CharSequence value) throws IOException {
+        appendPomValue(target, value, 0, value.length());
+    }
+
+    private static void appendPomValue(StringBuilder target, CharSequence value, int start, int end)
+            throws IOException {
+        if (end - start > MAX_POM_VALUE_CHARS - target.length()) {
+            throw new IOException("Catalog POM property expansion exceeds its size limit");
+        }
+        target.append(value, start, end);
+    }
+
+    private static MavenCoordinate gav(
+            String groupId, String artifactId, String version, String packaging)
+            throws IOException {
+        if (!Set.of("jar", "pom").contains(packaging)) {
+            throw new IOException("Catalog metadata contains an unsupported Maven artifact type");
+        }
+        try {
+            return MavenCoordinate.of(groupId, artifactId, version, packaging);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IOException("Catalog metadata contains an unsafe or mutable Maven coordinate", e);
+        }
+    }
+
+    private static boolean safe(String value) {
+        return value != null && value.length() <= 128 && SAFE_COORDINATE.matcher(value).matches()
+                && !value.startsWith(".") && !value.endsWith(".") && !value.contains("..");
+    }
+
+    private static boolean immutableRelease(String version) {
+        String normalized = version.toUpperCase(Locale.ROOT);
+        return !normalized.contains("SNAPSHOT")
+                && !"LATEST".equals(normalized)
+                && !"RELEASE".equals(normalized)
+                && !TIMESTAMPED_SNAPSHOT.matcher(version).matches();
+    }
+
+    private static String resolverString(MavenCoordinate gav) {
+        return gav.resolverString();
+    }
+
+    private static String sha256(byte[] bytes) {
+        return "sha256:" + hex(sha256Digest().digest(bytes));
+    }
+
+    private static MessageDigest sha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static String hex(byte[] bytes) {
+        return java.util.HexFormat.of().formatHex(bytes);
+    }
+
+    private static Element child(Element parent, String name) throws IOException {
+        if (parent == null) {
+            return null;
+        }
+        Element result = null;
+        for (Node node = parent.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node instanceof Element element && name.equals(localName(element))) {
+                requirePomNamespace(element);
+                if (result != null) {
+                    throw new IOException("Catalog POM contains duplicate " + name + " elements");
+                }
+                result = element;
+            }
+        }
+        return result;
+    }
+
+    private static String childText(Element parent, String name) throws IOException {
+        Element child = child(parent, name);
+        if (child == null) {
+            return null;
+        }
+        String value = elementText(child);
+        return value.isBlank() ? null : value;
+    }
+
+    private static String elementText(Element element) throws IOException {
+        StringBuilder result = new StringBuilder();
+        for (Node node = element.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node.getNodeType() != Node.TEXT_NODE && node.getNodeType() != Node.CDATA_SECTION_NODE) {
+                throw new IOException("Catalog POM scalar metadata contains nested structure");
+            }
+            String text = node.getNodeValue();
+            if (text.length() > MAX_POM_BYTES - result.length()) {
+                throw new IOException("Catalog POM scalar metadata exceeds its size limit");
+            }
+            result.append(text);
+        }
+        return result.toString().trim();
+    }
+
+    private static void requirePomNamespace(Element element) throws IOException {
+        if (!POM_NAMESPACE.equals(element.getNamespaceURI())) {
+            throw new IOException("Catalog POM contains foreign-namespace metadata");
+        }
+    }
+
+    private static String localName(Node node) {
+        return node.getLocalName() == null ? node.getNodeName() : node.getLocalName();
+    }
+
+    private static String resourceName(Kind kind, String name, String root) {
+        return root + '/' + CatalogArchive.directory(kind) + '/' + name + ".json";
+    }
+
+    private record ResolvedCatalog(
+            CatalogTarget target,
+            MavenCoordinate platformCoordinate,
+            ResolvedArtifactSnapshot main,
+            ResolvedArtifactSnapshot provider,
+            String providerRoot,
+            String providerVersion,
+            List<ResolvedArtifactSnapshot> artifacts) {
+    }
+
+    private static final class ResolvedArtifactSnapshot {
+        private final MavenCoordinate coordinate;
+        private final byte[] bytes;
+        private final String sha256;
+
+        private ResolvedArtifactSnapshot(MavenCoordinate coordinate, byte[] bytes, String sha256) {
+            this.coordinate = Objects.requireNonNull(coordinate, "coordinate");
+            this.bytes = Objects.requireNonNull(bytes, "bytes");
+            this.sha256 = Objects.requireNonNull(sha256, "sha256");
+        }
+
+        MavenCoordinate coordinate() {
+            return coordinate;
+        }
+
+        byte[] bytes() {
+            return bytes;
+        }
+
+        String sha256() {
+            return sha256;
+        }
+
+        ArtifactEvidence evidence() {
+            return new ArtifactEvidence(coordinate, sha256, bytes.length);
+        }
+    }
+
+    private static final class CatalogArchive {
+        private final ResolvedArtifactSnapshot artifact;
+        private final String root;
+        private final String resourceVersion;
+        private final Map<String, byte[]> entries;
+        private final Map<Kind, Set<String>> names = new HashMap<>();
+
+        private CatalogArchive(
+                               ResolvedArtifactSnapshot artifact,
+                               String root,
+                               String resourceVersion,
+                               Set<String> requestedResources)
+                                                               throws IOException {
+            this.artifact = artifact;
+            this.root = root;
+            this.resourceVersion = resourceVersion;
+            Set<String> required = new HashSet<>(requestedResources);
+            for (Kind kind : Kind.values()) {
+                if (kind != Kind.EIP || MAIN_ROOT.equals(root)) {
+                    required.add(root + '/' + directory(kind) + ".properties");
+                }
+            }
+            if (MAIN_ROOT.equals(root)) {
+                required.add("META-INF/version.properties");
+            }
+            this.entries = snapshotEntries(artifact.bytes(), required);
+            if (MAIN_ROOT.equals(root)) {
+                if (!resourceVersion.equals(embeddedVersion(read("META-INF/version.properties")))) {
+                    throw new IOException(
+                            "Camel catalog embedded version differs from the requested version");
+                }
+            }
+        }
+
+        private Set<String> names(Kind kind) throws IOException {
+            if (kind == Kind.EIP && !MAIN_ROOT.equals(root)) {
+                throw new IOException("Runtime provider catalog cannot supply EIP models");
+            }
+            Set<String> cached = names.get(kind);
+            if (cached != null) {
+                return cached;
+            }
+            LinkedHashMap<String, Boolean> values = new LinkedHashMap<>();
+            String content = strictUtf8(read(root + '/' + directory(kind) + ".properties"));
+            var lines = content.lines().iterator();
+            while (lines.hasNext()) {
+                String line = lines.next();
+                String name = line.trim();
+                if (name.isEmpty() || name.startsWith("#")) {
+                    continue;
+                }
+                try {
+                    new CatalogSubject(kind, name);
+                } catch (IllegalArgumentException e) {
+                    throw new IOException("Catalog index contains an unsafe name", e);
+                }
+                if (values.putIfAbsent(name, Boolean.TRUE) != null) {
+                    throw new IOException("Catalog index contains duplicate name: " + name);
+                }
+                if (values.size() > MAX_NAMES_PER_KIND) {
+                    throw new IOException("Catalog index contains too many names");
+                }
+            }
+            Set<String> immutable = Set.copyOf(values.keySet());
+            names.put(kind, immutable);
+            return immutable;
+        }
+
+        private SubjectEvidence verify(CatalogSubject subject, CatalogTarget target, boolean provider)
+                throws IOException {
+            String resource = root + '/' + directory(subject.kind()) + '/' + subject.name() + ".json";
+            byte[] bytes = read(resource);
+            JsonNode document;
+            try {
+                document = JSON.readTree(bytes);
+            } catch (IOException | RuntimeException e) {
+                throw new IOException("Catalog resource is not valid JSON: " + resource, e);
+            }
+            String identityName = identityNode(subject.kind());
+            JsonNode identity = document == null ? null : document.get(identityName);
+            if (identity == null || !identity.isObject()) {
+                throw new IOException("Catalog resource lacks " + identityName + " identity: " + resource);
+            }
+            String expectedKind = subject.kind() == Kind.EIP ? "model" : kindName(subject.kind());
+            if (!expectedKind.equals(text(identity, "kind")) || !subject.name().equals(text(identity, "name"))) {
+                throw new IOException("Catalog resource identity mismatch: " + resource);
+            }
+
+            String groupId = text(identity, "groupId");
+            String artifactId = text(identity, "artifactId");
+            String version = text(identity, "version");
+            if (subject.kind() != Kind.EIP) {
+                String expectedGroup = provider
+                        ? ("spring-boot".equals(target.runtime())
+                                ? "org.apache.camel.springboot" : "org.apache.camel.quarkus")
+                        : "org.apache.camel";
+                if (!expectedGroup.equals(groupId) || artifactId == null || artifactId.isBlank()
+                        || !resourceVersion.equals(version)) {
+                    throw new IOException("Catalog resource Maven identity mismatch: " + resource);
+                }
+                if (provider && "quarkus".equals(target.runtime())) {
+                    JsonNode metadata = identity.get("metadata");
+                    if (metadata == null || !target.camelVersion().equals(text(metadata, "camelVersion"))) {
+                        throw new IOException(
+                                "Quarkus catalog resource does not bind Camel "
+                                              + target.camelVersion() + ": " + resource);
+                    }
+                }
+            }
+            JsonNode deprecated = identity.get("deprecated");
+            if (deprecated == null || !deprecated.isBoolean()) {
+                throw new IOException("Catalog resource lacks a boolean deprecated flag: " + resource);
+            }
+            try {
+                return new SubjectEvidence(
+                        subject,
+                        artifact.coordinate(),
+                        artifact.sha256(),
+                        resource,
+                        sha256(bytes),
+                        groupId,
+                        artifactId,
+                        version,
+                        deprecated.booleanValue());
+            } catch (IllegalArgumentException e) {
+                throw new IOException("Catalog resource contains invalid bounded identity: " + resource, e);
+            }
+        }
+
+        private CatalogComponentModel componentModel(
+                CatalogSubject subject, CatalogTarget target, boolean provider)
+                throws IOException {
+            if (subject.kind() != Kind.COMPONENT) {
+                throw new IOException("Only component catalog resources contain endpoint option metadata");
+            }
+            SubjectEvidence evidence = verify(subject, target, provider);
+            byte[] bytes = read(evidence.resource());
+            JsonNode document;
+            try {
+                document = JSON.readTree(bytes);
+            } catch (IOException | RuntimeException e) {
+                throw new IOException("Catalog component resource is not valid JSON: " + evidence.resource(), e);
+            }
+            JsonNode identity = document == null ? null : document.get("component");
+            String syntax = text(identity, "syntax");
+            JsonNode lenient = identity == null ? null : identity.get("lenientProperties");
+            if (syntax == null || !syntax.startsWith(subject.name() + ':')
+                    || lenient == null || !lenient.isBoolean()) {
+                throw new IOException("Catalog component lacks a bounded syntax policy: " + evidence.resource());
+            }
+
+            List<CatalogComponentModel.Option> options = new ArrayList<>();
+            parseOptions(document.get("componentProperties"), CatalogComponentModel.Scope.COMPONENT,
+                    CatalogComponentModel.Kind.PROPERTY, options, evidence.resource());
+            parseOptions(document.get("properties"), CatalogComponentModel.Scope.ENDPOINT,
+                    null, options, evidence.resource());
+            options.sort(Comparator.comparing(CatalogComponentModel.Option::scope)
+                    .thenComparing(CatalogComponentModel.Option::kind)
+                    .thenComparingInt(CatalogComponentModel.Option::index)
+                    .thenComparing(CatalogComponentModel.Option::name));
+
+            Set<String> unique = new HashSet<>();
+            for (CatalogComponentModel.Option option : options) {
+                String key = option.scope() + ":" + normalizedOptionName(option.name());
+                if (!unique.add(key)) {
+                    throw new IOException("Catalog component has ambiguous option names: " + evidence.resource());
+                }
+            }
+            try {
+                return new CatalogComponentModel(evidence, syntax, lenient.booleanValue(), List.copyOf(options));
+            } catch (IllegalArgumentException e) {
+                throw new IOException(
+                        "Catalog component violates the bounded option model: "
+                                      + evidence.resource(),
+                        e);
+            }
+        }
+
+        private static void parseOptions(
+                JsonNode node,
+                CatalogComponentModel.Scope scope,
+                CatalogComponentModel.Kind requiredKind,
+                List<CatalogComponentModel.Option> result,
+                String resource)
+                throws IOException {
+            if (node == null || !node.isObject()) {
+                throw new IOException("Catalog component lacks option metadata: " + resource);
+            }
+            for (Map.Entry<String, JsonNode> entry : node.properties()) {
+                String name = entry.getKey();
+                JsonNode value = entry.getValue();
+                try {
+                    new CatalogSubject(Kind.COMPONENT, name);
+                } catch (IllegalArgumentException e) {
+                    throw new IOException("Catalog component has an unsafe option name: " + resource, e);
+                }
+                if (value == null || !value.isObject()) {
+                    throw new IOException("Catalog component option is not an object: " + resource + '#' + name);
+                }
+                String rawKind = text(value, "kind");
+                CatalogComponentModel.Kind kind = switch (rawKind == null ? "" : rawKind) {
+                    case "property" -> CatalogComponentModel.Kind.PROPERTY;
+                    case "path" -> CatalogComponentModel.Kind.PATH;
+                    case "parameter" -> CatalogComponentModel.Kind.PARAMETER;
+                    default -> throw new IOException(
+                            "Catalog component option has an unsupported kind: " + resource + '#' + name);
+                };
+                if (requiredKind != null ? kind != requiredKind : kind == CatalogComponentModel.Kind.PROPERTY) {
+                    throw new IOException("Catalog component option has the wrong scope: " + resource + '#' + name);
+                }
+                JsonNode index = value.get("index");
+                JsonNode required = value.get("required");
+                JsonNode multiValue = value.get("multiValue");
+                String type = text(value, "type");
+                String javaType = text(value, "javaType");
+                if (index == null || !index.isIntegralNumber() || !index.canConvertToInt()
+                        || index.intValue() < 0
+                        || required == null || !required.isBoolean()
+                        || multiValue != null && !multiValue.isBoolean()
+                        || type == null || javaType == null) {
+                    throw new IOException(
+                            "Catalog component option metadata is incomplete: "
+                                          + resource + '#' + name);
+                }
+                String prefix = text(value, "prefix");
+                if (prefix != null && (!prefix.matches("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}")
+                        || prefix.chars().anyMatch(Character::isISOControl))) {
+                    throw new IOException(
+                            "Catalog component option has an unsafe prefix: "
+                                          + resource + '#' + name);
+                }
+                String optionalPrefix = text(value, "optionalPrefix");
+                if (optionalPrefix != null
+                        && (!optionalPrefix.matches("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}")
+                                || optionalPrefix.chars().anyMatch(Character::isISOControl))) {
+                    throw new IOException(
+                            "Catalog component option has an unsafe optional prefix: "
+                                          + resource + '#' + name);
+                }
+                List<String> enumValues = enumValues(value.get("enum"), resource, name);
+                if (result.size() == CatalogComponentModel.MAX_OPTIONS) {
+                    throw new IOException("Catalog component has too many options: " + resource);
+                }
+                try {
+                    result.add(new CatalogComponentModel.Option(
+                            name, scope, kind, index.intValue(), type, javaType, required.booleanValue(),
+                            multiValue != null && multiValue.booleanValue(), prefix, optionalPrefix, enumValues));
+                } catch (IllegalArgumentException e) {
+                    throw new IOException(
+                            "Catalog component option violates the bounded model: "
+                                          + resource + '#' + name,
+                            e);
+                }
+            }
+        }
+
+        private static List<String> enumValues(JsonNode node, String resource, String option) throws IOException {
+            if (node == null) {
+                return List.of();
+            }
+            if (!node.isArray() || node.size() > CatalogComponentModel.MAX_ENUM_VALUES) {
+                throw new IOException("Catalog component option has an unsafe enum: " + resource + '#' + option);
+            }
+            List<String> result = new ArrayList<>();
+            Set<String> unique = new HashSet<>();
+            for (JsonNode value : node) {
+                if (!value.isTextual() || value.asText().isBlank()
+                        || value.asText().length() > 512 || !unique.add(value.asText())) {
+                    throw new IOException(
+                            "Catalog component option has an invalid enum: "
+                                          + resource + '#' + option);
+                }
+                result.add(value.asText());
+            }
+            return List.copyOf(result);
+        }
+
+        private static String normalizedOptionName(String value) {
+            return value.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+        }
+
+        private static String embeddedVersion(byte[] bytes) throws IOException {
+            String result = null;
+            var lines = strictUtf8(bytes).lines().iterator();
+            while (lines.hasNext()) {
+                String line = lines.next();
+                String value = line.trim();
+                if (value.isEmpty() || value.startsWith("#") || value.startsWith("!")) {
+                    continue;
+                }
+                if (!value.startsWith("version=") || result != null) {
+                    throw new IOException("Camel catalog version metadata is not canonical");
+                }
+                result = value.substring("version=".length()).trim();
+            }
+            if (result == null || !safe(result) || !immutableRelease(result)) {
+                throw new IOException("Camel catalog version metadata lacks an immutable version");
+            }
+            return result;
+        }
+
+        private static String strictUtf8(byte[] bytes) throws IOException {
+            try {
+                return StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT)
+                        .decode(ByteBuffer.wrap(bytes))
+                        .toString();
+            } catch (CharacterCodingException e) {
+                throw new IOException("Catalog text resource is not strict UTF-8", e);
+            }
+        }
+
+        private byte[] read(String name) throws IOException {
+            byte[] bytes = entries.get(name);
+            if (bytes == null) {
+                throw new IOException("Catalog artifact is missing resource: " + name);
+            }
+            return bytes;
+        }
+
+        private static Map<String, byte[]> snapshotEntries(byte[] archive, Set<String> required)
+                throws IOException {
+            Set<String> seen = new HashSet<>();
+            Map<String, byte[]> selected = new HashMap<>();
+            long total = 0;
+            int count = 0;
+            byte[] buffer = new byte[16_384];
+            try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(archive))) {
+                ZipEntry entry;
+                while ((entry = zip.getNextEntry()) != null) {
+                    String name = entry.getName();
+                    if (++count > MAX_ZIP_ENTRIES || !seen.add(name)) {
+                        throw new IOException("Catalog ZIP has too many or duplicate entries");
+                    }
+                    requireSafeZipName(name, entry.isDirectory());
+                    ByteArrayOutputStream retained = required.contains(name)
+                            ? new ByteArrayOutputStream() : null;
+                    long entryBytes = 0;
+                    int read;
+                    while ((read = zip.read(buffer)) >= 0) {
+                        if (read == 0) {
+                            continue;
+                        }
+                        entryBytes = Math.addExact(entryBytes, read);
+                        total = Math.addExact(total, read);
+                        if (total > MAX_ZIP_UNCOMPRESSED_BYTES) {
+                            throw new IOException("Catalog ZIP exceeds the uncompressed size limit");
+                        }
+                        if (retained != null) {
+                            if (entryBytes > MAX_RESOURCE_BYTES) {
+                                throw new IOException("Catalog resource exceeds its size limit: " + name);
+                            }
+                            retained.write(buffer, 0, read);
+                        }
+                    }
+                    if (retained != null) {
+                        selected.put(name, retained.toByteArray());
+                    }
+                    zip.closeEntry();
+                }
+            } catch (ArithmeticException e) {
+                throw new IOException("Catalog ZIP size accounting overflowed", e);
+            }
+            if (count == 0) {
+                throw new IOException("Catalog artifact is not a non-empty ZIP archive");
+            }
+            return Map.copyOf(selected);
+        }
+
+        private static void requireSafeZipName(String name, boolean directory) throws IOException {
+            if (name == null || name.isEmpty() || name.length() > 512 || name.startsWith("/")
+                    || name.indexOf('\\') >= 0
+                    || name.indexOf('\0') >= 0) {
+                throw new IOException("Catalog ZIP contains an unsafe entry name");
+            }
+            String[] segments = name.split("/", -1);
+            for (int i = 0; i < segments.length; i++) {
+                String segment = segments[i];
+                if (segment.isEmpty() && directory && i == segments.length - 1) {
+                    continue;
+                }
+                if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+                    throw new IOException("Catalog ZIP contains an unsafe entry name");
+                }
+            }
+        }
+
+        private static String identityNode(Kind kind) {
+            return switch (kind) {
+                case COMPONENT -> "component";
+                case EIP -> "model";
+                case DATAFORMAT -> "dataformat";
+                case LANGUAGE -> "language";
+            };
+        }
+
+        private static String kindName(Kind kind) {
+            return switch (kind) {
+                case COMPONENT -> "component";
+                case DATAFORMAT -> "dataformat";
+                case LANGUAGE -> "language";
+                case EIP -> "model";
+            };
+        }
+
+        private static String directory(Kind kind) {
+            return switch (kind) {
+                case COMPONENT -> "components";
+                case EIP -> "models";
+                case DATAFORMAT -> "dataformats";
+                case LANGUAGE -> "languages";
+            };
+        }
+
+        private static String text(JsonNode node, String name) {
+            JsonNode value = node == null ? null : node.get(name);
+            return value != null && value.isTextual() && !value.asText().isBlank() ? value.asText() : null;
+        }
+    }
+
+    @FunctionalInterface
+    interface ArtifactResolver {
+        List<ResolvedExactMavenArtifact> resolve(
+                Path repository, List<MavenCoordinate> coordinates, ResolutionMode mode)
+                throws IOException;
+    }
+
+    private static final class StrictXmlErrorHandler implements ErrorHandler {
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
@@ -575,6 +575,7 @@ public final class ShipCatalogService {
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setAttribute("jdk.xml.elementAttributeLimit", MAX_POM_ATTRIBUTES);
             var builder = factory.newDocumentBuilder();
             builder.setErrorHandler(new StrictXmlErrorHandler());
             try (InputStream input = new ByteArrayInputStream(pom)) {
@@ -589,7 +590,7 @@ public final class ShipCatalogService {
                 }
                 return document;
             }
-        } catch (ParserConfigurationException | SAXException e) {
+        } catch (IllegalArgumentException | ParserConfigurationException | SAXException e) {
             throw new IOException("Could not securely parse catalog POM", e);
         }
     }
@@ -597,6 +598,7 @@ public final class ShipCatalogService {
     private static void requireBoundedPomStructure(byte[] pom) throws IOException {
         XMLInputFactory factory = XMLInputFactory.newDefaultFactory();
         try {
+            factory.setProperty("jdk.xml.elementAttributeLimit", MAX_POM_ATTRIBUTES);
             factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ResolverClasspathIsolationTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ResolverClasspathIsolationTest.java
@@ -1,0 +1,28 @@
+package io.github.luigidemasi.camelkit.ship;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResolverClasspathIsolationTest {
+
+    @Test
+    void productionDependencyExposesOnlyTheCamelKitResolverBoundary() throws Exception {
+        ClassLoader loader = ShipMavenResolver.class.getClassLoader();
+        String pom = Files.readString(Path.of(System.getProperty("basedir"), "pom.xml"));
+        int artifact = pom.indexOf("<artifactId>camel-kit-ship-resolver</artifactId>");
+        int start = pom.lastIndexOf("<dependency>", artifact);
+        int end = pom.indexOf("</dependency>", artifact);
+        String resolverDependency = pom.substring(start, end);
+
+        assertSame(loader, Class.forName(ShipMavenResolver.class.getName(), false, loader).getClassLoader());
+        assertTrue(resolverDependency.contains("<groupId>*</groupId>"));
+        assertTrue(resolverDependency.contains("<artifactId>*</artifactId>"));
+        assertFalse(resolverDependency.contains("<scope>test</scope>"));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogComponentModelTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogComponentModelTest.java
@@ -1,0 +1,119 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogComponentModel.Kind;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogComponentModel.Option;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogComponentModel.Scope;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CatalogComponentModelTest {
+
+    @Test
+    void modelIsDeeplyImmutableAndRequiresCanonicalOptions() {
+        List<Option> source = new ArrayList<>(List.of(option("delay", 0)));
+        CatalogComponentModel model = new CatalogComponentModel(evidence(), "timer:timerName", false, source);
+        source.clear();
+
+        assertEquals(1, model.options().size());
+        assertThrows(UnsupportedOperationException.class, () -> model.options().clear());
+        assertThrows(IllegalArgumentException.class, () -> new CatalogComponentModel(
+                evidence(), "timer:timerName", false, List.of(option("z", 1), option("a", 0))));
+    }
+
+    @Test
+    void normalizedOptionNamesAreUniqueWithinScope() {
+        assertThrows(IllegalArgumentException.class, () -> new CatalogComponentModel(
+                evidence(), "timer:timerName", false,
+                List.of(option("foo-bar", 0), option("foo_bar", 1))));
+    }
+
+    @Test
+    void scopeAndKindMustAgree() {
+        assertThrows(IllegalArgumentException.class, () -> new Option(
+                "delay", Scope.COMPONENT, Kind.PARAMETER, 0, "integer", "long",
+                false, false, null, null, List.of()));
+        assertThrows(IllegalArgumentException.class, () -> new Option(
+                "delay", Scope.ENDPOINT, Kind.PROPERTY, 0, "integer", "long",
+                false, false, null, null, List.of()));
+    }
+
+    @Test
+    void multiValueAndOptionalPrefixesRemainDistinct() {
+        Option option = new Option(
+                "additional", Scope.ENDPOINT, Kind.PARAMETER, 0, "object", "java.util.Map",
+                false, true, "additional.", "consumer.", List.of());
+
+        assertEquals("additional.", option.prefix());
+        assertEquals("consumer.", option.optionalPrefix());
+    }
+
+    @Test
+    void enumAndOptionQuotasAcceptTheLimitAndRejectOneOver() {
+        List<String> enumLimit = IntStream.range(0, CatalogComponentModel.MAX_ENUM_VALUES)
+                .mapToObj(index -> "v" + index).toList();
+        assertEquals(CatalogComponentModel.MAX_ENUM_VALUES, new Option(
+                "delay", Scope.ENDPOINT, Kind.PARAMETER, 0, "integer", "long",
+                false, false, null, null, enumLimit).enumValues().size());
+        List<String> excessiveEnum = new ArrayList<>(enumLimit);
+        excessiveEnum.add("extra");
+        assertThrows(IllegalArgumentException.class, () -> new Option(
+                "delay", Scope.ENDPOINT, Kind.PARAMETER, 0, "integer", "long",
+                false, false, null, null, excessiveEnum));
+
+        List<Option> optionLimit = IntStream.range(0, CatalogComponentModel.MAX_OPTIONS)
+                .mapToObj(index -> option("option" + index, index))
+                .toList();
+        assertEquals(CatalogComponentModel.MAX_OPTIONS,
+                new CatalogComponentModel(evidence(), "timer:timerName", false, optionLimit).options().size());
+        List<Option> excessiveOptions = new ArrayList<>(optionLimit);
+        excessiveOptions.add(option("extra", CatalogComponentModel.MAX_OPTIONS));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CatalogComponentModel(evidence(), "timer:timerName", false, excessiveOptions));
+    }
+
+    @Test
+    void syntaxAcceptsTheLimitAndRejectsOneOver() {
+        String atLimit = "timer:" + "a".repeat(1_018);
+        assertEquals(1_024,
+                new CatalogComponentModel(evidence(), atLimit, false, List.of()).syntax().length());
+        assertThrows(IllegalArgumentException.class,
+                () -> new CatalogComponentModel(evidence(), atLimit + 'a', false, List.of()));
+    }
+
+    @Test
+    void diagnosticStringsDoNotDumpSyntaxOptionsOrEnumValues() {
+        Option option = new Option(
+                "delay", Scope.ENDPOINT, Kind.PARAMETER, 0, "string", "java.lang.String",
+                false, false, null, null, List.of("sensitive-enum-value"));
+        CatalogComponentModel model = new CatalogComponentModel(
+                evidence(), "timer:sensitive-syntax", false, List.of(option));
+
+        assertFalse(model.toString().contains("sensitive-syntax"));
+        assertFalse(option.toString().contains("sensitive-enum-value"));
+        assertTrue(model.toString().contains("options=<1 entries>"));
+    }
+
+    private static Option option(String name, int index) {
+        return new Option(
+                name, Scope.ENDPOINT, Kind.PARAMETER, index, "integer", "long",
+                false, false, null, null, List.of());
+    }
+
+    private static SubjectEvidence evidence() {
+        MavenCoordinate catalog = MavenCoordinate.jar("org.apache.camel", "camel-catalog", "4.21.0");
+        return new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.COMPONENT, "timer"), catalog,
+                "sha256:" + "a".repeat(64),
+                "org/apache/camel/catalog/components/timer.json",
+                "sha256:" + "b".repeat(64),
+                "org.apache.camel", "camel-timer", "4.21.0", false);
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogEvidenceSetTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogEvidenceSetTest.java
@@ -1,0 +1,157 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.ArtifactEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CatalogEvidenceSetTest {
+
+    private static final String ARTIFACT_DIGEST = "sha256:" + "a".repeat(64);
+    private static final String RESOURCE_DIGEST = "sha256:" + "b".repeat(64);
+    private static final MavenCoordinate MAIN
+            = MavenCoordinate.jar("org.apache.camel", "camel-catalog", "4.21.0");
+    private static final CatalogTarget TARGET = new CatalogTarget("main", "4.21.0", null, null);
+
+    @Test
+    void factoryCanonicalizesInputAndProducesAStableDigest() {
+        SubjectEvidence timer = component("timer", RESOURCE_DIGEST);
+        SubjectEvidence direct = component("direct", "sha256:" + "c".repeat(64));
+
+        CatalogEvidenceSet first = CatalogEvidenceSet.create(
+                TARGET, MAIN, List.of(artifact()), List.of(timer, direct));
+        CatalogEvidenceSet second = CatalogEvidenceSet.create(
+                TARGET, MAIN, List.of(artifact()), List.of(direct, timer));
+
+        assertEquals(List.of("direct", "timer"), first.subjects().stream()
+                .map(value -> value.subject().name()).toList());
+        assertEquals(first, second);
+        assertEquals("sha256:2e7a339aab7d855b21783f6a1c008d8c705f749475860136158502f70299fdaf",
+                first.digest());
+    }
+
+    @Test
+    void constructorRejectsDigestAndCanonicalOrderForgery() {
+        CatalogEvidenceSet snapshot = snapshot();
+        SubjectEvidence direct = component("direct", "sha256:" + "c".repeat(64));
+        List<SubjectEvidence> reversed = List.of(snapshot.subjects().get(0), direct).stream()
+                .sorted(Collections.reverseOrder(java.util.Comparator.comparing(SubjectEvidence::subject)))
+                .toList();
+
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () -> new CatalogEvidenceSet(
+                        snapshot.schemaVersion(), snapshot.target(), snapshot.platformCoordinate(),
+                        snapshot.artifacts(), snapshot.subjects(), "sha256:" + "0".repeat(64))),
+                () -> assertThrows(IllegalArgumentException.class, () -> new CatalogEvidenceSet(
+                        snapshot.schemaVersion(), snapshot.target(), snapshot.platformCoordinate(),
+                        snapshot.artifacts(), reversed, snapshot.digest())));
+    }
+
+    @Test
+    void snapshotIsDeeplyImmutableAndDigestChangesWithExactResourceBytes() {
+        List<ArtifactEvidence> artifacts = new ArrayList<>(List.of(artifact()));
+        List<SubjectEvidence> subjects = new ArrayList<>(List.of(component("timer", RESOURCE_DIGEST)));
+        CatalogEvidenceSet snapshot = CatalogEvidenceSet.create(TARGET, MAIN, artifacts, subjects);
+        artifacts.clear();
+        subjects.clear();
+
+        CatalogEvidenceSet changed = CatalogEvidenceSet.create(
+                TARGET, MAIN, List.of(artifact()),
+                List.of(component("timer", "sha256:" + "c".repeat(64))));
+
+        assertEquals(1, snapshot.artifacts().size());
+        assertEquals(1, snapshot.subjects().size());
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.subjects().clear());
+        assertNotEquals(snapshot.digest(), changed.digest());
+    }
+
+    @Test
+    void subjectEvidenceMustBindToAnIncludedArtifactAndCanonicalResource() {
+        MavenCoordinate other = MavenCoordinate.jar("org.apache.camel", "camel-catalog", "4.20.0");
+        SubjectEvidence wrongAuthority = new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.COMPONENT, "timer"), other, ARTIFACT_DIGEST,
+                "org/apache/camel/catalog/components/timer.json", RESOURCE_DIGEST,
+                "org.apache.camel", "camel-timer", "4.20.0", false);
+        SubjectEvidence wrongResource = new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.COMPONENT, "timer"), MAIN, ARTIFACT_DIGEST,
+                "org/apache/camel/catalog/components/direct.json", RESOURCE_DIGEST,
+                "org.apache.camel", "camel-timer", "4.21.0", false);
+
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> CatalogEvidenceSet.create(TARGET, MAIN, List.of(artifact()),
+                                List.of(wrongAuthority))),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> CatalogEvidenceSet.create(TARGET, MAIN, List.of(artifact()),
+                                List.of(wrongResource))));
+    }
+
+    @Test
+    void eipIdentityIsAbsentWhileOtherKindsRequireTheCompleteIdentity() {
+        SubjectEvidence eip = new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.EIP, "split"), MAIN, ARTIFACT_DIGEST,
+                "org/apache/camel/catalog/models/split.json", RESOURCE_DIGEST,
+                null, null, null, false);
+
+        assertDoesNotThrow(() -> CatalogEvidenceSet.create(
+                TARGET, MAIN, List.of(artifact()), List.of(eip)));
+        assertThrows(IllegalArgumentException.class, () -> new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.EIP, "split"), MAIN, ARTIFACT_DIGEST,
+                "org/apache/camel/catalog/models/split.json", RESOURCE_DIGEST,
+                "org.apache.camel", null, null, false));
+        assertThrows(IllegalArgumentException.class, () -> new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.COMPONENT, "timer"), MAIN, ARTIFACT_DIGEST,
+                "org/apache/camel/catalog/components/timer.json", RESOURCE_DIGEST,
+                null, null, null, false));
+    }
+
+    @Test
+    void subjectQuotaAcceptsTheLimitAndRejectsOneOver() {
+        List<SubjectEvidence> atLimit = IntStream.range(0, CatalogEvidenceSet.MAX_SUBJECTS)
+                .mapToObj(index -> component("c" + index, digest(index)))
+                .toList();
+
+        assertEquals(CatalogEvidenceSet.MAX_SUBJECTS,
+                CatalogEvidenceSet.create(TARGET, MAIN, List.of(artifact()), atLimit).subjects().size());
+        List<SubjectEvidence> excessive = new ArrayList<>(atLimit);
+        excessive.add(component("extra", "sha256:" + "f".repeat(64)));
+        assertThrows(IllegalArgumentException.class,
+                () -> CatalogEvidenceSet.create(TARGET, MAIN, List.of(artifact()), excessive));
+    }
+
+    @Test
+    void artifactSizeAcceptsTheLimitAndRejectsOneOver() {
+        assertDoesNotThrow(() -> new ArtifactEvidence(MAIN, ARTIFACT_DIGEST, 128L * 1024 * 1024));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ArtifactEvidence(MAIN, ARTIFACT_DIGEST, 128L * 1024 * 1024 + 1));
+    }
+
+    private static CatalogEvidenceSet snapshot() {
+        return CatalogEvidenceSet.create(
+                TARGET, MAIN, List.of(artifact()), List.of(component("timer", RESOURCE_DIGEST)));
+    }
+
+    private static ArtifactEvidence artifact() {
+        return new ArtifactEvidence(MAIN, ARTIFACT_DIGEST, 42);
+    }
+
+    private static SubjectEvidence component(String name, String digest) {
+        return new SubjectEvidence(
+                new CatalogSubject(CatalogSubject.Kind.COMPONENT, name), MAIN, ARTIFACT_DIGEST,
+                "org/apache/camel/catalog/components/" + name + ".json", digest,
+                "org.apache.camel", "camel-" + name, "4.21.0", false);
+    }
+
+    private static String digest(int value) {
+        return "sha256:" + String.format(Locale.ROOT, "%064x", value + 1L);
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTargetTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTargetTest.java
@@ -1,0 +1,56 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CatalogTargetTest {
+
+    @Test
+    void acceptsOnlyCompleteRuntimeSpecificTuples() {
+        assertAll(
+                () -> assertDoesNotThrow(() -> new CatalogTarget("main", "4.21.0", null, null)),
+                () -> assertDoesNotThrow(
+                        () -> new CatalogTarget("spring-boot", "4.21.0", "4.21.0", "4.1.0")),
+                () -> assertDoesNotThrow(
+                        () -> new CatalogTarget("quarkus", "4.18.2", "3.33.2", null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "4.21.0", "4.21.0", null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "4.21.0", null, "4.1.0")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("spring-boot", "4.21.0", null, "4.1.0")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("spring-boot", "4.21.0", "4.21.0", null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("quarkus", "4.18.2", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("quarkus", "4.18.2", "3.33.2", "3.5.0")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("MAIN", "4.21.0", null, null)));
+    }
+
+    @Test
+    void rejectsMutableUnsafeAndOverlongVersions() {
+        String atLimit = "1" + "a".repeat(127);
+        assertDoesNotThrow(() -> new CatalogTarget("main", atLimit, null, null));
+
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "4.21.0-SNAPSHOT", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "4.21.0-20260720.123456-1", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "LATEST", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget(null, "4.21.0", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "4..21", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "4.21.", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", "[4.18,5)", null, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new CatalogTarget("main", atLimit + 'a', null, null)));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogBoundaryTest.java
@@ -1,0 +1,444 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.io.IOException;
+import java.lang.reflect.Executable;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShipCatalogBoundaryTest {
+
+    private static final String CATALOG_PACKAGE = "io.github.luigidemasi.camelkit.ship.catalog.";
+    private static final Pattern DEPENDENCY = Pattern.compile("^\\s+(\\S+)\\s+->\\s+(\\S+)\\s+(.+)$");
+    private static final Set<String> ALLOWED_JDK_MODULES = Set.of("java.base", "java.xml");
+    private static final Set<String> ALLOWED_EXTERNAL_TYPES = Set.of(
+            "com.fasterxml.jackson.core.JsonFactory",
+            "com.fasterxml.jackson.core.StreamReadConstraints",
+            "com.fasterxml.jackson.core.StreamReadConstraints$Builder",
+            "com.fasterxml.jackson.core.StreamReadFeature",
+            "com.fasterxml.jackson.core.TSFBuilder",
+            "com.fasterxml.jackson.databind.DeserializationFeature",
+            "com.fasterxml.jackson.databind.JsonNode",
+            "com.fasterxml.jackson.databind.ObjectMapper",
+            "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate",
+            "io.github.luigidemasi.camelkit.ship.resolver.ResolvedExactMavenArtifact",
+            "io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver",
+            "io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver$ResolutionMode",
+            "javax.xml.XMLConstants",
+            "javax.xml.parsers.DocumentBuilder",
+            "javax.xml.parsers.DocumentBuilderFactory",
+            "javax.xml.parsers.ParserConfigurationException",
+            "javax.xml.stream.XMLInputFactory",
+            "javax.xml.stream.XMLResolver",
+            "javax.xml.stream.XMLStreamConstants",
+            "javax.xml.stream.XMLStreamException",
+            "javax.xml.stream.XMLStreamReader",
+            "org.w3c.dom.Document",
+            "org.w3c.dom.Element",
+            "org.w3c.dom.Node",
+            "org.xml.sax.ErrorHandler",
+            "org.xml.sax.SAXException",
+            "org.xml.sax.SAXParseException");
+    private static final Set<String> PUBLIC_RECORDS = Set.of(
+            CATALOG_PACKAGE + "CatalogTarget",
+            CATALOG_PACKAGE + "CatalogSubject",
+            CATALOG_PACKAGE + "CatalogEvidenceSet",
+            CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence",
+            CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence",
+            CATALOG_PACKAGE + "CatalogComponentModel",
+            CATALOG_PACKAGE + "CatalogComponentModel$Option");
+    private static final Set<String> PUBLIC_ENUMS = Set.of(
+            CATALOG_PACKAGE + "CatalogSubject$Kind",
+            CATALOG_PACKAGE + "CatalogComponentModel$Scope",
+            CATALOG_PACKAGE + "CatalogComponentModel$Kind");
+    private static final Map<String, List<String>> PUBLIC_ENUM_CONSTANTS = Map.of(
+            CATALOG_PACKAGE + "CatalogSubject$Kind",
+            List.of("COMPONENT", "EIP", "DATAFORMAT", "LANGUAGE"),
+            CATALOG_PACKAGE + "CatalogComponentModel$Scope",
+            List.of("COMPONENT", "ENDPOINT"),
+            CATALOG_PACKAGE + "CatalogComponentModel$Kind",
+            List.of("PROPERTY", "PATH", "PARAMETER"));
+    private static final Map<String, Set<String>> PUBLIC_INTERFACES = Map.of(
+            CATALOG_PACKAGE + "CatalogSubject",
+            Set.of("java.lang.Comparable<" + CATALOG_PACKAGE + "CatalogSubject>"));
+    private static final Map<String, Set<String>> PUBLIC_CONSTRUCTORS = Map.ofEntries(
+            Map.entry(CATALOG_PACKAGE + "CatalogTarget", Set.of(constructor(
+                    "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogSubject", Set.of(constructor(
+                    CATALOG_PACKAGE + "CatalogSubject$Kind", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogSubject$Kind", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet", Set.of(constructor(
+                    "int", CATALOG_PACKAGE + "CatalogTarget",
+                    "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence>",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence>",
+                    "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence", Set.of(constructor(
+                    "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate",
+                    "java.lang.String", "long"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence", Set.of(constructor(
+                    CATALOG_PACKAGE + "CatalogSubject",
+                    "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate",
+                    "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String",
+                    "java.lang.String", "java.lang.String", "boolean"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel", Set.of(constructor(
+                    CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence", "java.lang.String", "boolean",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogComponentModel$Option>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Option", Set.of(constructor(
+                    "java.lang.String", CATALOG_PACKAGE + "CatalogComponentModel$Scope",
+                    CATALOG_PACKAGE + "CatalogComponentModel$Kind", "int", "java.lang.String",
+                    "java.lang.String", "boolean", "boolean", "java.lang.String", "java.lang.String",
+                    "java.util.List<java.lang.String>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Scope", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Kind", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService", Set.of(constructor("java.nio.file.Path"))),
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of()));
+    private static final Map<String, Set<String>> PUBLIC_METHODS = Map.ofEntries(
+            Map.entry(CATALOG_PACKAGE + "CatalogTarget", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("runtime", "java.lang.String"),
+                    method("camelVersion", "java.lang.String"), method("platformVersion", "java.lang.String"),
+                    method("springBootVersion", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogSubject", Set.of(
+                    method("compareTo", "int", CATALOG_PACKAGE + "CatalogSubject"),
+                    method("compareTo", "int", "java.lang.Object"), method("toString", "java.lang.String"),
+                    method("hashCode", "int"), method("equals", "boolean", "java.lang.Object"),
+                    method("kind", CATALOG_PACKAGE + "CatalogSubject$Kind"),
+                    method("name", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogSubject$Kind", Set.of(
+                    staticMethod("values", CATALOG_PACKAGE + "CatalogSubject$Kind[]"),
+                    staticMethod("valueOf", CATALOG_PACKAGE + "CatalogSubject$Kind", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("schemaVersion", "int"),
+                    method("target", CATALOG_PACKAGE + "CatalogTarget"),
+                    method("platformCoordinate",
+                            "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate"),
+                    method("artifacts", "java.util.List<" + CATALOG_PACKAGE
+                                        + "CatalogEvidenceSet$ArtifactEvidence>"),
+                    method("subjects", "java.util.List<" + CATALOG_PACKAGE
+                                       + "CatalogEvidenceSet$SubjectEvidence>"),
+                    method("digest", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("coordinate", "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate"),
+                    method("sha256", "java.lang.String"), method("size", "long"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("subject", CATALOG_PACKAGE + "CatalogSubject"),
+                    method("catalogCoordinate",
+                            "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate"),
+                    method("catalogSha256", "java.lang.String"), method("resource", "java.lang.String"),
+                    method("resourceSha256", "java.lang.String"), method("groupId", "java.lang.String"),
+                    method("artifactId", "java.lang.String"), method("artifactVersion", "java.lang.String"),
+                    method("deprecated", "boolean"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("evidence", CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence"),
+                    method("syntax", "java.lang.String"), method("lenientProperties", "boolean"),
+                    method("options", "java.util.List<" + CATALOG_PACKAGE + "CatalogComponentModel$Option>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Option", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("name", "java.lang.String"),
+                    method("scope", CATALOG_PACKAGE + "CatalogComponentModel$Scope"),
+                    method("kind", CATALOG_PACKAGE + "CatalogComponentModel$Kind"), method("index", "int"),
+                    method("type", "java.lang.String"), method("javaType", "java.lang.String"),
+                    method("required", "boolean"), method("multiValue", "boolean"),
+                    method("prefix", "java.lang.String"), method("optionalPrefix", "java.lang.String"),
+                    method("enumValues", "java.util.List<java.lang.String>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Scope", Set.of(
+                    staticMethod("values", CATALOG_PACKAGE + "CatalogComponentModel$Scope[]"),
+                    staticMethod("valueOf", CATALOG_PACKAGE + "CatalogComponentModel$Scope",
+                            "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Kind", Set.of(
+                    staticMethod("values", CATALOG_PACKAGE + "CatalogComponentModel$Kind[]"),
+                    staticMethod("valueOf", CATALOG_PACKAGE + "CatalogComponentModel$Kind",
+                            "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService", Set.of(throwingMethod(
+                    "snapshot", CATALOG_PACKAGE + "ShipCatalogService$Snapshot", "java.io.IOException",
+                    CATALOG_PACKAGE + "CatalogTarget"))),
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of(
+                    method("target", CATALOG_PACKAGE + "CatalogTarget"),
+                    throwingMethod("evidenceFor", CATALOG_PACKAGE + "CatalogEvidenceSet", "java.io.IOException",
+                            "java.util.Collection<" + CATALOG_PACKAGE + "CatalogSubject>"),
+                    throwingMethod("availableSubjects",
+                            "java.util.List<" + CATALOG_PACKAGE + "CatalogSubject>", "java.io.IOException"),
+                    throwingMethod("componentModelsFor",
+                            "java.util.List<" + CATALOG_PACKAGE + "CatalogComponentModel>", "java.io.IOException",
+                            "java.util.Collection<" + CATALOG_PACKAGE + "CatalogSubject>"),
+                    method("toString", "java.lang.String"))));
+    private static final Map<String, Set<String>> PUBLIC_FIELDS = Map.ofEntries(
+            Map.entry(CATALOG_PACKAGE + "CatalogTarget", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogSubject", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogSubject$Kind", Set.of(
+                    field("COMPONENT", CATALOG_PACKAGE + "CatalogSubject$Kind"),
+                    field("EIP", CATALOG_PACKAGE + "CatalogSubject$Kind"),
+                    field("DATAFORMAT", CATALOG_PACKAGE + "CatalogSubject$Kind"),
+                    field("LANGUAGE", CATALOG_PACKAGE + "CatalogSubject$Kind"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet", Set.of(field("SCHEMA_VERSION", "int"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Option", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Scope", Set.of(
+                    field("COMPONENT", CATALOG_PACKAGE + "CatalogComponentModel$Scope"),
+                    field("ENDPOINT", CATALOG_PACKAGE + "CatalogComponentModel$Scope"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Kind", Set.of(
+                    field("PROPERTY", CATALOG_PACKAGE + "CatalogComponentModel$Kind"),
+                    field("PATH", CATALOG_PACKAGE + "CatalogComponentModel$Kind"),
+                    field("PARAMETER", CATALOG_PACKAGE + "CatalogComponentModel$Kind"))),
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of()));
+    private static final Map<String, Map<String, Object>> PUBLIC_CONSTANT_VALUES = Map.of(
+            CATALOG_PACKAGE + "CatalogEvidenceSet", Map.of("SCHEMA_VERSION", 1));
+
+    @Test
+    void compiledCatalogUsesOnlyApprovedModulesAndExactExternalTypes()
+            throws Exception {
+        Path classes = Path.of(System.getProperty("basedir"), "target", "classes");
+        Path catalog = classes.resolve("io/github/luigidemasi/camelkit/ship/catalog");
+        Process process = new ProcessBuilder(
+                jdkTool("jdeps"), "--multi-release", "17", "-verbose:class", catalog.toString())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.waitFor(), output);
+
+        int dependencies = 0;
+        for (String line : output.lines().toList()) {
+            Matcher dependency = DEPENDENCY.matcher(line);
+            if (!dependency.matches() || !dependency.group(1).startsWith(CATALOG_PACKAGE)) {
+                continue;
+            }
+            dependencies++;
+            String target = dependency.group(2);
+            String module = dependency.group(3).trim();
+            if (target.startsWith("java.")) {
+                assertTrue(ALLOWED_JDK_MODULES.contains(module),
+                        () -> "Catalog code added JDK dependency " + target + " from " + module + ":\n" + output);
+            } else {
+                assertTrue(ALLOWED_EXTERNAL_TYPES.contains(target),
+                        () -> "Catalog code added unapproved external dependency " + target + ":\n" + output);
+            }
+        }
+        assertTrue(dependencies > 0, "jdeps did not report catalog class dependencies:\n" + output);
+        assertTrue(output.contains(MavenCoordinate.class.getName()),
+                "jdeps did not observe the intended public resolver edge:\n" + output);
+    }
+
+    @Test
+    void publicCatalogSurfaceContainsOnlyJdkCatalogAndCoordinateTypes() throws Exception {
+        Set<Class<?>> expected = Set.of(
+                CatalogTarget.class,
+                CatalogSubject.class,
+                CatalogSubject.Kind.class,
+                CatalogEvidenceSet.class,
+                CatalogEvidenceSet.ArtifactEvidence.class,
+                CatalogEvidenceSet.SubjectEvidence.class,
+                CatalogComponentModel.class,
+                CatalogComponentModel.Option.class,
+                CatalogComponentModel.Scope.class,
+                CatalogComponentModel.Kind.class,
+                ShipCatalogService.class,
+                ShipCatalogService.Snapshot.class);
+        Path classes = Path.of(System.getProperty("basedir"), "target", "classes");
+        Path catalog = classes.resolve("io/github/luigidemasi/camelkit/ship/catalog");
+        Set<Class<?>> actual = new HashSet<>();
+        try (var files = Files.walk(catalog)) {
+            for (Path file : files.filter(path -> path.getFileName().toString().endsWith(".class")).toList()) {
+                String relative = classes.relativize(file).toString();
+                String name = relative.substring(0, relative.length() - ".class".length())
+                        .replace(file.getFileSystem().getSeparator(), ".");
+                Class<?> type = Class.forName(name, false, ShipCatalogBoundaryTest.class.getClassLoader());
+                if (Modifier.isPublic(type.getModifiers())) {
+                    actual.add(type);
+                }
+            }
+        }
+        assertEquals(expected, actual, "Public catalog types changed without an explicit boundary update");
+
+        for (Class<?> type : actual) {
+            String name = type.getName();
+            assertTrue(Modifier.isFinal(type.getModifiers()), name + " must remain final");
+            assertEquals(PUBLIC_RECORDS.contains(name), type.isRecord(), name + " record shape changed");
+            assertEquals(PUBLIC_ENUMS.contains(name), type.isEnum(), name + " enum shape changed");
+            if (type.isEnum()) {
+                assertEquals(PUBLIC_ENUM_CONSTANTS.get(name), Arrays.stream(type.getEnumConstants())
+                        .map(value -> ((Enum<?>) value).name()).toList(), name + " enum order changed");
+            }
+            assertEquals(type.isRecord() ? Record.class : type.isEnum() ? Enum.class : Object.class,
+                    type.getSuperclass(), name + " superclass changed");
+            assertEquals(0, type.getTypeParameters().length, name + " added type parameters");
+            Set<String> interfaces = Arrays.stream(type.getGenericInterfaces())
+                    .map(Type::getTypeName).collect(java.util.stream.Collectors.toSet());
+            assertEquals(PUBLIC_INTERFACES.getOrDefault(name, Set.of()), interfaces,
+                    name + " interfaces changed");
+            if (type.getEnclosingClass() != null) {
+                assertTrue(Modifier.isStatic(type.getModifiers()), name + " must remain static");
+            }
+
+            Set<String> constructors = new HashSet<>();
+            for (var constructor : type.getDeclaredConstructors()) {
+                if (Modifier.isPublic(constructor.getModifiers())) {
+                    constructors.add(constructor(constructor.getGenericParameterTypes()));
+                    assertExecutableTypes(constructor);
+                }
+            }
+            assertEquals(PUBLIC_CONSTRUCTORS.get(name), constructors, name + " constructors changed");
+
+            Set<String> methods = new HashSet<>();
+            for (var method : type.getDeclaredMethods()) {
+                if (Modifier.isPublic(method.getModifiers())) {
+                    methods.add(method(method));
+                    assertConsumerType(method.getGenericReturnType(), method.toGenericString(), new HashSet<>());
+                    assertExecutableTypes(method);
+                }
+            }
+            assertEquals(PUBLIC_METHODS.get(name), methods, name + " methods changed");
+
+            Set<String> fields = new HashSet<>();
+            for (var field : type.getDeclaredFields()) {
+                if (Modifier.isPublic(field.getModifiers())) {
+                    assertTrue(Modifier.isStatic(field.getModifiers()), field.toGenericString());
+                    assertTrue(Modifier.isFinal(field.getModifiers()), field.toGenericString());
+                    fields.add(field(field.getName(), field.getGenericType().getTypeName()));
+                    assertConsumerType(field.getGenericType(), field.toGenericString(), new HashSet<>());
+                }
+            }
+            assertEquals(PUBLIC_FIELDS.get(name), fields, name + " fields changed");
+            for (var constant : PUBLIC_CONSTANT_VALUES.getOrDefault(name, Map.of()).entrySet()) {
+                assertEquals(constant.getValue(), type.getField(constant.getKey()).get(null),
+                        name + '.' + constant.getKey() + " value changed");
+            }
+            if (type.isRecord()) {
+                for (var component : type.getRecordComponents()) {
+                    assertConsumerType(component.getGenericType(), component.toString(), new HashSet<>());
+                }
+            }
+        }
+    }
+
+    private static String constructor(String... parameterTypes) {
+        return "<init>(" + String.join(",", parameterTypes) + ')';
+    }
+
+    private static String constructor(Type... parameterTypes) {
+        return constructor(Arrays.stream(parameterTypes).map(Type::getTypeName).toArray(String[]::new));
+    }
+
+    private static String method(String name, String returnType, String... parameterTypes) {
+        return name + '(' + String.join(",", parameterTypes) + ")->" + returnType;
+    }
+
+    private static String staticMethod(String name, String returnType, String... parameterTypes) {
+        return "static " + method(name, returnType, parameterTypes);
+    }
+
+    private static String throwingMethod(
+            String name, String returnType, String exceptionType, String... parameterTypes) {
+        return method(name, returnType, parameterTypes) + " throws " + exceptionType;
+    }
+
+    private static String method(java.lang.reflect.Method method) {
+        String signature = (Modifier.isStatic(method.getModifiers()) ? "static " : "")
+                           + method(method.getName(), method.getGenericReturnType().getTypeName(),
+                                   Arrays.stream(method.getGenericParameterTypes())
+                                           .map(Type::getTypeName).toArray(String[]::new));
+        String[] exceptions = Arrays.stream(method.getGenericExceptionTypes())
+                .map(Type::getTypeName).toArray(String[]::new);
+        return exceptions.length == 0 ? signature : signature + " throws " + String.join(",", exceptions);
+    }
+
+    private static String field(String name, String type) {
+        return name + ':' + type;
+    }
+
+    private static void assertExecutableTypes(Executable executable) {
+        for (Type parameter : executable.getGenericParameterTypes()) {
+            assertConsumerType(parameter, executable.toGenericString(), new HashSet<>());
+        }
+        for (Type exception : executable.getGenericExceptionTypes()) {
+            assertConsumerType(exception, executable.toGenericString(), new HashSet<>());
+        }
+        for (TypeVariable<?> variable : executable.getTypeParameters()) {
+            assertConsumerType(variable, executable.toGenericString(), new HashSet<>());
+        }
+    }
+
+    private static void assertConsumerType(Type type, String owner, Set<Type> visited) {
+        if (type == null || !visited.add(type)) {
+            return;
+        }
+        if (type instanceof Class<?> clazz) {
+            if (clazz.isArray()) {
+                assertConsumerType(clazz.getComponentType(), owner, visited);
+                return;
+            }
+            String name = clazz.getName();
+            assertTrue(clazz.isPrimitive()
+                    || name.startsWith("java.")
+                    || name.startsWith(CATALOG_PACKAGE)
+                    || name.equals(MavenCoordinate.class.getName()),
+                    () -> owner + " leaks non-boundary type " + name);
+            return;
+        }
+        if (type instanceof ParameterizedType parameterized) {
+            assertConsumerType(parameterized.getRawType(), owner, visited);
+            assertConsumerType(parameterized.getOwnerType(), owner, visited);
+            for (Type argument : parameterized.getActualTypeArguments()) {
+                assertConsumerType(argument, owner, visited);
+            }
+            return;
+        }
+        if (type instanceof GenericArrayType array) {
+            assertConsumerType(array.getGenericComponentType(), owner, visited);
+            return;
+        }
+        if (type instanceof TypeVariable<?> variable) {
+            for (Type bound : variable.getBounds()) {
+                assertConsumerType(bound, owner, visited);
+            }
+            return;
+        }
+        if (type instanceof WildcardType wildcard) {
+            for (Type bound : wildcard.getUpperBounds()) {
+                assertConsumerType(bound, owner, visited);
+            }
+            for (Type bound : wildcard.getLowerBounds()) {
+                assertConsumerType(bound, owner, visited);
+            }
+            return;
+        }
+        fail(owner + " exposes unsupported generic type " + type);
+    }
+
+    private static String jdkTool(String name) throws IOException {
+        Path tool = Path.of(System.getProperty("java.home"), "bin", name);
+        if (!tool.toFile().canExecute()) {
+            throw new IOException("Required JDK tool is unavailable: " + name);
+        }
+        return tool.toString();
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogServiceTest.java
@@ -288,6 +288,24 @@ class ShipCatalogServiceTest {
     }
 
     @Test
+    void pomAttributeLimitAcceptsTheBoundaryAndRejectsOneBeyond() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusProvider("3.33.1", CAMEL_VERSION);
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        String body = minifiedQuarkusBomBody("3.33.1", CAMEL_VERSION);
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                attributeDeclarations(511), body);
+        assertEquals(3, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "kafka"))).artifacts().size());
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                attributeDeclarations(512), body);
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(excessive.getMessage().contains("structural limits"));
+    }
+
+    @Test
     void pomNamespaceModelAndSingletonAmbiguityFailClosed() throws Exception {
         writeMainCatalog(CAMEL_VERSION, "timer");
         CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
@@ -887,6 +905,14 @@ class ShipCatalogServiceTest {
         StringBuilder result = new StringBuilder();
         for (int index = 0; index < count; index++) {
             result.append(" xmlns:n").append(index).append("=\"urn:n").append(index).append("\"");
+        }
+        return result.toString();
+    }
+
+    private static String attributeDeclarations(int count) {
+        StringBuilder result = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            result.append(" a").append(index).append("=\"v\"");
         }
         return result.toString();
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogServiceTest.java
@@ -1,0 +1,1107 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+import io.github.luigidemasi.camelkit.ship.resolver.ResolvedExactMavenArtifact;
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver;
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver.ResolutionMode;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class ShipCatalogServiceTest {
+
+    private static final String CAMEL_VERSION = "4.18.0";
+
+    @Test
+    void mutableCatalogVersionsAreRejectedBeforeResolution() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CatalogTarget("main", "4.18.1-SNAPSHOT", null, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CatalogTarget("quarkus", CAMEL_VERSION, "LATEST", null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CatalogTarget("main", "4.18.0-20260716.123456-1", null, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CatalogTarget("main", "..", null, null));
+    }
+
+    @Test
+    void symbolicLocalRepositoryIsRejected() throws Exception {
+        Path realRepository = Files.createDirectory(repository.resolve("real-repository"));
+        Path symbolicRepository = repository.resolve("symbolic-repository");
+        Files.createSymbolicLink(symbolicRepository, realRepository);
+        ShipCatalogService service = offlineService(symbolicRepository);
+
+        IOException error = assertThrows(IOException.class, () -> service.snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)));
+
+        assertTrue(error.getMessage().contains("real directory"));
+    }
+
+    @TempDir
+    Path repository;
+
+    @Test
+    void verifiesAllMainCatalogKindsOffline() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        ShipCatalogService service = service();
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+
+        CatalogEvidenceSet result = service.snapshot(target).evidenceFor(List.of(
+                subject(Kind.COMPONENT, "timer"),
+                subject(Kind.EIP, "split"),
+                subject(Kind.DATAFORMAT, "csv"),
+                subject(Kind.LANGUAGE, "simple")));
+
+        assertEquals("org.apache.camel:camel-catalog:" + CAMEL_VERSION, result.platformCoordinate().gav());
+        assertEquals(1, result.artifacts().size());
+        assertEquals(4, result.subjects().size());
+        assertTrue(result.artifacts().get(0).sha256().matches("sha256:[0-9a-f]{64}"));
+        assertTrue(result.subjects().stream()
+                .allMatch(evidence -> evidence.resourceSha256().matches("sha256:[0-9a-f]{64}")));
+        assertTrue(result.digest().matches("sha256:[0-9a-f]{64}"));
+    }
+
+    @Test
+    void componentModelsRetainExactEvidenceAndBoundedOptions() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        put(entries, "org/apache/camel/catalog/components/timer.json", componentIdentity(
+                "timer", "org.apache.camel", "camel-timer", CAMEL_VERSION));
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+
+        ShipCatalogService.Snapshot snapshot = service().snapshot(target);
+        CatalogComponentModel model = snapshot.componentModelsFor(
+                List.of(subject(Kind.COMPONENT, "timer"))).get(0);
+        CatalogEvidenceSet evidence = snapshot.evidenceFor(
+                List.of(subject(Kind.COMPONENT, "timer")));
+
+        assertEquals(evidence.subjects().get(0), model.evidence());
+        assertEquals("timer:timerName", model.syntax());
+        assertEquals(List.of("timerName", "delay", "extra", "exceptionHandler"), model.options().stream()
+                .map(CatalogComponentModel.Option::name).toList());
+        CatalogComponentModel.Option extra = model.options().stream()
+                .filter(option -> "extra".equals(option.name())).findFirst().orElseThrow();
+        CatalogComponentModel.Option exceptionHandler = model.options().stream()
+                .filter(option -> "exceptionHandler".equals(option.name())).findFirst().orElseThrow();
+        assertEquals("extra.", extra.prefix());
+        assertNull(extra.optionalPrefix());
+        assertNull(exceptionHandler.prefix());
+        assertEquals("consumer.", exceptionHandler.optionalPrefix());
+    }
+
+    @Test
+    void componentEnumParsingAcceptsRealCatalogSizeAndTheFixedLimitButRejectsOneOver() throws Exception {
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+        CatalogSubject timer = subject(Kind.COMPONENT, "timer");
+
+        writeMainCatalogWithEnumValues(380);
+        assertEquals(380, service().snapshot(target).componentModelsFor(List.of(timer)).get(0)
+                .options().get(1).enumValues().size());
+
+        writeMainCatalogWithEnumValues(CatalogComponentModel.MAX_ENUM_VALUES);
+        assertEquals(CatalogComponentModel.MAX_ENUM_VALUES,
+                service().snapshot(target).componentModelsFor(List.of(timer)).get(0)
+                        .options().get(1).enumValues().size());
+
+        writeMainCatalogWithEnumValues(CatalogComponentModel.MAX_ENUM_VALUES + 1);
+        IOException excessive = assertThrows(IOException.class,
+                () -> service().snapshot(target).componentModelsFor(List.of(timer)));
+        assertTrue(excessive.getMessage().contains("unsafe enum"), excessive.getMessage());
+    }
+
+    @Test
+    void fractionalOptionIndexesAreRejectedInsteadOfTruncated() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        put(entries, "org/apache/camel/catalog/components/timer.json", componentIdentity(
+                "timer", "org.apache.camel", "camel-timer", CAMEL_VERSION)
+                .replace("\"index\": 0", "\"index\": 0.5"));
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).componentModelsFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertTrue(error.getMessage().contains("metadata is incomplete"));
+    }
+
+    @Test
+    void springProviderAvailabilityIsBoundWithoutFollowingDescriptorRepositories() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeSpringProvider("4.18.0", CAMEL_VERSION);
+        ShipCatalogService service = service();
+        CatalogTarget target = new CatalogTarget("spring-boot", CAMEL_VERSION, "4.18.0", "3.5.0");
+
+        CatalogEvidenceSet result = service.snapshot(target).evidenceFor(List.of(
+                subject(Kind.COMPONENT, "kafka"), subject(Kind.EIP, "split")));
+
+        assertEquals("org.apache.camel.springboot:camel-catalog-provider-springboot:4.18.0",
+                result.platformCoordinate().gav());
+        assertEquals(5, result.artifacts().size());
+        assertEquals("org.apache.camel.springboot", result.subjects().get(0).groupId());
+        assertEquals(Kind.EIP, result.subjects().get(1).subject().kind());
+        assertEquals("org.apache.camel:camel-catalog:" + CAMEL_VERSION,
+                result.subjects().get(1).catalogCoordinate().gav());
+    }
+
+    @Test
+    void springBootVersionIsVerifiedFromTheSnapshottedParentPom() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeSpringProvider("4.18.0", CAMEL_VERSION, "3.5.1");
+
+        IOException mismatch = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("spring-boot", CAMEL_VERSION, "4.18.0", "3.5.0")));
+        assertTrue(mismatch.getMessage().contains("approved Spring Boot version"));
+
+        writeSpringProvider("4.18.0", CAMEL_VERSION, null);
+        IOException missing = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("spring-boot", CAMEL_VERSION, "4.18.0", "3.5.0")));
+        assertTrue(missing.getMessage().contains("lacks an immutable Spring Boot version"));
+
+        writeSpringProvider("4.18.0", CAMEL_VERSION, "LATEST");
+        IOException mutable = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("spring-boot", CAMEL_VERSION, "4.18.0", "3.5.0")));
+        assertTrue(mutable.getMessage().contains("lacks an immutable Spring Boot version"));
+    }
+
+    @Test
+    void pomContentsMustMatchTheExactResolvedCoordinate() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusBom("3.33.2", "3.33.1", CAMEL_VERSION);
+        Path bom = artifact("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", "pom");
+        Files.writeString(bom, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>attacker.example</groupId>
+                  <artifactId>quarkus-camel-bom</artifactId>
+                  <version>3.33.2</version>
+                </project>
+                """);
+
+        IOException mismatch = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null)));
+
+        assertTrue(mismatch.getMessage().contains("POM identity"));
+    }
+
+    @Test
+    void pomDepthLimitAcceptsTheBoundaryAndRejectsOneBeyond() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusProvider("3.33.1", CAMEL_VERSION);
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        String body = quarkusBomBody("3.33.1", CAMEL_VERSION);
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                body + nestedPomElements(63));
+        assertEquals(3, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "kafka"))).artifacts().size());
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                body + nestedPomElements(64));
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(excessive.getMessage().contains("structural limits"));
+    }
+
+    @Test
+    void pomElementLimitAcceptsTheBoundaryAndRejectsOneBeyond() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusProvider("3.33.1", CAMEL_VERSION);
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        String body = quarkusBomBody("3.33.1", CAMEL_VERSION);
+        int fixedElements = 15;
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                body + "<padding/>".repeat(16_384 - fixedElements));
+        assertEquals(3, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "kafka"))).artifacts().size());
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                body + "<padding/>".repeat(16_385 - fixedElements));
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(excessive.getMessage().contains("structural limits"));
+    }
+
+    @Test
+    void pomNodeLimitAcceptsTheBoundaryAndRejectsOneBeyond() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusProvider("3.33.1", CAMEL_VERSION);
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        String body = minifiedQuarkusBomBody("3.33.1", CAMEL_VERSION);
+        int fixedNodes = 25;
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", "",
+                body + "<!---->".repeat(65_536 - fixedNodes));
+        assertEquals(3, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "kafka"))).artifacts().size());
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", "",
+                body + "<!---->".repeat(65_537 - fixedNodes));
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(excessive.getMessage().contains("structural limits"));
+    }
+
+    @Test
+    void pomNamespaceLimitAcceptsTheBoundaryAndRejectsOneBeyond() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusProvider("3.33.1", CAMEL_VERSION);
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        String body = minifiedQuarkusBomBody("3.33.1", CAMEL_VERSION);
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                namespaceDeclarations(511), body);
+        assertEquals(3, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "kafka"))).artifacts().size());
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                namespaceDeclarations(512), body);
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(excessive.getMessage().contains("structural limits"));
+    }
+
+    @Test
+    void pomNamespaceModelAndSingletonAmbiguityFailClosed() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        String body = minifiedQuarkusBomBody("3.33.1", CAMEL_VERSION);
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", "", body,
+                "urn:attacker.example:pom");
+        IOException namespace = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(namespace.getMessage().contains("root is not project"));
+
+        writeRawPom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", "", body);
+        Path pom = artifact("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", "pom");
+        Files.writeString(pom, Files.readString(pom).replace(
+                "<modelVersion>4.0.0</modelVersion>", "<modelVersion>3.0.0</modelVersion>"));
+        IOException model = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(model.getMessage().contains("unsupported model version"));
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2",
+                body + "<version>attacker</version>");
+        IOException coordinate = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(coordinate.getMessage().contains("duplicate version"));
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", """
+                <dependencyManagement>
+                  <dependencies></dependencies>
+                  <dependencies></dependencies>
+                </dependencyManagement>
+                """);
+        IOException container = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(container.getMessage().contains("duplicate dependencies"));
+    }
+
+    @Test
+    void repeatedPomPlaceholdersAreAllowedButCyclesFailClosed() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusProvider("3.3.1", CAMEL_VERSION);
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", """
+                <properties><part>3</part></properties>
+                <dependencyManagement><dependencies>
+                  <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-catalog</artifactId>
+                    <version>${part}.${part}.1</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-catalog</artifactId>
+                    <version>4.18.0</version>
+                  </dependency>
+                </dependencies></dependencyManagement>
+                """);
+        assertEquals(3, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "kafka"))).artifacts().size());
+
+        writePom("io.quarkus.platform", "quarkus-camel-bom", "3.33.2", """
+                <properties><catalog.version>${catalog.version}</catalog.version></properties>
+                <dependencyManagement><dependencies>
+                  <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-catalog</artifactId>
+                    <version>${catalog.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-catalog</artifactId>
+                    <version>4.18.0</version>
+                  </dependency>
+                </dependencies></dependencyManagement>
+                """);
+        IOException cycle = assertThrows(IOException.class, () -> service().snapshot(target));
+        assertTrue(cycle.getMessage().contains("cyclic Maven property"));
+    }
+
+    @Test
+    void quarkusProviderIsDerivedFromPlatformBomOffline() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusBom("3.33.2", "3.33.1", CAMEL_VERSION);
+        writeQuarkusProvider("3.33.1", CAMEL_VERSION);
+        ShipCatalogService service = service();
+        CatalogTarget target = new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.2", null);
+
+        CatalogEvidenceSet result = service.snapshot(target).evidenceFor(List.of(
+                subject(Kind.COMPONENT, "kafka"), subject(Kind.LANGUAGE, "simple")));
+
+        assertEquals("io.quarkus.platform:quarkus-camel-bom:3.33.2", result.platformCoordinate().gav());
+        assertEquals(3, result.artifacts().size());
+        assertTrue(result.subjects().stream()
+                .allMatch(evidence -> "org.apache.camel.quarkus".equals(evidence.groupId())));
+    }
+
+    @Test
+    void quarkusBomCamelMismatchFailsClosed() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusBom("3.33.1", "3.33.0", "4.18.1");
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.1", null)));
+
+        assertTrue(error.getMessage().contains("approved Camel version"));
+    }
+
+    @Test
+    void mutableVersionDerivedFromBomIsRejected() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeQuarkusBom("3.33.1", "LATEST", CAMEL_VERSION);
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("quarkus", CAMEL_VERSION, "3.33.1", null)));
+
+        assertTrue(error.getMessage().contains("unsafe or mutable Maven coordinate"));
+    }
+
+    @Test
+    void missingOfflineArtifactNeverFallsBackToBundledCatalog() {
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)));
+
+        assertTrue(error.getMessage().toLowerCase(Locale.ROOT).contains("offline"), error.getMessage());
+    }
+
+    @Test
+    void mismatchedResourceIdentityIsRejected() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "different-name");
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertTrue(error.getMessage().contains("identity mismatch"));
+    }
+
+    @Test
+    void trailingJsonTokensAreRejectedBehindASafeDiagnostic() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        String resource = "org/apache/camel/catalog/components/timer.json";
+        String valid = new String(entries.get(resource), StandardCharsets.UTF_8);
+        put(entries, resource, valid + "{\"secret\":\"do-not-reflect\"}");
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertTrue(error.getMessage().contains("not valid JSON"));
+        assertFalse(error.getMessage().contains("do-not-reflect"));
+    }
+
+    @Test
+    void oversizedCatalogResourceIsRejectedBeforeJsonParsing() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        entries.put("org/apache/camel/catalog/components/timer.json", new byte[2 * 1024 * 1024 + 1]);
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertTrue(error.getMessage().contains("exceeds its size limit"), error.getMessage());
+    }
+
+    @Test
+    void catalogResourceAtTheExactLimitIsAccepted() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        byte[] json = componentIdentity("timer", "org.apache.camel", "camel-timer", CAMEL_VERSION)
+                .getBytes(StandardCharsets.UTF_8);
+        byte[] atLimit = Arrays.copyOf(json, 2 * 1024 * 1024);
+        Arrays.fill(atLimit, json.length, atLimit.length, (byte) ' ');
+        entries.put("org/apache/camel/catalog/components/timer.json", atLimit);
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        CatalogEvidenceSet result = service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer")));
+
+        assertEquals(1, result.subjects().size());
+    }
+
+    @Test
+    void unsafeAndDuplicateZipEntryNamesFailClosed() throws Exception {
+        Map<String, byte[]> unsafe = mainEntries(CAMEL_VERSION, "timer");
+        unsafe.put("../outside", new byte[]{1});
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, unsafe);
+
+        IOException traversal = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+        assertTrue(traversal.getMessage().contains("unsafe entry name"), traversal.getMessage());
+
+        Map<String, byte[]> duplicate = mainEntries(CAMEL_VERSION, "timer");
+        duplicate.put("dup-one", new byte[]{1});
+        duplicate.put("dup-two", new byte[]{2});
+        byte[] duplicateArchive = replaceAscii(jarBytes(duplicate), "dup-two", "dup-one");
+        Files.write(artifact("org.apache.camel", "camel-catalog", CAMEL_VERSION, "jar"), duplicateArchive);
+
+        IOException repeated = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+        assertTrue(repeated.getMessage().contains("duplicate entries"), repeated.getMessage());
+    }
+
+    @Test
+    void zipEntryQuotaAcceptsTheLimitAndRejectsOneOver() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        int base = entries.size();
+        for (int index = base; index < 8_192; index++) {
+            entries.put("filler/entry-" + index, new byte[0]);
+        }
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        assertEquals(1, service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer")))
+                .subjects().size());
+
+        entries.put("filler/one-over", new byte[0]);
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+        assertTrue(excessive.getMessage().contains("too many"), excessive.getMessage());
+    }
+
+    @Test
+    void duplicateCatalogIndexNamesAreRejected() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        put(entries, "org/apache/camel/catalog/components.properties", "timer\ntimer\n");
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        IOException duplicate = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertTrue(duplicate.getMessage().contains("duplicate name"), duplicate.getMessage());
+    }
+
+    @Test
+    void unsafeCatalogIndexContentIsNotReflectedInTheTopLevelDiagnostic() throws Exception {
+        String sensitive = "https://user:secret@example.invalid/catalog";
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        put(entries, "org/apache/camel/catalog/components.properties", sensitive + '\n');
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertFalse(error.getMessage().contains(sensitive));
+        assertTrue(error.getMessage().contains("unsafe name"));
+    }
+
+    @Test
+    void catalogIndexesMustUseStrictUtf8() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        entries.put("org/apache/camel/catalog/components.properties",
+                new byte[]{'#', (byte) 0xc3, 0x28, '\n', 't', 'i', 'm', 'e', 'r', '\n'});
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer"))));
+
+        assertTrue(error.getMessage().contains("strict UTF-8"));
+    }
+
+    @Test
+    void perKindNameQuotaAcceptsTheLimitAndRejectsOneOver() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        String root = "org/apache/camel/catalog/";
+        put(entries, root + "components.properties", catalogNames("component", 8_192));
+        put(entries, root + "components/component0.json",
+                identity("component", "component", "component0",
+                        "org.apache.camel", "camel-test", CAMEL_VERSION, null));
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+
+        assertEquals(1, service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "component0"))).subjects().size());
+
+        put(entries, root + "components.properties", catalogNames("component", 8_193));
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        IOException excessive = assertThrows(IOException.class, () -> service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "component0"))));
+        assertTrue(excessive.getMessage().contains("too many names"));
+    }
+
+    @Test
+    void aggregateSubjectQuotaAcceptsTheLimitAndRejectsOneOver() throws Exception {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        String components = "org/apache/camel/catalog/components.properties";
+        put(entries, components, catalogNames("component", 8_189));
+        put(entries, "org/apache/camel/catalog/models.properties", "split\n");
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+
+        assertEquals(8_192, service().snapshot(target).availableSubjects().size());
+
+        put(entries, components, catalogNames("component", 8_190));
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+        IOException excessive = assertThrows(IOException.class,
+                () -> service().snapshot(target).availableSubjects());
+        assertTrue(excessive.getMessage().contains("more than 8192 subjects"));
+    }
+
+    @Test
+    void requestedOrderCannotChangeTheSnapshot() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+        CatalogSubject timer = subject(Kind.COMPONENT, "timer");
+        CatalogSubject split = subject(Kind.EIP, "split");
+
+        ShipCatalogService.Snapshot snapshot = service().snapshot(target);
+        CatalogEvidenceSet first = snapshot.evidenceFor(List.of(timer, split));
+        CatalogEvidenceSet second = snapshot.evidenceFor(List.of(split, timer));
+
+        assertEquals(first, second);
+    }
+
+    @Test
+    void allQueriesStayBoundToTheArtifactBytesCapturedByOneSnapshot() throws Exception {
+        Map<String, byte[]> original = mainEntries(CAMEL_VERSION, "timer");
+        put(original, "org/apache/camel/catalog/components/timer.json", componentIdentity(
+                "timer", "org.apache.camel", "camel-timer", CAMEL_VERSION));
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, original);
+        CatalogTarget target = new CatalogTarget("main", CAMEL_VERSION, null, null);
+        ShipCatalogService.Snapshot snapshot = service().snapshot(target);
+
+        writeMainCatalog(CAMEL_VERSION, "different-name");
+
+        assertTrue(snapshot.availableSubjects().contains(subject(Kind.COMPONENT, "timer")));
+        assertEquals(1, snapshot.evidenceFor(
+                List.of(subject(Kind.COMPONENT, "timer"))).subjects().size());
+        assertEquals("timer:timerName", snapshot.componentModelsFor(
+                List.of(subject(Kind.COMPONENT, "timer"))).get(0).syntax());
+        assertThrows(IOException.class, () -> service().snapshot(target).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "timer"))));
+    }
+
+    @Test
+    void subjectBoundsDoNotTrustCallerCollectionSize() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        ShipCatalogService.Snapshot snapshot = service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null));
+        AbstractCollection<CatalogSubject> lying = new AbstractCollection<>() {
+            @Override
+            public Iterator<CatalogSubject> iterator() {
+                return new Iterator<>() {
+                    private int index;
+
+                    @Override
+                    public boolean hasNext() {
+                        return index <= 512;
+                    }
+
+                    @Override
+                    public CatalogSubject next() {
+                        return subject(Kind.COMPONENT, "c" + index++);
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                throw new AssertionError("The catalog boundary must not trust Collection.size()");
+            }
+        };
+
+        IOException excessive = assertThrows(IOException.class, () -> snapshot.evidenceFor(lying));
+
+        assertTrue(excessive.getMessage().contains("between 1 and 512"));
+    }
+
+    @Test
+    void onlineAcquisitionDelegatesOnlyExactCoordinatesToTheResolverBoundary() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        AtomicReference<List<MavenCoordinate>> requested = new AtomicReference<>();
+        AtomicReference<ResolutionMode> mode = new AtomicReference<>();
+        ShipCatalogService service = new ShipCatalogService(
+                repository, ResolutionMode.ONLINE,
+                (local, coordinates, resolutionMode) -> {
+                    requested.set(coordinates);
+                    mode.set(resolutionMode);
+                    MavenCoordinate coordinate = coordinates.get(0);
+                    Path path = artifact(coordinate.groupId(), coordinate.artifactId(),
+                            coordinate.version(), coordinate.extension());
+                    byte[] bytes = Files.readAllBytes(path);
+                    return List.of(new ResolvedExactMavenArtifact(
+                            coordinate, path, sha256(bytes), bytes.length));
+                });
+
+        service.snapshot(new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                List.of(subject(Kind.COMPONENT, "timer")));
+
+        assertEquals(ResolutionMode.ONLINE, mode.get());
+        assertEquals(List.of(MavenCoordinate.jar("org.apache.camel", "camel-catalog", CAMEL_VERSION)),
+                requested.get());
+    }
+
+    @Test
+    void securelySnapshottedBytesMustMatchTheAcquiredCentralIdentity() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        MavenCoordinate coordinate = MavenCoordinate.jar("org.apache.camel", "camel-catalog", CAMEL_VERSION);
+        Path path = artifact(coordinate.groupId(), coordinate.artifactId(),
+                coordinate.version(), coordinate.extension());
+        byte[] acquired = Files.readAllBytes(path);
+        ShipCatalogService service = new ShipCatalogService(
+                repository, ResolutionMode.ONLINE,
+                (local, coordinates, mode) -> {
+                    byte[] changed = acquired.clone();
+                    changed[changed.length - 1] ^= 1;
+                    Files.write(path, changed);
+                    return List.of(new ResolvedExactMavenArtifact(
+                            coordinate, path, sha256(acquired), acquired.length));
+                });
+
+        IOException mismatch = assertThrows(IOException.class, () -> service.snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)));
+
+        assertTrue(mismatch.getMessage().contains("acquired content identity"));
+    }
+
+    @Test
+    void availableSubjectsUsesRuntimeProviderForRuntimeSensitiveKinds() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        writeSpringProvider("4.18.0", CAMEL_VERSION);
+
+        List<CatalogSubject> subjects = service().snapshot(
+                new CatalogTarget("spring-boot", CAMEL_VERSION, "4.18.0", "3.5.0"))
+                .availableSubjects();
+
+        assertTrue(subjects.contains(subject(Kind.COMPONENT, "kafka")));
+        assertTrue(subjects.contains(subject(Kind.EIP, "split")));
+        assertFalse(subjects.contains(subject(Kind.COMPONENT, "timer")));
+    }
+
+    @Test
+    void symbolicArtifactAncestorCannotEscapeThePrivateRepository() throws Exception {
+        Path privateRepository = Files.createDirectory(repository.resolve("private"));
+        Path outsideRepository = Files.createDirectory(repository.resolve("outside"));
+        writeJar(outsideRepository, "org.apache.camel", "camel-catalog", CAMEL_VERSION,
+                mainEntries(CAMEL_VERSION, "timer"));
+        Files.createSymbolicLink(privateRepository.resolve("org"), outsideRepository.resolve("org"));
+
+        IOException error = assertThrows(IOException.class, () -> offlineService(privateRepository).snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)));
+
+        assertTrue(error.getMessage().contains("offline mode"));
+        assertTrue(causeChainContains(error, "symbolic link"));
+    }
+
+    @Test
+    void hardLinkedCatalogArtifactIsRejected() throws Exception {
+        writeMainCatalog(CAMEL_VERSION, "timer");
+        Files.createLink(
+                repository.resolve("artifact-hard-link"),
+                artifact("org.apache.camel", "camel-catalog", CAMEL_VERSION, "jar"));
+
+        IOException error = assertThrows(IOException.class, () -> service().snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)));
+
+        assertTrue(causeChainContains(error, "hard-linked"));
+    }
+
+    private ShipCatalogService service() {
+        return offlineService(repository);
+    }
+
+    private static ShipCatalogService offlineService(Path path) {
+        return new ShipCatalogService(path, ResolutionMode.OFFLINE, ShipMavenResolver::resolveArtifacts);
+    }
+
+    private static boolean causeChainContains(Throwable error, String fragment) {
+        for (Throwable current = error; current != null; current = current.getCause()) {
+            if (current.getMessage() != null && current.getMessage().contains(fragment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static CatalogSubject subject(Kind kind, String name) {
+        return new CatalogSubject(kind, name);
+    }
+
+    private void writeMainCatalog(String version, String timerIdentity) throws IOException {
+        writeJar("org.apache.camel", "camel-catalog", version, mainEntries(version, timerIdentity));
+    }
+
+    private static Map<String, byte[]> mainEntries(String version, String timerIdentity) {
+        String root = "org/apache/camel/catalog/";
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        put(entries, "META-INF/version.properties", "version=" + version + "\n");
+        put(entries, root + "components.properties", "timer\n");
+        put(entries, root + "models.properties", "route\nfrom\nto\nsetBody\nsplit\nmarshal\nunmarshal\n");
+        put(entries, root + "dataformats.properties", "csv\n");
+        put(entries, root + "languages.properties", "simple\n");
+        put(entries, root + "components/timer.json",
+                identity("component", "component", timerIdentity,
+                        "org.apache.camel", "camel-timer", version, null));
+        put(entries, root + "models/split.json",
+                identity("model", "model", "split", null, null, null, null));
+        put(entries, root + "dataformats/csv.json",
+                identity("dataformat", "dataformat", "csv",
+                        "org.apache.camel", "camel-csv", version, null));
+        put(entries, root + "languages/simple.json",
+                identity("language", "language", "simple",
+                        "org.apache.camel", "camel-core-languages", version, null));
+        return entries;
+    }
+
+    private void writeSpringProvider(String providerVersion, String camelVersion) throws IOException {
+        writeSpringProvider(providerVersion, camelVersion, "3.5.0");
+    }
+
+    private void writeSpringProvider(
+            String providerVersion, String camelVersion, String springBootVersion)
+            throws IOException {
+        String root = "org/apache/camel/springboot/catalog/";
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        put(entries, root + "components.properties", "kafka\n");
+        put(entries, root + "dataformats.properties", "csv\n");
+        put(entries, root + "languages.properties", "simple\n");
+        put(entries, root + "components/kafka.json",
+                identity("component", "component", "kafka", "org.apache.camel.springboot",
+                        "camel-kafka-starter", providerVersion, null));
+        put(entries, root + "dataformats/csv.json",
+                identity("dataformat", "dataformat", "csv", "org.apache.camel.springboot",
+                        "camel-csv-starter", providerVersion, null));
+        put(entries, root + "languages/simple.json",
+                identity("language", "language", "simple", "org.apache.camel.springboot",
+                        "camel-core-languages-starter", providerVersion, null));
+        writeJar("org.apache.camel.springboot", "camel-catalog-provider-springboot", providerVersion, entries);
+        writePom("org.apache.camel.springboot", "camel-catalog-provider-springboot", providerVersion, """
+                <repositories>
+                  <repository><id>poison</id><url>https://repo.example.invalid/maven2</url></repository>
+                </repositories>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-catalog</artifactId>
+                    <version>${camel-version}</version>
+                  </dependency>
+                </dependencies>
+                """);
+        writePom("org.apache.camel.springboot", "spring-boot", providerVersion,
+                String.format(Locale.ROOT, """
+                        <parent>
+                          <groupId>org.apache.camel</groupId>
+                          <artifactId>camel-dependencies</artifactId>
+                          <version>%s</version>
+                        </parent>
+                        <properties><camel-version>%s</camel-version></properties>
+                        """, camelVersion, camelVersion));
+        String bootProperty = springBootVersion == null
+                ? ""
+                : "<spring-boot-version>" + springBootVersion + "</spring-boot-version>";
+        writePom("org.apache.camel", "camel-dependencies", camelVersion,
+                "<properties>" + bootProperty + "</properties>");
+    }
+
+    private void writeQuarkusBom(String platformVersion, String catalogVersion, String camelVersion)
+            throws IOException {
+        writePom("io.quarkus.platform", "quarkus-camel-bom", platformVersion,
+                quarkusBomBody(catalogVersion, camelVersion));
+    }
+
+    private static String quarkusBomBody(String catalogVersion, String camelVersion) {
+        return String.format(Locale.ROOT, """
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel.quarkus</groupId>
+                      <artifactId>camel-quarkus-catalog</artifactId>
+                      <version>%s</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-catalog</artifactId>
+                      <version>%s</version>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+                """, catalogVersion, camelVersion);
+    }
+
+    private static String minifiedQuarkusBomBody(String catalogVersion, String camelVersion) {
+        return "<dependencyManagement><dependencies>"
+               + "<dependency><groupId>org.apache.camel.quarkus</groupId>"
+               + "<artifactId>camel-quarkus-catalog</artifactId><version>" + catalogVersion
+               + "</version></dependency>"
+               + "<dependency><groupId>org.apache.camel</groupId>"
+               + "<artifactId>camel-catalog</artifactId><version>" + camelVersion
+               + "</version></dependency>"
+               + "</dependencies></dependencyManagement>";
+    }
+
+    private static String namespaceDeclarations(int count) {
+        StringBuilder result = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            result.append(" xmlns:n").append(index).append("=\"urn:n").append(index).append("\"");
+        }
+        return result.toString();
+    }
+
+    private static String catalogNames(String prefix, int count) {
+        StringBuilder result = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            result.append(prefix).append(index).append('\n');
+        }
+        return result.toString();
+    }
+
+    private static String nestedPomElements(int depth) {
+        return "<nested>".repeat(depth) + "</nested>".repeat(depth);
+    }
+
+    private void writeQuarkusProvider(String catalogVersion, String camelVersion) throws IOException {
+        String root = "org/apache/camel/catalog/quarkus/";
+        String metadata = "\"metadata\":{\"camelVersion\":\"" + camelVersion + "\"}";
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        put(entries, root + "components.properties", "kafka\n");
+        put(entries, root + "dataformats.properties", "csv\n");
+        put(entries, root + "languages.properties", "simple\n");
+        put(entries, root + "components/kafka.json",
+                identity("component", "component", "kafka", "org.apache.camel.quarkus",
+                        "camel-quarkus-kafka", catalogVersion, metadata));
+        put(entries, root + "dataformats/csv.json",
+                identity("dataformat", "dataformat", "csv", "org.apache.camel.quarkus",
+                        "camel-quarkus-csv", catalogVersion, metadata));
+        put(entries, root + "languages/simple.json",
+                identity("language", "language", "simple", "org.apache.camel.quarkus",
+                        "camel-quarkus-core", catalogVersion, metadata));
+        writeJar("org.apache.camel.quarkus", "camel-quarkus-catalog", catalogVersion, entries);
+    }
+
+    private void writeJar(String groupId, String artifactId, String version, Map<String, byte[]> entries)
+            throws IOException {
+        writeJar(repository, groupId, artifactId, version, entries);
+    }
+
+    private static void writeJar(
+            Path repository,
+            String groupId,
+            String artifactId,
+            String version,
+            Map<String, byte[]> entries)
+            throws IOException {
+        Path jar = artifact(repository, groupId, artifactId, version, "jar");
+        Files.createDirectories(jar.getParent());
+        Files.write(jar, jarBytes(entries));
+    }
+
+    private static byte[] jarBytes(Map<String, byte[]> entries) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(output)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zip.putNextEntry(new ZipEntry(entry.getKey()));
+                zip.write(entry.getValue());
+                zip.closeEntry();
+            }
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] replaceAscii(byte[] bytes, String from, String to) {
+        byte[] source = from.getBytes(StandardCharsets.US_ASCII);
+        byte[] replacement = to.getBytes(StandardCharsets.US_ASCII);
+        if (source.length != replacement.length) {
+            throw new IllegalArgumentException("ZIP entry replacement must preserve byte length");
+        }
+        byte[] result = bytes.clone();
+        int replacements = 0;
+        for (int offset = 0; offset <= result.length - source.length; offset++) {
+            boolean match = true;
+            for (int index = 0; index < source.length; index++) {
+                if (result[offset + index] != source[index]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                System.arraycopy(replacement, 0, result, offset, replacement.length);
+                replacements++;
+                offset += source.length - 1;
+            }
+        }
+        assertEquals(2, replacements, "Expected one local and one central ZIP entry name");
+        return result;
+    }
+
+    private void writePom(String groupId, String artifactId, String version, String body) throws IOException {
+        Path pom = artifact(groupId, artifactId, version, "pom");
+        Files.createDirectories(pom.getParent());
+        Files.writeString(pom, String.format(Locale.ROOT, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>%s</groupId>
+                  <artifactId>%s</artifactId>
+                  <version>%s</version>
+                  %s
+                </project>
+                """, groupId, artifactId, version, body));
+    }
+
+    private void writeRawPom(
+            String groupId, String artifactId, String version, String rootAttributes, String body)
+            throws IOException {
+        writeRawPom(groupId, artifactId, version, rootAttributes, body,
+                "http://maven.apache.org/POM/4.0.0");
+    }
+
+    private void writeRawPom(
+            String groupId,
+            String artifactId,
+            String version,
+            String rootAttributes,
+            String body,
+            String namespace)
+            throws IOException {
+        Path pom = artifact(groupId, artifactId, version, "pom");
+        Files.createDirectories(pom.getParent());
+        Files.writeString(pom,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                               + "<project xmlns=\"" + namespace + "\"" + rootAttributes + ">"
+                               + "<modelVersion>4.0.0</modelVersion>"
+                               + "<groupId>" + groupId + "</groupId>"
+                               + "<artifactId>" + artifactId + "</artifactId>"
+                               + "<version>" + version + "</version>"
+                               + body + "</project>");
+    }
+
+    private Path artifact(String groupId, String artifactId, String version, String extension) {
+        return artifact(repository, groupId, artifactId, version, extension);
+    }
+
+    private static Path artifact(
+            Path repository, String groupId, String artifactId, String version, String extension) {
+        return repository.resolve(groupId.replace('.', '/')).resolve(artifactId).resolve(version)
+                .resolve(artifactId + '-' + version + '.' + extension);
+    }
+
+    private static void put(Map<String, byte[]> entries, String name, String value) {
+        entries.put(name, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String sha256(byte[] bytes) {
+        try {
+            return "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String identity(
+            String root, String kind, String name, String groupId, String artifactId, String version, String extra) {
+        StringBuilder json = new StringBuilder("{\"").append(root).append("\":{")
+                .append("\"kind\":\"").append(kind).append("\",")
+                .append("\"name\":\"").append(name).append("\",")
+                .append("\"deprecated\":false");
+        if (groupId != null) {
+            json.append(",\"groupId\":\"").append(groupId).append("\"")
+                    .append(",\"artifactId\":\"").append(artifactId).append("\"")
+                    .append(",\"version\":\"").append(version).append("\"");
+        }
+        if (extra != null) {
+            json.append(',').append(extra);
+        }
+        return json.append("}}\n").toString();
+    }
+
+    private static String componentIdentity(
+            String name, String groupId, String artifactId, String version) {
+        return String.format(Locale.ROOT, """
+                {
+                  "component": {
+                    "kind": "component", "name": "%s", "deprecated": false,
+                    "groupId": "%s", "artifactId": "%s", "version": "%s",
+                    "syntax": "%s:timerName", "lenientProperties": false
+                  },
+                  "componentProperties": {},
+                  "properties": {
+                    "timerName": {
+                      "index": 0, "kind": "path", "required": true,
+                      "type": "string", "javaType": "java.lang.String"
+                    },
+                    "delay": {
+                      "index": 1, "kind": "parameter", "required": false,
+                      "type": "integer", "javaType": "long"
+                    },
+                    "extra": {
+                      "index": 2, "kind": "parameter", "required": false,
+                      "type": "object", "javaType": "java.util.Map",
+                      "multiValue": true, "prefix": "extra."
+                    },
+                    "exceptionHandler": {
+                      "index": 3, "kind": "parameter", "required": false,
+                      "type": "object", "javaType": "java.lang.Object",
+                      "optionalPrefix": "consumer."
+                    }
+                  }
+                }
+                """, name, groupId, artifactId, version, name);
+    }
+
+    private void writeMainCatalogWithEnumValues(int count) throws IOException {
+        Map<String, byte[]> entries = mainEntries(CAMEL_VERSION, "timer");
+        String enumValues = IntStream.range(0, count)
+                .mapToObj(index -> "\"value" + index + "\"")
+                .collect(java.util.stream.Collectors.joining(","));
+        String component = componentIdentity("timer", "org.apache.camel", "camel-timer", CAMEL_VERSION)
+                .replace("\"type\": \"integer\", \"javaType\": \"long\"",
+                        "\"type\": \"integer\", \"javaType\": \"long\", \"enum\": ["
+                                                                          + enumValues + "]");
+        put(entries, "org/apache/camel/catalog/components/timer.json", component);
+        writeJar("org.apache.camel", "camel-catalog", CAMEL_VERSION, entries);
+    }
+}

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/MavenCoordinate.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/MavenCoordinate.java
@@ -65,7 +65,7 @@ public record MavenCoordinate(
 
     private static String requirePart(String value, String label) {
         Objects.requireNonNull(value, label + " must not be null");
-        if (!SAFE_PART.matcher(value).matches()
+        if (value.length() > 128 || !SAFE_PART.matcher(value).matches()
                 || value.startsWith(".") || value.endsWith(".") || value.contains("..")) {
             throw new IllegalArgumentException("Unsafe Maven coordinate " + label);
         }

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ResolvedExactMavenArtifact.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ResolvedExactMavenArtifact.java
@@ -1,0 +1,36 @@
+package io.github.luigidemasi.camelkit.ship.resolver;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Descriptive exact-artifact identity reported by the resolver. This caller-constructible record is not a provenance or
+ * lifecycle capability; consumers must verify the identity against the bytes they actually open.
+ */
+public record ResolvedExactMavenArtifact(
+        MavenCoordinate coordinate,
+        Path path,
+        String contentSha256,
+        long contentLength) {
+
+    private static final Pattern SHA256 = Pattern.compile("sha256:[0-9a-f]{64}");
+
+    public ResolvedExactMavenArtifact {
+        Objects.requireNonNull(coordinate, "coordinate must not be null");
+        path = Objects.requireNonNull(path, "path must not be null").toAbsolutePath().normalize();
+        if (contentSha256 == null || !SHA256.matcher(contentSha256).matches()) {
+            throw new IllegalArgumentException("Exact artifact requires a SHA-256 content identity");
+        }
+        if (contentLength <= 0) {
+            throw new IllegalArgumentException("Exact artifact requires a positive content length");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ResolvedExactMavenArtifact[coordinate=" + coordinate
+               + ", path=<redacted>, contentSha256=" + contentSha256
+               + ", contentLength=" + contentLength + ']';
+    }
+}

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ResolvedMavenArtifact.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ResolvedMavenArtifact.java
@@ -10,4 +10,9 @@ public record ResolvedMavenArtifact(MavenCoordinate coordinate, Path path) {
         Objects.requireNonNull(coordinate, "coordinate must not be null");
         path = Objects.requireNonNull(path, "path must not be null").toAbsolutePath().normalize();
     }
+
+    @Override
+    public String toString() {
+        return "ResolvedMavenArtifact[coordinate=" + coordinate + ", path=<redacted>]";
+    }
 }

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -59,6 +60,8 @@ public final class ShipMavenResolver {
     private static final long MAX_EXACT_JAR_BYTES = 128L * 1024 * 1024;
     private static final long MAX_EXACT_POM_BYTES = 4L * 1024 * 1024;
     private static final Duration DIRECT_FETCH_TIMEOUT = Duration.ofSeconds(30);
+    private static final String DIRECT_FETCH_TIMEOUT_MESSAGE
+            = "Timed out fetching exact artifact bytes from Maven Central";
     private static final ScheduledThreadPoolExecutor DIRECT_FETCH_DEADLINES = directFetchDeadlines();
 
     /** Fixed fail-closed ceiling for unique direct roots in one resolution request. */
@@ -348,7 +351,7 @@ public final class ShipMavenResolver {
         CompletableFuture<HttpResponse<ContentIdentity>> exchange
                 = directClient().sendAsync(directRequest(uri, timeout), handler);
         AtomicBoolean deadlineExpired = new AtomicBoolean();
-        IOException timeoutFailure = new IOException("Timed out fetching exact artifact bytes from Maven Central");
+        IOException timeoutFailure = new IOException(DIRECT_FETCH_TIMEOUT_MESSAGE);
         ScheduledFuture<?> watchdog = DIRECT_FETCH_DEADLINES.schedule(() -> {
             deadlineExpired.set(true);
             handler.abort(timeoutFailure);
@@ -371,7 +374,13 @@ public final class ShipMavenResolver {
             Thread.currentThread().interrupt();
             throw new IOException("Interrupted while fetching an exact artifact from Maven Central", e);
         } catch (ExecutionException e) {
-            throw directFetchFailure(e.getCause());
+            IOException failure = directFetchFailure(e.getCause());
+            if (e.getCause() instanceof HttpTimeoutException) {
+                deadlineExpired.set(true);
+                handler.abort(failure);
+                exchange.cancel(true);
+            }
+            throw failure;
         } catch (CancellationException e) {
             if (deadlineExpired.get()) {
                 throw timeoutFailure;
@@ -407,7 +416,10 @@ public final class ShipMavenResolver {
                 .build();
     }
 
-    private static IOException directFetchFailure(Throwable failure) {
+    static IOException directFetchFailure(Throwable failure) {
+        if (failure instanceof HttpTimeoutException) {
+            return new IOException(DIRECT_FETCH_TIMEOUT_MESSAGE, failure);
+        }
         if (failure instanceof IOException ioFailure) {
             return ioFailure;
         }

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
@@ -1,14 +1,37 @@
 package io.github.luigidemasi.camelkit.ship.resolver;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Flow;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.ConfigurationProperties;
@@ -22,6 +45,8 @@ import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
@@ -30,13 +55,23 @@ import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
 /** Maven Resolver boundary whose third-party implementation is relocated in the published JAR. */
 public final class ShipMavenResolver {
 
-    private static final String CENTRAL = "https://repo.maven.apache.org/maven2/";
+    private static final URI CENTRAL = URI.create("https://repo.maven.apache.org/maven2/");
+    private static final long MAX_EXACT_JAR_BYTES = 128L * 1024 * 1024;
+    private static final long MAX_EXACT_POM_BYTES = 4L * 1024 * 1024;
+    private static final Duration DIRECT_FETCH_TIMEOUT = Duration.ofSeconds(30);
+    private static final ScheduledThreadPoolExecutor DIRECT_FETCH_DEADLINES = directFetchDeadlines();
 
     /** Fixed fail-closed ceiling for unique direct roots in one resolution request. */
     public static final int MAX_ROOTS = 64;
 
     /** Fixed fail-closed ceiling for artifacts returned by one resolution request. */
     public static final int MAX_ARTIFACTS = 512;
+
+    /** Whether exact artifacts may be downloaded from the fixed Maven Central repository. */
+    public enum ResolutionMode {
+        OFFLINE,
+        ONLINE
+    }
 
     private ShipMavenResolver() {
     }
@@ -56,7 +91,7 @@ public final class ShipMavenResolver {
         rejectRepositoryOverrides();
         try {
             RepositorySystem system = repositorySystem();
-            DefaultRepositorySystemSession session = session(system, local);
+            DefaultRepositorySystemSession session = session(system, local, ResolutionMode.ONLINE);
             CollectRequest collect = new CollectRequest();
             for (MavenDependencyRoot root : requested) {
                 List<Exclusion> exclusions = root.exclusions().stream()
@@ -99,6 +134,82 @@ public final class ShipMavenResolver {
         }
     }
 
+    /**
+     * Resolves exact artifacts without reading descriptors or traversing dependencies. Requests must contain between
+     * one and {@value #MAX_ARTIFACTS} unique immutable coordinates and results retain request order. Online results are
+     * byte-matched against a direct, non-redirecting request to the fixed Maven Central origin; offline results are
+     * bound to the local bytes. The online request relies on the controlling process's TLS, DNS, and security-provider
+     * trust domain. Consumers must compare the returned identity with the bytes they actually read.
+     */
+    public static List<ResolvedExactMavenArtifact> resolveArtifacts(
+            Path repository, List<MavenCoordinate> artifacts, ResolutionMode mode)
+            throws IOException {
+        return resolveArtifacts(repository, artifacts, mode, ShipMavenResolver::fetchDirect);
+    }
+
+    static List<ResolvedExactMavenArtifact> resolveArtifacts(
+            Path repository,
+            List<MavenCoordinate> artifacts,
+            ResolutionMode mode,
+            CentralDigestSource centralDigestSource)
+            throws IOException {
+        Path local = requireRepository(repository);
+        List<MavenCoordinate> requested = copyExactArtifacts(artifacts);
+        Objects.requireNonNull(mode, "mode must not be null");
+        Objects.requireNonNull(centralDigestSource, "centralDigestSource must not be null");
+        rejectRepositoryOverrides();
+        try {
+            RepositorySystem system = repositorySystem();
+            DefaultRepositorySystemSession session = session(system, local, mode);
+            List<ResolvedExactMavenArtifact> result = new ArrayList<>(requested.size());
+            for (MavenCoordinate coordinate : requested) {
+                rejectExistingSymlinks(local, coordinate);
+                long limit = exactArtifactLimit(coordinate);
+                ContentIdentity authoritative = null;
+                if (mode == ResolutionMode.ONLINE) {
+                    authoritative = centralDigestSource.identity(centralUri(coordinate), limit);
+                    if (authoritative == null || authoritative.length() > limit) {
+                        throw new IOException("Maven Central returned an invalid exact artifact identity");
+                    }
+                }
+                ArtifactRequest request = new ArtifactRequest(
+                        new DefaultArtifact(coordinate.resolverString()), List.of(central()), null);
+                ArtifactResult resolved = system.resolveArtifact(session, request);
+                ResolvedMavenArtifact artifact = requireExactArtifact(local, coordinate, resolved);
+                ContentIdentity localContent = contentIdentity(artifact.path(), limit);
+                if (authoritative != null && !authoritative.equals(localContent)) {
+                    throw new IOException("Cached exact artifact differs from authoritative Maven Central bytes");
+                }
+                ContentIdentity identity = authoritative == null ? localContent : authoritative;
+                result.add(new ResolvedExactMavenArtifact(
+                        coordinate, artifact.path(), identity.sha256(), identity.length()));
+            }
+            return List.copyOf(result);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception | LinkageError e) {
+            throw new IOException("Could not resolve an exact Ship artifact: " + safeMessage(e), e);
+        }
+    }
+
+    private static List<MavenCoordinate> copyExactArtifacts(List<MavenCoordinate> artifacts) throws IOException {
+        Objects.requireNonNull(artifacts, "artifacts must not be null");
+        List<MavenCoordinate> requested = new ArrayList<>();
+        Set<MavenCoordinate> unique = new java.util.HashSet<>();
+        for (MavenCoordinate coordinate : artifacts) {
+            if (requested.size() == MAX_ARTIFACTS || coordinate == null || !unique.add(coordinate)) {
+                throw new IOException(
+                        "Ship resolver requires between 1 and " + MAX_ARTIFACTS + " unique exact artifacts");
+            }
+            requested.add(coordinate);
+        }
+        if (requested.isEmpty()) {
+            throw new IOException(
+                    "Ship resolver requires between 1 and " + MAX_ARTIFACTS + " unique exact artifacts");
+        }
+        return List.copyOf(requested);
+    }
+
     private static Path requireRepository(Path repository) throws IOException {
         Path path = Objects.requireNonNull(repository, "repository must not be null").toAbsolutePath().normalize();
         if (Files.isSymbolicLink(path) || !Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
@@ -111,12 +222,13 @@ public final class ShipMavenResolver {
         return new RepositorySystemSupplier().get();
     }
 
-    private static DefaultRepositorySystemSession session(RepositorySystem system, Path repository) {
+    static DefaultRepositorySystemSession session(
+            RepositorySystem system, Path repository, ResolutionMode mode) {
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
         // Maven's utility session ignores missing and invalid descriptors by default, which can silently
         // turn a transitive graph into direct roots only. An evidence payload must fail closed instead.
         session.setArtifactDescriptorPolicy(new SimpleArtifactDescriptorPolicy(false, false));
-        session.setOffline(false);
+        session.setOffline(mode == ResolutionMode.OFFLINE);
         session.setIgnoreArtifactDescriptorRepositories(true);
         session.setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_FAIL);
         session.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_NEVER);
@@ -126,10 +238,234 @@ public final class ShipMavenResolver {
         session.setUserProperties(Map.of());
         session.setConfigProperties(Map.of(
                 ConfigurationProperties.CONNECT_TIMEOUT, 10_000,
-                ConfigurationProperties.REQUEST_TIMEOUT, 60_000));
+                ConfigurationProperties.REQUEST_TIMEOUT, 60_000,
+                ConfigurationProperties.HTTP_FOLLOW_REDIRECTS, false,
+                ConfigurationProperties.HTTP_MAX_REDIRECTS, 0,
+                ConfigurationProperties.HTTPS_SECURITY_MODE,
+                ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT,
+                "aether.connector.http.useSystemProperties", false,
+                "aether.checksums.algorithms", "SHA-1"));
+        session.setProxySelector(remote -> null);
         session.setLocalRepositoryManager(
                 system.newLocalRepositoryManager(session, new LocalRepository(repository.toFile())));
         return session;
+    }
+
+    private static ResolvedMavenArtifact requireExactArtifact(
+            Path repository, MavenCoordinate requested, ArtifactResult result)
+            throws IOException {
+        if (!result.isResolved() || !result.getExceptions().isEmpty()) {
+            throw new IOException("Ship resolver returned an incomplete exact artifact result");
+        }
+        Artifact artifact = result.getArtifact();
+        if (artifact == null || artifact.getFile() == null) {
+            throw new IOException("Ship resolver returned an incomplete exact artifact");
+        }
+        MavenCoordinate actual = new MavenCoordinate(
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                artifact.getExtension(),
+                artifact.getClassifier(),
+                artifact.getVersion());
+        if (!requested.equals(actual)) {
+            throw new IOException("Ship resolver returned a different exact artifact");
+        }
+
+        Path expected = repository.resolve(requested.groupId().replace('.', '/'))
+                .resolve(requested.artifactId())
+                .resolve(requested.version())
+                .resolve(requested.fileName())
+                .normalize();
+        Path returned = artifact.getFile().toPath().toAbsolutePath().normalize();
+        if (!returned.equals(expected)) {
+            throw new IOException("Ship resolver returned an artifact outside its exact repository path");
+        }
+        Path current = repository;
+        for (Path part : repository.relativize(expected)) {
+            current = current.resolve(part);
+            if (Files.isSymbolicLink(current)) {
+                throw new IOException("Ship resolver returned an artifact through a symbolic link");
+            }
+        }
+        if (!Files.isRegularFile(expected, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Ship resolver returned a missing or non-regular exact artifact");
+        }
+        return new ResolvedMavenArtifact(actual, expected);
+    }
+
+    private static void rejectExistingSymlinks(Path repository, MavenCoordinate coordinate) throws IOException {
+        Path expected = repository.resolve(coordinate.groupId().replace('.', '/'))
+                .resolve(coordinate.artifactId())
+                .resolve(coordinate.version())
+                .resolve(coordinate.fileName())
+                .normalize();
+        Path current = repository;
+        for (Path part : repository.relativize(expected)) {
+            current = current.resolve(part);
+            if (Files.isSymbolicLink(current)) {
+                throw new IOException("Ship resolver repository path contains a symbolic link");
+            }
+            if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+                break;
+            }
+        }
+    }
+
+    private static long exactArtifactLimit(MavenCoordinate coordinate) {
+        return "pom".equals(coordinate.extension()) ? MAX_EXACT_POM_BYTES : MAX_EXACT_JAR_BYTES;
+    }
+
+    private static URI centralUri(MavenCoordinate coordinate) throws IOException {
+        String relative = coordinate.groupId().replace('.', '/') + '/' + coordinate.artifactId() + '/'
+                          + coordinate.version() + '/' + coordinate.fileName();
+        URI uri = CENTRAL.resolve(relative);
+        if (!"https".equals(uri.getScheme()) || !CENTRAL.getHost().equals(uri.getHost())
+                || uri.getPort() != -1 || uri.getUserInfo() != null
+                || !uri.getPath().startsWith(CENTRAL.getPath())) {
+            throw new IOException("Exact artifact coordinate escaped the fixed Maven Central origin");
+        }
+        return uri;
+    }
+
+    static ContentIdentity fetchDirect(URI uri, long maxBytes) throws IOException {
+        return fetchDirect(uri, maxBytes, DIRECT_FETCH_TIMEOUT);
+    }
+
+    static ContentIdentity fetchDirect(URI uri, long maxBytes, Duration timeout) throws IOException {
+        Objects.requireNonNull(uri, "uri must not be null");
+        Objects.requireNonNull(timeout, "timeout must not be null");
+        if (maxBytes <= 0 || timeout.isZero() || timeout.isNegative()) {
+            throw new IOException("Direct Maven Central fetch bounds must be positive");
+        }
+        long timeoutNanos;
+        try {
+            timeoutNanos = timeout.toNanos();
+        } catch (ArithmeticException e) {
+            throw new IOException("Direct Maven Central fetch timeout is too large", e);
+        }
+
+        DirectBodyHandler handler = new DirectBodyHandler(maxBytes);
+        CompletableFuture<HttpResponse<ContentIdentity>> exchange
+                = directClient().sendAsync(directRequest(uri, timeout), handler);
+        AtomicBoolean deadlineExpired = new AtomicBoolean();
+        IOException timeoutFailure = new IOException("Timed out fetching exact artifact bytes from Maven Central");
+        ScheduledFuture<?> watchdog = DIRECT_FETCH_DEADLINES.schedule(() -> {
+            deadlineExpired.set(true);
+            handler.abort(timeoutFailure);
+            exchange.cancel(true);
+        }, timeoutNanos, TimeUnit.NANOSECONDS);
+        try {
+            HttpResponse<ContentIdentity> response = exchange.get(timeoutNanos, TimeUnit.NANOSECONDS);
+            if (!uri.equals(response.uri())) {
+                throw new IOException("Maven Central returned an unexpected HTTP response");
+            }
+            return response.body();
+        } catch (TimeoutException e) {
+            deadlineExpired.set(true);
+            handler.abort(timeoutFailure);
+            exchange.cancel(true);
+            throw timeoutFailure;
+        } catch (InterruptedException e) {
+            handler.abort(new IOException("Interrupted while fetching an exact artifact from Maven Central", e));
+            exchange.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while fetching an exact artifact from Maven Central", e);
+        } catch (ExecutionException e) {
+            throw directFetchFailure(e.getCause());
+        } catch (CancellationException e) {
+            if (deadlineExpired.get()) {
+                throw timeoutFailure;
+            }
+            throw new IOException("Maven Central exact artifact fetch was cancelled", e);
+        } finally {
+            watchdog.cancel(false);
+        }
+    }
+
+    static HttpClient directClient() {
+        return DirectClientHolder.INSTANCE;
+    }
+
+    private static HttpClient newDirectClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .proxy(DirectProxySelector.INSTANCE)
+                .build();
+    }
+
+    static HttpRequest directRequest(URI uri) {
+        return directRequest(uri, DIRECT_FETCH_TIMEOUT);
+    }
+
+    private static HttpRequest directRequest(URI uri, Duration timeout) {
+        return HttpRequest.newBuilder(uri)
+                .timeout(timeout)
+                .header("Accept", "application/octet-stream")
+                .header("Accept-Encoding", "identity")
+                .GET()
+                .build();
+    }
+
+    private static IOException directFetchFailure(Throwable failure) {
+        if (failure instanceof IOException ioFailure) {
+            return ioFailure;
+        }
+        return new IOException("Could not fetch exact artifact bytes from Maven Central", failure);
+    }
+
+    private static ScheduledThreadPoolExecutor directFetchDeadlines() {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, task -> {
+            Thread thread = new Thread(task, "camel-kit-ship-central-fetch-deadline");
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.setRemoveOnCancelPolicy(true);
+        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        return executor;
+    }
+
+    private static ContentIdentity contentIdentity(Path path, long maxBytes) throws IOException {
+        try (InputStream input = Files.newInputStream(path)) {
+            return contentIdentity(input, maxBytes);
+        }
+    }
+
+    static ContentIdentity contentIdentity(InputStream input, long maxBytes) throws IOException {
+        Objects.requireNonNull(input, "input must not be null");
+        if (maxBytes <= 0) {
+            throw new IOException("Exact artifact size limit must be positive");
+        }
+        MessageDigest digest = sha256();
+        byte[] buffer = new byte[8192];
+        long length = 0;
+        int read;
+        try {
+            while ((read = input.read(buffer)) >= 0) {
+                if (read == 0) {
+                    continue;
+                }
+                length = Math.addExact(length, read);
+                if (length > maxBytes) {
+                    throw new IOException("Exact artifact exceeds its size limit");
+                }
+                digest.update(buffer, 0, read);
+            }
+        } catch (ArithmeticException e) {
+            throw new IOException("Exact artifact size accounting overflowed", e);
+        }
+        if (length == 0) {
+            throw new IOException("Exact artifact is empty");
+        }
+        return new ContentIdentity("sha256:" + HexFormat.of().formatHex(digest.digest()), length);
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
     }
 
     private static RemoteRepository central() {
@@ -137,7 +473,7 @@ public final class ShipMavenResolver {
                 true, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_FAIL);
         RepositoryPolicy snapshots = new RepositoryPolicy(
                 false, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_FAIL);
-        return new RemoteRepository.Builder("camel-kit-central", "default", CENTRAL)
+        return new RemoteRepository.Builder("camel-kit-central", "default", CENTRAL.toString())
                 .setReleasePolicy(releases)
                 .setSnapshotPolicy(snapshots)
                 .build();
@@ -165,5 +501,215 @@ public final class ShipMavenResolver {
         return error.getMessage() == null || error.getMessage().isBlank()
                 ? error.getClass().getSimpleName()
                 : error.getMessage();
+    }
+
+    @FunctionalInterface
+    interface CentralDigestSource {
+        ContentIdentity identity(URI uri, long maxBytes) throws IOException;
+    }
+
+    record ContentIdentity(String sha256, long length) {
+        ContentIdentity {
+            if (sha256 == null || !sha256.matches("sha256:[0-9a-f]{64}") || length <= 0) {
+                throw new IllegalArgumentException("Invalid exact artifact content identity");
+            }
+        }
+    }
+
+    static final class DirectBodySubscriber implements HttpResponse.BodySubscriber<ContentIdentity> {
+        private final CompletableFuture<ContentIdentity> body = new CompletableFuture<>();
+        private final MessageDigest digest = sha256();
+        private final long maxBytes;
+        private Flow.Subscription subscription;
+        private long declaredLength = -1;
+        private long length;
+        private boolean terminal;
+
+        DirectBodySubscriber(long maxBytes) {
+            if (maxBytes <= 0) {
+                throw new IllegalArgumentException("Direct body limit must be positive");
+            }
+            this.maxBytes = maxBytes;
+        }
+
+        synchronized void expectLength(long declaredLength) {
+            if (!terminal) {
+                this.declaredLength = declaredLength;
+            }
+        }
+
+        @Override
+        public CompletionStage<ContentIdentity> getBody() {
+            return body;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription nextSubscription) {
+            Objects.requireNonNull(nextSubscription, "subscription must not be null");
+            boolean cancel;
+            synchronized (this) {
+                cancel = terminal || subscription != null;
+                if (!cancel) {
+                    subscription = nextSubscription;
+                }
+            }
+            if (cancel) {
+                nextSubscription.cancel();
+            } else {
+                nextSubscription.request(1);
+            }
+        }
+
+        @Override
+        public void onNext(List<ByteBuffer> buffers) {
+            IOException failure = null;
+            Flow.Subscription next;
+            synchronized (this) {
+                if (terminal) {
+                    return;
+                }
+                next = subscription;
+                if (next == null) {
+                    failure = new IOException("Maven Central body arrived before subscription");
+                } else if (buffers == null) {
+                    failure = new IOException("Maven Central returned an invalid response body");
+                } else {
+                    for (ByteBuffer buffer : buffers) {
+                        if (buffer == null || buffer.remaining() > maxBytes - length) {
+                            failure = new IOException("Exact artifact exceeds its size limit");
+                            break;
+                        }
+                        int bytes = buffer.remaining();
+                        digest.update(buffer);
+                        length += bytes;
+                    }
+                }
+            }
+            if (failure != null) {
+                abort(failure);
+            } else {
+                next.request(1);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            abort(error instanceof IOException ioFailure
+                    ? ioFailure
+                    : new IOException("Could not read exact artifact bytes from Maven Central", error));
+        }
+
+        @Override
+        public void onComplete() {
+            ContentIdentity identity = null;
+            IOException failure = null;
+            synchronized (this) {
+                if (terminal) {
+                    return;
+                }
+                if (length == 0) {
+                    failure = new IOException("Exact artifact is empty");
+                } else if (declaredLength >= 0 && declaredLength != length) {
+                    failure = new IOException("Maven Central response length does not match Content-Length");
+                } else {
+                    terminal = true;
+                    identity = new ContentIdentity(
+                            "sha256:" + HexFormat.of().formatHex(digest.digest()), length);
+                }
+            }
+            if (failure != null) {
+                abort(failure);
+            } else {
+                body.complete(identity);
+            }
+        }
+
+        void abort(IOException failure) {
+            Objects.requireNonNull(failure, "failure must not be null");
+            Flow.Subscription toCancel;
+            synchronized (this) {
+                if (terminal) {
+                    return;
+                }
+                terminal = true;
+                toCancel = subscription;
+            }
+            if (toCancel != null) {
+                toCancel.cancel();
+            }
+            body.completeExceptionally(failure);
+        }
+    }
+
+    private static final class DirectBodyHandler implements HttpResponse.BodyHandler<ContentIdentity> {
+        private final long maxBytes;
+        private final DirectBodySubscriber subscriber;
+
+        private DirectBodyHandler(long maxBytes) {
+            this.maxBytes = maxBytes;
+            this.subscriber = new DirectBodySubscriber(maxBytes);
+        }
+
+        @Override
+        public HttpResponse.BodySubscriber<ContentIdentity> apply(HttpResponse.ResponseInfo response) {
+            IOException failure = validate(response);
+            if (failure != null) {
+                subscriber.abort(failure);
+            }
+            return subscriber;
+        }
+
+        private IOException validate(HttpResponse.ResponseInfo response) {
+            if (response.statusCode() != 200) {
+                return new IOException("Maven Central returned an unexpected HTTP response");
+            }
+            List<String> encodings = response.headers().allValues("Content-Encoding");
+            if (encodings.stream().anyMatch(value -> !"identity".equalsIgnoreCase(value.trim()))) {
+                return new IOException("Maven Central returned encoded artifact bytes");
+            }
+            List<String> lengths = response.headers().allValues("Content-Length");
+            if (lengths.size() > 1) {
+                return new IOException("Maven Central returned an invalid Content-Length");
+            }
+            if (!lengths.isEmpty()) {
+                long declared;
+                try {
+                    declared = Long.parseLong(lengths.get(0));
+                } catch (NumberFormatException e) {
+                    return new IOException("Maven Central returned an invalid Content-Length", e);
+                }
+                if (declared <= 0 || declared > maxBytes) {
+                    return new IOException("Maven Central returned an unsafe artifact size");
+                }
+                subscriber.expectLength(declared);
+            }
+            return null;
+        }
+
+        private void abort(IOException failure) {
+            subscriber.abort(failure);
+        }
+    }
+
+    private static final class DirectProxySelector extends ProxySelector {
+        private static final DirectProxySelector INSTANCE = new DirectProxySelector();
+
+        @Override
+        public List<Proxy> select(URI uri) {
+            Objects.requireNonNull(uri, "uri must not be null");
+            return List.of(Proxy.NO_PROXY);
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+            // A direct connection has no proxy to retry.
+        }
+    }
+
+    private static final class DirectClientHolder {
+        private static final HttpClient INSTANCE = newDirectClient();
+
+        private DirectClientHolder() {
+        }
     }
 }

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
@@ -1,0 +1,322 @@
+package io.github.luigidemasi.camelkit.ship.resolver;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.Proxy;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExactArtifactResolutionTest {
+
+    @TempDir
+    Path repository;
+
+    @Test
+    void resolvesExactJarAndPomOfflineInRequestOrderWithoutParsingDescriptors() throws IOException {
+        MavenCoordinate jar = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
+        MavenCoordinate pom = jar.withExtension("pom");
+        seed(jar, "not a jar");
+        seed(pom, "<not-a-valid-pom>");
+
+        List<ResolvedExactMavenArtifact> resolved = ShipMavenResolver.resolveArtifacts(
+                repository, List.of(pom, jar), ShipMavenResolver.ResolutionMode.OFFLINE);
+
+        assertEquals(List.of(pom, jar), resolved.stream().map(ResolvedExactMavenArtifact::coordinate).toList());
+        assertEquals(List.of(path(pom), path(jar)), resolved.stream().map(ResolvedExactMavenArtifact::path).toList());
+        assertEquals("<not-a-valid-pom>", Files.readString(resolved.get(0).path()));
+    }
+
+    @Test
+    void rejectsDuplicateAndExcessiveExactRequests() throws IOException {
+        MavenCoordinate coordinate = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
+        IOException duplicate = assertThrows(IOException.class, () -> ShipMavenResolver.resolveArtifacts(
+                repository,
+                List.of(coordinate, coordinate),
+                ShipMavenResolver.ResolutionMode.OFFLINE));
+
+        List<MavenCoordinate> excessive = IntStream.rangeClosed(0, ShipMavenResolver.MAX_ARTIFACTS)
+                .mapToObj(index -> MavenCoordinate.jar("example.test", "catalog-" + index, "1.0.0"))
+                .toList();
+        IOException aboveLimit = assertThrows(IOException.class, () -> ShipMavenResolver.resolveArtifacts(
+                repository, excessive, ShipMavenResolver.ResolutionMode.OFFLINE));
+
+        String expected = "Ship resolver requires between 1 and "
+                          + ShipMavenResolver.MAX_ARTIFACTS + " unique exact artifacts";
+        assertEquals(expected, duplicate.getMessage());
+        assertEquals(expected, aboveLimit.getMessage());
+    }
+
+    @Test
+    void acceptsTheExactArtifactRequestLimitOffline() throws IOException {
+        List<MavenCoordinate> coordinates = IntStream.range(0, ShipMavenResolver.MAX_ARTIFACTS)
+                .mapToObj(index -> MavenCoordinate.jar("example.test", "catalog-" + index, "1.0.0"))
+                .toList();
+        for (MavenCoordinate coordinate : coordinates) {
+            seed(coordinate, "artifact");
+        }
+
+        List<ResolvedExactMavenArtifact> resolved = ShipMavenResolver.resolveArtifacts(
+                repository, coordinates, ShipMavenResolver.ResolutionMode.OFFLINE);
+
+        assertEquals(coordinates, resolved.stream().map(ResolvedExactMavenArtifact::coordinate).toList());
+    }
+
+    @Test
+    void resolvedArtifactToStringRedactsTheRepositoryPath() throws IOException {
+        MavenCoordinate coordinate = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
+        seed(coordinate, "artifact");
+
+        ResolvedExactMavenArtifact resolved = ShipMavenResolver.resolveArtifacts(
+                repository, List.of(coordinate), ShipMavenResolver.ResolutionMode.OFFLINE).get(0);
+
+        assertFalse(resolved.toString().contains(repository.toString()));
+        assertTrue(resolved.toString().contains("path=<redacted>"));
+    }
+
+    @Test
+    void missingExactArtifactFailsOffline() {
+        MavenCoordinate missing = MavenCoordinate.jar("example.test", "missing", "1.0.0");
+
+        IOException failure = assertThrows(IOException.class, () -> ShipMavenResolver.resolveArtifacts(
+                repository, List.of(missing), ShipMavenResolver.ResolutionMode.OFFLINE));
+
+        assertTrue(failure.getMessage().startsWith("Could not resolve an exact Ship artifact:"),
+                failure.getMessage());
+    }
+
+    @Test
+    void onlineResolutionRejectsAPoisonedCacheAndBindsMatchingCentralBytes() throws IOException {
+        MavenCoordinate coordinate = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
+        seed(coordinate, "poisoned-cache");
+
+        IOException poisoned = assertThrows(IOException.class, () -> ShipMavenResolver.resolveArtifacts(
+                repository,
+                List.of(coordinate),
+                ShipMavenResolver.ResolutionMode.ONLINE,
+                (uri, maxBytes) -> identity("central-bytes")));
+        assertTrue(poisoned.getMessage().contains("differs from authoritative Maven Central bytes"));
+
+        seed(coordinate, "central-bytes");
+        AtomicReference<URI> requested = new AtomicReference<>();
+        ResolvedExactMavenArtifact resolved = ShipMavenResolver.resolveArtifacts(
+                repository,
+                List.of(coordinate),
+                ShipMavenResolver.ResolutionMode.ONLINE,
+                (uri, maxBytes) -> {
+                    requested.set(uri);
+                    assertTrue("central-bytes".getBytes(StandardCharsets.UTF_8).length <= maxBytes);
+                    return identity("central-bytes");
+                }).get(0);
+
+        assertEquals(URI.create(
+                "https://repo.maven.apache.org/maven2/example/test/catalog/1.0.0/catalog-1.0.0.jar"),
+                requested.get());
+        assertEquals("central-bytes".length(), resolved.contentLength());
+        assertEquals(sha256("central-bytes".getBytes(StandardCharsets.UTF_8)), resolved.contentSha256());
+    }
+
+    @Test
+    void directCentralTransportDisablesRedirectsProxiesAndContentEncoding() {
+        URI uri = URI.create("https://repo.maven.apache.org/maven2/example.test");
+        HttpClient client = ShipMavenResolver.directClient();
+        HttpRequest request = ShipMavenResolver.directRequest(uri);
+
+        assertSame(client, ShipMavenResolver.directClient());
+        assertEquals(HttpClient.Redirect.NEVER, client.followRedirects());
+        assertEquals(List.of(Proxy.NO_PROXY), client.proxy().orElseThrow().select(uri));
+        assertEquals("identity", request.headers().firstValue("Accept-Encoding").orElseThrow());
+        assertEquals(uri, request.uri());
+    }
+
+    @Test
+    void aetherCacheFillAlsoDisablesRedirectsAndAmbientProxyConfiguration() {
+        var session = ShipMavenResolver.session(
+                new RepositorySystemSupplier().get(), repository, ShipMavenResolver.ResolutionMode.ONLINE);
+        Map<String, Object> configuration = session.getConfigProperties();
+        RemoteRepository central = new RemoteRepository.Builder(
+                "camel-kit-central", "default", "https://repo.maven.apache.org/maven2/").build();
+
+        assertEquals(false, configuration.get(ConfigurationProperties.HTTP_FOLLOW_REDIRECTS));
+        assertEquals(0, configuration.get(ConfigurationProperties.HTTP_MAX_REDIRECTS));
+        assertEquals(ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT,
+                configuration.get(ConfigurationProperties.HTTPS_SECURITY_MODE));
+        assertEquals(false, configuration.get("aether.connector.http.useSystemProperties"));
+        assertEquals("SHA-1", configuration.get("aether.checksums.algorithms"));
+        assertNull(session.getProxySelector().getProxy(central));
+    }
+
+    @Test
+    void streamedIdentityAcceptsTheExactLimitAndRejectsEmptyOrOneOver() throws IOException {
+        byte[] exact = new byte[1024];
+
+        ShipMavenResolver.ContentIdentity identity = ShipMavenResolver.contentIdentity(
+                new ByteArrayInputStream(exact), exact.length);
+
+        assertEquals(exact.length, identity.length());
+        assertEquals(sha256(exact), identity.sha256());
+        assertThrows(IOException.class, () -> ShipMavenResolver.contentIdentity(
+                new ByteArrayInputStream(new byte[0]), exact.length));
+        assertThrows(IOException.class, () -> ShipMavenResolver.contentIdentity(
+                new ByteArrayInputStream(new byte[exact.length + 1]), exact.length));
+    }
+
+    @Test
+    void directFetchTimesOutAndClosesAnExchangeStalledBeforeHeaders() throws Exception {
+        assertStalledExchangeIsBounded(false);
+    }
+
+    @Test
+    void directFetchTimesOutAndClosesAnExchangeStalledMidBody() throws Exception {
+        assertStalledExchangeIsBounded(true);
+    }
+
+    @Test
+    void directBodySubscriberCancelsExactlyOnceAndRejectsLateSignals() {
+        ShipMavenResolver.DirectBodySubscriber overflow = new ShipMavenResolver.DirectBodySubscriber(2);
+        RecordingSubscription overflowSubscription = new RecordingSubscription();
+        overflow.onSubscribe(overflowSubscription);
+        overflow.onNext(List.of(ByteBuffer.wrap(new byte[3])));
+
+        CompletionException overflowFailure = assertThrows(
+                CompletionException.class, () -> overflow.getBody().toCompletableFuture().join());
+        assertInstanceOf(IOException.class, overflowFailure.getCause());
+        assertEquals(1, overflowSubscription.cancellations.get());
+        overflow.onComplete();
+        overflow.onNext(List.of(ByteBuffer.wrap(new byte[]{1})));
+        overflow.abort(new IOException("late abort"));
+        assertEquals(1, overflowSubscription.cancellations.get());
+
+        ShipMavenResolver.DirectBodySubscriber aborted = new ShipMavenResolver.DirectBodySubscriber(2);
+        RecordingSubscription abortedSubscription = new RecordingSubscription();
+        aborted.onSubscribe(abortedSubscription);
+        aborted.abort(new IOException("deadline"));
+        aborted.abort(new IOException("duplicate deadline"));
+        aborted.onComplete();
+        assertEquals(1, abortedSubscription.cancellations.get());
+    }
+
+    private static void assertStalledExchangeIsBounded(boolean partialBody) throws Exception {
+        ExecutorService serverExecutor = Executors.newSingleThreadExecutor();
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            Future<Boolean> clientClosed = serverExecutor.submit(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(3_000);
+                    readRequest(socket.getInputStream());
+                    if (partialBody) {
+                        socket.getOutputStream().write(("HTTP/1.1 200 OK\r\n"
+                                                        + "Content-Length: 2\r\n"
+                                                        + "Content-Encoding: identity\r\n"
+                                                        + "Connection: close\r\n\r\n"
+                                                        + "x")
+                                .getBytes(StandardCharsets.US_ASCII));
+                        socket.getOutputStream().flush();
+                    }
+                    return socket.getInputStream().read() == -1;
+                }
+            });
+
+            URI endpoint = URI.create("http://127.0.0.1:" + server.getLocalPort() + "/artifact.jar");
+            long started = System.nanoTime();
+            IOException failure = assertThrows(IOException.class,
+                    () -> ShipMavenResolver.fetchDirect(endpoint, 2, Duration.ofMillis(300)));
+            long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started);
+
+            assertTrue(failure.getMessage().contains("Timed out"), failure.getMessage());
+            assertTrue(elapsedMillis < 2_000, "stalled fetch took " + elapsedMillis + " ms");
+            assertTrue(clientClosed.get(2, TimeUnit.SECONDS), "cancelled exchange did not close its connection");
+        } finally {
+            serverExecutor.shutdownNow();
+            assertTrue(serverExecutor.awaitTermination(3, TimeUnit.SECONDS));
+        }
+    }
+
+    private static void readRequest(InputStream input) throws IOException {
+        int matched = 0;
+        byte[] terminator = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        while (matched < terminator.length) {
+            int next = input.read();
+            if (next < 0) {
+                throw new IOException("client closed before sending an HTTP request");
+            }
+            matched = next == terminator[matched] ? matched + 1 : next == terminator[0] ? 1 : 0;
+        }
+    }
+
+    private void seed(MavenCoordinate coordinate, String content) throws IOException {
+        Path artifact = path(coordinate);
+        Files.createDirectories(artifact.getParent());
+        Files.writeString(artifact, content, StandardCharsets.UTF_8);
+        Files.writeString(
+                artifact.getParent().resolve("_remote.repositories"),
+                coordinate.fileName() + ">=\n",
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND);
+    }
+
+    private Path path(MavenCoordinate coordinate) {
+        return repository.resolve(coordinate.groupId().replace('.', '/'))
+                .resolve(coordinate.artifactId())
+                .resolve(coordinate.version())
+                .resolve(coordinate.fileName());
+    }
+
+    private static String sha256(byte[] bytes) {
+        try {
+            return "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static ShipMavenResolver.ContentIdentity identity(String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        return new ShipMavenResolver.ContentIdentity(sha256(bytes), bytes.length);
+    }
+
+    private static final class RecordingSubscription implements Flow.Subscription {
+        private final AtomicInteger cancellations = new AtomicInteger();
+
+        @Override
+        public void request(long count) {
+            // The fixture emits data explicitly.
+        }
+
+        @Override
+        public void cancel() {
+            cancellations.incrementAndGet();
+        }
+    }
+}

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
@@ -10,6 +10,7 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -200,6 +201,16 @@ class ExactArtifactResolutionTest {
     @Test
     void directFetchTimesOutAndClosesAnExchangeStalledMidBody() throws Exception {
         assertStalledExchangeIsBounded(true);
+    }
+
+    @Test
+    void directFetchNormalizesTheJdkRequestTimeout() {
+        HttpTimeoutException jdkFailure = new HttpTimeoutException("request timed out");
+
+        IOException normalized = ShipMavenResolver.directFetchFailure(jdkFailure);
+
+        assertEquals("Timed out fetching exact artifact bytes from Maven Central", normalized.getMessage());
+        assertSame(jdkFailure, normalized.getCause());
     }
 
     @Test

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/MavenCoordinateTest.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/MavenCoordinateTest.java
@@ -54,6 +54,15 @@ class MavenCoordinateTest {
     }
 
     @Test
+    void coordinatePartsAcceptTheLimitAndRejectOneOver() {
+        String atLimit = "a".repeat(128);
+
+        assertEquals(atLimit, MavenCoordinate.jar("org.example", atLimit, "1.0.0").artifactId());
+        assertThrows(IllegalArgumentException.class,
+                () -> MavenCoordinate.jar("org.example", atLimit + 'a', "1.0.0"));
+    }
+
+    @Test
     void rejectsNullRequiredPartsAndNormalizesNullClassifier() {
         assertAll(
                 () -> assertThrows(NullPointerException.class,

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ResolverIsolationIT.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ResolverIsolationIT.java
@@ -14,8 +14,10 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -39,6 +41,99 @@ class ResolverIsolationIT {
     private static final String INTERNAL_PREFIX = "io/github/luigidemasi/camelkit/ship/resolver/internal/";
     private static final String MULTI_RELEASE_PREFIX = "META-INF/versions/";
     private static final String RELOCATED_PLEXUS_UTILS = INTERNAL_PREFIX + "org/codehaus/plexus/util/";
+    private static final Set<String> PUBLIC_CLASSES = Set.of(
+            API_PACKAGE + "MavenCoordinate",
+            API_PACKAGE + "MavenDependencyExclusion",
+            API_PACKAGE + "MavenDependencyRoot",
+            API_PACKAGE + "ResolvedExactMavenArtifact",
+            API_PACKAGE + "ResolvedMavenArtifact",
+            API_PACKAGE + "ShipMavenResolver",
+            API_PACKAGE + "ShipMavenResolver$ResolutionMode");
+    private static final Set<String> PUBLIC_RECORDS = Set.of(
+            API_PACKAGE + "MavenCoordinate",
+            API_PACKAGE + "MavenDependencyExclusion",
+            API_PACKAGE + "MavenDependencyRoot",
+            API_PACKAGE + "ResolvedExactMavenArtifact",
+            API_PACKAGE + "ResolvedMavenArtifact");
+    private static final Set<String> PUBLIC_ENUMS = Set.of(API_PACKAGE + "ShipMavenResolver$ResolutionMode");
+    private static final Map<String, List<String>> PUBLIC_ENUM_CONSTANTS = Map.of(
+            API_PACKAGE + "ShipMavenResolver$ResolutionMode", List.of("OFFLINE", "ONLINE"));
+    private static final Map<String, Set<String>> PUBLIC_CONSTRUCTORS = Map.ofEntries(
+            Map.entry(API_PACKAGE + "MavenCoordinate", Set.of(constructor(
+                    "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String",
+                    "java.lang.String"))),
+            Map.entry(API_PACKAGE + "MavenDependencyExclusion", Set.of(constructor(
+                    "java.lang.String", "java.lang.String"))),
+            Map.entry(API_PACKAGE + "MavenDependencyRoot", Set.of(constructor(
+                    API_PACKAGE + "MavenCoordinate",
+                    "java.util.List<" + API_PACKAGE + "MavenDependencyExclusion>"))),
+            Map.entry(API_PACKAGE + "ResolvedExactMavenArtifact", Set.of(constructor(
+                    API_PACKAGE + "MavenCoordinate", "java.nio.file.Path", "java.lang.String", "long"))),
+            Map.entry(API_PACKAGE + "ResolvedMavenArtifact", Set.of(constructor(
+                    API_PACKAGE + "MavenCoordinate", "java.nio.file.Path"))),
+            Map.entry(API_PACKAGE + "ShipMavenResolver", Set.of()),
+            Map.entry(API_PACKAGE + "ShipMavenResolver$ResolutionMode", Set.of()));
+    private static final Map<String, Set<String>> PUBLIC_METHODS = Map.ofEntries(
+            Map.entry(API_PACKAGE + "MavenCoordinate", Set.of(
+                    staticMethod("jar", API_PACKAGE + "MavenCoordinate",
+                            "java.lang.String", "java.lang.String", "java.lang.String"),
+                    staticMethod("of", API_PACKAGE + "MavenCoordinate",
+                            "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String"),
+                    staticMethod("parseGav", API_PACKAGE + "MavenCoordinate", "java.lang.String"),
+                    method("withExtension", API_PACKAGE + "MavenCoordinate", "java.lang.String"),
+                    method("gav", "java.lang.String"), method("resolverString", "java.lang.String"),
+                    method("fileName", "java.lang.String"), method("toString", "java.lang.String"),
+                    method("hashCode", "int"), method("equals", "boolean", "java.lang.Object"),
+                    method("groupId", "java.lang.String"), method("artifactId", "java.lang.String"),
+                    method("extension", "java.lang.String"), method("classifier", "java.lang.String"),
+                    method("version", "java.lang.String"))),
+            Map.entry(API_PACKAGE + "MavenDependencyExclusion", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("groupId", "java.lang.String"),
+                    method("artifactId", "java.lang.String"))),
+            Map.entry(API_PACKAGE + "MavenDependencyRoot", Set.of(
+                    staticMethod("jar", API_PACKAGE + "MavenDependencyRoot",
+                            "java.lang.String", "java.lang.String", "java.lang.String"),
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("coordinate", API_PACKAGE + "MavenCoordinate"),
+                    method("exclusions", "java.util.List<" + API_PACKAGE + "MavenDependencyExclusion>"))),
+            Map.entry(API_PACKAGE + "ResolvedExactMavenArtifact", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("coordinate", API_PACKAGE + "MavenCoordinate"),
+                    method("path", "java.nio.file.Path"), method("contentSha256", "java.lang.String"),
+                    method("contentLength", "long"))),
+            Map.entry(API_PACKAGE + "ResolvedMavenArtifact", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("coordinate", API_PACKAGE + "MavenCoordinate"), method("path", "java.nio.file.Path"))),
+            Map.entry(API_PACKAGE + "ShipMavenResolver", Set.of(
+                    staticThrowingMethod("resolve",
+                            "java.util.List<" + API_PACKAGE + "ResolvedMavenArtifact>", "java.io.IOException",
+                            "java.nio.file.Path", "java.util.List<" + API_PACKAGE + "MavenDependencyRoot>"),
+                    staticThrowingMethod("resolveArtifacts",
+                            "java.util.List<" + API_PACKAGE + "ResolvedExactMavenArtifact>", "java.io.IOException",
+                            "java.nio.file.Path", "java.util.List<" + API_PACKAGE + "MavenCoordinate>",
+                            API_PACKAGE + "ShipMavenResolver$ResolutionMode"))),
+            Map.entry(API_PACKAGE + "ShipMavenResolver$ResolutionMode", Set.of(
+                    staticMethod("values", API_PACKAGE + "ShipMavenResolver$ResolutionMode[]"),
+                    staticMethod("valueOf", API_PACKAGE + "ShipMavenResolver$ResolutionMode",
+                            "java.lang.String"))));
+    private static final Map<String, Set<String>> PUBLIC_FIELDS = Map.ofEntries(
+            Map.entry(API_PACKAGE + "MavenCoordinate", Set.of()),
+            Map.entry(API_PACKAGE + "MavenDependencyExclusion", Set.of()),
+            Map.entry(API_PACKAGE + "MavenDependencyRoot", Set.of(field("MAX_EXCLUSIONS", "int"))),
+            Map.entry(API_PACKAGE + "ResolvedExactMavenArtifact", Set.of()),
+            Map.entry(API_PACKAGE + "ResolvedMavenArtifact", Set.of()),
+            Map.entry(API_PACKAGE + "ShipMavenResolver", Set.of(
+                    field("MAX_ROOTS", "int"), field("MAX_ARTIFACTS", "int"))),
+            Map.entry(API_PACKAGE + "ShipMavenResolver$ResolutionMode", Set.of(
+                    field("OFFLINE", API_PACKAGE + "ShipMavenResolver$ResolutionMode"),
+                    field("ONLINE", API_PACKAGE + "ShipMavenResolver$ResolutionMode"))));
+    private static final Map<String, Map<String, Object>> PUBLIC_CONSTANT_VALUES = Map.of(
+            API_PACKAGE + "MavenDependencyRoot", Map.of("MAX_EXCLUSIONS", 16),
+            API_PACKAGE + "ShipMavenResolver", Map.of("MAX_ROOTS", 64, "MAX_ARTIFACTS", 512));
 
     @TempDir
     Path directory;
@@ -101,7 +196,7 @@ class ResolverIsolationIT {
                     .toList();
         }
 
-        int publicClasses = 0;
+        Set<String> publicClasses = new HashSet<>();
         try (URLClassLoader isolated = new URLClassLoader(
                 new URL[]{resolverJar().toUri().toURL()}, ClassLoader.getPlatformClassLoader())) {
             for (String className : apiClasses) {
@@ -109,7 +204,23 @@ class ResolverIsolationIT {
                 if (!Modifier.isPublic(apiClass.getModifiers())) {
                     continue;
                 }
-                publicClasses++;
+                publicClasses.add(className);
+                assertTrue(Modifier.isFinal(apiClass.getModifiers()), className + " must remain final");
+                assertEquals(PUBLIC_RECORDS.contains(className), apiClass.isRecord(), className);
+                assertEquals(PUBLIC_ENUMS.contains(className), apiClass.isEnum(), className);
+                if (apiClass.isEnum()) {
+                    assertEquals(PUBLIC_ENUM_CONSTANTS.get(className), Arrays.stream(apiClass.getEnumConstants())
+                            .map(value -> ((Enum<?>) value).name()).toList(), className + " enum order changed");
+                }
+                assertEquals(apiClass.isRecord() ? Record.class : apiClass.isEnum() ? Enum.class : Object.class,
+                        apiClass.getSuperclass(), className + " superclass changed");
+                assertEquals(0, apiClass.getTypeParameters().length, className + " added type parameters");
+                assertEquals(Set.of(), Arrays.stream(apiClass.getGenericInterfaces())
+                        .map(Type::getTypeName).collect(java.util.stream.Collectors.toSet()),
+                        className + " interfaces changed");
+                if (apiClass.getEnclosingClass() != null) {
+                    assertTrue(Modifier.isStatic(apiClass.getModifiers()), className + " must remain static");
+                }
                 assertConsumerType(apiClass.getGenericSuperclass(), apiClass.getName(), new HashSet<>());
                 for (Type interfaceType : apiClass.getGenericInterfaces()) {
                     assertConsumerType(interfaceType, apiClass.getName(), new HashSet<>());
@@ -117,19 +228,36 @@ class ResolverIsolationIT {
                 for (TypeVariable<?> variable : apiClass.getTypeParameters()) {
                     assertConsumerType(variable, apiClass.getName(), new HashSet<>());
                 }
+                Set<String> constructors = new HashSet<>();
                 for (var constructor : apiClass.getDeclaredConstructors()) {
+                    if (Modifier.isPublic(constructor.getModifiers())) {
+                        constructors.add(constructor(constructor.getGenericParameterTypes()));
+                    }
                     assertExecutableTypes(constructor);
                 }
+                assertEquals(PUBLIC_CONSTRUCTORS.get(className), constructors, className + " constructors changed");
+                Set<String> methods = new HashSet<>();
                 for (var method : apiClass.getDeclaredMethods()) {
                     if (Modifier.isPublic(method.getModifiers())) {
+                        methods.add(method(method));
                         assertConsumerType(method.getGenericReturnType(), method.toGenericString(), new HashSet<>());
                     }
                     assertExecutableTypes(method);
                 }
+                assertEquals(PUBLIC_METHODS.get(className), methods, className + " methods changed");
+                Set<String> fields = new HashSet<>();
                 for (var field : apiClass.getDeclaredFields()) {
                     if (Modifier.isPublic(field.getModifiers())) {
+                        assertTrue(Modifier.isStatic(field.getModifiers()), field.toGenericString());
+                        assertTrue(Modifier.isFinal(field.getModifiers()), field.toGenericString());
+                        fields.add(field(field.getName(), field.getGenericType().getTypeName()));
                         assertConsumerType(field.getGenericType(), field.toGenericString(), new HashSet<>());
                     }
+                }
+                assertEquals(PUBLIC_FIELDS.get(className), fields, className + " fields changed");
+                for (var constant : PUBLIC_CONSTANT_VALUES.getOrDefault(className, Map.of()).entrySet()) {
+                    assertEquals(constant.getValue(), apiClass.getField(constant.getKey()).get(null),
+                            className + '.' + constant.getKey() + " value changed");
                 }
                 if (apiClass.isRecord()) {
                     for (var component : apiClass.getRecordComponents()) {
@@ -141,7 +269,43 @@ class ResolverIsolationIT {
                 }
             }
         }
-        assertTrue(publicClasses > 0, "Shaded resolver has no public Camel-Kit API classes");
+        assertEquals(PUBLIC_CLASSES, publicClasses,
+                "Resolver public API changed without an explicit isolation-boundary update");
+    }
+
+    private static String constructor(String... parameterTypes) {
+        return "<init>(" + String.join(",", parameterTypes) + ')';
+    }
+
+    private static String constructor(Type... parameterTypes) {
+        return constructor(Arrays.stream(parameterTypes).map(Type::getTypeName).toArray(String[]::new));
+    }
+
+    private static String method(String name, String returnType, String... parameterTypes) {
+        return name + '(' + String.join(",", parameterTypes) + ")->" + returnType;
+    }
+
+    private static String staticMethod(String name, String returnType, String... parameterTypes) {
+        return "static " + method(name, returnType, parameterTypes);
+    }
+
+    private static String staticThrowingMethod(
+            String name, String returnType, String exceptionType, String... parameterTypes) {
+        return staticMethod(name, returnType, parameterTypes) + " throws " + exceptionType;
+    }
+
+    private static String method(java.lang.reflect.Method method) {
+        String signature = (Modifier.isStatic(method.getModifiers()) ? "static " : "")
+                           + method(method.getName(), method.getGenericReturnType().getTypeName(),
+                                   Arrays.stream(method.getGenericParameterTypes())
+                                           .map(Type::getTypeName).toArray(String[]::new));
+        String[] exceptions = Arrays.stream(method.getGenericExceptionTypes())
+                .map(Type::getTypeName).toArray(String[]::new);
+        return exceptions.length == 0 ? signature : signature + " throws " + String.join(",", exceptions);
+    }
+
+    private static String field(String name, String type) {
+        return name + ':' + type;
     }
 
     @Test
@@ -167,6 +331,17 @@ class ResolverIsolationIT {
             Object artifact = ((List<?>) resolved).get(0);
             assertSame(isolated, artifact.getClass().getClassLoader());
             assertSame(isolated, coordinateType.getClassLoader());
+
+            Class<?> modeType = isolated.loadClass(ShipMavenResolver.ResolutionMode.class.getName());
+            Object jar = coordinateType.getMethod("jar", String.class, String.class, String.class)
+                    .invoke(null, "example.test", "isolated", "1.0.0");
+            Object pom = coordinateType.getMethod("withExtension", String.class).invoke(jar, "pom");
+            Object exact = assertDoesNotThrow(() -> resolver
+                    .getMethod("resolveArtifacts", Path.class, List.class, modeType)
+                    .invoke(null, repository, List.of(pom, jar), modeType.getField("OFFLINE").get(null)));
+            assertEquals(2, ((List<?>) exact).size(), exact.toString());
+            assertTrue(((List<?>) exact).stream()
+                    .allMatch(item -> item.getClass().getClassLoader() == isolated));
         }
     }
 


### PR DESCRIPTION
## Summary

- Add opaque, runtime/version-bound catalog snapshots for Camel Main, Spring Boot, and Quarkus.
- Extend the isolated resolver with exact offline/online artifact acquisition, direct Maven Central byte-identity checks, bounded streaming deadlines, and redacted diagnostics.
- Produce canonical catalog evidence and bounded component metadata without loading catalog classes.
- Lock filesystem, classpath, dependency, and public API boundaries with fail-closed tests.

## Scope

This is the catalog-snapshot half of the planned 2C work. Normalized expression/YAML policy, controller integration, harness behavior, and public command changes remain separate follow-up slices.

## Verification

- `./mvnw -B clean install`
- All seven reactor modules passed, including resolver and controller isolation suites and all forbidden-API scans.
- `ExactArtifactResolutionTest` passed all 13 tests on Java 17, 21, and 25.
- The exact POM attribute/namespace 512 acceptance and 513 rejection tests passed on Java 17, 21, and 25.

## CI follow-up

The first hosted run exposed two cross-JDK differences:

- Java 21 could surface `HttpTimeoutException` from `HttpClient` before Ship's watchdog. Native request timeouts are now normalized to the same bounded diagnostic and explicitly abort the body subscriber and cancel the exchange.
- Java 25 lowered the ambient JAXP per-element attribute limit to 200. Both StAX preflight and DOM parsing now explicitly use Ship's 512 limit, while Ship's aggregate attribute-plus-namespace accounting still rejects 513.

Regression coverage pins the native timeout mapping and both ordinary-attribute and namespace boundaries. The original failed run is [29777968084](https://github.com/luigidemasi/camel-kit/actions/runs/29777968084).

## Website impact

Not required for this internal foundation slice. Issue #149 retains the required user-facing documentation work before completion.

Part of #149
