### PR TITLE
Add closed Ship expression policy

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicy.java
@@ -1,0 +1,391 @@
+package io.github.luigidemasi.camelkit.ship.expression;
+
+/**
+ * Pure, bounded permission policy for the YAML expression forms and Simple-language subset accepted by Ship.
+ *
+ * <p>
+ * Schema-aware YAML traversal must determine whether a scalar is a template or a predicate before calling the matching
+ * method here. This class does not validate YAML shape or scalar typing. It establishes syntax permission only; catalog
+ * availability and runtime compatibility remain separate, exact-version evidence checks. Unicode format-control
+ * classification is frozen to Unicode 16.0 so results do not vary with the running JDK.
+ * </p>
+ */
+public final class ShipExpressionPolicy {
+
+    private static final int MAX_EXPRESSION_UTF8_BYTES = 16_384;
+    private static final String SIMPLE = "simple";
+    private static final String GENERIC = "language";
+    private static final String[] COMPARISON_OPERATORS = {
+            "!startsWith", "!endsWith", "!contains", "startsWith", "endsWith", "contains",
+            "!=~", ">=", "<=", "==", "!=", "=~", ">", "<"
+    };
+    // Inclusive, sorted Unicode 16.0 General_Category=Cf ranges.
+    private static final int[] UNICODE_16_FORMAT_RANGES = {
+            0x00ad, 0x00ad,
+            0x0600, 0x0605,
+            0x061c, 0x061c,
+            0x06dd, 0x06dd,
+            0x070f, 0x070f,
+            0x0890, 0x0891,
+            0x08e2, 0x08e2,
+            0x180e, 0x180e,
+            0x200b, 0x200f,
+            0x202a, 0x202e,
+            0x2060, 0x2064,
+            0x2066, 0x206f,
+            0xfeff, 0xfeff,
+            0xfff9, 0xfffb,
+            0x110bd, 0x110bd,
+            0x110cd, 0x110cd,
+            0x13430, 0x1343f,
+            0x1bca0, 0x1bca3,
+            0x1d173, 0x1d17a,
+            0xe0001, 0xe0001,
+            0xe0020, 0xe007f
+    };
+
+    private ShipExpressionPolicy() {
+    }
+
+    /**
+     * Returns whether {@code selector} is exactly {@code simple}. This classifies a selector string only; YAML shape
+     * and scalar typing are validated separately.
+     */
+    public static boolean isDirectSimpleSelector(String selector) {
+        return SIMPLE.equals(selector);
+    }
+
+    /**
+     * Returns whether the selector is exactly {@code language} and its language is exactly {@code simple}. This does
+     * not validate the surrounding YAML object.
+     */
+    public static boolean isGenericSimpleSelector(String selector, String language) {
+        return GENERIC.equals(selector) && SIMPLE.equals(language);
+    }
+
+    /**
+     * Returns whether the value is a bounded Simple template containing only approved literal text and lookups. The
+     * lookup set is {@code body}, {@code routeId}, {@code exchangeId}, {@code messageTimestamp}, and single-level ASCII
+     * keys under {@code header}, {@code headers}, {@code exchangeProperty}, {@code variable}, or {@code variables}.
+     * Plural {@code headers} and {@code variables} reject keys {@code size} and {@code length}, which Camel interprets
+     * as collection functions. Backslashes, property/init expansion markers, and active Elvis, chain, or unary syntax
+     * are not approved literal text.
+     */
+    public static boolean isSafeSimpleTemplate(String value) {
+        if (!isBoundedText(value) || hasIndirectExpansion(value)
+                || value.contains("~>") || value.contains("?:") || hasTemplateUnaryOperator(value)) {
+            return false;
+        }
+
+        int cursor = 0;
+        while (true) {
+            int start = value.indexOf("${", cursor);
+            if (start < 0) {
+                return true;
+            }
+            int end = value.indexOf('}', start + 2);
+            if (end < 0 || !isAllowedLookup(value.substring(start + 2, end))) {
+                return false;
+            }
+            cursor = end + 1;
+        }
+    }
+
+    /**
+     * Returns whether the value conforms to Ship's closed, comparison-only Simple predicate grammar. Comparisons use
+     * one ASCII space around operators, single-quoted scalars, and at most one logical operator kind. Permitted
+     * comparison operators are {@code ==}, {@code !=}, {@code =~}, {@code !=~}, ordering, {@code contains},
+     * {@code startsWith}, and {@code endsWith}, including their explicit negated forms. The right operand may be an
+     * approved lookup, an unescaped single-quoted scalar, a canonical finite decimal or signed-long integer, lowercase
+     * {@code true}/{@code false}, or {@code null}. The {@code =~} pair means case-insensitive equality, not
+     * regular-expression matching.
+     */
+    public static boolean isSafeSimplePredicate(String value) {
+        return isBoundedText(value) && !hasIndirectExpansion(value) && new PredicateParser(value).parse();
+    }
+
+    private static boolean isBoundedText(String value) {
+        if (value == null) {
+            return false;
+        }
+        int utf8Bytes = 0;
+        for (int offset = 0; offset < value.length();) {
+            char first = value.charAt(offset);
+            int codePoint;
+            int width;
+            if (first <= 0x7f) {
+                codePoint = first;
+                width = 1;
+            } else if (first <= 0x7ff) {
+                codePoint = first;
+                width = 2;
+            } else if (Character.isHighSurrogate(first)) {
+                if (offset + 1 >= value.length() || !Character.isLowSurrogate(value.charAt(offset + 1))) {
+                    return false;
+                }
+                codePoint = Character.toCodePoint(first, value.charAt(offset + 1));
+                width = 4;
+                offset++;
+            } else if (Character.isLowSurrogate(first)) {
+                return false;
+            } else {
+                codePoint = first;
+                width = 3;
+            }
+
+            if (isForbiddenCodePoint(codePoint) || utf8Bytes > MAX_EXPRESSION_UTF8_BYTES - width) {
+                return false;
+            }
+            utf8Bytes += width;
+            offset++;
+        }
+        return true;
+    }
+
+    private static boolean hasIndirectExpansion(String value) {
+        return value.contains("$simple{")
+                || value.contains("$init{")
+                || value.contains("}init$")
+                || value.contains("{{")
+                || value.contains("}}")
+                || value.indexOf('\\') >= 0;
+    }
+
+    private static boolean hasTemplateUnaryOperator(String value) {
+        for (int closingBrace = value.indexOf('}');
+             closingBrace >= 0;
+             closingBrace = value.indexOf('}', closingBrace + 1)) {
+            int operator = closingBrace + 1;
+            if ((value.startsWith("++", operator) || value.startsWith("--", operator))
+                    && (operator + 2 == value.length() || value.charAt(operator + 2) == ' ')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isForbiddenCodePoint(int codePoint) {
+        if (codePoint <= 0x1f || codePoint >= 0x7f && codePoint <= 0x9f
+                || codePoint == 0x2028 || codePoint == 0x2029) {
+            return true;
+        }
+        for (int index = 0; index < UNICODE_16_FORMAT_RANGES.length; index += 2) {
+            if (codePoint < UNICODE_16_FORMAT_RANGES[index]) {
+                return false;
+            }
+            if (codePoint <= UNICODE_16_FORMAT_RANGES[index + 1]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isAllowedLookup(String lookup) {
+        return "body".equals(lookup)
+                || "routeId".equals(lookup)
+                || "exchangeId".equals(lookup)
+                || "messageTimestamp".equals(lookup)
+                || hasAllowedKey(lookup, "header.", false)
+                || hasAllowedKey(lookup, "headers.", true)
+                || hasAllowedKey(lookup, "exchangeProperty.", false)
+                || hasAllowedKey(lookup, "variable.", false)
+                || hasAllowedKey(lookup, "variables.", true);
+    }
+
+    private static boolean hasAllowedKey(String lookup, String prefix, boolean rejectCollectionFunctions) {
+        if (!lookup.startsWith(prefix) || lookup.length() == prefix.length()) {
+            return false;
+        }
+        String key = lookup.substring(prefix.length());
+        if (rejectCollectionFunctions && ("size".equals(key) || "length".equals(key))) {
+            return false;
+        }
+        for (int index = 0; index < key.length(); index++) {
+            char value = key.charAt(index);
+            if (!isAsciiLetterOrDigit(value) && value != '_' && value != '-') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAsciiLetterOrDigit(char value) {
+        return value >= 'a' && value <= 'z'
+                || value >= 'A' && value <= 'Z'
+                || value >= '0' && value <= '9';
+    }
+
+    private static final class PredicateParser {
+
+        private final String value;
+        private int cursor;
+        private String logicalOperator;
+
+        private PredicateParser(String value) {
+            this.value = value;
+        }
+
+        private boolean parse() {
+            if (!readLookup() || !readSpace() || !readComparisonOperator() || !readSpace() || !readOperand()) {
+                return false;
+            }
+            while (cursor < value.length()) {
+                if (!readSpace()) {
+                    return false;
+                }
+                String currentLogicalOperator = readLogicalOperator();
+                if (currentLogicalOperator == null
+                        || (logicalOperator != null && !logicalOperator.equals(currentLogicalOperator))
+                        || !readSpace()
+                        || !readLookup()
+                        || !readSpace()
+                        || !readComparisonOperator()
+                        || !readSpace()
+                        || !readOperand()) {
+                    return false;
+                }
+                logicalOperator = currentLogicalOperator;
+            }
+            return true;
+        }
+
+        private boolean readLookup() {
+            if (!value.startsWith("${", cursor)) {
+                return false;
+            }
+            int end = value.indexOf('}', cursor + 2);
+            if (end < 0 || !isAllowedLookup(value.substring(cursor + 2, end))) {
+                return false;
+            }
+            cursor = end + 1;
+            return true;
+        }
+
+        private boolean readComparisonOperator() {
+            for (String operator : COMPARISON_OPERATORS) {
+                if (value.startsWith(operator, cursor)) {
+                    cursor += operator.length();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private String readLogicalOperator() {
+            if (value.startsWith("&&", cursor)) {
+                cursor += 2;
+                return "&&";
+            }
+            if (value.startsWith("||", cursor)) {
+                cursor += 2;
+                return "||";
+            }
+            return null;
+        }
+
+        private boolean readOperand() {
+            if (readLookup()) {
+                return true;
+            }
+            if (cursor >= value.length()) {
+                return false;
+            }
+            if (value.charAt(cursor) == '\'') {
+                return readQuotedScalar();
+            }
+            if (readKeyword("true") || readKeyword("false") || readKeyword("null")) {
+                return true;
+            }
+            return readNumber();
+        }
+
+        private boolean readQuotedScalar() {
+            cursor++;
+            while (cursor < value.length()) {
+                char character = value.charAt(cursor);
+                if (character == '\'') {
+                    cursor++;
+                    return true;
+                }
+                if (character == '\\'
+                        || value.startsWith("${", cursor)
+                        || value.startsWith("$simple{", cursor)
+                        || value.startsWith("$init{", cursor)
+                        || value.startsWith("{{", cursor)
+                        || value.startsWith("}}", cursor)) {
+                    return false;
+                }
+                cursor++;
+            }
+            return false;
+        }
+
+        private boolean readKeyword(String keyword) {
+            if (!value.startsWith(keyword, cursor)) {
+                return false;
+            }
+            int end = cursor + keyword.length();
+            if (end < value.length() && value.charAt(end) != ' ') {
+                return false;
+            }
+            cursor = end;
+            return true;
+        }
+
+        private boolean readNumber() {
+            int start = cursor;
+            if (cursor < value.length() && value.charAt(cursor) == '-') {
+                cursor++;
+            }
+            int integerStart = cursor;
+            while (cursor < value.length() && isAsciiDigit(value.charAt(cursor))) {
+                cursor++;
+            }
+            if (cursor == integerStart) {
+                cursor = start;
+                return false;
+            }
+            if (cursor - integerStart > 1 && value.charAt(integerStart) == '0') {
+                return false;
+            }
+
+            boolean decimal = cursor < value.length() && value.charAt(cursor) == '.';
+            if (decimal) {
+                cursor++;
+                int fractionStart = cursor;
+                while (cursor < value.length() && isAsciiDigit(value.charAt(cursor))) {
+                    cursor++;
+                }
+                if (cursor == fractionStart) {
+                    return false;
+                }
+            }
+            if (cursor < value.length() && value.charAt(cursor) != ' ') {
+                return false;
+            }
+
+            String number = value.substring(start, cursor);
+            try {
+                if (decimal) {
+                    return Double.isFinite(Double.parseDouble(number));
+                }
+                Long.parseLong(number);
+                return true;
+            } catch (NumberFormatException ignored) {
+                return false;
+            }
+        }
+
+        private boolean readSpace() {
+            if (cursor >= value.length() || value.charAt(cursor) != ' ') {
+                return false;
+            }
+            cursor++;
+            return cursor >= value.length() || value.charAt(cursor) != ' ';
+        }
+
+        private static boolean isAsciiDigit(char value) {
+            return value >= '0' && value <= '9';
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicyBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicyBoundaryTest.java
@@ -1,0 +1,203 @@
+package io.github.luigidemasi.camelkit.ship.expression;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.spi.ToolProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipExpressionPolicyBoundaryTest {
+
+    private static final String PACKAGE = "io.github.luigidemasi.camelkit.ship.expression.";
+    private static final String INTERNAL_NAME_PREFIX = PACKAGE.replace('.', '/');
+    private static final Pattern DEPENDENCY = Pattern.compile("^\\s+(\\S+)\\s+->\\s+(\\S+)\\s+(.+)$");
+    private static final Pattern METHOD_REFERENCE = Pattern.compile(
+            "^\\s+#[0-9]+ = (?:Interface)?Methodref\\s+#[^\\r\\n]*//\\s+(\\S+)$", Pattern.MULTILINE);
+    private static final Pattern FIELD_REFERENCE = Pattern.compile(
+            "^\\s+#[0-9]+ = Fieldref\\s+#[^\\r\\n]*//\\s+(\\S+)$", Pattern.MULTILINE);
+    private static final Set<String> ALLOWED_EXTERNAL_TYPES = Set.of(
+            "java.lang.Character",
+            "java.lang.CharSequence",
+            "java.lang.Double",
+            "java.lang.Long",
+            "java.lang.NumberFormatException",
+            "java.lang.Object",
+            "java.lang.String");
+    private static final Set<String> ALLOWED_EXTERNAL_METHODS = Set.of(
+            "java/lang/Character.isHighSurrogate:(C)Z",
+            "java/lang/Character.isLowSurrogate:(C)Z",
+            "java/lang/Character.toCodePoint:(CC)I",
+            "java/lang/Double.isFinite:(D)Z",
+            "java/lang/Double.parseDouble:(Ljava/lang/String;)D",
+            "java/lang/Long.parseLong:(Ljava/lang/String;)J",
+            "java/lang/Object.\"<init>\":()V",
+            "java/lang/String.charAt:(I)C",
+            "java/lang/String.contains:(Ljava/lang/CharSequence;)Z",
+            "java/lang/String.equals:(Ljava/lang/Object;)Z",
+            "java/lang/String.indexOf:(I)I",
+            "java/lang/String.indexOf:(II)I",
+            "java/lang/String.indexOf:(Ljava/lang/String;I)I",
+            "java/lang/String.length:()I",
+            "java/lang/String.startsWith:(Ljava/lang/String;)Z",
+            "java/lang/String.startsWith:(Ljava/lang/String;I)Z",
+            "java/lang/String.substring:(I)Ljava/lang/String;",
+            "java/lang/String.substring:(II)Ljava/lang/String;");
+    private static final Set<String> PUBLIC_METHODS = Set.of(
+            "isDirectSimpleSelector(java.lang.String)->boolean",
+            "isGenericSimpleSelector(java.lang.String,java.lang.String)->boolean",
+            "isSafeSimplePredicate(java.lang.String)->boolean",
+            "isSafeSimpleTemplate(java.lang.String)->boolean");
+
+    @Test
+    void compiledPolicyUsesOnlyExactJavaBaseCapabilities() throws Exception {
+        Path classes = Path.of(ShipExpressionPolicy.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI());
+        Path packageDirectory = classes.resolve(PACKAGE.replace('.', '/'));
+        assertTrue(Files.isDirectory(packageDirectory), packageDirectory.toString());
+
+        ToolProvider jdeps = ToolProvider.findFirst("jdeps").orElseThrow(
+                () -> new AssertionError("Ship expression boundary test requires a JDK with jdeps"));
+        StringWriter output = new StringWriter();
+        StringWriter errors = new StringWriter();
+        int result = jdeps.run(
+                new PrintWriter(output),
+                new PrintWriter(errors),
+                "--multi-release", "17",
+                "-verbose:class",
+                "-filter:none",
+                "--class-path", classes.toString(),
+                packageDirectory.toString());
+        assertEquals(0, result, () -> errors + System.lineSeparator() + output);
+
+        Set<String> externalTypes = new HashSet<>();
+        int sourceDependencies = 0;
+        for (String line : output.toString().lines().toList()) {
+            if (!line.stripLeading().startsWith(PACKAGE)) {
+                continue;
+            }
+            Matcher dependency = DEPENDENCY.matcher(line);
+            assertTrue(dependency.matches(), () -> "Unparsed jdeps dependency line: " + line);
+            sourceDependencies++;
+            String target = dependency.group(2);
+            String module = dependency.group(3).trim();
+            if (!target.startsWith(PACKAGE)) {
+                externalTypes.add(target);
+                assertEquals("java.base", module, line);
+            }
+        }
+
+        assertTrue(sourceDependencies > 0, () -> "jdeps reported no policy dependencies:\n" + output);
+        assertEquals(ALLOWED_EXTERNAL_TYPES, externalTypes);
+
+        ToolProvider javap = ToolProvider.findFirst("javap").orElseThrow(
+                () -> new AssertionError("Ship expression boundary test requires a JDK with javap"));
+        Set<String> externalMethods = new HashSet<>();
+        Set<String> externalFields = new HashSet<>();
+        try (var paths = Files.walk(packageDirectory)) {
+            for (Path classFile : paths.filter(path -> path.toString().endsWith(".class")).toList()) {
+                String bytecode = javap(javap, classes, className(classes, classFile));
+                collectExternalReferences(METHOD_REFERENCE, bytecode, externalMethods);
+                collectExternalReferences(FIELD_REFERENCE, bytecode, externalFields);
+                assertFalse(bytecode.contains("= MethodHandle"), "Expression policy gained a method handle");
+                assertFalse(bytecode.contains("= InvokeDynamic"), "Expression policy gained an invokedynamic call");
+                assertFalse(bytecode.contains("= Dynamic"), "Expression policy gained a dynamic constant");
+                assertFalse(bytecode.contains("ACC_NATIVE"), "Expression policy gained a native method");
+            }
+        }
+        assertEquals(ALLOWED_EXTERNAL_METHODS, externalMethods);
+        assertTrue(externalFields.isEmpty(), () -> "Expression policy gained external fields: " + externalFields);
+    }
+
+    @Test
+    void publicSurfaceIsClosed() throws Exception {
+        Class<?> policy = ShipExpressionPolicy.class;
+        assertTrue(Modifier.isPublic(policy.getModifiers()));
+        assertTrue(Modifier.isFinal(policy.getModifiers()));
+        assertEquals(Object.class, policy.getSuperclass());
+        assertEquals(0, policy.getInterfaces().length);
+        assertEquals(0, policy.getTypeParameters().length);
+        assertEquals(0, policy.getFields().length);
+        assertTrue(Arrays.stream(policy.getDeclaredClasses())
+                .noneMatch(type -> Modifier.isPublic(type.getModifiers())));
+
+        Constructor<?>[] constructors = policy.getDeclaredConstructors();
+        assertEquals(1, constructors.length);
+        assertEquals(0, constructors[0].getParameterCount());
+        assertTrue(Modifier.isPrivate(constructors[0].getModifiers()));
+
+        Set<String> methods = new HashSet<>();
+        for (Method method : policy.getDeclaredMethods()) {
+            if (!Modifier.isPublic(method.getModifiers())) {
+                continue;
+            }
+            assertTrue(Modifier.isStatic(method.getModifiers()), method.toString());
+            assertEquals(boolean.class, method.getReturnType(), method.toString());
+            assertEquals(0, method.getExceptionTypes().length, method.toString());
+            assertEquals(0, method.getTypeParameters().length, method.toString());
+            methods.add(signature(method));
+        }
+        assertEquals(PUBLIC_METHODS, methods);
+
+        Path classes = Path.of(policy.getProtectionDomain().getCodeSource().getLocation().toURI());
+        Path packageDirectory = classes.resolve(PACKAGE.replace('.', '/'));
+        try (var paths = Files.walk(packageDirectory)) {
+            for (Path classFile : paths.filter(path -> path.toString().endsWith(".class")).toList()) {
+                Class<?> type = Class.forName(className(classes, classFile), false, policy.getClassLoader());
+                if (Modifier.isPublic(type.getModifiers())) {
+                    assertEquals(policy, type, "Unexpected public expression-policy type");
+                }
+            }
+        }
+    }
+
+    private static String signature(Method method) {
+        String parameters = Arrays.stream(method.getParameterTypes())
+                .map(Class::getTypeName)
+                .collect(java.util.stream.Collectors.joining(","));
+        return method.getName() + '(' + parameters + ")->" + method.getReturnType().getTypeName();
+    }
+
+    private static String javap(ToolProvider tool, Path classes, String className) {
+        StringWriter output = new StringWriter();
+        StringWriter errors = new StringWriter();
+        int result = tool.run(
+                new PrintWriter(output),
+                new PrintWriter(errors),
+                "-classpath", classes.toString(),
+                "-v",
+                "-p",
+                className);
+        assertEquals(0, result, () -> errors + System.lineSeparator() + output);
+        return output.toString();
+    }
+
+    private static void collectExternalReferences(Pattern pattern, String bytecode, Set<String> references) {
+        Matcher matcher = pattern.matcher(bytecode);
+        while (matcher.find()) {
+            String reference = matcher.group(1);
+            if (!reference.startsWith(INTERNAL_NAME_PREFIX)) {
+                references.add(reference);
+            }
+        }
+    }
+
+    private static String className(Path classes, Path classFile) {
+        String relative = classes.relativize(classFile).toString();
+        return relative.substring(0, relative.length() - ".class".length())
+                .replace(classFile.getFileSystem().getSeparator(), ".");
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicyTest.java
@@ -1,0 +1,255 @@
+package io.github.luigidemasi.camelkit.ship.expression;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipExpressionPolicyTest {
+
+    @Test
+    void acceptsOnlyExactSimpleYamlSelectors() {
+        assertTrue(ShipExpressionPolicy.isDirectSimpleSelector("simple"));
+        assertTrue(ShipExpressionPolicy.isGenericSimpleSelector("language", "simple"));
+
+        for (String selector : List.of(
+                "Simple", "SIMPLE", "simple-", "simple_", "constant", "csimple", "method", "java",
+                "jsonpath", "xpath", "\"simple\"", "!!str simple")) {
+            assertFalse(ShipExpressionPolicy.isDirectSimpleSelector(selector), selector);
+        }
+        for (String selector : List.of(
+                "", " simple", "simple ", "simple\n",
+                "s" + scalar(0x0456) + "mple",
+                scalar(0xff53) + "imple",
+                "sim" + scalar(0x200b) + "ple")) {
+            assertFalse(ShipExpressionPolicy.isDirectSimpleSelector(selector), selector);
+        }
+        assertFalse(ShipExpressionPolicy.isDirectSimpleSelector(null));
+        assertFalse(ShipExpressionPolicy.isGenericSimpleSelector(null, "simple"));
+        assertFalse(ShipExpressionPolicy.isGenericSimpleSelector("language", null));
+        assertFalse(ShipExpressionPolicy.isGenericSimpleSelector("Language", "simple"));
+        assertFalse(ShipExpressionPolicy.isGenericSimpleSelector("language", "Simple"));
+        assertFalse(ShipExpressionPolicy.isGenericSimpleSelector("simple", "simple"));
+    }
+
+    @Test
+    void acceptsClosedTemplateSurface() {
+        for (String expression : List.of(
+                "",
+                "literal text",
+                "ordinary Unicode: café 漢字 😀",
+                "C++ and regex are literal template text",
+                "${body}",
+                "${routeId}",
+                "${exchangeId}",
+                "${messageTimestamp}",
+                "${header.request-id}",
+                "${header.size}",
+                "${header.-}",
+                "${header._}",
+                "${header.0}",
+                "${header.A0_-}",
+                "${headers.request_id}",
+                "${exchangeProperty.correlationId}",
+                "${variable.route-key}",
+                "${variable.length}",
+                "${variables.route_key}",
+                "${header.first}${header.second}",
+                "Order is ${header.order-id}; route is ${routeId}",
+                "Status : ${header.status}",
+                "Question ? ${body}",
+                "${body} ? 'yes' : 'no'",
+                "C}++suffix")) {
+            assertTrue(ShipExpressionPolicy.isSafeSimpleTemplate(expression), expression);
+        }
+    }
+
+    @Test
+    void rejectsDynamicTemplateSurfacesOutsideTheAllowlist() {
+        for (String expression : List.of(
+                "${}",
+                "${header.}",
+                "${header.foo.bar}",
+                "${header.foo[0]}",
+                "${header(foo)}",
+                "${header.na" + scalar(0x043c) + "e}",
+                "${headers}",
+                "${headers.size}",
+                "${headers.length}",
+                "${exchangeProperties.foo}",
+                "${body.foo}",
+                "${variables.size}",
+                "${variables.length}",
+                "${bean:service}",
+                "${ref:service}",
+                "${type:java.lang.Runtime}",
+                "${sys.user.home}",
+                "${file:name}",
+                "${date:now}",
+                "${header.foo",
+                "${${body}}",
+                "$simple{body}",
+                "$init{ int x = 1 }init$",
+                "{{secret}}",
+                "literal }} text",
+                "escaped\\ntext",
+                "escaped\\rtext",
+                "escaped\\ttext",
+                "escaped\\}text",
+                "${body}++",
+                "${body}--",
+                "${body}++ suffix",
+                "${body}-- suffix",
+                "${body}}++",
+                "${body}text}--",
+                "${body} ?: fallback",
+                "${body} ~> ${header.next}",
+                "${body}~> ${header.next}",
+                "${body} ?~> ${header.next}",
+                "${body}?~> ${header.next}",
+                "before ${body} after ${bean:service}")) {
+            assertFalse(ShipExpressionPolicy.isSafeSimpleTemplate(expression), expression);
+        }
+        assertFalse(ShipExpressionPolicy.isSafeSimpleTemplate(null));
+    }
+
+    @Test
+    void acceptsOnlyTheClosedPredicateGrammar() {
+        for (String operator : List.of(
+                "==", "!=", "=~", "!=~", "<", "<=", ">", ">=",
+                "contains", "!contains", "startsWith", "!startsWith", "endsWith", "!endsWith")) {
+            assertTrue(
+                    ShipExpressionPolicy.isSafeSimplePredicate("${header.value} " + operator + " 'target'"),
+                    operator);
+        }
+
+        for (String expression : List.of(
+                "${header.score} >= -1.5",
+                "${header.enabled} == true",
+                "${header.disabled} == false",
+                "${header.optional} == null",
+                "${header.left} == ${exchangeProperty.right}",
+                "${body} == ''",
+                "${body} contains 'order' && ${header.confidence} >= 0.8",
+                "${header.first} == 'a' && ${header.second} != 'b' && ${routeId} == 'route-a'",
+                "${header.first} == 'a' || ${header.second} != 'b' || ${routeId} == 'route-a'",
+                "${body} == 'the words is, regex, and contains are data here'")) {
+            assertTrue(ShipExpressionPolicy.isSafeSimplePredicate(expression), expression);
+        }
+    }
+
+    @Test
+    void rejectsEveryUnapprovedPredicateSurface() {
+        for (String operator : List.of(
+                "~~", "!~~", "regex", "!regex", "not regex", "is", "!is", "not is",
+                "in", "!in", "not in", "range", "!range", "not range", "not contains",
+                "starts with", "ends with", "=", "===", "!==", "<>", "and", "or", "not",
+                "matches", "containsx", "StartsWith")) {
+            assertFalse(
+                    ShipExpressionPolicy.isSafeSimplePredicate("${body} " + operator + " 'value'"),
+                    operator);
+        }
+
+        for (String expression : List.of(
+                "",
+                "true",
+                "${header.enabled}",
+                "${body} == value",
+                "${body} == \"a value\"",
+                "${body}=='value'",
+                " ${body} == 'value'",
+                "${body}  == 'value'",
+                "${body} ==  'value'",
+                "${body} == 'value' ",
+                "${body} == 'unterminated",
+                "${body} == 'escaped\\'value'",
+                "${body} == '${bean:service}'",
+                "${body} == '$simple{body}'",
+                "${body} == '$init{x}init$'",
+                "${body} == '{{secret}}'",
+                "${body} == 'escaped\\nvalue'",
+                "${body} == 'value' && true",
+                "${body} == 'value' && ${header.other}",
+                "${body} == 'value' &&",
+                "${header.first} == 'a' || ${header.second} != 'b' && ${routeId} == 'route-a'",
+                "(${body} == 'value')",
+                "${body} ?: 'fallback'",
+                "${body} ? 'yes' : 'no'",
+                "${body} ~> ${header.next}",
+                "${body} ?~> ${header.next}",
+                "${header.count} ++",
+                "${header.count} --",
+                "${body} Contains 'value'",
+                "${type:java.lang.String} == 'value'",
+                "${header.foo.bar} == 'value'")) {
+            assertFalse(ShipExpressionPolicy.isSafeSimplePredicate(expression), expression);
+        }
+        assertFalse(ShipExpressionPolicy.isSafeSimplePredicate(null));
+    }
+
+    @Test
+    void enforcesStrictUnicodeAndUtf8ByteLimits() {
+        String asciiAtLimit = "a".repeat(16_384);
+        String twoByteAtLimit = "é".repeat(8_192);
+        String threeByteAtLimit = "€".repeat(5_461) + "a";
+        String fourByteAtLimit = "😀".repeat(4_096);
+
+        for (String expression : List.of(asciiAtLimit, twoByteAtLimit, threeByteAtLimit, fourByteAtLimit)) {
+            assertTrue(ShipExpressionPolicy.isSafeSimpleTemplate(expression));
+            assertFalse(ShipExpressionPolicy.isSafeSimpleTemplate(expression + 'a'));
+        }
+
+        String predicatePrefix = "${header.value} == '";
+        String predicateSuffix = "'";
+        String predicateAtLimit = predicatePrefix
+                                  + "a".repeat(16_384 - predicatePrefix.length() - predicateSuffix.length())
+                                  + predicateSuffix;
+        String predicateOverLimit = predicatePrefix
+                                    + "a".repeat(16_385 - predicatePrefix.length() - predicateSuffix.length())
+                                    + predicateSuffix;
+        assertTrue(ShipExpressionPolicy.isSafeSimplePredicate(predicateAtLimit));
+        assertFalse(ShipExpressionPolicy.isSafeSimplePredicate(predicateOverLimit));
+
+        for (String number : List.of(
+                "-9223372036854775808", "-2147483649", "-2147483648", "2147483647",
+                "9223372036854775807", "0", "-0", "0.0", "-1.5")) {
+            assertTrue(ShipExpressionPolicy.isSafeSimplePredicate("${header.value} == " + number), number);
+        }
+        for (String number : List.of(
+                "-9223372036854775809", "9223372036854775808", "00", "01", "00.1", "1e3", ".5", "1.", "+1",
+                "1,5", "1..2", "--1", "NaN", "Infinity", "١",
+                "9".repeat(400) + ".0")) {
+            assertFalse(ShipExpressionPolicy.isSafeSimplePredicate("${header.value} == " + number), number);
+        }
+
+        for (String expression : List.of(
+                "line\nfeed",
+                "tab\tvalue",
+                "nul\0value",
+                "line" + scalar(0x2028) + "separator",
+                "paragraph" + scalar(0x2029) + "separator",
+                "bidi" + scalar(0x202e) + "override",
+                "isolate" + scalar(0x2066) + "text",
+                "zero" + scalar(0x200b) + "width",
+                "bom" + scalar(0xfeff) + "value",
+                scalar(0x0890),
+                scalar(0x110bd),
+                scalar(0x13430),
+                scalar(0xe0001),
+                scalar(0xe007f),
+                "\ud800",
+                "\udc00",
+                "\ud800x")) {
+            assertFalse(ShipExpressionPolicy.isSafeSimpleTemplate(expression));
+        }
+        assertFalse(ShipExpressionPolicy.isSafeSimplePredicate("${body} == 'line" + scalar(0x2028) + "separator'"));
+        assertTrue(ShipExpressionPolicy.isSafeSimpleTemplate(scalar(0x088f)));
+        assertTrue(ShipExpressionPolicy.isSafeSimpleTemplate(scalar(0x0892)));
+    }
+
+    private static String scalar(int codePoint) {
+        return new String(Character.toChars(codePoint));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/expression/ShipExpressionPolicyTest.java
@@ -190,6 +190,54 @@ class ShipExpressionPolicyTest {
     }
 
     @Test
+    void pinsEveryUnicode16FormatControlRange() {
+        int[][] formatControlRanges = {
+                {0x00ad, 0x00ad},
+                {0x0600, 0x0605},
+                {0x061c, 0x061c},
+                {0x06dd, 0x06dd},
+                {0x070f, 0x070f},
+                {0x0890, 0x0891},
+                {0x08e2, 0x08e2},
+                {0x180e, 0x180e},
+                {0x200b, 0x200f},
+                {0x202a, 0x202e},
+                {0x2060, 0x2064},
+                {0x2066, 0x206f},
+                {0xfeff, 0xfeff},
+                {0xfff9, 0xfffb},
+                {0x110bd, 0x110bd},
+                {0x110cd, 0x110cd},
+                {0x13430, 0x1343f},
+                {0x1bca0, 0x1bca3},
+                {0x1d173, 0x1d17a},
+                {0xe0001, 0xe0001},
+                {0xe0020, 0xe007f}
+        };
+
+        for (int[] range : formatControlRanges) {
+            for (int codePoint = range[0]; codePoint <= range[1]; codePoint++) {
+                assertFalse(
+                        ShipExpressionPolicy.isSafeSimpleTemplate(scalar(codePoint)),
+                        "U+" + Integer.toHexString(codePoint));
+            }
+
+            int before = range[0] - 1;
+            if (before == 0x2029) {
+                assertFalse(
+                        ShipExpressionPolicy.isSafeSimpleTemplate(scalar(before)),
+                        "U+2029 is independently forbidden as a paragraph separator");
+            } else {
+                assertTrue(
+                        ShipExpressionPolicy.isSafeSimpleTemplate(scalar(before)),
+                        "U+" + Integer.toHexString(before));
+            }
+            int after = range[1] + 1;
+            assertTrue(ShipExpressionPolicy.isSafeSimpleTemplate(scalar(after)), "U+" + Integer.toHexString(after));
+        }
+    }
+
+    @Test
     void enforcesStrictUnicodeAndUtf8ByteLimits() {
         String asciiAtLimit = "a".repeat(16_384);
         String twoByteAtLimit = "é".repeat(8_192);


### PR DESCRIPTION
## Summary

- add a bounded, permission-only Ship policy for exact YAML `simple` selectors
- allow only approved scalar Simple lookups, templates, and comparison predicates
- reject indirect expansion, OGNL-capable lookups, active chain/Elvis/unary syntax, regex/type/range operators, malformed Unicode, and oversized input
- freeze Unicode 16.0 format-control classification so results are identical across supported JDKs
- pin the public API plus exact `java.base` types, methods, fields, and dynamic bytecode capabilities

This is the expression-policy continuation of the catalog foundation added in #154. Schema-aware YAML traversal must choose template versus predicate positions. Exact catalog and runtime compatibility remain later validation-kernel checks; this policy deliberately does not claim that every permitted operator or numeric literal is supported by every Camel version.

## Verification

- `./mvnw -B -pl camel-kit-core -Dtest=ShipExpressionPolicyTest,ShipExpressionPolicyBoundaryTest test`
- `./mvnw -B -pl camel-kit-core test` — 489 tests, zero failures
- `./mvnw -B clean install` — all seven reactor modules passed

## Website impact

Not required. This adds an internal policy primitive and does not expose command behavior yet. The umbrella #149 website work remains required when the controller becomes user-facing.

Part of #149

## Summary by Sourcery

Introduce a closed, permission-based policy for Ship YAML Simple expressions, with strict bounds on allowed templates, predicates, Unicode, and input size.

New Features:
- Add ShipExpressionPolicy utility to classify YAML Simple selectors and validate safe Simple templates and predicates.

Enhancements:
- Freeze Unicode format-control handling to a Unicode 16.0-based allowlist and enforce UTF-8 byte limits for expressions.
- Constrain allowed lookups, operators, and numeric formats in predicates to a comparison-only Simple subset.
- Lock down the public API surface of ShipExpressionPolicy and assert its dependencies are restricted to specific java.base types and methods.

Tests:
- Add ShipExpressionPolicyTest to cover accepted and rejected selectors, templates, predicates, Unicode handling, and size limits.
- Add ShipExpressionPolicyBoundaryTest to verify bytecode-level API boundaries and dependency restrictions for the expression policy implementation.