### PR TITLE
Enforce Ship artifact policy and controller-owned evidence runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes apparmor-profiles bubblewrap
           sudo apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
-          bwrap --unshare-user --unshare-net --disable-userns --ro-bind /usr /usr --symlink usr/lib64 /lib64 --proc /proc --dev /dev -- /usr/bin/true
+          bwrap \
+            --unshare-user --unshare-net --disable-userns \
+            --dir /usr --dir /opt \
+            --ro-bind /usr/lib /usr/lib --ro-bind /usr/lib64 /usr/lib64 \
+            --ro-bind "$JAVA_HOME" /opt/jdk \
+            --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
+            --proc /proc --dev /dev -- /opt/jdk/bin/java -version
 
       - name: Check code formatting and imports
         run: ./mvnw -B -Psourcecheck validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      - name: Install Bubblewrap
+        run: sudo apt-get update && sudo apt-get install --yes bubblewrap
+
       - name: Check code formatting and imports
         run: ./mvnw -B -Psourcecheck validate
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release
       - 'release/**'
   pull_request:
     branches:
@@ -49,14 +50,8 @@ jobs:
       - name: Check code formatting and imports
         run: ./mvnw -B -Psourcecheck validate
 
-      - name: Build with Maven
-        run: ./mvnw clean install -B -V -Dformat.skip=true
-
-      - name: Run tests
-        run: ./mvnw test -B -Dformat.skip=true
-
-      - name: Verify package
-        run: ./mvnw verify -B -Dformat.skip=true
+      - name: Build and certify Ship payloads
+        run: ./mvnw -B -V -Plinux-ship-certification -Dformat.skip=true clean install
 
       - name: Upload build artifacts
         if: success() && matrix.java == '17'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,11 @@ jobs:
           cache: maven
 
       - name: Install Bubblewrap
-        run: sudo apt-get update && sudo apt-get install --yes bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes apparmor-profiles bubblewrap
+          sudo apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+          bwrap --unshare-user --unshare-net --disable-userns --ro-bind /usr /usr --symlink usr/bin /bin --proc /proc --dev /dev -- /bin/true
 
       - name: Check code formatting and imports
         run: ./mvnw -B -Psourcecheck validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes apparmor-profiles bubblewrap
           sudo apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
-          bwrap --unshare-user --unshare-net --disable-userns --ro-bind /usr /usr --symlink usr/bin /bin --proc /proc --dev /dev -- /bin/true
+          bwrap --unshare-user --unshare-net --disable-userns --ro-bind /usr /usr --symlink usr/lib64 /lib64 --proc /proc --dev /dev -- /usr/bin/true
 
       - name: Check code formatting and imports
         run: ./mvnw -B -Psourcecheck validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,19 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      - name: Install Bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes apparmor-profiles bubblewrap
+          sudo apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+          bwrap \
+            --unshare-user --unshare-net --disable-userns \
+            --dir /usr --dir /opt \
+            --ro-bind /usr/lib /usr/lib --ro-bind /usr/lib64 /usr/lib64 \
+            --ro-bind "$JAVA_HOME" /opt/jdk \
+            --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
+            --proc /proc --dev /dev -- /opt/jdk/bin/java -version
+
       - name: Set up Maven settings
         uses: s4u/maven-settings-action@v4.0.0
         with:
@@ -48,7 +61,7 @@ jobs:
           MAVEN_REPO_SERVER_ID: ${{ secrets.MVN_CENTRAL }}
           MAVEN_REPO_SERVER_USERNAME: ${{ secrets.MVN_CENTRAL_USER }}
           MAVEN_REPO_SERVER_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
-          MAVEN_ARGS: "-Dgpg.passphrase="
+          MAVEN_ARGS: "-Dgpg.passphrase= -Plinux-ship-certification"
 
           GIT_RELEASE_BOT_NAME: "release-bot"
           GIT_RELEASE_BOT_EMAIL: "luigidemasi@gmail.com"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,8 +27,21 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
+      - name: Install Bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes apparmor-profiles bubblewrap
+          sudo apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+          bwrap \
+            --unshare-user --unshare-net --disable-userns \
+            --dir /usr --dir /opt \
+            --ro-bind /usr/lib /usr/lib --ro-bind /usr/lib64 /usr/lib64 \
+            --ro-bind "$JAVA_HOME" /opt/jdk \
+            --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
+            --proc /proc --dev /dev -- /opt/jdk/bin/java -version
+
       - name: Deploy snapshot
-        run: ./mvnw -B -Psourcecheck -Dformat.skip=true -DdeployAtEnd=true deploy
+        run: ./mvnw -B -Psourcecheck,linux-ship-certification -Dformat.skip=true -DdeployAtEnd=true deploy
         env:
           MAVEN_USERNAME: ${{ secrets.MVN_CENTRAL_USER }}
           MAVEN_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,11 @@ This project follows the [Apache Software Foundation Code of Conduct](https://ww
 ### Building the Project
 
 ```bash
-# Build all modules using Maven Wrapper
+# Portable build of all modules using Maven Wrapper
 ./mvnw clean install
+
+# On Linux with Bubblewrap, also certify the packaged Ship payloads
+./mvnw -B -Plinux-ship-certification clean install
 
 # Run CLI using JBang (from jbang-catalog.json)
 jbang camel-kit@. --help
@@ -183,7 +186,11 @@ Before opening an issue:
 
 3. **Build the project:**
    ```bash
+   # Portable build
    ./mvnw clean install
+
+   # Required packaged-payload certification on Linux with Bubblewrap
+   ./mvnw -B -Plinux-ship-certification clean install
    ```
 
 4. **Test the CLI:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ This project follows the [Apache Software Foundation Code of Conduct](https://ww
 # Portable build of all modules using Maven Wrapper
 ./mvnw clean install
 
-# On Linux with Bubblewrap, also certify the packaged Ship payloads
+# CI always certifies packaged Ship payloads on Linux; reproduce it locally when Bubblewrap is available
 ./mvnw -B -Plinux-ship-certification clean install
 
 # Run CLI using JBang (from jbang-catalog.json)
@@ -189,7 +189,7 @@ Before opening an issue:
    # Portable build
    ./mvnw clean install
 
-   # Required packaged-payload certification on Linux with Bubblewrap
+   # CI always certifies packaged Ship payloads on Linux; reproduce it locally when Bubblewrap is available
    ./mvnw -B -Plinux-ship-certification clean install
    ```
 

--- a/camel-kit-core/pom.xml
+++ b/camel-kit-core/pom.xml
@@ -81,6 +81,38 @@
             </exclusions>
         </dependency>
 
+        <!-- Compile only; Ship resolves the exact accepted runtime into an isolated payload. -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-yaml-dsl-validator</artifactId>
+            <version>${camel.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-main</artifactId>
+            <version>${camel.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-yaml-dsl</artifactId>
+            <version>${camel.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-stub</artifactId>
+            <version>${camel.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-direct</artifactId>
+            <version>${camel.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- No camel-catalog or citrus-catalog-schema dependency - JSON downloaded at runtime -->
 
         <!-- Graph builder for project code analysis -->
@@ -145,6 +177,31 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.failsafe.plugin.version}</version>
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>io.github.luigidemasi:camel-kit-ship-resolver</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${maven.multiModuleProjectDirectory}/camel-kit-ship-resolver/target/camel-kit-ship-resolver-${project.version}.jar</additionalClasspathElement>
+                    </additionalClasspathElements>
+                    <systemPropertyVariables>
+                        <ship.resolver.jar>${maven.multiModuleProjectDirectory}/camel-kit-ship-resolver/target/camel-kit-ship-resolver-${project.version}.jar</ship.resolver.jar>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>verify-packaged-ship-payloads</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/camel-kit-core/pom.xml
+++ b/camel-kit-core/pom.xml
@@ -176,32 +176,41 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.failsafe.plugin.version}</version>
-                <configuration>
-                    <classpathDependencyExcludes>
-                        <classpathDependencyExclude>io.github.luigidemasi:camel-kit-ship-resolver</classpathDependencyExclude>
-                    </classpathDependencyExcludes>
-                    <additionalClasspathElements>
-                        <additionalClasspathElement>${maven.multiModuleProjectDirectory}/camel-kit-ship-resolver/target/camel-kit-ship-resolver-${project.version}.jar</additionalClasspathElement>
-                    </additionalClasspathElements>
-                    <systemPropertyVariables>
-                        <ship.resolver.jar>${maven.multiModuleProjectDirectory}/camel-kit-ship-resolver/target/camel-kit-ship-resolver-${project.version}.jar</ship.resolver.jar>
-                    </systemPropertyVariables>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>verify-packaged-ship-payloads</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
+
+    <profiles>
+        <!-- Explicit Linux/Bubblewrap certification; ordinary reactor builds stay platform-portable. -->
+        <profile>
+            <id>linux-ship-certification</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven.failsafe.plugin.version}</version>
+                        <configuration>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>io.github.luigidemasi:camel-kit-ship-resolver</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${maven.multiModuleProjectDirectory}/camel-kit-ship-resolver/target/camel-kit-ship-resolver-${project.version}.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            <systemPropertyVariables>
+                                <ship.resolver.jar>${maven.multiModuleProjectDirectory}/camel-kit-ship-resolver/target/camel-kit-ship-resolver-${project.version}.jar</ship.resolver.jar>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>verify-packaged-ship-payloads</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ShipArtifactLimits.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ShipArtifactLimits.java
@@ -1,0 +1,11 @@
+package io.github.luigidemasi.camelkit.ship;
+
+/** Canonical byte limits shared by Ship artifact admission and isolated evidence launchers. */
+public final class ShipArtifactLimits {
+
+    public static final int MAX_ROUTE_YAML_BYTES = 2 * 1024 * 1024;
+    public static final int MAX_CITRUS_YAML_BYTES = 2 * 1024 * 1024;
+
+    private ShipArtifactLimits() {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ShipDigest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ShipDigest.java
@@ -1,0 +1,32 @@
+package io.github.luigidemasi.camelkit.ship;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/** Content-address validation shared by Ship's controller-neutral wire records. */
+public final class ShipDigest {
+
+    private ShipDigest() {
+    }
+
+    public static String sha256(byte[] value) {
+        return "sha256:" + HexFormat.of().formatHex(messageDigest().digest(value));
+    }
+
+    public static boolean isSha256(String value) {
+        return value != null && value.matches("sha256:[0-9a-f]{64}");
+    }
+
+    public static boolean isHmacSha256(String value) {
+        return value != null && value.matches("hmac-sha256:[0-9a-f]{64}");
+    }
+
+    private static MessageDigest messageDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactFinding.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactFinding.java
@@ -1,0 +1,10 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+/** Deterministic artifact-manifest validation result. */
+public record ArtifactFinding(Severity severity, String code, String path, String message) {
+
+    public enum Severity {
+        ERROR,
+        WARNING
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactManifest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactManifest.java
@@ -1,0 +1,52 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.util.List;
+
+/** Controller-validated declaration of every implementation artifact required by a Ship run. */
+public record ArtifactManifest(
+        int schemaVersion,
+        String runtime,
+        String camelVersion,
+        String platformVersion,
+        String springBootVersion,
+        String routeDsl,
+        String expressionLanguage,
+        String citrusVersion,
+        List<String> citrusDependencies,
+        JavaPolicy javaPolicy,
+        List<String> approvedJavaExceptions,
+        List<RouteArtifact> routes,
+        List<TestArtifact> citrusTests,
+        List<DeclaredArtifact> artifacts,
+        boolean testsRequired,
+        boolean oneTestPerRoute) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public ArtifactManifest {
+        citrusDependencies = immutable(citrusDependencies);
+        approvedJavaExceptions = immutable(approvedJavaExceptions);
+        routes = immutable(routes);
+        citrusTests = immutable(citrusTests);
+        artifacts = immutable(artifacts);
+    }
+
+    private static <T> List<T> immutable(List<T> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+
+    public enum JavaPolicy {
+        FORBIDDEN,
+        JUSTIFICATION_REQUIRED,
+        ALLOWED
+    }
+
+    public record RouteArtifact(String routeId, String path, String digest) {
+    }
+
+    public record TestArtifact(String routeId, String path, String digest) {
+    }
+
+    public record DeclaredArtifact(String kind, String path, String digest, boolean required) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidationResult.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidationResult.java
@@ -1,0 +1,15 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.util.List;
+
+/** Immutable result of deterministic artifact validation. */
+public record ArtifactValidationResult(List<ArtifactFinding> findings) {
+
+    public ArtifactValidationResult {
+        findings = findings == null ? List.of() : List.copyOf(findings);
+    }
+
+    public boolean passed() {
+        return findings.stream().noneMatch(finding -> finding.severity() == ArtifactFinding.Severity.ERROR);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidator.java
@@ -69,7 +69,8 @@ public final class ArtifactValidator {
             "io.quarkus:quarkus-maven-plugin");
     private static final Set<String> TEST_SKIP_CONTROLS = Set.of(
             "skip", "skiptests", "skipits", "skipit", "surefire.skip", "failsafe.skip",
-            "maven.test.skip", "maven.test.skip.exec", "quarkus.test.skip");
+            "maven.test.skip", "maven.test.skip.exec", "maven.test.failure.ignore",
+            "testfailureignore", "quarkus.test.skip");
     private static final ObjectReader YAML_READER = new com.fasterxml.jackson.databind.ObjectMapper(
             YAMLFactory.builder()
                     .streamReadConstraints(StreamReadConstraints.builder()
@@ -1154,6 +1155,7 @@ public final class ArtifactValidator {
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setAttribute("jdk.xml.maxElementDepth", "100");
             var builder = factory.newDocumentBuilder();
             builder.setErrorHandler(new StrictXmlErrorHandler());
             byte[] source = readPomBytes(pom);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidator.java
@@ -1,0 +1,1785 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactFinding.Severity;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.DeclaredArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.TestArtifact;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCamelMainBootstrap;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCitrusYamlMain;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/** Deterministic filesystem checks used before execution output can be accepted. */
+public final class ArtifactValidator {
+
+    private static final long MAX_POM_INSPECTION_BYTES = 2 * 1024 * 1024;
+    private static final long MAX_CONFIG_INSPECTION_BYTES = 64 * 1024;
+    private static final String MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0";
+    private static final Pattern MAVEN_PROPERTY = Pattern.compile("\\$\\{([^}]+)}");
+    private static final Pattern SAFE_MAVEN_TOKEN = Pattern.compile("[A-Za-z0-9_.-]+");
+    private static final Pattern ROUTE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}");
+    private static final Set<String> APPROVED_BUILD_PLUGINS = Set.of(
+            "org.springframework.boot:spring-boot-maven-plugin",
+            "io.quarkus:quarkus-maven-plugin");
+    private static final Set<String> TEST_SKIP_CONTROLS = Set.of(
+            "skip", "skiptests", "skipits", "skipit", "surefire.skip", "failsafe.skip",
+            "maven.test.skip", "maven.test.skip.exec", "quarkus.test.skip");
+    private static final ObjectReader YAML_READER = new com.fasterxml.jackson.databind.ObjectMapper(
+            YAMLFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(100)
+                            .maxStringLength(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES)
+                            .build())
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .reader()
+            .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+    private ArtifactValidator() {
+    }
+
+    public static ArtifactValidationResult validate(Path projectRoot, ArtifactManifest manifest) {
+        return validate(projectRoot, manifest, null);
+    }
+
+    /** Validates both filesystem artifacts and their exact approved requirements policy. */
+    public static ArtifactValidationResult validate(
+            Path projectRoot, ArtifactManifest manifest, RequirementsPolicy policy) {
+        Path root = projectRoot.toAbsolutePath().normalize();
+        List<ArtifactFinding> findings = new ArrayList<>();
+        if (manifest == null) {
+            return new ArtifactValidationResult(
+                    List.of(error("manifest-missing", null,
+                            "The execution result did not include an artifact manifest")));
+        }
+        if (manifest.schemaVersion() != ArtifactManifest.SCHEMA_VERSION) {
+            findings.add(error("manifest-schema", null,
+                    "Unsupported artifact-manifest schema version: " + manifest.schemaVersion()));
+        }
+        requireText("runtime", manifest.runtime(), findings);
+        requireText("camel-version", manifest.camelVersion(), findings);
+        requireText("route-dsl", manifest.routeDsl(), findings);
+        requireText("expression-language", manifest.expressionLanguage(), findings);
+        for (String violation : CitrusDependencyPolicy.violations(
+                manifest.citrusVersion(), manifest.citrusDependencies())) {
+            findings.add(error("citrus-dependencies", null, violation));
+        }
+        if (manifest.javaPolicy() == null) {
+            findings.add(error("java-policy-missing", null, "The Java policy is required"));
+        }
+        if (manifest.routes().isEmpty()) {
+            findings.add(error("routes-empty", null, "At least one route must be declared"));
+        }
+
+        Set<String> declaredPaths = new LinkedHashSet<>();
+        Set<String> routeIds = new LinkedHashSet<>();
+        Map<String, String> routePaths = new HashMap<>();
+        for (RouteArtifact route : manifest.routes()) {
+            validateRoute(root, route, routeIds, declaredPaths, findings);
+            if (route != null && !isBlank(route.routeId()) && !isBlank(route.path())) {
+                routePaths.putIfAbsent(route.routeId(), route.path());
+            }
+        }
+        validateTests(root, manifest, routeIds, routePaths, declaredPaths, findings);
+        validateCitrusConfiguration(root, manifest, findings);
+        for (DeclaredArtifact artifact : manifest.artifacts()) {
+            validateDeclaredArtifact(root, artifact, declaredPaths, findings);
+        }
+
+        findWronglySuffixedRoutes(root, Set.copyOf(routePaths.values()), findings);
+        validateRuntimeJavaPolicy(manifest, findings);
+        validateJavaPolicy(root, manifest, findings);
+        validateRuntimeConsistency(root, manifest, policy, findings);
+        if ("main".equals(normalizeRuntime(manifest.runtime()))) {
+            try {
+                ShipCamelMainBootstrap.validateLaunchSurface(
+                        root,
+                        manifest.routes().stream()
+                                .filter(Objects::nonNull)
+                                .map(route -> Path.of(route.path()))
+                                .toList());
+            } catch (IOException | RuntimeException e) {
+                findings.add(error("main-launch-surface", null,
+                        "Camel Main launch surface is not controller-bounded: " + safeMessage(e)));
+            }
+        }
+        if (policy != null) {
+            validateApprovedPolicy(manifest, policy, findings);
+        }
+        return new ArtifactValidationResult(findings);
+    }
+
+    /** Binds every used Camel component model to an exact runtime dependency in the accepted POM. */
+    public static ArtifactValidationResult validateCatalogDependencies(
+            Path projectRoot, RequirementsPolicy policy, CatalogEvidenceSet usageEvidence) {
+        return bindCatalogDependencies(projectRoot, policy, usageEvidence).validation();
+    }
+
+    /** Validate and retain the exact candidate runtime dependency roots used for controller execution. */
+    public static CatalogDependencyBinding bindCatalogDependencies(
+            Path projectRoot, RequirementsPolicy policy, CatalogEvidenceSet usageEvidence) {
+        Path root = projectRoot.toAbsolutePath().normalize();
+        List<ArtifactFinding> findings = new ArrayList<>();
+        List<SubjectEvidence> runtimeSubjects = usageEvidence.subjects().stream()
+                // EIP resources describe YAML model grammar; they are not route-selectable runtime artifacts.
+                .filter(subject -> subject.subject().kind() != Kind.EIP)
+                .toList();
+        Path pom = root.resolve("pom.xml");
+        if (Files.isSymbolicLink(pom) || !Files.isRegularFile(pom, LinkOption.NOFOLLOW_LINKS)) {
+            findings.add(error("catalog-component-pom-missing", "pom.xml",
+                    "Catalog-derived runtime usage requires a regular Maven POM"));
+            return new CatalogDependencyBinding(new ArtifactValidationResult(findings), null, List.of());
+        }
+        try {
+            if (Files.size(pom) > MAX_POM_INSPECTION_BYTES) {
+                throw new IOException("Maven POM is too large for deterministic inspection");
+            }
+            String runtime = normalizeRuntime(policy.runtime());
+            MavenModel model = parseMavenModel(pom, "main".equals(runtime));
+            if ("main".equals(runtime)) {
+                List<RuntimeDependency> dependencies = validateExactMainDependencies(
+                        model, policy, runtimeSubjects, findings);
+                return new CatalogDependencyBinding(
+                        new ArtifactValidationResult(findings), model.sourceDigest(), dependencies);
+            }
+            for (SubjectEvidence component : runtimeSubjects) {
+                MavenCoordinate dependency = model.dependencies().stream()
+                        .filter(candidate -> candidate.matches(component.groupId(), component.artifactId())
+                                && candidate.runtimeScoped() && candidate.classifier() == null)
+                        .findFirst()
+                        .orElse(null);
+                String coordinate = component.groupId() + ':' + component.artifactId();
+                if (dependency == null) {
+                    findings.add(error("catalog-component-dependency-missing", "pom.xml",
+                            "Route component " + component.subject().name()
+                                                                                          + " requires runtime dependency "
+                                                                                          + coordinate));
+                    continue;
+                }
+                if (dependency.version() == null) {
+                    if (!managedByApprovedBom(model, runtime, policy)) {
+                        findings.add(error("catalog-component-dependency-version", "pom.xml",
+                                "Route component dependency " + coordinate
+                                                                                              + " has no version from the approved runtime BOM"));
+                    }
+                } else if (!dependency.version().equals(component.artifactVersion())) {
+                    findings.add(error("catalog-component-dependency-version", "pom.xml",
+                            "Route component dependency " + coordinate + " version " + dependency.version()
+                                                                                          + " differs from catalog version "
+                                                                                          + component
+                                                                                                  .artifactVersion()));
+                }
+            }
+            List<RuntimeDependency> dependencies = runtimeSubjects.stream()
+                    .map(subject -> new RuntimeDependency(
+                            subject.groupId(), subject.artifactId(), subject.artifactVersion(), "compile"))
+                    .distinct()
+                    .sorted(java.util.Comparator.comparing(RuntimeDependency::coordinate))
+                    .toList();
+            return new CatalogDependencyBinding(
+                    new ArtifactValidationResult(findings), model.sourceDigest(), dependencies);
+        } catch (ExactMainPomPolicyException e) {
+            findings.add(error("catalog-runtime-pom-policy", "pom.xml", e.getMessage()));
+            return new CatalogDependencyBinding(new ArtifactValidationResult(findings), null, List.of());
+        } catch (IOException | RuntimeException e) {
+            findings.add(error("catalog-component-pom-invalid", "pom.xml",
+                    "Could not verify catalog-derived runtime dependencies: " + safeMessage(e)));
+            return new CatalogDependencyBinding(new ArtifactValidationResult(findings), null, List.of());
+        }
+    }
+
+    private static List<RuntimeDependency> validateExactMainDependencies(
+            MavenModel model,
+            RequirementsPolicy policy,
+            List<SubjectEvidence> runtimeSubjects,
+            List<ArtifactFinding> findings) {
+        if (model.parent() != null || model.hasProperties() || model.hasDependencyManagement()
+                || !model.managedDependencies().isEmpty() || model.hasBuild() || !model.plugins().isEmpty()
+                || model.packaging() != null && !"jar".equals(model.packaging())
+                || model.hasProfiles() || model.hasModules() || model.hasRepositories()
+                || model.hasPluginRepositories() || model.hasBuildExtensions() || model.hasPluginManagement()) {
+            findings.add(error("catalog-runtime-pom-policy", "pom.xml",
+                    "Ship protocol v1 Main requires a self-contained POM without parents, properties, "
+                                                                        + "dependency management, profiles, repositories, extensions, or plugins"));
+        }
+
+        Map<String, RuntimeDependency> expected = new HashMap<>();
+        putExpected(expected, new RuntimeDependency(
+                "org.apache.camel", "camel-main", policy.camelVersion(), "compile"), findings);
+        putExpected(expected, new RuntimeDependency(
+                "org.apache.camel", "camel-yaml-dsl", policy.camelVersion(), "compile"), findings);
+        Map<String, List<SubjectEvidence>> subjectsByGa = new HashMap<>();
+        for (SubjectEvidence subject : runtimeSubjects) {
+            RuntimeDependency dependency = new RuntimeDependency(
+                    subject.groupId(), subject.artifactId(), subject.artifactVersion(), "compile");
+            putExpected(expected, dependency, findings);
+            subjectsByGa.computeIfAbsent(subject.groupId() + ':' + subject.artifactId(), ignored -> new ArrayList<>())
+                    .add(subject);
+        }
+
+        Map<String, RuntimeDependency> actual = new HashMap<>();
+        for (MavenCoordinate coordinate : model.dependencies()) {
+            String ga = coordinate.groupId() + ':' + coordinate.artifactId();
+            String scope = coordinate.scope() == null ? "compile" : coordinate.scope();
+            if (!coordinate.runtimeScoped() || coordinate.optionalDeclared() || coordinate.exclusionsDeclared()
+                    || coordinate.expressionDeclared()
+                    || coordinate.type() != null && !"jar".equals(coordinate.type())
+                    || coordinate.classifier() != null || !safeMavenToken(coordinate.groupId())
+                    || !safeMavenToken(coordinate.artifactId()) || !exactRelease(coordinate.version())) {
+                findings.add(error("catalog-runtime-dependency-policy", "pom.xml",
+                        "Ship protocol v1 Main requires every dependency to be an exact, non-optional, "
+                                                                                   + "unexcluded compile/runtime JAR: "
+                                                                                   + ga));
+                continue;
+            }
+            RuntimeDependency dependency = new RuntimeDependency(
+                    coordinate.groupId(), coordinate.artifactId(), coordinate.version(), scope);
+            if (actual.putIfAbsent(ga, dependency) != null) {
+                findings.add(error("catalog-runtime-dependency-duplicate", "pom.xml",
+                        "Candidate POM repeats runtime dependency " + ga));
+                continue;
+            }
+            RuntimeDependency allowed = expected.get(ga);
+            if (allowed == null) {
+                findings.add(error("catalog-runtime-dependency-extra", "pom.xml",
+                        "Candidate POM contains an unverified runtime dependency: " + dependency.coordinate()));
+            } else if (!allowed.version().equals(dependency.version())) {
+                findings.add(error("catalog-component-dependency-version", "pom.xml",
+                        "Runtime dependency " + ga + " version " + dependency.version()
+                                                                                      + " differs from catalog-bound version "
+                                                                                      + allowed.version()));
+            }
+        }
+        for (Map.Entry<String, RuntimeDependency> entry : expected.entrySet()) {
+            if (actual.containsKey(entry.getKey())) {
+                continue;
+            }
+            List<SubjectEvidence> missingSubjects = subjectsByGa.get(entry.getKey());
+            String code = missingSubjects != null && missingSubjects.stream()
+                    .anyMatch(subject -> subject.subject().kind() == Kind.COMPONENT)
+                            ? "catalog-component-dependency-missing"
+                            : "catalog-runtime-dependency-missing";
+            String label = missingSubjects == null
+                    ? "required controller base" : "catalog-derived route usage";
+            findings.add(error(code, "pom.xml",
+                    "Candidate POM omits " + label + " dependency " + entry.getValue().coordinate()));
+        }
+        return actual.values().stream()
+                .sorted(java.util.Comparator.comparing(RuntimeDependency::coordinate)
+                        .thenComparing(RuntimeDependency::scope))
+                .toList();
+    }
+
+    private static void putExpected(
+            Map<String, RuntimeDependency> expected,
+            RuntimeDependency dependency,
+            List<ArtifactFinding> findings) {
+        String ga = dependency.groupId() + ':' + dependency.artifactId();
+        RuntimeDependency previous = expected.putIfAbsent(ga, dependency);
+        if (previous != null && !previous.version().equals(dependency.version())) {
+            findings.add(error("catalog-runtime-dependency-ambiguous", "pom.xml",
+                    "Verified catalog subjects require conflicting versions of " + ga));
+        }
+    }
+
+    private static boolean safeMavenToken(String value) {
+        return value != null && SAFE_MAVEN_TOKEN.matcher(value).matches();
+    }
+
+    private static boolean exactRelease(String value) {
+        if (!safeMavenToken(value)) {
+            return false;
+        }
+        String normalized = value.toUpperCase(Locale.ROOT);
+        return !normalized.contains("SNAPSHOT")
+                && !"LATEST".equals(normalized)
+                && !"RELEASE".equals(normalized);
+    }
+
+    public record CatalogDependencyBinding(
+            ArtifactValidationResult validation,
+            String pomDigest,
+            List<RuntimeDependency> runtimeDependencies) {
+
+        public CatalogDependencyBinding {
+            runtimeDependencies = runtimeDependencies == null ? List.of() : List.copyOf(runtimeDependencies);
+        }
+    }
+
+    private static boolean managedByApprovedBom(
+            MavenModel model, String runtime, RequirementsPolicy policy) {
+        MavenCoordinate bom = switch (runtime) {
+            case "main" -> findImportedBom(model, "org.apache.camel", "camel-bom");
+            case "spring-boot" ->
+                findImportedBom(model, "org.apache.camel.springboot", "camel-spring-boot-bom");
+            case "quarkus" -> findImportedBom(model, "io.quarkus.platform", "quarkus-camel-bom");
+            default -> null;
+        };
+        String expected = "main".equals(runtime) ? policy.camelVersion() : policy.platformVersion();
+        return bom != null && Objects.equals(expected, bom.version());
+    }
+
+    private static void validateRoute(
+            Path root,
+            RouteArtifact route,
+            Set<String> routeIds,
+            Set<String> declaredPaths,
+            List<ArtifactFinding> findings) {
+        if (route == null || isBlank(route.routeId()) || isBlank(route.path())) {
+            findings.add(error("route-invalid", null, "Every route requires a route ID and path"));
+            return;
+        }
+        if (!routeIds.add(route.routeId())) {
+            findings.add(error("route-id-duplicate", route.path(), "Duplicate route ID: " + route.routeId()));
+        }
+        if (!safeFileSegment(route.routeId())) {
+            findings.add(error("route-id-invalid", route.path(),
+                    "Route IDs must be single filename segments without separators or control characters"));
+        }
+        if (!route.path().endsWith(".camel.yaml")) {
+            findings.add(error("route-suffix", route.path(), "Camel YAML routes must use the .camel.yaml suffix"));
+        }
+        if (!hasFileName(route.path(), route.routeId() + ".camel.yaml")) {
+            findings.add(error("route-name", route.path(),
+                    "Camel YAML route must be named exactly " + route.routeId() + ".camel.yaml"));
+        }
+        Path routeFile = validateFile(root, route.path(), route.digest(), true, declaredPaths, findings);
+        if (routeFile != null) {
+            validateRouteYaml(root, routeFile, route.routeId(), findings);
+        }
+    }
+
+    private static void validateTests(
+            Path root,
+            ArtifactManifest manifest,
+            Set<String> routeIds,
+            Map<String, String> routePaths,
+            Set<String> declaredPaths,
+            List<ArtifactFinding> findings) {
+        Map<String, Integer> testsPerRoute = new HashMap<>();
+        for (TestArtifact test : manifest.citrusTests()) {
+            if (test == null || isBlank(test.routeId()) || isBlank(test.path())) {
+                findings.add(error("citrus-test-invalid", null, "Every Citrus test requires a route ID and path"));
+                continue;
+            }
+            if (!test.path().endsWith(".camel.it.yaml")) {
+                findings.add(error(
+                        "citrus-test-suffix", test.path(), "Citrus YAML tests must use the .camel.it.yaml suffix"));
+            }
+            if (!hasFileName(test.path(), test.routeId() + ".camel.it.yaml")) {
+                findings.add(error("citrus-test-name", test.path(),
+                        "Citrus YAML test must be named exactly " + test.routeId() + ".camel.it.yaml"));
+            }
+            String expectedPath = "test/" + test.routeId() + ".camel.it.yaml";
+            if (!expectedPath.equals(test.path())) {
+                findings.add(error("citrus-test-location", test.path(),
+                        "Citrus YAML test path must be exactly " + expectedPath));
+            }
+            if (!routeIds.contains(test.routeId())) {
+                findings.add(error("citrus-test-route", test.path(),
+                        "Citrus test references undeclared route ID: " + test.routeId()));
+            }
+            testsPerRoute.merge(test.routeId(), 1, Integer::sum);
+            Path testFile = validateFile(root, test.path(), test.digest(), true, declaredPaths, findings);
+            if (testFile != null) {
+                validateCitrusYaml(root, testFile, test.routeId(), findings);
+            }
+        }
+        if (manifest.testsRequired() && manifest.citrusTests().isEmpty()) {
+            findings.add(error("citrus-tests-missing", null,
+                    "Citrus tests are required but the manifest declares none"));
+        }
+        if (manifest.testsRequired() && manifest.oneTestPerRoute()) {
+            for (String routeId : routeIds) {
+                int count = testsPerRoute.getOrDefault(routeId, 0);
+                if (count != 1) {
+                    findings.add(error("citrus-route-uncovered", null,
+                            "Expected exactly one Citrus YAML integration test for route " + routeId
+                                                                       + " but found " + count));
+                }
+            }
+        }
+    }
+
+    private static void validateCitrusConfiguration(
+            Path root, ArtifactManifest manifest, List<ArtifactFinding> findings) {
+        List<DeclaredArtifact> matching = manifest.artifacts().stream()
+                .filter(java.util.Objects::nonNull)
+                .filter(artifact -> CitrusDependencyPolicy.FORBIDDEN_JBANG_ARTIFACT_KIND.equals(artifact.kind())
+                        || CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH.equals(artifact.path()))
+                .toList();
+        if (!matching.isEmpty()) {
+            findings.add(error("citrus-jbang-forbidden", CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH,
+                    "Direct controller-owned Citrus execution forbids Citrus JBang configuration"));
+        }
+
+        Path propertiesFile = root.resolve(CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH);
+        if (Files.exists(propertiesFile, LinkOption.NOFOLLOW_LINKS)
+                || Files.isSymbolicLink(propertiesFile)) {
+            findings.add(error("citrus-jbang-forbidden", CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH,
+                    "Direct controller-owned Citrus execution must not use test/jbang.properties"));
+        }
+    }
+
+    private static void validateDeclaredArtifact(
+            Path root,
+            DeclaredArtifact artifact,
+            Set<String> declaredPaths,
+            List<ArtifactFinding> findings) {
+        if (artifact == null || isBlank(artifact.kind()) || isBlank(artifact.path())) {
+            findings.add(error("artifact-invalid", null, "Declared artifacts require a kind and path"));
+            return;
+        }
+        validateFile(root, artifact.path(), artifact.digest(), artifact.required(), declaredPaths, findings);
+    }
+
+    private static Path validateFile(
+            Path root,
+            String relativePath,
+            String expectedDigest,
+            boolean required,
+            Set<String> declaredPaths,
+            List<ArtifactFinding> findings) {
+        Path path = safeResolve(root, relativePath, findings);
+        if (path == null) {
+            return null;
+        }
+        String normalized = root.relativize(path).toString().replace('\\', '/');
+        if (!declaredPaths.add(normalized)) {
+            findings.add(error("artifact-path-duplicate", normalized, "Artifact path is declared more than once"));
+        }
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            if (required) {
+                findings.add(error("artifact-missing", normalized, "Required artifact is missing"));
+            }
+            return null;
+        }
+        if (Files.isSymbolicLink(path) || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            findings.add(error("artifact-type", normalized, "Artifact must be a regular non-symbolic-link file"));
+            return null;
+        }
+        if (required && isBlank(expectedDigest)) {
+            findings.add(error("artifact-digest-missing", normalized,
+                    "Required artifacts must declare a SHA-256 digest"));
+        } else if (!isBlank(expectedDigest) && !expectedDigest.matches("sha256:[0-9a-f]{64}")) {
+            findings.add(error("artifact-digest-format", normalized,
+                    "Artifact digest must be a lowercase SHA-256 content address"));
+        } else if (!isBlank(expectedDigest)) {
+            try {
+                String actual = digest(path);
+                if (!actual.equals(expectedDigest)) {
+                    findings.add(error("artifact-digest", normalized,
+                            "Artifact digest mismatch: expected " + expectedDigest + " but found " + actual));
+                }
+            } catch (IOException e) {
+                findings.add(error("artifact-read", normalized, "Could not hash artifact: " + e.getMessage()));
+            }
+        }
+        return path;
+    }
+
+    private static Path safeResolve(Path root, String relativePath, List<ArtifactFinding> findings) {
+        if (isBlank(relativePath)) {
+            findings.add(error("artifact-path", relativePath, "Artifact path must not be blank"));
+            return null;
+        }
+        Path relative;
+        try {
+            relative = Path.of(relativePath);
+        } catch (java.nio.file.InvalidPathException e) {
+            findings.add(error("artifact-path", relativePath, "Artifact path is not a valid filesystem path"));
+            return null;
+        }
+        if (relative.isAbsolute()) {
+            findings.add(error("artifact-path", relativePath, "Artifact paths must be relative to the project"));
+            return null;
+        }
+        if (relativePath.indexOf('\\') >= 0 || !relative.equals(relative.normalize())) {
+            findings.add(error("artifact-path", relativePath,
+                    "Artifact paths must use canonical project-relative POSIX form"));
+            return null;
+        }
+        Path path = root.resolve(relative).normalize();
+        if (!path.startsWith(root)) {
+            findings.add(error("artifact-path", relativePath, "Artifact path escapes the project root"));
+            return null;
+        }
+        if (containsSymbolicLink(root, path)) {
+            findings.add(error("artifact-path", relativePath,
+                    "Artifact path contains a symbolic-link component"));
+            return null;
+        }
+        return path;
+    }
+
+    private static boolean containsSymbolicLink(Path root, Path path) {
+        Path current = root;
+        for (Path part : root.relativize(path)) {
+            current = current.resolve(part);
+            if (Files.isSymbolicLink(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void validateRouteYaml(
+            Path root, Path path, String expectedRouteId, List<ArtifactFinding> findings) {
+        String relative = root.relativize(path).toString().replace('\\', '/');
+        try {
+            if (Files.size(path) > ShipArtifactLimits.MAX_ROUTE_YAML_BYTES) {
+                findings.add(error("route-yaml-size", relative,
+                        "Camel YAML route is too large for deterministic inspection"));
+                return;
+            }
+            JsonNode document;
+            try (var input = Files.newInputStream(path)) {
+                document = YAML_READER.readTree(input);
+            }
+            List<String> declaredRouteIds = new ArrayList<>();
+            collectRouteIds(document, declaredRouteIds);
+            if (declaredRouteIds.isEmpty() || declaredRouteIds.get(0) == null
+                    || declaredRouteIds.get(0).isBlank()) {
+                findings.add(error("route-yaml-id-missing", relative,
+                        "Camel YAML route must declare its route ID"));
+            } else if (declaredRouteIds.size() != 1) {
+                findings.add(error("route-yaml-count", relative,
+                        "Each declared route artifact must contain exactly one Camel route"));
+            } else if (!expectedRouteId.equals(declaredRouteIds.get(0))) {
+                findings.add(error("route-yaml-id-mismatch", relative,
+                        "Camel YAML declares route ID " + declaredRouteIds.get(0)
+                                                                       + " but the manifest declares "
+                                                                       + expectedRouteId));
+            }
+            ShipCamelMainBootstrap.validatePolicy(path);
+        } catch (IOException | RuntimeException e) {
+            findings.add(error("route-yaml-parse", relative,
+                    "Could not parse Camel YAML route: " + safeMessage(e)));
+        }
+    }
+
+    private static void validateCitrusYaml(
+            Path root, Path path, String expectedRouteId, List<ArtifactFinding> findings) {
+        String relative = root.relativize(path).toString().replace('\\', '/');
+        try {
+            if (Files.size(path) > ShipArtifactLimits.MAX_CITRUS_YAML_BYTES) {
+                findings.add(error("citrus-yaml-size", relative,
+                        "Citrus YAML test is too large for deterministic inspection"));
+                return;
+            }
+            ShipCitrusYamlMain.validatePolicy(path, expectedRouteId);
+        } catch (IOException | RuntimeException e) {
+            findings.add(error("citrus-yaml-policy", relative,
+                    "Citrus YAML is outside the direct execution allowlist: " + safeMessage(e)));
+        }
+    }
+
+    private static void collectRouteIds(JsonNode document, List<String> routeIds) {
+        if (document == null || document.isNull()) {
+            return;
+        }
+        if (document.isArray()) {
+            document.forEach(item -> collectRouteIds(item, routeIds));
+            return;
+        }
+        if (!document.isObject()) {
+            return;
+        }
+        JsonNode route = document.get("route");
+        if (route != null) {
+            JsonNode id = route.isObject() ? route.get("id") : null;
+            routeIds.add(id != null && id.isTextual() ? id.textValue().trim() : null);
+        }
+        JsonNode routes = document.get("routes");
+        if (routes != null) {
+            collectRouteIds(routes, routeIds);
+        }
+    }
+
+    private static void findWronglySuffixedRoutes(
+            Path root, Set<String> declaredRoutePaths, List<ArtifactFinding> findings) {
+        try (Stream<Path> files = Files.walk(root)) {
+            files.filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+                    .filter(ArtifactValidator::isYaml)
+                    .forEach(path -> inspectYamlCandidate(root, path, declaredRoutePaths, findings));
+        } catch (IOException e) {
+            findings.add(error("route-scan", null,
+                    "Could not enumerate possible route files: " + e.getMessage()));
+        }
+    }
+
+    private static void inspectYamlCandidate(
+            Path root, Path path, Set<String> declaredRoutePaths, List<ArtifactFinding> findings) {
+        String relative = root.relativize(path).toString().replace('\\', '/');
+        if (relative.endsWith(".camel.yaml")) {
+            if (!declaredRoutePaths.contains(relative)) {
+                findings.add(error("route-undeclared", relative,
+                        "Camel route exists on disk but is absent from the route manifest"));
+            }
+            return;
+        }
+        try {
+            if (Files.size(path) > ShipArtifactLimits.MAX_ROUTE_YAML_BYTES) {
+                findings.add(error("route-scan-size", relative,
+                        "YAML file is too large to prove that it does not contain a wrongly suffixed Camel route"));
+                return;
+            }
+            JsonNode document;
+            try (var input = Files.newInputStream(path)) {
+                document = YAML_READER.readTree(input);
+            }
+            if (containsCamelDefinition(document)) {
+                findings.add(error("route-suffix", relative,
+                        "Possible Camel YAML route has the wrong suffix; expected .camel.yaml"));
+            }
+        } catch (IOException | RuntimeException e) {
+            findings.add(error("route-scan-parse", relative,
+                    "Could not prove that YAML is not an alternate Camel route definition: " + safeMessage(e)));
+        }
+    }
+
+    private static boolean containsCamelDefinition(JsonNode document) {
+        if (document == null || document.isNull()) {
+            return false;
+        }
+        if (document.isArray()) {
+            for (JsonNode item : document) {
+                if (containsCamelDefinition(item)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (!document.isObject()) {
+            return false;
+        }
+        JsonNode apiVersion = document.get("apiVersion");
+        JsonNode kind = document.get("kind");
+        boolean camelCustomResource = apiVersion != null && apiVersion.isTextual()
+                && apiVersion.asText().toLowerCase(Locale.ROOT).startsWith("camel.apache.org/")
+                && kind != null && kind.isTextual()
+                && Set.of("pipe", "kamelet").contains(kind.asText().toLowerCase(Locale.ROOT));
+        return document.has("route")
+                || document.has("routes")
+                || document.has("from")
+                || document.has("routeConfiguration")
+                || document.has("routeConfigurations")
+                || document.has("routeTemplate")
+                || document.has("routeTemplates")
+                || document.has("templatedRoute")
+                || document.has("templatedRoutes")
+                || document.has("rest")
+                || document.has("rests")
+                || document.has("restConfiguration")
+                || document.has("restConfigurations")
+                || camelCustomResource;
+    }
+
+    private static void validateJavaPolicy(
+            Path root, ArtifactManifest manifest, List<ArtifactFinding> findings) {
+        if (manifest.javaPolicy() == null || manifest.javaPolicy() == ArtifactManifest.JavaPolicy.ALLOWED) {
+            return;
+        }
+        Path source = root.resolve("src");
+        if (!Files.isDirectory(source)) {
+            return;
+        }
+        Set<String> exceptions = new HashSet<>(manifest.approvedJavaExceptions());
+        try (Stream<Path> files = Files.walk(source)) {
+            files.filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+                    .filter(path -> path.getFileName().toString().endsWith(".java"))
+                    .forEach(path -> {
+                        String relative = root.relativize(path).toString().replace('\\', '/');
+                        if (manifest.javaPolicy() == ArtifactManifest.JavaPolicy.FORBIDDEN) {
+                            findings.add(error("java-forbidden", relative,
+                                    "Java source is forbidden by the approved requirements"));
+                        } else if (!exceptions.contains(relative)) {
+                            findings.add(error("java-unapproved", relative,
+                                    "Java source lacks a controller-approved exception"));
+                        }
+                    });
+        } catch (IOException e) {
+            findings.add(error("java-scan", "src", "Could not inspect Java sources: " + e.getMessage()));
+        }
+    }
+
+    private static void validateRuntimeJavaPolicy(
+            ArtifactManifest manifest, List<ArtifactFinding> findings) {
+        if ("main".equals(normalizeRuntime(manifest.runtime()))
+                && manifest.javaPolicy() != null
+                && manifest.javaPolicy() != ArtifactManifest.JavaPolicy.FORBIDDEN) {
+            findings.add(error("main-java-policy", null,
+                    "Camel Main requires Java policy FORBIDDEN in Ship protocol v1 because its mandatory startup "
+                                                         + "evidence does not compile Java sources"));
+        }
+    }
+
+    private static void validateRuntimeConsistency(
+            Path root,
+            ArtifactManifest manifest,
+            RequirementsPolicy policy,
+            List<ArtifactFinding> findings) {
+        boolean approvedPolicy = policy != null;
+        String runtime = normalizeRuntime(approvedPolicy ? policy.runtime() : manifest.runtime());
+        String camelVersion = normalizeNullable(approvedPolicy ? policy.camelVersion() : manifest.camelVersion());
+        String platformVersion = normalizeNullable(
+                approvedPolicy ? policy.platformVersion() : manifest.platformVersion());
+        String springBootVersion = normalizeNullable(
+                approvedPolicy ? policy.springBootVersion() : manifest.springBootVersion());
+        String citrusVersion = normalizeNullable(
+                approvedPolicy ? policy.citrusVersion() : manifest.citrusVersion());
+        if (!Set.of("main", "spring-boot", "quarkus").contains(runtime)) {
+            findings.add(error("runtime-invalid", null,
+                    "Runtime must be one of main, spring-boot, or quarkus"));
+            return;
+        }
+        validateRuntimeConfiguration(
+                root, runtime, camelVersion, platformVersion, springBootVersion, citrusVersion, true, findings);
+        validatePom(root, runtime, camelVersion, platformVersion, springBootVersion, approvedPolicy, findings);
+    }
+
+    private static void validateRuntimeConfiguration(
+            Path root,
+            String runtime,
+            String camelVersion,
+            String platformVersion,
+            String springBootVersion,
+            String citrusVersion,
+            boolean required,
+            List<ArtifactFinding> findings) {
+        String relative = ".camel-kit/config.properties";
+        Path config = root.resolve(relative);
+        if (containsSymbolicLink(root, config)) {
+            findings.add(error("runtime-config-type", relative,
+                    "Runtime configuration path must not contain symbolic links"));
+            return;
+        }
+        if (!Files.exists(config, LinkOption.NOFOLLOW_LINKS)) {
+            if (required) {
+                findings.add(error("runtime-config-missing", relative,
+                        "Approved Ship output requires .camel-kit/config.properties"));
+            }
+            return;
+        }
+        if (Files.isSymbolicLink(config) || !Files.isRegularFile(config, LinkOption.NOFOLLOW_LINKS)) {
+            findings.add(error("runtime-config-type", relative,
+                    "Runtime configuration must be a regular non-symbolic-link file"));
+            return;
+        }
+        try {
+            if (Files.size(config) > MAX_CONFIG_INSPECTION_BYTES) {
+                findings.add(error("runtime-config-size", relative,
+                        "Runtime configuration is too large for deterministic inspection"));
+                return;
+            }
+            Properties properties = new UniqueProperties();
+            try (var reader = Files.newBufferedReader(config, StandardCharsets.UTF_8)) {
+                properties.load(reader);
+            }
+            validateConfigValue(properties, "project.runtime", runtime, required, true, findings);
+            validateConfigValue(properties, "project.camelVersion", camelVersion, required, false, findings);
+            validateConfigValue(properties, "citrus.version", citrusVersion, required, false, findings);
+            String expectedPlatform = "main".equals(runtime) ? camelVersion : platformVersion;
+            validateConfigValue(
+                    properties, "project.platformBomVersion", expectedPlatform, required, false, findings);
+            if ("spring-boot".equals(runtime)) {
+                validateConfigValue(
+                        properties, "project.springBootVersion", springBootVersion, required, false, findings);
+            } else if (normalizeNullable(properties.getProperty("project.springBootVersion")) != null) {
+                findings.add(error("runtime-config-mismatch", relative,
+                        "project.springBootVersion is valid only for the spring-boot runtime"));
+            }
+        } catch (IOException | IllegalArgumentException e) {
+            findings.add(error("runtime-config-read", relative,
+                    "Could not parse runtime configuration: " + safeMessage(e)));
+        }
+    }
+
+    private static void validateConfigValue(
+            Properties properties,
+            String key,
+            String expected,
+            boolean required,
+            boolean runtimeValue,
+            List<ArtifactFinding> findings) {
+        String configured = normalizeNullable(properties.getProperty(key));
+        if (configured == null) {
+            if (required) {
+                findings.add(error("runtime-config-value-missing", ".camel-kit/config.properties",
+                        "Runtime configuration is missing " + key));
+            }
+            return;
+        }
+        String actual = runtimeValue ? normalizeRuntime(configured) : configured;
+        if (expected != null && !expected.equals(actual)) {
+            findings.add(error("runtime-config-mismatch", ".camel-kit/config.properties",
+                    "Configured " + key + " value " + actual + " differs from approved value " + expected));
+        }
+    }
+
+    private static void validatePom(
+            Path root,
+            String runtime,
+            String camelVersion,
+            String platformVersion,
+            String springBootVersion,
+            boolean approvedPolicy,
+            List<ArtifactFinding> findings) {
+        validateMavenProjectHooks(root, findings);
+        Path pom = root.resolve("pom.xml");
+        if (!Files.exists(pom, LinkOption.NOFOLLOW_LINKS)) {
+            if (approvedPolicy && !"main".equals(runtime)) {
+                findings.add(error("runtime-pom-missing", "pom.xml",
+                        runtime + " Ship output requires a Maven POM"));
+            }
+            return;
+        }
+        if (Files.isSymbolicLink(pom) || !Files.isRegularFile(pom, LinkOption.NOFOLLOW_LINKS)) {
+            findings.add(error("runtime-pom-type", "pom.xml",
+                    "Maven POM must be a regular non-symbolic-link file"));
+            return;
+        }
+        try {
+            if (Files.size(pom) > MAX_POM_INSPECTION_BYTES) {
+                findings.add(error("runtime-pom-size", "pom.xml",
+                        "Maven POM is too large for deterministic inspection"));
+                return;
+            }
+            MavenModel model = parseMavenModel(pom, "main".equals(runtime));
+            validateMavenExecutionPolicy(model, findings);
+            boolean hasSpring = model.hasFamily("org.springframework.boot")
+                    || model.hasFamily("org.apache.camel.springboot");
+            boolean hasQuarkus = model.hasFamily("io.quarkus")
+                    || model.hasFamily("io.quarkus.platform")
+                    || model.hasFamily("org.apache.camel.quarkus");
+            switch (runtime) {
+                case "main" -> validateMainPom(model, camelVersion, hasSpring, hasQuarkus, findings);
+                case "spring-boot" -> validateSpringBootPom(
+                        model, camelVersion, platformVersion, springBootVersion, hasQuarkus, findings);
+                case "quarkus" -> validateQuarkusPom(model, platformVersion, hasSpring, findings);
+                default -> throw new IllegalStateException("Unexpected runtime: " + runtime);
+            }
+        } catch (ExactMainPomPolicyException e) {
+            findings.add(error("runtime-pom-policy", "pom.xml", e.getMessage()));
+        } catch (IOException | RuntimeException e) {
+            findings.add(error("runtime-pom-parse", "pom.xml",
+                    "Could not securely parse Maven POM: " + safeMessage(e)));
+        }
+    }
+
+    private static void validateMavenProjectHooks(Path root, List<ArtifactFinding> findings) {
+        for (String relative : List.of(
+                ".mvn/extensions.xml", ".mvn/maven.config", ".mvn/jvm.config")) {
+            Path path = root.resolve(relative);
+            if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+                findings.add(error("runtime-maven-hook", relative,
+                        "Ship protocol v1 forbids project-controlled Maven startup hooks"));
+            }
+        }
+    }
+
+    private static void validateMavenExecutionPolicy(
+            MavenModel model, List<ArtifactFinding> findings) {
+        if (model.parent() != null) {
+            findings.add(error("runtime-pom-parent", "pom.xml",
+                    "Ship protocol v1 requires a self-contained POM without inherited build behavior"));
+        }
+        if (model.packaging() != null && !"jar".equals(model.packaging())) {
+            findings.add(error("runtime-pom-packaging", "pom.xml",
+                    "Ship protocol v1 requires jar packaging; found " + model.packaging()));
+        }
+        if (model.hasProfiles() || model.hasModules() || model.hasRepositories()
+                || model.hasPluginRepositories() || model.hasBuildExtensions()
+                || model.hasPluginManagement()) {
+            findings.add(error("runtime-pom-dynamic-model", "pom.xml",
+                    "Ship protocol v1 forbids profiles, modules, custom repositories, build extensions, "
+                                                                       + "and plugin management because they escape deterministic inspection"));
+        }
+        for (MavenCoordinate plugin : model.plugins()) {
+            String coordinate = plugin.groupId() + ':' + plugin.artifactId();
+            if (!APPROVED_BUILD_PLUGINS.contains(coordinate)) {
+                findings.add(error("runtime-pom-plugin", "pom.xml",
+                        "Ship protocol v1 does not approve build plugin " + coordinate));
+            }
+        }
+        if (model.enabledTestSkipControl() != null) {
+            findings.add(error("runtime-pom-test-skip", "pom.xml",
+                    "Maven test execution is disabled by " + model.enabledTestSkipControl()));
+        }
+    }
+
+    private static void validateMainPom(
+            MavenModel model,
+            String camelVersion,
+            boolean hasSpring,
+            boolean hasQuarkus,
+            List<ArtifactFinding> findings) {
+        if (hasSpring || hasQuarkus) {
+            findings.add(error("runtime-pom-mismatch", "pom.xml",
+                    "Camel Main runtime cannot use Spring Boot or Quarkus runtime coordinates"));
+        }
+        MavenCoordinate main = requireRuntimeDependency(
+                model, "org.apache.camel", "camel-main", "Camel Main", findings);
+        MavenCoordinate bom = findImportedBom(model, "org.apache.camel", "camel-bom");
+        if (bom != null) {
+            validateVersion(bom, camelVersion, "Camel BOM", findings);
+        }
+        if (main != null && main.version() == null && bom == null) {
+            findings.add(error("runtime-pom-version", "pom.xml",
+                    "Camel Main version is neither explicit nor managed by org.apache.camel:camel-bom"));
+        }
+        validateExplicitDependencyVersions(
+                model, "org.apache.camel", camelVersion, "Camel dependency", false, findings);
+    }
+
+    private static void validateSpringBootPom(
+            MavenModel model,
+            String camelVersion,
+            String platformVersion,
+            String springBootVersion,
+            boolean hasQuarkus,
+            List<ArtifactFinding> findings) {
+        if (hasQuarkus) {
+            findings.add(error("runtime-pom-mismatch", "pom.xml",
+                    "Spring Boot runtime cannot use Quarkus runtime coordinates"));
+        }
+        if (model.parent() != null
+                && model.parent().matches("org.springframework.boot", "spring-boot-starter-parent")) {
+            findings.add(error("runtime-pom-coordinate", "pom.xml",
+                    "Spring Boot parent POM is forbidden; use the approved Camel Spring Boot BOM"));
+        }
+        requireImportedBom(model, "org.apache.camel.springboot", "camel-spring-boot-bom",
+                platformVersion, "Camel Spring Boot BOM", findings);
+        requireRuntimeDependency(model, "org.springframework.boot", "spring-boot-starter",
+                "Spring Boot starter", findings);
+        requireRuntimeDependency(model, "org.apache.camel.springboot", "camel-spring-boot-starter",
+                "Camel Spring Boot starter", findings);
+        MavenCoordinate plugin = requirePlugin(
+                model, "org.springframework.boot", "spring-boot-maven-plugin",
+                "Spring Boot Maven plugin", findings);
+        if (plugin != null) {
+            validateVersion(plugin, springBootVersion, "Spring Boot Maven plugin", findings);
+        }
+        validateExplicitDependencyVersions(
+                model, "org.apache.camel.springboot", camelVersion, "Camel Spring Boot dependency", false, findings);
+        validateExplicitDependencyVersions(
+                model, "org.springframework.boot", springBootVersion, "Spring Boot dependency", false, findings);
+    }
+
+    private static void validateQuarkusPom(
+            MavenModel model,
+            String platformVersion,
+            boolean hasSpring,
+            List<ArtifactFinding> findings) {
+        if (hasSpring) {
+            findings.add(error("runtime-pom-mismatch", "pom.xml",
+                    "Quarkus runtime cannot use Spring Boot runtime coordinates"));
+        }
+        requireImportedBom(model, "io.quarkus.platform", "quarkus-bom",
+                platformVersion, "Quarkus platform BOM", findings);
+        requireImportedBom(model, "io.quarkus.platform", "quarkus-camel-bom",
+                platformVersion, "Camel Quarkus platform BOM", findings);
+        boolean camelExtension = model.dependencies().stream()
+                .anyMatch(coordinate -> "org.apache.camel.quarkus".equals(coordinate.groupId())
+                        && coordinate.artifactId() != null
+                        && coordinate.artifactId().startsWith("camel-quarkus-")
+                        && coordinate.runtimeScoped());
+        if (!camelExtension) {
+            findings.add(error("runtime-pom-coordinate", "pom.xml",
+                    "Quarkus runtime requires at least one org.apache.camel.quarkus:camel-quarkus-* dependency"));
+        }
+        MavenCoordinate plugin = requirePlugin(
+                model, "io.quarkus", "quarkus-maven-plugin", "Quarkus Maven plugin", findings);
+        if (plugin != null) {
+            validateVersion(plugin, platformVersion, "Quarkus Maven plugin", findings);
+        }
+        validateExplicitDependencyVersions(
+                model, "org.apache.camel.quarkus", null, "Camel Quarkus dependency", true, findings);
+        validateExplicitDependencyVersions(
+                model, "io.quarkus", null, "Quarkus dependency", true, findings);
+    }
+
+    private static MavenCoordinate requireRuntimeDependency(
+            MavenModel model,
+            String groupId,
+            String artifactId,
+            String label,
+            List<ArtifactFinding> findings) {
+        MavenCoordinate coordinate = model.dependencies().stream()
+                .filter(candidate -> candidate.matches(groupId, artifactId) && candidate.runtimeScoped())
+                .findFirst()
+                .orElse(null);
+        if (coordinate == null) {
+            findings.add(error("runtime-pom-coordinate", "pom.xml",
+                    label + " dependency " + groupId + ":" + artifactId + " is required"));
+        }
+        return coordinate;
+    }
+
+    private static MavenCoordinate requirePlugin(
+            MavenModel model,
+            String groupId,
+            String artifactId,
+            String label,
+            List<ArtifactFinding> findings) {
+        MavenCoordinate coordinate = model.plugins().stream()
+                .filter(candidate -> candidate.matches(groupId, artifactId))
+                .findFirst()
+                .orElse(null);
+        if (coordinate == null) {
+            findings.add(error("runtime-pom-coordinate", "pom.xml",
+                    label + " coordinate " + groupId + ":" + artifactId + " is required"));
+        }
+        return coordinate;
+    }
+
+    private static void requireImportedBom(
+            MavenModel model,
+            String groupId,
+            String artifactId,
+            String expectedVersion,
+            String label,
+            List<ArtifactFinding> findings) {
+        MavenCoordinate coordinate = findImportedBom(model, groupId, artifactId);
+        if (coordinate == null) {
+            findings.add(error("runtime-pom-coordinate", "pom.xml",
+                    label + " import " + groupId + ":" + artifactId + " is required"));
+            return;
+        }
+        validateVersion(coordinate, expectedVersion, label, findings);
+    }
+
+    private static MavenCoordinate findImportedBom(MavenModel model, String groupId, String artifactId) {
+        return model.managedDependencies().stream()
+                .filter(candidate -> candidate.matches(groupId, artifactId)
+                        && "pom".equals(candidate.type())
+                        && "import".equals(candidate.scope()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static void validateVersion(
+            MavenCoordinate coordinate,
+            String expectedVersion,
+            String label,
+            List<ArtifactFinding> findings) {
+        if (expectedVersion == null || !expectedVersion.equals(coordinate.version())) {
+            findings.add(error("runtime-pom-version", "pom.xml",
+                    label + " version " + coordinate.version()
+                                                                 + " differs from approved version "
+                                                                 + expectedVersion));
+        }
+    }
+
+    private static void validateExplicitDependencyVersions(
+            MavenModel model,
+            String groupId,
+            String expectedVersion,
+            String label,
+            boolean mustBeManaged,
+            List<ArtifactFinding> findings) {
+        model.dependencies().stream()
+                .filter(coordinate -> groupId.equals(coordinate.groupId()) && coordinate.version() != null)
+                .forEach(coordinate -> {
+                    if (mustBeManaged) {
+                        findings.add(error("runtime-pom-version", "pom.xml",
+                                label + " " + coordinate.groupId() + ':' + coordinate.artifactId()
+                                                                             + " must omit its version and use the approved platform BOM"));
+                    } else if (!java.util.Objects.equals(expectedVersion, coordinate.version())) {
+                        findings.add(error("runtime-pom-version", "pom.xml",
+                                label + " " + coordinate.groupId() + ':' + coordinate.artifactId()
+                                                                             + " version " + coordinate.version()
+                                                                             + " differs from approved version "
+                                                                             + expectedVersion));
+                    }
+                });
+    }
+
+    private static MavenModel parseMavenModel(Path pom, boolean exactMain) throws IOException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        try {
+            factory.setNamespaceAware(true);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            var builder = factory.newDocumentBuilder();
+            builder.setErrorHandler(new StrictXmlErrorHandler());
+            byte[] source = readPomBytes(pom);
+            Document document = builder.parse(new ByteArrayInputStream(source));
+            Element project = document.getDocumentElement();
+            if (exactMain) {
+                try {
+                    validateExactMainPomGrammar(document, project);
+                } catch (IOException e) {
+                    throw new ExactMainPomPolicyException(e.getMessage(), e);
+                }
+            }
+            String namespace = project.getNamespaceURI();
+            if (!"project".equals(localName(project))
+                    || (namespace != null && !namespace.isBlank() && !MAVEN_NAMESPACE.equals(namespace))) {
+                throw new IOException("Document root is not a Maven project");
+            }
+            for (Node node = project; node != null; node = nextNode(project, node)) {
+                if (node instanceof Element element) {
+                    String elementNamespace = element.getNamespaceURI();
+                    if (elementNamespace != null && !elementNamespace.isBlank()
+                            && !MAVEN_NAMESPACE.equals(elementNamespace)) {
+                        throw new IOException("Maven POM contains a foreign XML namespace");
+                    }
+                }
+            }
+
+            Map<String, String> properties = readMavenProperties(project);
+            Element parentElement = child(project, "parent");
+            String parentGroup = childText(parentElement, "groupId");
+            String parentArtifact = childText(parentElement, "artifactId");
+            String parentVersion = childText(parentElement, "version");
+            String projectGroup = childText(project, "groupId");
+            if (projectGroup == null) {
+                projectGroup = parentGroup;
+            }
+            String projectVersion = childText(project, "version");
+            if (projectVersion == null) {
+                projectVersion = parentVersion;
+            }
+            putMavenBuiltin(properties, "project.groupId", projectGroup);
+            putMavenBuiltin(properties, "pom.groupId", projectGroup);
+            putMavenBuiltin(properties, "project.artifactId", childText(project, "artifactId"));
+            putMavenBuiltin(properties, "pom.artifactId", childText(project, "artifactId"));
+            putMavenBuiltin(properties, "project.version", projectVersion);
+            putMavenBuiltin(properties, "pom.version", projectVersion);
+            putMavenBuiltin(properties, "project.parent.groupId", parentGroup);
+            putMavenBuiltin(properties, "project.parent.artifactId", parentArtifact);
+            putMavenBuiltin(properties, "project.parent.version", parentVersion);
+
+            MavenCoordinate parent = parentElement == null ? null : coordinate(parentElement, properties, false);
+            List<MavenCoordinate> dependencies = coordinates(child(project, "dependencies"), properties, "dependency");
+            Element dependencyManagement = child(project, "dependencyManagement");
+            List<MavenCoordinate> managed = coordinates(
+                    child(dependencyManagement, "dependencies"), properties, "dependency");
+            Element build = child(project, "build");
+            List<MavenCoordinate> plugins = coordinates(child(build, "plugins"), properties, "plugin");
+            rejectDuplicateCoordinates(dependencies, "dependencies");
+            rejectDuplicateCoordinates(managed, "managed dependencies");
+            rejectDuplicateCoordinates(plugins, "plugins");
+            return new MavenModel(
+                    dependencies,
+                    managed,
+                    plugins,
+                    parent,
+                    resolveMavenValue(childText(project, "packaging"), properties),
+                    child(project, "properties") != null,
+                    dependencyManagement != null,
+                    build != null,
+                    child(project, "profiles") != null,
+                    child(project, "modules") != null,
+                    child(project, "repositories") != null,
+                    child(project, "pluginRepositories") != null,
+                    child(build, "extensions") != null,
+                    child(build, "pluginManagement") != null,
+                    enabledTestSkipControl(project, properties),
+                    digest(source));
+        } catch (ParserConfigurationException | SAXException | IllegalArgumentException e) {
+            throw new IOException(safeMessage(e), e);
+        }
+    }
+
+    private static byte[] readPomBytes(Path pom) throws IOException {
+        Path parent = pom.getParent();
+        Path name = pom.getFileName();
+        if (parent == null || name == null) {
+            throw new IOException("Maven POM has no secure parent directory");
+        }
+        return ProjectEvidenceFiles.readMaterial(
+                parent, name.toString(), Math.toIntExact(MAX_POM_INSPECTION_BYTES));
+    }
+
+    private static void validateExactMainPomGrammar(Document document, Element project) throws IOException {
+        requireDocumentStructure(document, project);
+        requireDefaultMavenElement(project, true);
+
+        Map<String, Element> root = exactChildren(project, Set.of(
+                "modelVersion", "groupId", "artifactId", "version", "packaging", "dependencies"));
+        requireLiteral(root, "modelVersion", "4.0.0");
+        requireSafeLiteral(root, "groupId", "project groupId");
+        requireSafeLiteral(root, "artifactId", "project artifactId");
+        requireSafeLiteral(root, "version", "project version");
+        if (root.containsKey("packaging")) {
+            requireLiteral(root, "packaging", "jar");
+        }
+
+        Element dependencies = requireElement(root, "dependencies");
+        requireDefaultMavenElement(dependencies, false);
+        int count = 0;
+        for (Node node = dependencies.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node.getNodeType() == Node.TEXT_NODE && node.getTextContent().isBlank()) {
+                continue;
+            }
+            if (!(node instanceof Element dependency) || !"dependency".equals(localName(dependency))) {
+                throw new IOException("Exact Main POM dependencies may contain only dependency elements");
+            }
+            validateExactMainDependency(dependency);
+            count++;
+        }
+        if (count == 0) {
+            throw new IOException("Exact Main POM dependencies must not be empty");
+        }
+    }
+
+    private static void requireDocumentStructure(Document document, Element project) throws IOException {
+        if (project == null) {
+            throw new IOException("Exact Main POM is missing its project root");
+        }
+        for (Node node = document.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node == project || node.getNodeType() == Node.TEXT_NODE && node.getTextContent().isBlank()) {
+                continue;
+            }
+            throw new IOException("Exact Main POM forbids comments, processing instructions, and extra roots");
+        }
+    }
+
+    private static void validateExactMainDependency(Element dependency) throws IOException {
+        requireDefaultMavenElement(dependency, false);
+        Map<String, Element> fields = exactChildren(
+                dependency, Set.of("groupId", "artifactId", "version", "type", "scope"));
+        requireSafeLiteral(fields, "groupId", "dependency groupId");
+        requireSafeLiteral(fields, "artifactId", "dependency artifactId");
+        String version = requireSafeLiteral(fields, "version", "dependency version");
+        if (!exactRelease(version)) {
+            throw new IOException("Exact Main POM dependency versions must be fixed releases");
+        }
+        if (fields.containsKey("type")) {
+            requireLiteral(fields, "type", "jar");
+        }
+        if (fields.containsKey("scope")) {
+            String scope = literalText(fields.get("scope"), "dependency scope");
+            if (!Set.of("compile", "runtime").contains(scope)) {
+                throw new IOException("Exact Main POM dependency scope must be compile or runtime");
+            }
+        }
+    }
+
+    private static Map<String, Element> exactChildren(Element parent, Set<String> allowed) throws IOException {
+        Map<String, Element> children = new HashMap<>();
+        for (Node node = parent.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node.getNodeType() == Node.TEXT_NODE && node.getTextContent().isBlank()) {
+                continue;
+            }
+            if (!(node instanceof Element element)) {
+                throw new IOException("Exact Main POM forbids comments and processing instructions");
+            }
+            requireDefaultMavenElement(element, false);
+            String name = localName(element);
+            if (!allowed.contains(name)) {
+                throw new IOException("Exact Main POM contains unsupported element " + name);
+            }
+            if (children.putIfAbsent(name, element) != null) {
+                throw new IOException("Exact Main POM repeats element " + name);
+            }
+        }
+        return children;
+    }
+
+    private static void requireDefaultMavenElement(Element element, boolean root) throws IOException {
+        if (!MAVEN_NAMESPACE.equals(element.getNamespaceURI()) || element.getPrefix() != null) {
+            throw new IOException("Exact Main POM requires unprefixed elements in the Maven namespace");
+        }
+        int expectedAttributes = root ? 1 : 0;
+        if (element.getAttributes().getLength() != expectedAttributes
+                || root && !MAVEN_NAMESPACE.equals(element.getAttributeNS(
+                        XMLConstants.XMLNS_ATTRIBUTE_NS_URI, XMLConstants.XMLNS_ATTRIBUTE))) {
+            throw new IOException("Exact Main POM contains unsupported XML attributes or namespace declarations");
+        }
+    }
+
+    private static Element requireElement(Map<String, Element> elements, String name) throws IOException {
+        Element element = elements.get(name);
+        if (element == null) {
+            throw new IOException("Exact Main POM is missing " + name);
+        }
+        return element;
+    }
+
+    private static String requireSafeLiteral(
+            Map<String, Element> elements, String name, String label)
+            throws IOException {
+        String value = literalText(requireElement(elements, name), label);
+        if (!safeMavenToken(value)) {
+            throw new IOException("Exact Main POM " + label + " is not a safe literal");
+        }
+        return value;
+    }
+
+    private static void requireLiteral(
+            Map<String, Element> elements, String name, String expected)
+            throws IOException {
+        Element element = requireElement(elements, name);
+        String value = literalText(element, name);
+        if (!expected.equals(value)) {
+            throw new IOException("Exact Main POM " + name + " must be " + expected);
+        }
+    }
+
+    private static String literalText(Element element, String label) throws IOException {
+        requireDefaultMavenElement(element, false);
+        StringBuilder value = new StringBuilder();
+        for (Node node = element.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node.getNodeType() != Node.TEXT_NODE) {
+                throw new IOException("Exact Main POM " + label + " must be literal text");
+            }
+            value.append(node.getNodeValue());
+        }
+        String literal = value.toString().trim();
+        if (literal.isEmpty() || literal.contains("${")) {
+            throw new IOException("Exact Main POM " + label + " must be a non-empty literal");
+        }
+        return literal;
+    }
+
+    private static String enabledTestSkipControl(Element root, Map<String, String> properties) {
+        for (Node node = root; node != null; node = nextNode(root, node)) {
+            if (!(node instanceof Element element)) {
+                continue;
+            }
+            String name = localName(element).toLowerCase(Locale.ROOT);
+            if (!TEST_SKIP_CONTROLS.contains(name)) {
+                continue;
+            }
+            String value = element.getTextContent().trim();
+            try {
+                value = resolveMavenValue(value, properties);
+            } catch (IllegalArgumentException ignored) {
+                return localName(element) + " with an unresolved value";
+            }
+            if (value != null && Set.of("true", "yes", "on", "1")
+                    .contains(value.toLowerCase(Locale.ROOT))) {
+                return localName(element) + '=' + value;
+            }
+        }
+        return null;
+    }
+
+    private static Node nextNode(Node root, Node current) {
+        if (current.getFirstChild() != null) {
+            return current.getFirstChild();
+        }
+        Node node = current;
+        while (node != null && node != root && node.getNextSibling() == null) {
+            node = node.getParentNode();
+        }
+        return node == null || node == root ? null : node.getNextSibling();
+    }
+
+    private static Map<String, String> readMavenProperties(Element project) {
+        Map<String, String> properties = new HashMap<>();
+        Element propertiesElement = child(project, "properties");
+        if (propertiesElement == null) {
+            return properties;
+        }
+        for (Node node = propertiesElement.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node instanceof Element property) {
+                String name = localName(property);
+                if (properties.putIfAbsent(name, property.getTextContent().trim()) != null) {
+                    throw new IllegalArgumentException("Duplicate Maven property: " + name);
+                }
+            }
+        }
+        return properties;
+    }
+
+    private static void putMavenBuiltin(Map<String, String> properties, String key, String value) {
+        if (value != null) {
+            properties.put(key, value);
+        }
+    }
+
+    private static List<MavenCoordinate> coordinates(
+            Element container, Map<String, String> properties, String elementName) {
+        if (container == null) {
+            return List.of();
+        }
+        List<MavenCoordinate> result = new ArrayList<>();
+        for (Node node = container.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node instanceof Element element && elementName.equals(localName(element))) {
+                result.add(coordinate(element, properties, "plugin".equals(elementName)));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static MavenCoordinate coordinate(
+            Element element, Map<String, String> properties, boolean plugin) {
+        boolean expressionDeclared = element.getTextContent().contains("${");
+        String groupId = resolveMavenValue(childText(element, "groupId"), properties);
+        if (plugin && groupId == null) {
+            groupId = "org.apache.maven.plugins";
+        }
+        String artifactId = resolveMavenValue(childText(element, "artifactId"), properties);
+        if (groupId == null || artifactId == null) {
+            throw new IllegalArgumentException("Maven coordinate is missing groupId or artifactId");
+        }
+        return new MavenCoordinate(
+                groupId,
+                artifactId,
+                resolveMavenValue(childText(element, "version"), properties),
+                resolveMavenValue(childText(element, "type"), properties),
+                resolveMavenValue(childText(element, "scope"), properties),
+                resolveMavenValue(childText(element, "classifier"), properties),
+                child(element, "optional") != null,
+                child(element, "exclusions") != null,
+                expressionDeclared);
+    }
+
+    private static String resolveMavenValue(String value, Map<String, String> properties) {
+        return resolveMavenValue(value, properties, new LinkedHashSet<>(), 0);
+    }
+
+    private static String resolveMavenValue(
+            String value,
+            Map<String, String> properties,
+            Set<String> resolving,
+            int depth) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if (depth > 20) {
+            throw new IllegalArgumentException("Maven property expansion is too deep");
+        }
+        Matcher matcher = MAVEN_PROPERTY.matcher(value);
+        StringBuffer resolved = new StringBuffer();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String replacement = properties.get(key);
+            if (replacement == null) {
+                throw new IllegalArgumentException("Unresolved Maven property: " + key);
+            }
+            if (!resolving.add(key)) {
+                throw new IllegalArgumentException("Cyclic Maven property: " + key);
+            }
+            replacement = resolveMavenValue(replacement, properties, resolving, depth + 1);
+            resolving.remove(key);
+            if (replacement == null) {
+                throw new IllegalArgumentException("Empty Maven property: " + key);
+            }
+            matcher.appendReplacement(resolved, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(resolved);
+        String result = resolved.toString().trim();
+        if (MAVEN_PROPERTY.matcher(result).find()) {
+            return resolveMavenValue(result, properties, resolving, depth + 1);
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private static void rejectDuplicateCoordinates(List<MavenCoordinate> coordinates, String label) {
+        Set<String> seen = new HashSet<>();
+        for (MavenCoordinate coordinate : coordinates) {
+            String key = coordinate.groupId() + ':' + coordinate.artifactId();
+            if (!seen.add(key)) {
+                throw new IllegalArgumentException("Duplicate Maven " + label + " coordinate: " + key);
+            }
+        }
+    }
+
+    private static Element child(Element parent, String name) {
+        if (parent == null) {
+            return null;
+        }
+        Element result = null;
+        for (Node node = parent.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node instanceof Element element && name.equals(localName(element))) {
+                if (result != null) {
+                    throw new IllegalArgumentException("Duplicate Maven element: " + name);
+                }
+                result = element;
+            }
+        }
+        return result;
+    }
+
+    private static String childText(Element parent, String name) {
+        Element child = child(parent, name);
+        if (child == null) {
+            return null;
+        }
+        String value = child.getTextContent().trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    private static String localName(Node node) {
+        return node.getLocalName() == null ? node.getNodeName() : node.getLocalName();
+    }
+
+    private record MavenCoordinate(
+            String groupId,
+            String artifactId,
+            String version,
+            String type,
+            String scope,
+            String classifier,
+            boolean optionalDeclared,
+            boolean exclusionsDeclared,
+            boolean expressionDeclared) {
+
+        private boolean matches(String expectedGroupId, String expectedArtifactId) {
+            return expectedGroupId.equals(groupId) && expectedArtifactId.equals(artifactId);
+        }
+
+        private boolean runtimeScoped() {
+            return (scope == null || "compile".equals(scope) || "runtime".equals(scope))
+                    && (type == null || "jar".equals(type))
+                    && classifier == null;
+        }
+    }
+
+    private record MavenModel(
+            List<MavenCoordinate> dependencies,
+            List<MavenCoordinate> managedDependencies,
+            List<MavenCoordinate> plugins,
+            MavenCoordinate parent,
+            String packaging,
+            boolean hasProperties,
+            boolean hasDependencyManagement,
+            boolean hasBuild,
+            boolean hasProfiles,
+            boolean hasModules,
+            boolean hasRepositories,
+            boolean hasPluginRepositories,
+            boolean hasBuildExtensions,
+            boolean hasPluginManagement,
+            String enabledTestSkipControl,
+            String sourceDigest) {
+
+        private boolean hasFamily(String groupId) {
+            return java.util.stream.Stream.of(
+                    dependencies.stream(), managedDependencies.stream(), plugins.stream(),
+                    parent == null ? Stream.<MavenCoordinate>empty() : Stream.of(parent))
+                    .flatMap(stream -> stream)
+                    .anyMatch(coordinate -> groupId.equals(coordinate.groupId()));
+        }
+    }
+
+    private static final class UniqueProperties extends Properties {
+
+        @Override
+        public synchronized Object put(Object key, Object value) {
+            if (containsKey(key)) {
+                throw new IllegalArgumentException("Duplicate property: " + key);
+            }
+            return super.put(key, value);
+        }
+    }
+
+    private static final class StrictXmlErrorHandler implements ErrorHandler {
+
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+    }
+
+    private static final class ExactMainPomPolicyException extends IOException {
+
+        private ExactMainPomPolicyException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private static void validateApprovedPolicy(
+            ArtifactManifest manifest, RequirementsPolicy policy, List<ArtifactFinding> findings) {
+        requirePolicyEqual("runtime", normalizeRuntime(policy.runtime()), normalizeRuntime(manifest.runtime()),
+                findings);
+        requirePolicyEqual("camel-version", policy.camelVersion(), manifest.camelVersion(), findings);
+        requirePolicyEqual("platform-version", normalizeNullable(policy.platformVersion()),
+                normalizeNullable(manifest.platformVersion()), findings);
+        requirePolicyEqual("spring-boot-version", normalizeNullable(policy.springBootVersion()),
+                normalizeNullable(manifest.springBootVersion()), findings);
+        requirePolicyEqual("route-dsl", normalizeRuntime(policy.routeDsl()),
+                normalizeRuntime(manifest.routeDsl()), findings);
+        requirePolicyEqual("expression-language", normalizeRuntime(policy.expressionLanguage()),
+                normalizeRuntime(manifest.expressionLanguage()), findings);
+        requirePolicyEqual("citrus-version", policy.citrusVersion(), manifest.citrusVersion(), findings);
+        if (!policy.citrusDependencies().equals(manifest.citrusDependencies())) {
+            findings.add(error("approved-policy-citrus-dependencies", null,
+                    "Artifact Citrus dependencies differ from the approved requirements policy"));
+        }
+        String expectedJava = policy.javaPolicy() == null ? null : policy.javaPolicy().name();
+        String actualJava = manifest.javaPolicy() == null ? null : manifest.javaPolicy().name();
+        requirePolicyEqual("java-policy", expectedJava, actualJava, findings);
+        if (!new HashSet<>(policy.approvedJavaExceptions())
+                .equals(new HashSet<>(manifest.approvedJavaExceptions()))) {
+            findings.add(error("approved-policy-java-exceptions", null,
+                    "Artifact Java exceptions differ from the approved requirements policy"));
+        }
+        if (manifest.testsRequired() != policy.citrusTestsRequired()
+                || manifest.oneTestPerRoute() != policy.oneCitrusTestPerRoute()) {
+            findings.add(error("approved-policy-test-coverage", null,
+                    "Artifact test coverage flags differ from the approved requirements policy"));
+        }
+
+        Set<String> expectedRoutes = policy.routes().stream()
+                .filter(java.util.Objects::nonNull)
+                .map(route -> route.routeId() + "\0" + route.routePath())
+                .collect(java.util.stream.Collectors.toSet());
+        Set<String> actualRoutes = manifest.routes().stream()
+                .filter(java.util.Objects::nonNull)
+                .map(route -> route.routeId() + "\0" + route.path())
+                .collect(java.util.stream.Collectors.toSet());
+        if (!expectedRoutes.equals(actualRoutes)) {
+            findings.add(error("approved-policy-routes", null,
+                    "Artifact routes differ from the exact approved route contracts"));
+        }
+        Set<String> expectedTests = policy.routes().stream()
+                .filter(java.util.Objects::nonNull)
+                .map(route -> route.routeId() + "\0" + route.citrusTestPath())
+                .collect(java.util.stream.Collectors.toSet());
+        Set<String> actualTests = manifest.citrusTests().stream()
+                .filter(java.util.Objects::nonNull)
+                .map(test -> test.routeId() + "\0" + test.path())
+                .collect(java.util.stream.Collectors.toSet());
+        if (!expectedTests.equals(actualTests)) {
+            findings.add(error("approved-policy-citrus-tests", null,
+                    "Artifact Citrus tests differ from the exact approved route contracts"));
+        }
+    }
+
+    private static void requirePolicyEqual(
+            String field, String expected, String actual, List<ArtifactFinding> findings) {
+        if (!java.util.Objects.equals(expected, actual)) {
+            findings.add(error("approved-policy-" + field, null,
+                    "Artifact " + field + " " + actual + " differs from approved value " + expected));
+        }
+    }
+
+    private static String normalizeNullable(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static String normalizeRuntime(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean safeFileSegment(String value) {
+        return value != null && ROUTE_ID.matcher(value).matches();
+    }
+
+    private static boolean hasFileName(String value, String expected) {
+        try {
+            Path name = Path.of(value).getFileName();
+            return name != null && expected.equals(name.toString());
+        } catch (java.nio.file.InvalidPathException e) {
+            return false;
+        }
+    }
+
+    private static String safeMessage(Throwable failure) {
+        String message = failure.getMessage();
+        return message == null || message.isBlank() ? failure.getClass().getSimpleName() : message;
+    }
+
+    private static boolean isYaml(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        return name.endsWith(".yaml") || name.endsWith(".yml");
+    }
+
+    private static String digest(Path path) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (var input = Files.newInputStream(path)) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = input.read(buffer)) >= 0) {
+                    digest.update(buffer, 0, read);
+                }
+            }
+            return "sha256:" + java.util.HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static String digest(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return "sha256:" + java.util.HexFormat.of().formatHex(digest.digest(bytes));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static void requireText(String code, String value, List<ArtifactFinding> findings) {
+        if (isBlank(value)) {
+            findings.add(error(code + "-missing", null, code + " is required"));
+        }
+    }
+
+    private static ArtifactFinding error(String code, String path, String message) {
+        return new ArtifactFinding(Severity.ERROR, code, path, message);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/CitrusDependencyPolicy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/CitrusDependencyPolicy.java
@@ -1,0 +1,86 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/** Canonical, version-bound dependency contract for controller-run Citrus YAML tests. */
+public final class CitrusDependencyPolicy {
+
+    public static final String FORBIDDEN_JBANG_PROPERTIES_PATH = "test/jbang.properties";
+    public static final String FORBIDDEN_JBANG_ARTIFACT_KIND = "citrus-jbang-properties";
+
+    private static final int MAX_DEPENDENCIES = 64;
+    private static final Pattern VERSION = Pattern.compile(
+            "(?:0|[1-9][0-9]*)(?:\\.[0-9A-Za-z][0-9A-Za-z_-]*)+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?");
+    private static final Pattern ARTIFACT_ID = Pattern.compile("[a-z0-9][a-z0-9.-]*");
+
+    private CitrusDependencyPolicy() {
+    }
+
+    public static List<String> required(String citrusVersion) {
+        return List.of(
+                coordinate("citrus-camel", citrusVersion),
+                coordinate("citrus-junit-jupiter", citrusVersion),
+                coordinate("citrus-yaml", citrusVersion));
+    }
+
+    public static List<String> violations(String citrusVersion, List<String> dependencies) {
+        List<String> violations = new ArrayList<>();
+        if (!validVersion(citrusVersion)) {
+            violations.add("Citrus version must be an explicit immutable release version");
+            return List.copyOf(violations);
+        }
+        List<String> values = dependencies == null ? List.of() : dependencies;
+        if (values.size() > MAX_DEPENDENCIES) {
+            violations.add("Citrus dependency policy contains more than " + MAX_DEPENDENCIES + " coordinates");
+        }
+        boolean containsNull = values.stream().anyMatch(java.util.Objects::isNull);
+        if (containsNull) {
+            violations.add("Citrus dependencies must not contain null coordinates");
+        } else if (!values.equals(values.stream().sorted().toList())) {
+            violations.add("Citrus dependencies must be sorted canonically");
+        }
+        if (new HashSet<>(values).size() != values.size()) {
+            violations.add("Citrus dependencies must not contain duplicates");
+        }
+        for (String value : values) {
+            if (!validCoordinate(value, citrusVersion)) {
+                violations.add("Invalid or unpinned Citrus dependency: " + value);
+            }
+        }
+        List<String> required = required(citrusVersion);
+        if (!required.equals(values)) {
+            violations.add("Citrus dependencies must equal the controller-approved base coordinates: " + required);
+        }
+        return List.copyOf(violations);
+    }
+
+    public static boolean validVersion(String value) {
+        if (value == null || !VERSION.matcher(value).matches()) {
+            return false;
+        }
+        String normalized = value.toUpperCase(Locale.ROOT);
+        return !normalized.contains("SNAPSHOT")
+                && !normalized.equals("LATEST")
+                && !normalized.equals("RELEASE");
+    }
+
+    private static boolean validCoordinate(String value, String citrusVersion) {
+        if (value == null || value.indexOf(' ') >= 0 || value.indexOf('\t') >= 0
+                || value.indexOf('$') >= 0 || value.indexOf('[') >= 0 || value.indexOf('(') >= 0) {
+            return false;
+        }
+        String[] parts = value.split(":", -1);
+        return parts.length == 3
+                && "org.citrusframework".equals(parts[0])
+                && ARTIFACT_ID.matcher(parts[1]).matches()
+                && citrusVersion.equals(parts[2]);
+    }
+
+    private static String coordinate(String artifactId, String version) {
+        return "org.citrusframework:" + artifactId + ':' + version;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractor.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractor.java
@@ -45,10 +45,11 @@ public final class CamelYamlCatalogUsageExtractor {
     private static final Set<String> DOCUMENT_CONTAINERS = Set.of("routes");
     private static final Set<String> NESTED_EIPS = Set.of(
             "from", "when", "otherwise", "doCatch", "doFinally", "onException", "onCompletion", "onWhen");
-    private static final Set<String> ENDPOINT_EIPS = Set.of(
-            "from", "to", "toD", "enrich", "poll", "pollEnrich", "wireTap", "interceptSendToEndpoint");
-    private static final Set<String> OPAQUE_FIELDS = Set.of(
-            "parameters", "componentParameters", "endpointParameters", "additionalProperties");
+    private static final Set<String> PRIMARY_ENDPOINT_EIPS = Set.of(
+            "from", "to", "toD", "poll", "wireTap", "interceptFrom", "interceptSendToEndpoint");
+    private static final Set<String> UNPROVABLE_ENDPOINT_EIPS = Set.of(
+            "dynamicRouter", "enrich", "pollEnrich", "recipientList", "routingSlip", "serviceCall");
+    private static final Set<String> OPAQUE_FIELDS = Set.of("parameters", "additionalProperties");
     private static final Set<String> DATAFORMAT_STEP_OPTIONS = Set.of("id", "description", "disabled");
     private static final ObjectReader YAML = new com.fasterxml.jackson.databind.ObjectMapper(
             YAMLFactory.builder()
@@ -140,6 +141,11 @@ public final class CamelYamlCatalogUsageExtractor {
             Set<CatalogSubject> result,
             List<EndpointUsage> endpoints)
             throws IOException {
+        if (!stepMapping && operation != null && UNPROVABLE_ENDPOINT_EIPS.contains(operation)) {
+            throw new IOException(
+                    "Ship v1 cannot catalog-prove expression-driven or service-discovered endpoint EIP: "
+                                  + operation);
+        }
         if (node == null || node.isNull()) {
             return;
         }
@@ -150,11 +156,8 @@ public final class CamelYamlCatalogUsageExtractor {
             return;
         }
         if (node.isTextual()) {
-            if (operation != null && ENDPOINT_EIPS.contains(operation)) {
-                addComponent(node.asText(), index, result);
-                if (models != null) {
-                    endpoints.add(validateEndpoint(node.asText(), null, null, models));
-                }
+            if (isPrimaryEndpoint(operation)) {
+                addEndpoint(node.asText(), index, models, result, endpoints);
             } else if ("marshal".equals(operation) || "unmarshal".equals(operation)) {
                 addDataformat(node.asText(), index, result);
             }
@@ -167,7 +170,7 @@ public final class CamelYamlCatalogUsageExtractor {
         if (("marshal".equals(operation) || "unmarshal".equals(operation))) {
             requireSingleDataformat(node, index);
         }
-        if (models != null && !stepMapping && operation != null && ENDPOINT_EIPS.contains(operation)) {
+        if (models != null && !stepMapping && isPrimaryEndpoint(operation)) {
             endpoints.add(validateEndpointObject(node, models));
         }
         if (!stepMapping) {
@@ -210,6 +213,9 @@ public final class CamelYamlCatalogUsageExtractor {
             if (CatalogExpressionInventory.isRejectedAlias(rawKey)) {
                 throw new IOException("Ship v1 permits only the Simple expression language: " + rawKey);
             }
+            if (CatalogExpressionInventory.isNonExactAlias(rawKey)) {
+                throw new IOException("Camel expression uses an unsupported non-exact language alias: " + rawKey);
+            }
 
             String nestedEip = index.canonical(Kind.EIP, rawKey);
             if (nestedEip != null && NESTED_EIPS.contains(nestedEip)) {
@@ -218,8 +224,15 @@ public final class CamelYamlCatalogUsageExtractor {
                 continue;
             }
 
-            if ("uri".equals(rawKey) && value.isTextual()) {
+            if (isEndpointUriField(operation, rawKey)) {
+                if (!value.isTextual()) {
+                    throw new IOException("Endpoint URI field must contain one static textual URI: " + rawKey);
+                }
                 addComponent(value.asText(), index, result);
+                if (models != null
+                        && !("uri".equals(rawKey) && isPrimaryEndpoint(operation))) {
+                    endpoints.add(validateEndpoint(value.asText(), null, null, models));
+                }
                 continue;
             }
             if (operation != null && ("marshal".equals(operation) || "unmarshal".equals(operation))) {
@@ -244,8 +257,20 @@ public final class CamelYamlCatalogUsageExtractor {
             if (index.canonical(Kind.LANGUAGE, rawKey) != null) {
                 throw new IOException("Camel expression uses an unsupported or non-exact language alias: " + rawKey);
             }
-            visit(value, false, operation, index, models, result, endpoints);
+            visit(value, false, isPrimaryEndpoint(operation) ? null : operation,
+                    index, models, result, endpoints);
         }
+    }
+
+    private static boolean isPrimaryEndpoint(String operation) {
+        return operation != null && PRIMARY_ENDPOINT_EIPS.contains(operation);
+    }
+
+    private static boolean isEndpointUriField(String operation, String field) {
+        return "uri".equals(field)
+                || "deadLetterUri".equals(field)
+                || "interceptSendToEndpoint".equals(operation) && "afterUri".equals(field)
+                || "saga".equals(operation) && ("compensation".equals(field) || "completion".equals(field));
     }
 
     private static void requireSingleExpressionSelector(JsonNode node) throws IOException {
@@ -323,12 +348,7 @@ public final class CamelYamlCatalogUsageExtractor {
         if (uri == null || !uri.isTextual()) {
             throw new IOException("Endpoint definition must contain one static textual URI");
         }
-        Map<String, JsonNode> componentOptions = optionMap(node.get("componentParameters"), "componentParameters");
-        Map<String, JsonNode> endpointOptions = new HashMap<>();
-        mergeOptions(endpointOptions, optionMap(node.get("parameters"), "parameters"), "endpoint parameters");
-        mergeOptions(endpointOptions, optionMap(node.get("endpointParameters"), "endpointParameters"),
-                "endpoint parameters");
-        return validateEndpoint(uri.asText(), componentOptions, endpointOptions, models);
+        return validateEndpoint(uri.asText(), null, optionMap(node.get("parameters"), "parameters"), models);
     }
 
     private static Map<String, JsonNode> optionMap(JsonNode node, String name) throws IOException {
@@ -353,16 +373,6 @@ public final class CamelYamlCatalogUsageExtractor {
             }
         }
         return result;
-    }
-
-    private static void mergeOptions(
-            Map<String, JsonNode> target, Map<String, JsonNode> source, String label)
-            throws IOException {
-        for (Map.Entry<String, JsonNode> entry : source.entrySet()) {
-            if (target.putIfAbsent(entry.getKey(), entry.getValue()) != null) {
-                throw new IOException("Endpoint " + label + " contains duplicate option: " + entry.getKey());
-            }
-        }
     }
 
     private static EndpointUsage validateEndpoint(
@@ -544,6 +554,19 @@ public final class CamelYamlCatalogUsageExtractor {
             throw new IOException("Endpoint URI uses a component unavailable in the resolved catalog: " + scheme);
         }
         result.add(new CatalogSubject(Kind.COMPONENT, component));
+    }
+
+    private static void addEndpoint(
+            String uri,
+            CatalogIndex index,
+            ComponentModelIndex models,
+            Set<CatalogSubject> result,
+            List<EndpointUsage> endpoints)
+            throws IOException {
+        addComponent(uri, index, result);
+        if (models != null) {
+            endpoints.add(validateEndpoint(uri, null, null, models));
+        }
     }
 
     private static String safeMessage(Throwable error) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractor.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractor.java
@@ -46,7 +46,9 @@ public final class CamelYamlCatalogUsageExtractor {
     private static final Set<String> NESTED_EIPS = Set.of(
             "from", "when", "otherwise", "doCatch", "doFinally", "onException", "onCompletion", "onWhen");
     private static final Set<String> PRIMARY_ENDPOINT_EIPS = Set.of(
-            "from", "to", "toD", "poll", "wireTap", "interceptFrom", "interceptSendToEndpoint");
+            "from", "to", "toD", "poll", "wireTap");
+    private static final Set<String> ENDPOINT_SELECTOR_EIPS = Set.of(
+            "interceptFrom", "interceptSendToEndpoint");
     private static final Set<String> UNPROVABLE_ENDPOINT_EIPS = Set.of(
             "dynamicRouter", "enrich", "pollEnrich", "recipientList", "routingSlip", "serviceCall");
     private static final Set<String> OPAQUE_FIELDS = Set.of("parameters", "additionalProperties");
@@ -156,7 +158,9 @@ public final class CamelYamlCatalogUsageExtractor {
             return;
         }
         if (node.isTextual()) {
-            if (isPrimaryEndpoint(operation)) {
+            if (isEndpointSelector(operation)) {
+                requireStatic(node.asText(), operation + " URI pattern");
+            } else if (isPrimaryEndpoint(operation)) {
                 addEndpoint(node.asText(), index, models, result, endpoints);
             } else if ("marshal".equals(operation) || "unmarshal".equals(operation)) {
                 addDataformat(node.asText(), index, result);
@@ -169,6 +173,18 @@ public final class CamelYamlCatalogUsageExtractor {
 
         if (("marshal".equals(operation) || "unmarshal".equals(operation))) {
             requireSingleDataformat(node, index);
+        }
+        if (!stepMapping && isEndpointSelector(operation)) {
+            JsonNode uriPattern = node.get("uri");
+            if (uriPattern == null && "interceptSendToEndpoint".equals(operation)) {
+                throw new IOException("interceptSendToEndpoint requires a URI pattern");
+            }
+            if (uriPattern != null && !uriPattern.isTextual()) {
+                throw new IOException(operation + " URI pattern must be textual");
+            }
+            if (uriPattern != null) {
+                requireStatic(uriPattern.asText(), operation + " URI pattern");
+            }
         }
         if (models != null && !stepMapping && isPrimaryEndpoint(operation)) {
             endpoints.add(validateEndpointObject(node, models));
@@ -257,7 +273,8 @@ public final class CamelYamlCatalogUsageExtractor {
             if (index.canonical(Kind.LANGUAGE, rawKey) != null) {
                 throw new IOException("Camel expression uses an unsupported or non-exact language alias: " + rawKey);
             }
-            visit(value, false, isPrimaryEndpoint(operation) ? null : operation,
+            visit(value, false,
+                    isPrimaryEndpoint(operation) || isEndpointSelector(operation) ? null : operation,
                     index, models, result, endpoints);
         }
     }
@@ -266,8 +283,12 @@ public final class CamelYamlCatalogUsageExtractor {
         return operation != null && PRIMARY_ENDPOINT_EIPS.contains(operation);
     }
 
+    private static boolean isEndpointSelector(String operation) {
+        return operation != null && ENDPOINT_SELECTOR_EIPS.contains(operation);
+    }
+
     private static boolean isEndpointUriField(String operation, String field) {
-        return "uri".equals(field)
+        return "uri".equals(field) && !isEndpointSelector(operation)
                 || "deadLetterUri".equals(field)
                 || "interceptSendToEndpoint".equals(operation) && "afterUri".equals(field)
                 || "saga".equals(operation) && ("compensation".equals(field) || "completion".equals(field));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractor.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractor.java
@@ -1,0 +1,610 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.EndpointUsage;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/** Deterministically derives catalog usage from bounded Camel YAML DSL documents. */
+public final class CamelYamlCatalogUsageExtractor {
+
+    private static final long MAX_YAML_BYTES = 2L * 1024 * 1024;
+    private static final int MAX_USED_SUBJECTS = 512;
+    private static final int MAX_ENDPOINTS = 2_048;
+    private static final Pattern URI_SCHEME = Pattern.compile("[A-Za-z][A-Za-z0-9+.-]*");
+    private static final Pattern OPTION_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
+    private static final Pattern INTEGER = Pattern.compile("[+-]?[0-9]+");
+    private static final Pattern NUMBER = Pattern.compile("[+-]?(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)");
+    private static final Set<String> STEP_CONTAINERS = Set.of("steps", "outputs");
+    private static final Set<String> DOCUMENT_CONTAINERS = Set.of("routes");
+    private static final Set<String> NESTED_EIPS = Set.of(
+            "from", "when", "otherwise", "doCatch", "doFinally", "onException", "onCompletion", "onWhen");
+    private static final Set<String> ENDPOINT_EIPS = Set.of(
+            "from", "to", "toD", "enrich", "poll", "pollEnrich", "wireTap", "interceptSendToEndpoint");
+    private static final Set<String> OPAQUE_FIELDS = Set.of(
+            "parameters", "componentParameters", "endpointParameters", "additionalProperties");
+    private static final Set<String> DATAFORMAT_STEP_OPTIONS = Set.of("id", "description", "disabled");
+    private static final ObjectReader YAML = new com.fasterxml.jackson.databind.ObjectMapper(
+            YAMLFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(100)
+                            .maxStringLength((int) MAX_YAML_BYTES)
+                            .build())
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .reader()
+            .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+    public List<CatalogSubject> extract(Path yaml, Collection<CatalogSubject> available) throws IOException {
+        return extractBound(yaml, available).subjects();
+    }
+
+    /** Returns subjects and the digest of the exact bytes parsed for acceptance. */
+    public Extraction extractBound(Path yaml, Collection<CatalogSubject> available) throws IOException {
+        return extractBound(yaml, available, null);
+    }
+
+    /** Parse and validate every static endpoint against exact, controller-verified component metadata. */
+    public Extraction extractBound(
+            Path yaml,
+            Collection<CatalogSubject> available,
+            Collection<CatalogComponentModel> componentModels)
+            throws IOException {
+        Objects.requireNonNull(yaml, "yaml must not be null");
+        Path file = yaml.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Camel YAML must be a regular non-symbolic-link file: " + file);
+        }
+        long size = Files.size(file);
+        if (size <= 0 || size > MAX_YAML_BYTES) {
+            throw new IOException("Camel YAML has an unsafe size: " + size);
+        }
+        byte[] content;
+        try (InputStream input = Files.newInputStream(file)) {
+            content = input.readNBytes((int) MAX_YAML_BYTES + 1);
+            if (content.length > MAX_YAML_BYTES || input.read() != -1) {
+                throw new IOException("Camel YAML grew beyond the safe size while it was read");
+            }
+        }
+        if (content.length != size) {
+            throw new IOException("Camel YAML changed size while it was read");
+        }
+        JsonNode document;
+        try (ByteArrayInputStream input = new ByteArrayInputStream(content)) {
+            document = YAML.readTree(input);
+        } catch (RuntimeException e) {
+            throw new IOException("Could not parse Camel YAML: " + safeMessage(e), e);
+        }
+        if (document == null || (!document.isArray() && !document.isObject())) {
+            throw new IOException("Camel YAML must contain a mapping or sequence document");
+        }
+
+        CatalogIndex index = new CatalogIndex(available);
+        ComponentModelIndex models = componentModels == null ? null : new ComponentModelIndex(componentModels);
+        TreeSet<CatalogSubject> result = new TreeSet<>();
+        List<EndpointUsage> endpoints = new ArrayList<>();
+        visit(document, true, null, index, models, result, endpoints);
+        if (result.size() > MAX_USED_SUBJECTS) {
+            throw new IOException("Camel YAML uses too many catalog subjects: " + result.size());
+        }
+        if (endpoints.size() > MAX_ENDPOINTS) {
+            throw new IOException("Camel YAML declares too many endpoints: " + endpoints.size());
+        }
+        endpoints.sort(Comparator.comparing((EndpointUsage usage) -> usage.component().name())
+                .thenComparingInt(EndpointUsage::pathParameterCount)
+                .thenComparing(usage -> String.join("\u0000", usage.componentOptions()))
+                .thenComparing(usage -> String.join("\u0000", usage.endpointOptions())));
+        return new Extraction(ShipDigest.sha256(content), List.copyOf(result), List.copyOf(endpoints));
+    }
+
+    public record Extraction(String digest, List<CatalogSubject> subjects, List<EndpointUsage> endpoints) {
+
+        public Extraction {
+            subjects = subjects == null ? List.of() : List.copyOf(subjects);
+            endpoints = endpoints == null ? List.of() : List.copyOf(endpoints);
+        }
+    }
+
+    private static void visit(
+            JsonNode node,
+            boolean stepMapping,
+            String operation,
+            CatalogIndex index,
+            ComponentModelIndex models,
+            Set<CatalogSubject> result,
+            List<EndpointUsage> endpoints)
+            throws IOException {
+        if (node == null || node.isNull()) {
+            return;
+        }
+        if (node.isArray()) {
+            for (JsonNode child : node) {
+                visit(child, stepMapping, operation, index, models, result, endpoints);
+            }
+            return;
+        }
+        if (node.isTextual()) {
+            if (operation != null && ENDPOINT_EIPS.contains(operation)) {
+                addComponent(node.asText(), index, result);
+                if (models != null) {
+                    endpoints.add(validateEndpoint(node.asText(), null, null, models));
+                }
+            } else if ("marshal".equals(operation) || "unmarshal".equals(operation)) {
+                addDataformat(node.asText(), index, result);
+            }
+            return;
+        }
+        if (!node.isObject()) {
+            return;
+        }
+
+        if (("marshal".equals(operation) || "unmarshal".equals(operation))) {
+            requireSingleDataformat(node, index);
+        }
+        if (models != null && !stepMapping && operation != null && ENDPOINT_EIPS.contains(operation)) {
+            endpoints.add(validateEndpointObject(node, models));
+        }
+        if (!stepMapping) {
+            requireSingleExpressionSelector(node);
+        }
+
+        for (Map.Entry<String, JsonNode> field : node.properties()) {
+            String rawKey = field.getKey();
+            String key = index.canonical(Kind.EIP, rawKey);
+            JsonNode value = field.getValue();
+
+            if (stepMapping && key != null) {
+                result.add(new CatalogSubject(Kind.EIP, key));
+                visit(value, false, key, index, models, result, endpoints);
+                continue;
+            }
+            if (stepMapping && DOCUMENT_CONTAINERS.contains(rawKey)) {
+                visit(value, true, operation, index, models, result, endpoints);
+                continue;
+            }
+            if (stepMapping) {
+                throw new IOException("Unknown Camel YAML step or document definition: " + rawKey);
+            }
+            if (OPAQUE_FIELDS.contains(rawKey)) {
+                continue;
+            }
+            if (STEP_CONTAINERS.contains(rawKey)) {
+                visit(value, true, operation, index, models, result, endpoints);
+                continue;
+            }
+
+            if (CatalogExpressionInventory.SIMPLE.equals(rawKey)) {
+                addSimple(value, index, result);
+                continue;
+            }
+            if (CatalogExpressionInventory.GENERIC.equals(rawKey)) {
+                addGenericSimple(value, index, result);
+                continue;
+            }
+            if (CatalogExpressionInventory.isRejectedAlias(rawKey)) {
+                throw new IOException("Ship v1 permits only the Simple expression language: " + rawKey);
+            }
+
+            String nestedEip = index.canonical(Kind.EIP, rawKey);
+            if (nestedEip != null && NESTED_EIPS.contains(nestedEip)) {
+                result.add(new CatalogSubject(Kind.EIP, nestedEip));
+                visit(value, false, nestedEip, index, models, result, endpoints);
+                continue;
+            }
+
+            if ("uri".equals(rawKey) && value.isTextual()) {
+                addComponent(value.asText(), index, result);
+                continue;
+            }
+            if (operation != null && ("marshal".equals(operation) || "unmarshal".equals(operation))) {
+                String format = index.canonical(Kind.DATAFORMAT, rawKey);
+                if (format != null) {
+                    result.add(new CatalogSubject(Kind.DATAFORMAT, format));
+                    visit(value, false, null, index, models, result, endpoints);
+                    continue;
+                }
+                if (!DATAFORMAT_STEP_OPTIONS.contains(rawKey)) {
+                    throw new IOException("Unknown or dynamic Camel data format: " + rawKey);
+                }
+            }
+            if (("dataFormat".equals(rawKey) || "data-format".equals(rawKey)) && value.isTextual()) {
+                String format = index.canonical(Kind.DATAFORMAT, value.asText());
+                if (format == null) {
+                    throw new IOException("Unknown Camel data format: " + value.asText());
+                }
+                result.add(new CatalogSubject(Kind.DATAFORMAT, format));
+            }
+
+            if (index.canonical(Kind.LANGUAGE, rawKey) != null) {
+                throw new IOException("Camel expression uses an unsupported or non-exact language alias: " + rawKey);
+            }
+            visit(value, false, operation, index, models, result, endpoints);
+        }
+    }
+
+    private static void requireSingleExpressionSelector(JsonNode node) throws IOException {
+        int selected = 0;
+        for (Map.Entry<String, JsonNode> field : node.properties()) {
+            if (CatalogExpressionInventory.isKnownAlias(field.getKey())) {
+                selected++;
+            }
+        }
+        if (selected > 1) {
+            throw new IOException("Camel expression must select exactly one unambiguous language alias");
+        }
+    }
+
+    private static void addSimple(JsonNode value, CatalogIndex index, Set<CatalogSubject> result)
+            throws IOException {
+        if (value == null || !value.isTextual() || !CatalogExpressionInventory.isSafeSimple(value.asText())) {
+            throw new IOException("Only scalar allowlisted Simple expressions are supported");
+        }
+        addSimpleSubject(index, result);
+    }
+
+    private static void addGenericSimple(JsonNode value, CatalogIndex index, Set<CatalogSubject> result)
+            throws IOException {
+        if (value == null || !value.isObject() || value.size() != 2
+                || !value.has(CatalogExpressionInventory.GENERIC) || !value.has("expression")) {
+            throw new IOException(
+                    "Generic Camel language expressions must contain exactly language and expression");
+        }
+        JsonNode language = value.get(CatalogExpressionInventory.GENERIC);
+        JsonNode expression = value.get("expression");
+        if (!language.isTextual() || !CatalogExpressionInventory.SIMPLE.equals(language.asText())) {
+            throw new IOException("Ship v1 generic Camel expressions must select exactly Simple");
+        }
+        if (!expression.isTextual() || !CatalogExpressionInventory.isSafeSimple(expression.asText())) {
+            throw new IOException("Only scalar allowlisted Simple expressions are supported");
+        }
+        addSimpleSubject(index, result);
+    }
+
+    private static void addSimpleSubject(CatalogIndex index, Set<CatalogSubject> result) throws IOException {
+        String simple = index.canonical(Kind.LANGUAGE, CatalogExpressionInventory.SIMPLE);
+        if (!CatalogExpressionInventory.SIMPLE.equals(simple)) {
+            throw new IOException("Simple is unavailable in the resolved Camel catalog");
+        }
+        result.add(new CatalogSubject(Kind.LANGUAGE, simple));
+    }
+
+    private static void requireSingleDataformat(JsonNode node, CatalogIndex index) throws IOException {
+        int count = 0;
+        for (Map.Entry<String, JsonNode> field : node.properties()) {
+            if (index.canonical(Kind.DATAFORMAT, field.getKey()) != null) {
+                count++;
+            } else if (!DATAFORMAT_STEP_OPTIONS.contains(field.getKey())) {
+                throw new IOException("Unknown or dynamic Camel data format: " + field.getKey());
+            }
+        }
+        if (count != 1) {
+            throw new IOException("Camel marshal/unmarshal must select exactly one static data format");
+        }
+    }
+
+    private static void addDataformat(String value, CatalogIndex index, Set<CatalogSubject> result)
+            throws IOException {
+        String format = index.canonical(Kind.DATAFORMAT, value == null ? null : value.trim());
+        if (format == null) {
+            throw new IOException("Unknown or dynamic Camel data format: " + value);
+        }
+        result.add(new CatalogSubject(Kind.DATAFORMAT, format));
+    }
+
+    private static EndpointUsage validateEndpointObject(JsonNode node, ComponentModelIndex models)
+            throws IOException {
+        JsonNode uri = node.get("uri");
+        if (uri == null || !uri.isTextual()) {
+            throw new IOException("Endpoint definition must contain one static textual URI");
+        }
+        Map<String, JsonNode> componentOptions = optionMap(node.get("componentParameters"), "componentParameters");
+        Map<String, JsonNode> endpointOptions = new HashMap<>();
+        mergeOptions(endpointOptions, optionMap(node.get("parameters"), "parameters"), "endpoint parameters");
+        mergeOptions(endpointOptions, optionMap(node.get("endpointParameters"), "endpointParameters"),
+                "endpoint parameters");
+        return validateEndpoint(uri.asText(), componentOptions, endpointOptions, models);
+    }
+
+    private static Map<String, JsonNode> optionMap(JsonNode node, String name) throws IOException {
+        if (node == null) {
+            return Map.of();
+        }
+        if (!node.isObject() || node.size() > 512) {
+            throw new IOException("Endpoint " + name + " must be a bounded mapping");
+        }
+        Map<String, JsonNode> result = new HashMap<>();
+        for (Map.Entry<String, JsonNode> field : node.properties()) {
+            if (!OPTION_NAME.matcher(field.getKey()).matches()
+                    || field.getValue() == null
+                    || !(field.getValue().isTextual() || field.getValue().isNumber()
+                            || field.getValue().isBoolean())) {
+                throw new IOException(
+                        "Endpoint " + name + " contains a dynamic or unsafe option: "
+                                      + field.getKey());
+            }
+            if (result.putIfAbsent(field.getKey(), field.getValue()) != null) {
+                throw new IOException("Endpoint " + name + " contains duplicate options");
+            }
+        }
+        return result;
+    }
+
+    private static void mergeOptions(
+            Map<String, JsonNode> target, Map<String, JsonNode> source, String label)
+            throws IOException {
+        for (Map.Entry<String, JsonNode> entry : source.entrySet()) {
+            if (target.putIfAbsent(entry.getKey(), entry.getValue()) != null) {
+                throw new IOException("Endpoint " + label + " contains duplicate option: " + entry.getKey());
+            }
+        }
+    }
+
+    private static EndpointUsage validateEndpoint(
+            String rawUri,
+            Map<String, JsonNode> yamlComponentOptions,
+            Map<String, JsonNode> yamlEndpointOptions,
+            ComponentModelIndex models)
+            throws IOException {
+        String uri = rawUri == null ? "" : rawUri.trim();
+        requireStatic(uri, "endpoint URI");
+        int colon = uri.indexOf(':');
+        if (colon <= 0 || !URI_SCHEME.matcher(uri.substring(0, colon)).matches()) {
+            throw new IOException("Endpoint URI has no statically classifiable component scheme: " + uri);
+        }
+        CatalogComponentModel model = models.model(uri.substring(0, colon));
+        String remainder = uri.substring(colon + 1);
+        int queryIndex = remainder.indexOf('?');
+        String path = queryIndex < 0 ? remainder : remainder.substring(0, queryIndex);
+        String query = queryIndex < 0 ? null : remainder.substring(queryIndex + 1);
+        requireStatic(path, "endpoint path");
+        if (path.indexOf('#') >= 0 || path.indexOf('%') >= 0) {
+            throw new IOException("Endpoint path uses an unsupported encoded or fragment form");
+        }
+
+        List<CatalogComponentModel.Option> pathOptions = model.options().stream()
+                .filter(option -> option.scope() == CatalogComponentModel.Scope.ENDPOINT
+                        && option.kind() == CatalogComponentModel.Kind.PATH)
+                .sorted(Comparator.comparingInt(CatalogComponentModel.Option::index))
+                .toList();
+        if (pathOptions.size() > 1) {
+            throw new IOException(
+                    "Protocol v1 cannot prove multi-segment endpoint path syntax for "
+                                  + model.evidence().subject().name());
+        }
+        int pathCount = path.isEmpty() ? 0 : 1;
+        if (pathOptions.isEmpty() && pathCount != 0
+                || pathOptions.size() == 1 && pathOptions.get(0).required() && pathCount != 1) {
+            throw new IOException("Endpoint path does not satisfy catalog syntax " + model.syntax());
+        }
+        if (pathCount == 1) {
+            validateValue(pathOptions.get(0), path, "endpoint path");
+        }
+
+        Map<String, JsonNode> componentOptions = yamlComponentOptions == null
+                ? new HashMap<>() : new HashMap<>(yamlComponentOptions);
+        Map<String, JsonNode> endpointOptions = yamlEndpointOptions == null
+                ? new HashMap<>() : new HashMap<>(yamlEndpointOptions);
+        if (query != null) {
+            if (query.isEmpty()) {
+                throw new IOException("Endpoint URI contains an empty query");
+            }
+            for (String pair : query.split("&", -1)) {
+                int separator = pair.indexOf('=');
+                if (separator <= 0 || separator != pair.lastIndexOf('=')) {
+                    throw new IOException("Endpoint URI query option must use one key=value pair");
+                }
+                String name = pair.substring(0, separator);
+                String value = pair.substring(separator + 1);
+                if (!OPTION_NAME.matcher(name).matches() || name.indexOf('%') >= 0 || value.indexOf('%') >= 0) {
+                    throw new IOException("Endpoint URI query uses unsupported encoded option syntax");
+                }
+                if (endpointOptions.putIfAbsent(name, com.fasterxml.jackson.databind.node.TextNode.valueOf(value))
+                    != null) {
+                    throw new IOException("Endpoint declares duplicate option: " + name);
+                }
+            }
+        }
+
+        List<String> acceptedComponent = validateOptions(
+                componentOptions, model, CatalogComponentModel.Scope.COMPONENT);
+        List<String> acceptedEndpoint = validateOptions(
+                endpointOptions, model, CatalogComponentModel.Scope.ENDPOINT);
+        requireRequiredOptions(model, acceptedComponent, acceptedEndpoint);
+        return new EndpointUsage(
+                model.evidence().subject(), pathCount, acceptedComponent, acceptedEndpoint);
+    }
+
+    private static List<String> validateOptions(
+            Map<String, JsonNode> supplied,
+            CatalogComponentModel model,
+            CatalogComponentModel.Scope scope)
+            throws IOException {
+        Map<String, CatalogComponentModel.Option> exact = new HashMap<>();
+        List<CatalogComponentModel.Option> multiValue = new ArrayList<>();
+        for (CatalogComponentModel.Option option : model.options()) {
+            if (option.scope() != scope || option.kind() == CatalogComponentModel.Kind.PATH) {
+                continue;
+            }
+            exact.put(normalized(option.name()), option);
+            if (option.multiValue() && option.prefix() != null) {
+                multiValue.add(option);
+            }
+        }
+        TreeSet<String> accepted = new TreeSet<>();
+        Set<String> suppliedNames = new HashSet<>();
+        for (Map.Entry<String, JsonNode> entry : supplied.entrySet()) {
+            String normalized = normalized(entry.getKey());
+            if (!suppliedNames.add(normalized)) {
+                throw new IOException("Endpoint contains ambiguous duplicate option: " + entry.getKey());
+            }
+            CatalogComponentModel.Option option = exact.get(normalized);
+            if (option == null) {
+                option = multiValue.stream()
+                        .filter(candidate -> entry.getKey().startsWith(candidate.prefix())
+                                && entry.getKey().length() > candidate.prefix().length())
+                        .findFirst()
+                        .orElse(null);
+            }
+            if (option == null) {
+                throw new IOException(
+                        "Endpoint option is absent from frozen component metadata: "
+                                      + entry.getKey());
+            }
+            validateValue(option, entry.getValue().asText(), "endpoint option " + entry.getKey());
+            accepted.add(option.name());
+        }
+        return List.copyOf(accepted);
+    }
+
+    private static void requireRequiredOptions(
+            CatalogComponentModel model, List<String> component, List<String> endpoint)
+            throws IOException {
+        for (CatalogComponentModel.Option option : model.options()) {
+            if (!option.required() || option.kind() == CatalogComponentModel.Kind.PATH) {
+                continue;
+            }
+            List<String> observed = option.scope() == CatalogComponentModel.Scope.COMPONENT ? component : endpoint;
+            if (!observed.contains(option.name())) {
+                throw new IOException("Endpoint omits required catalog option: " + option.name());
+            }
+        }
+    }
+
+    private static void validateValue(CatalogComponentModel.Option option, String value, String label)
+            throws IOException {
+        requireStatic(value, label);
+        if (!option.enumValues().isEmpty() && !option.enumValues().contains(value)) {
+            throw new IOException(label + " is outside the catalog enum");
+        }
+        String type = option.type().toLowerCase(Locale.ROOT);
+        boolean valid = switch (type) {
+            case "string", "enum" -> true;
+            case "boolean" -> "true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value);
+            case "integer" -> INTEGER.matcher(value).matches();
+            case "number" -> NUMBER.matcher(value).matches();
+            case "object" -> option.multiValue() && option.prefix() != null;
+            default -> false;
+        };
+        if (!valid) {
+            throw new IOException(label + " cannot be proven against catalog type " + option.type());
+        }
+    }
+
+    private static void requireStatic(String value, String label) throws IOException {
+        if (value == null || value.length() > 16_384 || value.chars().anyMatch(Character::isISOControl)
+                || value.contains("{{") || value.contains("}}") || value.contains("${")
+                || value.contains("$simple") || value.contains("$bean")
+                || value.contains("#bean:") || value.contains("#class:") || value.contains("#type:")) {
+            throw new IOException("Dynamic or unsafe " + label + " cannot be catalog-proven");
+        }
+    }
+
+    private static String normalized(String value) {
+        return value.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+    }
+
+    private static void addComponent(String uri, CatalogIndex index, Set<CatalogSubject> result) throws IOException {
+        String value = uri == null ? "" : uri.trim();
+        int colon = value.indexOf(':');
+        if (colon <= 0) {
+            throw new IOException("Endpoint URI has no statically classifiable component scheme: " + value);
+        }
+        String scheme = value.substring(0, colon);
+        if (!URI_SCHEME.matcher(scheme).matches()) {
+            throw new IOException("Endpoint URI has a dynamic or unsafe component scheme: " + value);
+        }
+        String component = index.canonical(Kind.COMPONENT, scheme);
+        if (component == null) {
+            throw new IOException("Endpoint URI uses a component unavailable in the resolved catalog: " + scheme);
+        }
+        result.add(new CatalogSubject(Kind.COMPONENT, component));
+    }
+
+    private static String safeMessage(Throwable error) {
+        String message = error.getMessage();
+        return message == null || message.isBlank() ? error.getClass().getSimpleName() : message;
+    }
+
+    private static final class CatalogIndex {
+        private final Map<Kind, Map<String, String>> names = new EnumMap<>(Kind.class);
+
+        private CatalogIndex(Collection<CatalogSubject> available) {
+            Objects.requireNonNull(available, "available must not be null");
+            for (Kind kind : Kind.values()) {
+                names.put(kind, new HashMap<>());
+            }
+            for (CatalogSubject subject : available) {
+                Objects.requireNonNull(subject, "available must not contain null");
+                String lookup = lookup(subject.name());
+                String previous = names.get(subject.kind()).putIfAbsent(lookup, subject.name());
+                if (previous != null && !previous.equals(subject.name())) {
+                    throw new IllegalArgumentException(
+                            "Ambiguous catalog names after YAML normalization: " + previous + ", " + subject.name());
+                }
+            }
+        }
+
+        private String canonical(Kind kind, String value) {
+            return value == null ? null : names.get(kind).get(lookup(value));
+        }
+
+        private static String lookup(String value) {
+            return value.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+        }
+    }
+
+    private static final class ComponentModelIndex {
+        private final Map<String, CatalogComponentModel> models = new HashMap<>();
+
+        private ComponentModelIndex(Collection<CatalogComponentModel> componentModels) {
+            Objects.requireNonNull(componentModels, "componentModels must not be null");
+            if (componentModels.isEmpty() || componentModels.size() > MAX_USED_SUBJECTS) {
+                throw new IllegalArgumentException("Component metadata has an invalid size");
+            }
+            for (CatalogComponentModel model : componentModels) {
+                if (model == null || model.evidence() == null || model.evidence().subject() == null
+                        || model.evidence().subject().kind() != Kind.COMPONENT) {
+                    throw new IllegalArgumentException("Component metadata contains an invalid model");
+                }
+                String key = normalized(model.evidence().subject().name());
+                if (models.putIfAbsent(key, model) != null) {
+                    throw new IllegalArgumentException("Component metadata contains duplicate models");
+                }
+            }
+        }
+
+        private CatalogComponentModel model(String scheme) throws IOException {
+            CatalogComponentModel result = models.get(normalized(scheme));
+            if (result == null) {
+                throw new IOException("Endpoint component lacks frozen option metadata: " + scheme);
+            }
+            return result;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogEvidenceSet.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogEvidenceSet.java
@@ -67,7 +67,7 @@ public record CatalogEvidenceSet(
     }
 
     /** Creates a canonically ordered snapshot and derives its content digest. */
-    static CatalogEvidenceSet create(
+    public static CatalogEvidenceSet create(
             CatalogTarget target,
             MavenCoordinate platformCoordinate,
             List<ArtifactEvidence> artifacts,

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogExpressionInventory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogExpressionInventory.java
@@ -1,0 +1,63 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.Locale;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.ship.expression.ShipExpressionPolicy;
+
+/** Exact Camel YAML selector inventory layered over Ship's closed Simple syntax policy. */
+public final class CatalogExpressionInventory {
+
+    public static final String SIMPLE = "simple";
+    public static final String GENERIC = "language";
+    public static final String METHOD = "method";
+
+    private static final Set<String> YAML_ALIASES = Set.of(
+            "constant", "csimple", "datasonnet", "exchangeProperty", "groovy", "header",
+            "hl7terser", "java", "joor", "jq", "js", "jsonpath", GENERIC, METHOD, "mvel",
+            "ognl", "python", "ref", SIMPLE, "spel", "tokenize", "variable", "wasm", "xpath",
+            "xquery", "xtokenize");
+    private static final Set<String> CATALOG_LANGUAGES = Set.of(
+            "bean", "constant", "csimple", "datasonnet", "exchangeProperty", "file", "groovy",
+            "header", "hl7terser", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
+            "python", "ref", SIMPLE, "spel", "tokenize", "variable", "wasm", "xpath", "xquery",
+            "xtokenize");
+
+    private CatalogExpressionInventory() {
+    }
+
+    public static Set<String> yamlAliases() {
+        return YAML_ALIASES;
+    }
+
+    public static Set<String> catalogLanguages() {
+        return CATALOG_LANGUAGES;
+    }
+
+    public static boolean isKnownAlias(String value) {
+        return YAML_ALIASES.contains(value) || CATALOG_LANGUAGES.contains(value);
+    }
+
+    public static boolean isRejectedAlias(String value) {
+        return isKnownAlias(value) && !SIMPLE.equals(value) && !GENERIC.equals(value);
+    }
+
+    public static boolean isNonExactAlias(String value) {
+        if (value == null || isKnownAlias(value)) {
+            return false;
+        }
+        String normalized = normalize(value);
+        return YAML_ALIASES.stream().anyMatch(alias -> normalize(alias).equals(normalized))
+                || CATALOG_LANGUAGES.stream().anyMatch(alias -> normalize(alias).equals(normalized));
+    }
+
+    /** Syntax permission only; the exact runtime launcher remains the compatibility authority. */
+    public static boolean isSafeSimple(String value) {
+        return ShipExpressionPolicy.isSafeSimpleTemplate(value)
+                || ShipExpressionPolicy.isSafeSimplePredicate(value);
+    }
+
+    private static String normalize(String value) {
+        return value.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogUsageRecord.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogUsageRecord.java
@@ -1,0 +1,62 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.util.List;
+
+/** Controller-derived catalog usage for the exact accepted route bytes. */
+public record CatalogUsageRecord(
+        int schemaVersion,
+        String runId,
+        String catalogEvidenceDigest,
+        String artifactManifestDigest,
+        String candidateSnapshotDigest,
+        String candidateContentDigest,
+        String pomDigest,
+        String inventoryDigest,
+        List<RouteUsage> routes,
+        List<CatalogComponentModel> componentModels,
+        List<RuntimeDependency> runtimeDependencies,
+        CatalogEvidenceSet evidence) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public CatalogUsageRecord {
+        routes = routes == null ? List.of() : List.copyOf(routes);
+        componentModels = componentModels == null ? List.of() : List.copyOf(componentModels);
+        runtimeDependencies = runtimeDependencies == null ? List.of() : List.copyOf(runtimeDependencies);
+    }
+
+    /** Usage extracted from one exact manifest route. */
+    public record RouteUsage(
+            String routeId,
+            String path,
+            String routeDigest,
+            List<CatalogSubject> subjects,
+            List<EndpointUsage> endpoints) {
+
+        public RouteUsage {
+            subjects = subjects == null ? List.of() : List.copyOf(subjects);
+            endpoints = endpoints == null ? List.of() : List.copyOf(endpoints);
+        }
+    }
+
+    /** Static endpoint shape proven against one frozen component model. Values are deliberately not retained. */
+    public record EndpointUsage(
+            CatalogSubject component,
+            int pathParameterCount,
+            List<String> componentOptions,
+            List<String> endpointOptions) {
+
+        public EndpointUsage {
+            componentOptions = componentOptions == null ? List.of() : List.copyOf(componentOptions);
+            endpointOptions = endpointOptions == null ? List.of() : List.copyOf(endpointOptions);
+        }
+    }
+
+    /** Exact direct dependency root accepted from the candidate POM. */
+    public record RuntimeDependency(String groupId, String artifactId, String version, String scope) {
+
+        public String coordinate() {
+            return groupId + ':' + artifactId + ':' + version;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/BubblewrapSandboxLauncher.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/BubblewrapSandboxLauncher.java
@@ -17,6 +17,7 @@ final class BubblewrapSandboxLauncher implements EvidenceSandboxLauncher {
     static final String PROVIDER = "bubblewrap-linux-v1";
     static final String PROFILE_ID = PROVIDER
                                      + ":die-with-parent,new-session,clearenv,drop-all-caps,merged-usr"
+                                     + ":ro-system-lib,ro-system-lib64"
                                      + ":unshare-user,pid,ipc,uts,cgroup,net";
 
     private final Path configuredExecutable;
@@ -64,6 +65,7 @@ final class BubblewrapSandboxLauncher implements EvidenceSandboxLauncher {
                 "--disable-userns",
                 "--cap-drop", "ALL",
                 "--clearenv",
+                "--symlink", "usr/lib", "/lib",
                 "--symlink", "usr/lib64", "/lib64",
                 "--proc", "/proc",
                 "--dev", "/dev",
@@ -134,7 +136,9 @@ final class BubblewrapSandboxLauncher implements EvidenceSandboxLauncher {
     }
 
     private static void requireMergedUsr() throws IOException {
-        Map<Path, Path> required = Map.of(Path.of("/lib64"), Path.of("usr/lib64"));
+        Map<Path, Path> required = Map.of(
+                Path.of("/lib"), Path.of("usr/lib"),
+                Path.of("/lib64"), Path.of("usr/lib64"));
         for (Map.Entry<Path, Path> entry : required.entrySet().stream()
                 .sorted(Comparator.comparing(item -> item.getKey().toString())).toList()) {
             if (!Files.isSymbolicLink(entry.getKey())

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/BubblewrapSandboxLauncher.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/BubblewrapSandboxLauncher.java
@@ -1,0 +1,146 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** Linux bubblewrap launcher. There is deliberately no unsandboxed fallback. */
+final class BubblewrapSandboxLauncher implements EvidenceSandboxLauncher {
+
+    static final String PROVIDER = "bubblewrap-linux-v1";
+    static final String PROFILE_ID = PROVIDER
+                                     + ":die-with-parent,new-session,clearenv,drop-all-caps,merged-usr"
+                                     + ":unshare-user,pid,ipc,uts,cgroup,net";
+
+    private final Path configuredExecutable;
+
+    BubblewrapSandboxLauncher() {
+        this(configuredPath());
+    }
+
+    BubblewrapSandboxLauncher(Path configuredExecutable) {
+        this.configuredExecutable = configuredExecutable;
+    }
+
+    @Override
+    public Identity identity() throws IOException {
+        Path executable = requireExecutable(configuredExecutable, "bubblewrap");
+        requireMergedUsr();
+        return new Identity(PROVIDER, executable);
+    }
+
+    @Override
+    public String profileId() {
+        return PROFILE_ID;
+    }
+
+    @Override
+    public Process launch(Invocation invocation) throws IOException {
+        List<String> arguments = arguments(identity().executable(), invocation);
+        ProcessBuilder builder = new ProcessBuilder(arguments);
+        builder.environment().clear();
+        return builder.start();
+    }
+
+    static List<String> arguments(Path bubblewrap, Invocation invocation) {
+        List<String> arguments = new ArrayList<>();
+        arguments.add(bubblewrap.toString());
+        arguments.addAll(List.of(
+                "--die-with-parent",
+                "--new-session",
+                "--unshare-user",
+                "--unshare-pid",
+                "--unshare-ipc",
+                "--unshare-uts",
+                "--unshare-cgroup",
+                "--unshare-net",
+                "--disable-userns",
+                "--cap-drop", "ALL",
+                "--clearenv",
+                "--symlink", "usr/lib64", "/lib64",
+                "--proc", "/proc",
+                "--dev", "/dev",
+                "--tmpfs", "/run",
+                "--dir", "/etc",
+                "--dir", "/etc/ssl",
+                "--dir", "/etc/ssl/certs",
+                "--dir", "/etc/pki",
+                "--dir", "/etc/pki/tls",
+                "--dir", "/etc/pki/tls/certs",
+                "--dir", "/home",
+                "--dir", "/opt",
+                "--dir", "/opt/camel-kit",
+                "--dir", "/opt/camel-kit/bin"));
+        Set<String> existing = Set.of("/", "/dev", "/etc", "/home", "/opt", "/opt/camel-kit", "/proc", "/run");
+        TreeSet<String> parents = new TreeSet<>(
+                Comparator
+                        .comparingInt((String value) -> Path.of(value).getNameCount())
+                        .thenComparing(value -> value));
+        for (Mount mount : invocation.mounts()) {
+            Path parent = Path.of(mount.target()).getParent();
+            while (parent != null && !existing.contains(parent.toString())) {
+                parents.add(parent.toString());
+                parent = parent.getParent();
+            }
+        }
+        for (String parent : parents) {
+            arguments.add("--dir");
+            arguments.add(parent);
+        }
+        for (Mount mount : invocation.mounts()) {
+            arguments.add(mount.access() == Access.READ_ONLY ? "--ro-bind" : "--bind");
+            arguments.add(mount.source().toString());
+            arguments.add(mount.target());
+        }
+        invocation.environment().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    arguments.add("--setenv");
+                    arguments.add(entry.getKey());
+                    arguments.add(entry.getValue());
+                });
+        arguments.add("--chdir");
+        arguments.add(invocation.sandboxWorkingDirectory());
+        arguments.add("--");
+        arguments.addAll(invocation.arguments());
+        return List.copyOf(arguments);
+    }
+
+    private static Path configuredPath() {
+        String configured = System.getProperty("camel.kit.ship.bwrap");
+        if (configured != null && !configured.isBlank()) {
+            return Path.of(configured);
+        }
+        if (Files.exists(Path.of("/usr/bin/bwrap"), LinkOption.NOFOLLOW_LINKS)) {
+            return Path.of("/usr/bin/bwrap");
+        }
+        return Path.of("/bin/bwrap");
+    }
+
+    private static Path requireExecutable(Path path, String label) throws IOException {
+        if (path == null || !path.isAbsolute() || Files.isSymbolicLink(path)
+                || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isExecutable(path)) {
+            throw new IOException(label + " executable is unavailable or unsafe: " + path);
+        }
+        return path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static void requireMergedUsr() throws IOException {
+        Map<Path, Path> required = Map.of(Path.of("/lib64"), Path.of("usr/lib64"));
+        for (Map.Entry<Path, Path> entry : required.entrySet().stream()
+                .sorted(Comparator.comparing(item -> item.getKey().toString())).toList()) {
+            if (!Files.isSymbolicLink(entry.getKey())
+                    || !entry.getValue().equals(Files.readSymbolicLink(entry.getKey()))) {
+                throw new IOException("Ship evidence requires a merged-/usr Linux host: " + entry.getKey());
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/CommandEvidence.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/CommandEvidence.java
@@ -1,0 +1,72 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/** Content-addressed result of a controller-owned process execution. */
+public record CommandEvidence(
+        int schemaVersion,
+        String commandId,
+        SandboxIdentity sandbox,
+        String toolchainDigest,
+        String postToolchainDigest,
+        String toolchainSnapshot,
+        String toolchainSnapshotDigest,
+        String executable,
+        String executableDigest,
+        String postExecutableDigest,
+        String executableSnapshot,
+        String executableVersion,
+        List<String> arguments,
+        String workingDirectory,
+        Map<String, String> controlledEnvironment,
+        Instant startedAt,
+        Instant endedAt,
+        boolean launched,
+        boolean timedOut,
+        Integer exitCode,
+        String launchError,
+        String stdoutLog,
+        String stdoutDigest,
+        String stderrLog,
+        String stderrDigest,
+        List<String> inputDigests) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public CommandEvidence {
+        arguments = arguments == null ? List.of() : List.copyOf(arguments);
+        controlledEnvironment = controlledEnvironment == null
+                ? Map.of()
+                : Map.copyOf(controlledEnvironment);
+        inputDigests = inputDigests == null ? List.of() : List.copyOf(inputDigests);
+    }
+
+    public boolean passed() {
+        return launched && !timedOut && exitCode != null && exitCode == 0 && launchError == null
+                && sandbox != null && sandbox.intact()
+                && toolchainDigest != null && toolchainDigest.equals(postToolchainDigest)
+                && toolchainSnapshot != null && toolchainSnapshotDigest != null
+                && executableDigest != null && executableDigest.equals(postExecutableDigest)
+                && executableVersion != null && !executableVersion.isBlank()
+                && !executableVersion.startsWith("version-query-")
+                && !executableVersion.startsWith("exit-")
+                && !"unreported".equals(executableVersion);
+    }
+
+    /** Identity of the OS process/filesystem sandbox which launched the command. */
+    public record SandboxIdentity(
+            String provider,
+            String executable,
+            String executableDigest,
+            String postExecutableDigest,
+            String executableSnapshot,
+            String profileDigest) {
+
+        public boolean intact() {
+            return executableDigest != null && executableDigest.equals(postExecutableDigest)
+                    && profileDigest != null;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceCommand.java
@@ -1,0 +1,53 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/** Controller-selected command vector. Worker-provided shell strings are deliberately unsupported. */
+public record EvidenceCommand(
+        String id,
+        List<String> arguments,
+        List<String> versionArguments,
+        String relativeWorkingDirectory,
+        Duration timeout,
+        List<String> inputDigests,
+        Map<String, String> environment,
+        List<String> inheritedEnvironmentKeys,
+        String requiredToolchainDigest,
+        JvmPayloadRequest jvmPayload) {
+
+    public EvidenceCommand {
+        arguments = arguments == null ? List.of() : List.copyOf(arguments);
+        versionArguments = versionArguments == null ? List.of() : List.copyOf(versionArguments);
+        timeout = timeout == null ? Duration.ofMinutes(10) : timeout;
+        inputDigests = inputDigests == null ? List.of() : List.copyOf(inputDigests);
+        environment = environment == null ? Map.of() : Map.copyOf(environment);
+        inheritedEnvironmentKeys = inheritedEnvironmentKeys == null
+                ? List.of()
+                : List.copyOf(inheritedEnvironmentKeys);
+        if (id == null || !id.matches("[a-z0-9][a-z0-9-]*")) {
+            throw new IllegalArgumentException("Evidence command ID must be lowercase alphanumeric with hyphens");
+        }
+        if (arguments.isEmpty() || arguments.stream().anyMatch(value -> value == null || value.isEmpty())) {
+            throw new IllegalArgumentException("Evidence command requires a nonempty argument vector");
+        }
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("Evidence command timeout must be positive");
+        }
+        if (!inheritedEnvironmentKeys.isEmpty()) {
+            throw new IllegalArgumentException("Evidence commands cannot inherit the controller environment");
+        }
+        if (!environment.keySet().stream().allMatch(key -> "LANG".equals(key) || "LC_ALL".equals(key))) {
+            throw new IllegalArgumentException("Evidence commands may only select deterministic locale values");
+        }
+        if (requiredToolchainDigest != null
+                && !requiredToolchainDigest.matches("sha256:[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("Required toolchain digest must be a SHA-256 digest");
+        }
+        if (jvmPayload == null || !EvidenceRunner.JAVA_EXECUTABLE.equals(arguments.get(0))) {
+            throw new IllegalArgumentException(
+                    "Evidence commands require a controller-owned direct JVM payload");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -73,6 +74,7 @@ public final class EvidenceRunner {
     private final EvidenceSandboxLauncher sandboxLauncher;
     private final ToolchainResolver toolchains;
     private final JdkResolver jdks;
+    private final List<Mount> systemLibraries;
 
     public EvidenceRunner() {
         this(Clock.systemUTC(), new BubblewrapSandboxLauncher(), new ControllerToolchainResolver(),
@@ -97,10 +99,20 @@ public final class EvidenceRunner {
                    EvidenceSandboxLauncher sandboxLauncher,
                    ToolchainResolver toolchains,
                    JdkResolver jdks) {
+        this(clock, sandboxLauncher, toolchains, jdks, linuxSystemLibraries());
+    }
+
+    EvidenceRunner(
+                   Clock clock,
+                   EvidenceSandboxLauncher sandboxLauncher,
+                   ToolchainResolver toolchains,
+                   JdkResolver jdks,
+                   List<Mount> systemLibraries) {
         this.clock = Objects.requireNonNull(clock, "clock");
         this.sandboxLauncher = Objects.requireNonNull(sandboxLauncher, "sandboxLauncher");
         this.toolchains = Objects.requireNonNull(toolchains, "toolchains");
         this.jdks = Objects.requireNonNull(jdks, "jdks");
+        this.systemLibraries = List.copyOf(systemLibraries);
     }
 
     public static String expectedSandboxProfileDigest(EvidenceCommand command) throws IOException {
@@ -153,10 +165,13 @@ public final class EvidenceRunner {
         return Map.copyOf(environment);
     }
 
+    /**
+     * Runs one command with an atomically claimed, previously absent evidence directory. Each concurrent or sibling run
+     * must use its own directory.
+     */
     public CommandEvidence run(Path projectRoot, Path evidenceDirectory, EvidenceCommand command) throws IOException {
         Path candidate = realDirectory(projectRoot, "project root");
         Path logs = createEvidenceDirectory(evidenceDirectory);
-        pruneEphemeral(logs);
         Path workingDirectory = resolveWorkingDirectory(candidate, command.relativeWorkingDirectory());
         Path sandboxRoot = privateTempDirectory(logs, "." + command.id() + "-sandbox-");
         boolean handedToCollector = false;
@@ -183,7 +198,8 @@ public final class EvidenceRunner {
             String executableDigest = digest(executable);
             Map<String, String> controlledEnvironment = expectedEnvironment(command, jdk.digest());
             List<Mount> mounts = mounts(
-                    candidate, acceptedSnapshot, logs, privateHome, privateTemporaryDirectory, toolchain, jdk);
+                    candidate, acceptedSnapshot, logs, privateHome, privateTemporaryDirectory,
+                    toolchain, jdk, systemLibraries);
             String sandboxWorkingDirectory = sandboxWorkingDirectory(candidate, workingDirectory);
             Invocation invocation = new Invocation(
                     candidate,
@@ -205,17 +221,17 @@ public final class EvidenceRunner {
             boolean launched = false;
             boolean timedOut = false;
             Integer exitCode = null;
-            String launchError = versionResult.residualFailure();
+            String launchError = versionResult.failure();
             Process process = null;
             boolean processTreeReaped = versionResult.reaped();
-            boolean logPumpsQuiesced = !versionResult.reaped();
+            boolean logPumpsQuiesced = versionResult.failure() != null;
 
             ExecutorService pumps = Executors.newFixedThreadPool(2, runnable -> {
                 Thread thread = new Thread(runnable, "camel-kit-ship-evidence-log");
                 thread.setDaemon(true);
                 return thread;
             });
-            if (versionResult.reaped()) {
+            if (versionResult.failure() == null) {
                 try (FileChannel stdoutChannel = openLog(stdout.path());
                      FileChannel stderrChannel = openLog(stderr.path())) {
                     process = sandboxLauncher.launch(invocation);
@@ -369,40 +385,6 @@ public final class EvidenceRunner {
         }
     }
 
-    private static void pruneEphemeral(Path root) throws IOException {
-        List<String> directories = new ArrayList<>();
-        List<String> candidateFiles = new ArrayList<>();
-        Set<String> retainedSandboxes = new LinkedHashSet<>();
-        try (var entries = Files.newDirectoryStream(root)) {
-            for (Path entry : entries) {
-                String name = entry.getFileName().toString();
-                if (name.matches("\\.[a-z0-9][a-z0-9-]*-sandbox-[A-Za-z0-9._-]+")) {
-                    if (hasProcessRetentionMarker(entry)) {
-                        retainedSandboxes.add(name);
-                    } else {
-                        directories.add(name);
-                    }
-                } else if (name.matches("\\.[a-z0-9][a-z0-9-]*-.*\\.(stdout|stderr)\\.log")) {
-                    candidateFiles.add(name);
-                }
-            }
-        }
-        List<String> files = candidateFiles.stream()
-                .filter(file -> retainedSandboxes.stream().noneMatch(
-                        sandbox -> file.equals(sandbox + ".stdout.log")
-                                || file.equals(sandbox + ".stderr.log")))
-                .toList();
-        if (directories.isEmpty() && files.isEmpty()) {
-            return;
-        }
-        for (String file : files) {
-            deleteRelativeFile(root, file);
-        }
-        for (String directory : directories) {
-            deleteRelativeTree(root, directory);
-        }
-    }
-
     private static void deleteSandbox(Path root, Path sandbox, String commandId) throws IOException {
         Path normalizedRoot = root.toRealPath(LinkOption.NOFOLLOW_LINKS);
         Path normalizedSandbox = sandbox.toAbsolutePath().normalize();
@@ -514,39 +496,46 @@ public final class EvidenceRunner {
             Future<byte[]> errors = reader.submit(() -> readBounded(running.getErrorStream(), MAX_VERSION_BYTES));
             if (!waitForExecution(process, output, errors, VERSION_TIMEOUT)) {
                 boolean reaped = terminateAndWait(process);
-                return versionResult("version-query-timeout", reaped, process);
+                return failedVersionResult("version-query-timeout", reaped, process);
             }
             if (!terminateDescendantsAndWait(process)) {
-                return versionResult("version-query-descendants-not-reaped", false, process);
+                return failedVersionResult("version-query-descendants-not-reaped", false, process);
             }
             byte[] stdout = output.get(5, TimeUnit.SECONDS);
-            byte[] stderr = errors.get(5, TimeUnit.SECONDS);
-            ByteArrayOutputStream combined = new ByteArrayOutputStream(stdout.length + stderr.length);
-            combined.write(stdout);
-            combined.write(stderr);
-            String value = combined.toString(StandardCharsets.UTF_8).strip();
-            return new VersionResult(
-                    value.isEmpty() ? "exit-" + process.exitValue() : value.lines().findFirst().orElse("unreported"),
-                    true,
-                    null);
+            errors.get(5, TimeUnit.SECONDS);
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                return failedVersionResult("exit-" + exitCode, true, process);
+            }
+            String value = new String(stdout, StandardCharsets.UTF_8).strip();
+            if (value.isEmpty()) {
+                return failedVersionResult("unreported", true, process);
+            }
+            return new VersionResult(value.lines().findFirst().orElseThrow(), true, null);
         } catch (IOException e) {
             boolean reaped = process == null || terminateAndWait(process);
-            return versionResult("version-query-error:" + e.getClass().getSimpleName(), reaped, process);
+            return failedVersionResult("version-query-error:" + e.getClass().getSimpleName(), reaped, process);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             boolean reaped = process == null || terminateAndWait(process);
-            return versionResult("version-query-interrupted", reaped, process);
+            return failedVersionResult("version-query-interrupted", reaped, process);
         } catch (ExecutionException | TimeoutException e) {
             boolean reaped = process == null || terminateAndWait(process);
-            return versionResult("version-query-error:" + e.getClass().getSimpleName(), reaped, process);
+            return failedVersionResult("version-query-error:" + e.getClass().getSimpleName(), reaped, process);
         } finally {
             reader.shutdownNow();
         }
     }
 
-    private static VersionResult versionResult(String value, boolean reaped, Process process) {
+    private static VersionResult failedVersionResult(String value, boolean reaped, Process process) {
+        String failure = "Version query failed: " + value;
+        if (!reaped) {
+            failure = appendFailure(failure, residualProcessFailure("Version query", process));
+        }
         return new VersionResult(
-                value, reaped, reaped ? null : residualProcessFailure("Version query", process));
+                value,
+                reaped,
+                failure);
     }
 
     private static String residualProcessFailure(String phase, Process process) {
@@ -573,15 +562,18 @@ public final class EvidenceRunner {
             Path privateHome,
             Path privateTemporaryDirectory,
             ResolvedToolchain toolchain,
-            JdkIdentity jdk)
+            JdkIdentity jdk,
+            List<Mount> configuredSystemLibraries)
             throws IOException {
-        List<Mount> systemLibraries = List.of(
-                new Mount(
-                        realDirectory(Path.of("/usr/lib"), "system library root"),
-                        "/usr/lib", Access.READ_ONLY),
-                new Mount(
-                        realDirectory(Path.of("/usr/lib64"), "system library root"),
-                        "/usr/lib64", Access.READ_ONLY));
+        List<Mount> systemLibraries = new ArrayList<>();
+        for (Mount configured : configuredSystemLibraries) {
+            if (configured.access() != Access.READ_ONLY) {
+                throw new IOException("System library mounts must be read-only");
+            }
+            systemLibraries.add(new Mount(
+                    realDirectory(configured.source(), "system library root"),
+                    configured.target(), Access.READ_ONLY));
+        }
         for (Mount system : systemLibraries) {
             if (candidate.startsWith(system.source()) || evidenceDirectory.startsWith(system.source())) {
                 throw new IOException("Candidate and controller evidence must be outside system library mounts");
@@ -613,6 +605,12 @@ public final class EvidenceRunner {
             mounts.add(mount);
         }
         return List.copyOf(mounts);
+    }
+
+    private static List<Mount> linuxSystemLibraries() {
+        return List.of(
+                new Mount(Path.of("/usr/lib"), "/usr/lib", Access.READ_ONLY),
+                new Mount(Path.of("/usr/lib64"), "/usr/lib64", Access.READ_ONLY));
     }
 
     private static String sandboxWorkingDirectory(Path candidate, Path workingDirectory) {
@@ -666,8 +664,8 @@ public final class EvidenceRunner {
         }
         Path absolute = path.toAbsolutePath().normalize();
         Path current = absolute.getRoot();
-        for (Path part : absolute) {
-            current = current.resolve(part);
+        for (int index = 0; index < absolute.getNameCount() - 1; index++) {
+            current = current.resolve(absolute.getName(index));
             if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
                 Files.createDirectory(current);
             }
@@ -675,7 +673,13 @@ public final class EvidenceRunner {
                 throw new IOException("Evidence path contains an unsafe component: " + current);
             }
         }
-        return privateDirectory(absolute.toRealPath(LinkOption.NOFOLLOW_LINKS));
+        try {
+            Files.createDirectory(absolute, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rwx------")));
+        } catch (FileAlreadyExistsException e) {
+            throw new IOException("Evidence directory must be new and exclusive to one command run: " + absolute, e);
+        }
+        return privateDirectory(absolute);
     }
 
     private static Path privateTempDirectory(Path parent, String prefix) throws IOException {
@@ -1329,7 +1333,7 @@ public final class EvidenceRunner {
         }
     }
 
-    private record VersionResult(String value, boolean reaped, String residualFailure) {
+    private record VersionResult(String value, boolean reaped, String failure) {
     }
 
     private record LogFile(Path path, Object fileKey) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
@@ -1,0 +1,1332 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence.SandboxIdentity;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Access;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Invocation;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Mount;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+
+/** Runs controller-selected commands in a fail-closed OS filesystem/process sandbox. */
+public final class EvidenceRunner {
+
+    public static final String JAVA_EXECUTABLE = "/opt/camel-kit/jdk/bin/java";
+    public static final String SANDBOX_PROVIDER = BubblewrapSandboxLauncher.PROVIDER;
+
+    private static final String SANDBOX_WORKSPACE = "/workspace";
+    private static final String SANDBOX_HOME = "/home/camel-kit";
+    private static final String SANDBOX_TMP = "/tmp";
+    private static final String SANDBOX_JDK = "/opt/camel-kit/jdk";
+    private static final String PROCESS_RETENTION_MARKER = ".camel-kit-process-retention";
+    private static final String PROCESS_RETENTION_TEMPORARY = ".camel-kit-process-retention.tmp";
+    private static final String SANDBOX_PROFILE = BubblewrapSandboxLauncher.PROFILE_ID
+                                                  + ":ro-system-libraries-only:ro-accepted-snapshot=/workspace"
+                                                  + ":private-home=/home/camel-kit:private-tmp=/tmp"
+                                                  + ":exact-jdk-ro:payload-ro:no-network:no-dns:no-cache:no-controller-home:no-global-path";
+    private static final Duration VERSION_TIMEOUT = Duration.ofSeconds(15);
+    private static final int MAX_VERSION_BYTES = 64 * 1024;
+    private static final long MAX_LOG_BYTES = 64L * 1024 * 1024;
+    private static final Duration TERMINATION_GRACE = Duration.ofMillis(500);
+    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+
+    private final Clock clock;
+    private final EvidenceSandboxLauncher sandboxLauncher;
+    private final ToolchainResolver toolchains;
+    private final JdkResolver jdks;
+
+    public EvidenceRunner() {
+        this(Clock.systemUTC(), new BubblewrapSandboxLauncher(), new ControllerToolchainResolver(),
+             EvidenceRunner::freezeControllerJdk);
+    }
+
+    EvidenceRunner(Clock clock) {
+        this(clock, new BubblewrapSandboxLauncher(), new ControllerToolchainResolver(),
+             EvidenceRunner::freezeControllerJdk);
+    }
+
+    EvidenceRunner(Clock clock, EvidenceSandboxLauncher sandboxLauncher) {
+        this(clock, sandboxLauncher, new ControllerToolchainResolver(), EvidenceRunner::freezeControllerJdk);
+    }
+
+    EvidenceRunner(Clock clock, EvidenceSandboxLauncher sandboxLauncher, ToolchainResolver toolchains) {
+        this(clock, sandboxLauncher, toolchains, EvidenceRunner::freezeControllerJdk);
+    }
+
+    EvidenceRunner(
+                   Clock clock,
+                   EvidenceSandboxLauncher sandboxLauncher,
+                   ToolchainResolver toolchains,
+                   JdkResolver jdks) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.sandboxLauncher = Objects.requireNonNull(sandboxLauncher, "sandboxLauncher");
+        this.toolchains = Objects.requireNonNull(toolchains, "toolchains");
+        this.jdks = Objects.requireNonNull(jdks, "jdks");
+    }
+
+    public static String expectedSandboxProfileDigest(EvidenceCommand command) throws IOException {
+        return sandboxProfileDigest(command, expectedEnvironment(command));
+    }
+
+    /** Rebuilds a historical sandbox profile from its authenticated, recorded JDK identity. */
+    public static String expectedSandboxProfileDigest(EvidenceCommand command, String jdkDigest) {
+        return sandboxProfileDigest(command, expectedEnvironment(command, jdkDigest));
+    }
+
+    private static String sandboxProfileDigest(
+            EvidenceCommand command, Map<String, String> controlledEnvironment) {
+        MessageDigest digest = sha256();
+        update(digest, SANDBOX_PROFILE);
+        update(digest, command.id());
+        command.arguments().forEach(value -> update(digest, value));
+        command.versionArguments().forEach(value -> update(digest, value));
+        update(digest, command.relativeWorkingDirectory() == null ? "" : command.relativeWorkingDirectory());
+        controlledEnvironment.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    update(digest, entry.getKey());
+                    update(digest, entry.getValue());
+                });
+        update(digest,
+                command.requiredToolchainDigest() == null ? "external-toolchain" : command.requiredToolchainDigest());
+        update(digest, command.jvmPayload() == null ? "no-jvm-payload" : command.jvmPayload().digest());
+        return digest(digest);
+    }
+
+    public static Map<String, String> expectedEnvironment(EvidenceCommand command) throws IOException {
+        return expectedEnvironment(command, controllerJdk().digest());
+    }
+
+    /** Rebuilds the deterministic environment without consulting the controller's current JDK. */
+    public static Map<String, String> expectedEnvironment(EvidenceCommand command, String jdkDigest) {
+        if (jdkDigest == null || !jdkDigest.matches("sha256:[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("Evidence environment requires an authenticated JDK digest");
+        }
+        Map<String, String> environment = new LinkedHashMap<>();
+        environment.put("HOME", SANDBOX_HOME);
+        environment.put("TMPDIR", SANDBOX_TMP);
+        environment.put("JAVA_HOME", SANDBOX_JDK);
+        environment.put("JAVA_TOOL_OPTIONS", "-Duser.home=" + SANDBOX_HOME + " -Djava.io.tmpdir=" + SANDBOX_TMP);
+        environment.put("CAMEL_KIT_JDK_DIGEST", jdkDigest);
+        environment.put("LANG", "C");
+        environment.put("LC_ALL", "C");
+        environment.putAll(command.environment());
+        return Map.copyOf(environment);
+    }
+
+    public CommandEvidence run(Path projectRoot, Path evidenceDirectory, EvidenceCommand command) throws IOException {
+        Path candidate = realDirectory(projectRoot, "project root");
+        Path logs = createEvidenceDirectory(evidenceDirectory);
+        pruneEphemeral(logs);
+        Path workingDirectory = resolveWorkingDirectory(candidate, command.relativeWorkingDirectory());
+        Path sandboxRoot = privateTempDirectory(logs, "." + command.id() + "-sandbox-");
+        boolean handedToCollector = false;
+        try {
+            Path privateHome = privateDirectory(sandboxRoot.resolve("home"));
+            Path privateTemporaryDirectory = privateDirectory(sandboxRoot.resolve("tmp"));
+            Path acceptedSnapshot = acceptedSnapshot(candidate, sandboxRoot, command);
+            JdkIdentity jdk = jdks.freeze(sandboxRoot);
+
+            EvidenceSandboxLauncher.Identity launcherIdentity = sandboxLauncher.identity();
+            Path sandboxExecutable = requireExecutable(launcherIdentity.executable(), "sandbox");
+            String sandboxExecutableDigest = digest(sandboxExecutable);
+
+            ResolvedToolchain toolchain = toolchains.resolve(candidate, sandboxRoot, command, jdk);
+            Path executable = requireExecutable(toolchain.executable(), "toolchain");
+            if (!command.arguments().get(0).equals(toolchain.sandboxExecutable())) {
+                throw new IOException("Controller command does not name the resolved in-sandbox toolchain executable");
+            }
+            if (!command.versionArguments().isEmpty()
+                    && !command.versionArguments().get(0).equals(toolchain.sandboxExecutable())) {
+                throw new IOException("Version command does not name the resolved in-sandbox toolchain executable");
+            }
+            requireExpectedToolchain(command, toolchain.digest());
+            String executableDigest = digest(executable);
+            Map<String, String> controlledEnvironment = expectedEnvironment(command, jdk.digest());
+            List<Mount> mounts = mounts(
+                    candidate, acceptedSnapshot, logs, privateHome, privateTemporaryDirectory, toolchain, jdk);
+            String sandboxWorkingDirectory = sandboxWorkingDirectory(candidate, workingDirectory);
+            Invocation invocation = new Invocation(
+                    candidate,
+                    workingDirectory,
+                    sandboxWorkingDirectory,
+                    privateHome,
+                    privateTemporaryDirectory,
+                    executable,
+                    mounts,
+                    command.arguments(),
+                    controlledEnvironment);
+            String sandboxProfileDigest = sandboxProfileDigest(command, controlledEnvironment);
+            createProcessRetentionMarker(sandboxRoot, command.id());
+            VersionResult versionResult = readVersion(invocation, command.versionArguments());
+
+            LogFile stdout = createLog(logs, sandboxRoot, ".stdout.log");
+            LogFile stderr = createLog(logs, sandboxRoot, ".stderr.log");
+            Instant startedAt = clock.instant();
+            boolean launched = false;
+            boolean timedOut = false;
+            Integer exitCode = null;
+            String launchError = versionResult.residualFailure();
+            Process process = null;
+            boolean processTreeReaped = versionResult.reaped();
+            boolean logPumpsQuiesced = !versionResult.reaped();
+
+            ExecutorService pumps = Executors.newFixedThreadPool(2, runnable -> {
+                Thread thread = new Thread(runnable, "camel-kit-ship-evidence-log");
+                thread.setDaemon(true);
+                return thread;
+            });
+            if (versionResult.reaped()) {
+                try (FileChannel stdoutChannel = openLog(stdout.path());
+                     FileChannel stderrChannel = openLog(stderr.path())) {
+                    process = sandboxLauncher.launch(invocation);
+                    launched = true;
+                    Process running = process;
+                    Future<?> stdoutPump = pumps.submit(() -> {
+                        copy(running.getInputStream(), stdoutChannel);
+                        return null;
+                    });
+                    Future<?> stderrPump = pumps.submit(() -> {
+                        copy(running.getErrorStream(), stderrChannel);
+                        return null;
+                    });
+                    if (waitForExecution(process, stdoutPump, stderrPump, command.timeout())) {
+                        exitCode = process.exitValue();
+                        processTreeReaped = terminateDescendantsAndWait(process);
+                        if (!processTreeReaped) {
+                            launchError = appendFailure(
+                                    launchError, residualProcessFailure("Command", process));
+                        }
+                    } else {
+                        timedOut = true;
+                        processTreeReaped = terminateAndWait(process);
+                        if (!processTreeReaped) {
+                            launchError = appendFailure(
+                                    launchError, residualProcessFailure("Timed-out command", process));
+                        }
+                    }
+                    awaitPump(stdoutPump);
+                    awaitPump(stderrPump);
+                    logPumpsQuiesced = true;
+                    stdoutChannel.force(true);
+                    stderrChannel.force(true);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    launchError = appendFailure(launchError, "Interrupted while waiting for the command");
+                    processTreeReaped = process != null && terminateAndWait(process);
+                    if (!processTreeReaped) {
+                        launchError = appendFailure(
+                                launchError, residualProcessFailure("Interrupted command", process));
+                    }
+                } catch (IOException e) {
+                    launchError = appendFailure(launchError, e.getClass().getSimpleName() + ": " + e.getMessage());
+                    processTreeReaped = process != null && terminateAndWait(process);
+                    if (!processTreeReaped) {
+                        launchError = appendFailure(
+                                launchError, residualProcessFailure("Failed command", process));
+                    }
+                } catch (ExecutionException e) {
+                    launchError = appendFailure(
+                            launchError, "Could not retain command logs: " + e.getCause().getMessage());
+                    processTreeReaped = process != null && terminateAndWait(process);
+                    if (!processTreeReaped) {
+                        launchError = appendFailure(
+                                launchError, residualProcessFailure("Log-flooding command", process));
+                    }
+                } finally {
+                    pumps.shutdownNow();
+                }
+            } else {
+                pumps.shutdownNow();
+            }
+
+            if (processTreeReaped && logPumpsQuiesced) {
+                clearProcessRetentionMarker(sandboxRoot);
+            } else {
+                launchError = appendFailure(
+                        launchError, "Ephemeral evidence quarantined at " + sandboxRoot);
+            }
+
+            verifyLog(stdout);
+            verifyLog(stderr);
+            String postExecutableDigest = null;
+            String postToolchainDigest = null;
+            String postSandboxExecutableDigest = null;
+            try {
+                postExecutableDigest = digest(executable);
+                postToolchainDigest = toolchain.identitySource().identity().aggregateDigest();
+                postSandboxExecutableDigest = digest(sandboxExecutable);
+            } catch (IOException e) {
+                launchError
+                        = appendFailure(launchError, "Execution authority could not be reverified: " + e.getMessage());
+            }
+            Instant endedAt = clock.instant();
+            CommandEvidence evidence = new CommandEvidence(
+                    CommandEvidence.SCHEMA_VERSION,
+                    command.id(),
+                    new SandboxIdentity(
+                            launcherIdentity.provider(),
+                            sandboxExecutable.toString(),
+                            sandboxExecutableDigest,
+                            postSandboxExecutableDigest,
+                            null,
+                            sandboxProfileDigest),
+                    toolchain.digest(),
+                    postToolchainDigest,
+                    toolchain.snapshot().toString(),
+                    toolchain.snapshotDigest(),
+                    executable.toString(),
+                    executableDigest,
+                    postExecutableDigest,
+                    null,
+                    versionResult.value(),
+                    command.arguments(),
+                    workingDirectory.toString(),
+                    controlledEnvironment,
+                    startedAt,
+                    endedAt,
+                    launched,
+                    timedOut,
+                    exitCode,
+                    launchError,
+                    stdout.path().toString(),
+                    digest(stdout.path()),
+                    stderr.path().toString(),
+                    digest(stderr.path()),
+                    command.inputDigests());
+            handedToCollector = true;
+            return evidence;
+        } finally {
+            if (!handedToCollector) {
+                deleteSandbox(logs, sandboxRoot, command.id());
+            }
+        }
+    }
+
+    /** Removes raw logs and the exact controller-created sandbox after CAS retention. */
+    public static void cleanupEphemeral(
+            Path evidenceDirectory, EvidenceCommand command, CommandEvidence evidence)
+            throws IOException {
+        Path root = realDirectory(evidenceDirectory, "evidence directory");
+        Set<String> sandboxes = new LinkedHashSet<>();
+        collectSandbox(root, command.id(), evidence.toolchainSnapshot(), sandboxes);
+        collectSandbox(root, command.id(), evidence.executable(), sandboxes);
+        if (sandboxes.size() > 1) {
+            throw new IOException("Command evidence references multiple ephemeral sandbox roots");
+        }
+        for (String sandbox : sandboxes) {
+            if (hasProcessRetentionMarker(root.resolve(sandbox))) {
+                return;
+            }
+        }
+        Set<String> logs = new LinkedHashSet<>();
+        logs.add(ephemeralFile(root, evidence.stdoutLog(), "stdout log"));
+        logs.add(ephemeralFile(root, evidence.stderrLog(), "stderr log"));
+        for (String log : logs) {
+            deleteRelativeFile(root, log);
+        }
+        for (String sandbox : sandboxes) {
+            deleteRelativeTree(root, sandbox);
+        }
+    }
+
+    private static void pruneEphemeral(Path root) throws IOException {
+        List<String> directories = new ArrayList<>();
+        List<String> candidateFiles = new ArrayList<>();
+        Set<String> retainedSandboxes = new LinkedHashSet<>();
+        try (var entries = Files.newDirectoryStream(root)) {
+            for (Path entry : entries) {
+                String name = entry.getFileName().toString();
+                if (name.matches("\\.[a-z0-9][a-z0-9-]*-sandbox-[A-Za-z0-9._-]+")) {
+                    if (hasProcessRetentionMarker(entry)) {
+                        retainedSandboxes.add(name);
+                    } else {
+                        directories.add(name);
+                    }
+                } else if (name.matches("\\.[a-z0-9][a-z0-9-]*-.*\\.(stdout|stderr)\\.log")) {
+                    candidateFiles.add(name);
+                }
+            }
+        }
+        List<String> files = candidateFiles.stream()
+                .filter(file -> retainedSandboxes.stream().noneMatch(
+                        sandbox -> file.equals(sandbox + ".stdout.log")
+                                || file.equals(sandbox + ".stderr.log")))
+                .toList();
+        if (directories.isEmpty() && files.isEmpty()) {
+            return;
+        }
+        for (String file : files) {
+            deleteRelativeFile(root, file);
+        }
+        for (String directory : directories) {
+            deleteRelativeTree(root, directory);
+        }
+    }
+
+    private static void deleteSandbox(Path root, Path sandbox, String commandId) throws IOException {
+        Path normalizedRoot = root.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        Path normalizedSandbox = sandbox.toAbsolutePath().normalize();
+        String expectedPrefix = "." + commandId + "-sandbox-";
+        if (!normalizedSandbox.getParent().equals(normalizedRoot)
+                || !normalizedSandbox.getFileName().toString().startsWith(expectedPrefix)) {
+            throw new IOException("Refusing to delete an unrecognized evidence sandbox");
+        }
+        if (hasProcessRetentionMarker(normalizedSandbox)) {
+            return;
+        }
+        deleteRelativeTree(normalizedRoot, normalizedSandbox.getFileName().toString());
+    }
+
+    private static void createProcessRetentionMarker(Path sandbox, String commandId) throws IOException {
+        byte[] content = ("camel-kit-evidence-process-retention-v1\n"
+                          + "command=" + commandId + "\n"
+                          + "state=process-lifecycle-unresolved\n")
+                .getBytes(StandardCharsets.UTF_8);
+        writeBytesAtomically(
+                sandbox, PROCESS_RETENTION_MARKER, content, "r--------", PROCESS_RETENTION_TEMPORARY);
+    }
+
+    private static void clearProcessRetentionMarker(Path sandbox) throws IOException {
+        deleteRelativeFile(sandbox, PROCESS_RETENTION_MARKER);
+    }
+
+    /** Any marker-shaped entry is a permanent fail-safe quarantine until an operator inspects it. */
+    private static boolean hasProcessRetentionMarker(Path sandbox) {
+        if (sandbox == null) {
+            return true;
+        }
+        try {
+            if (!Files.exists(sandbox, LinkOption.NOFOLLOW_LINKS)) {
+                return false;
+            }
+            if (Files.isSymbolicLink(sandbox) || !Files.isDirectory(sandbox, LinkOption.NOFOLLOW_LINKS)) {
+                return true;
+            }
+            try (var entries = Files.newDirectoryStream(sandbox)) {
+                for (Path entry : entries) {
+                    if (PROCESS_RETENTION_MARKER.equals(entry.getFileName().toString())) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (IOException | SecurityException e) {
+            return true;
+        }
+    }
+
+    private static void collectSandbox(
+            Path root, String commandId, String value, Set<String> sandboxes)
+            throws IOException {
+        if (value == null) {
+            return;
+        }
+        Path path;
+        try {
+            path = Path.of(value).toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            throw new IOException("Command evidence contains an invalid ephemeral path", e);
+        }
+        if (!path.startsWith(root) || root.equals(path)) {
+            return;
+        }
+        Path relative = root.relativize(path);
+        String first = relative.getName(0).toString();
+        if (first.startsWith("." + commandId + "-sandbox-")) {
+            sandboxes.add(first);
+        }
+    }
+
+    private static String ephemeralFile(Path root, String value, String label) throws IOException {
+        if (value == null) {
+            throw new IOException("Command evidence is missing its raw " + label);
+        }
+        Path path;
+        try {
+            path = Path.of(value).toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            throw new IOException("Command evidence has an invalid raw " + label, e);
+        }
+        if (!path.getParent().equals(root)) {
+            throw new IOException("Command evidence raw " + label + " escaped its evidence directory");
+        }
+        return path.getFileName().toString();
+    }
+
+    private VersionResult readVersion(Invocation invocation, List<String> versionArguments) {
+        if (versionArguments.isEmpty()) {
+            return new VersionResult("unreported", true, null);
+        }
+        Invocation versionInvocation = new Invocation(
+                invocation.candidate(), invocation.workingDirectory(), invocation.sandboxWorkingDirectory(),
+                invocation.privateHome(), invocation.privateTemporaryDirectory(), invocation.toolchainExecutable(),
+                invocation.mounts(), versionArguments, invocation.environment());
+        Process process = null;
+        ExecutorService reader = Executors.newFixedThreadPool(2, runnable -> {
+            Thread thread = new Thread(runnable, "camel-kit-ship-version-output");
+            thread.setDaemon(true);
+            return thread;
+        });
+        try {
+            process = sandboxLauncher.launch(versionInvocation);
+            Process running = process;
+            Future<byte[]> output = reader.submit(() -> readBounded(running.getInputStream(), MAX_VERSION_BYTES));
+            Future<byte[]> errors = reader.submit(() -> readBounded(running.getErrorStream(), MAX_VERSION_BYTES));
+            if (!waitForExecution(process, output, errors, VERSION_TIMEOUT)) {
+                boolean reaped = terminateAndWait(process);
+                return versionResult("version-query-timeout", reaped, process);
+            }
+            if (!terminateDescendantsAndWait(process)) {
+                return versionResult("version-query-descendants-not-reaped", false, process);
+            }
+            byte[] stdout = output.get(5, TimeUnit.SECONDS);
+            byte[] stderr = errors.get(5, TimeUnit.SECONDS);
+            ByteArrayOutputStream combined = new ByteArrayOutputStream(stdout.length + stderr.length);
+            combined.write(stdout);
+            combined.write(stderr);
+            String value = combined.toString(StandardCharsets.UTF_8).strip();
+            return new VersionResult(
+                    value.isEmpty() ? "exit-" + process.exitValue() : value.lines().findFirst().orElse("unreported"),
+                    true,
+                    null);
+        } catch (IOException e) {
+            boolean reaped = process == null || terminateAndWait(process);
+            return versionResult("version-query-error:" + e.getClass().getSimpleName(), reaped, process);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            boolean reaped = process == null || terminateAndWait(process);
+            return versionResult("version-query-interrupted", reaped, process);
+        } catch (ExecutionException | TimeoutException e) {
+            boolean reaped = process == null || terminateAndWait(process);
+            return versionResult("version-query-error:" + e.getClass().getSimpleName(), reaped, process);
+        } finally {
+            reader.shutdownNow();
+        }
+    }
+
+    private static VersionResult versionResult(String value, boolean reaped, Process process) {
+        return new VersionResult(
+                value, reaped, reaped ? null : residualProcessFailure("Version query", process));
+    }
+
+    private static String residualProcessFailure(String phase, Process process) {
+        return phase + " process tree could not be reaped (" + processIdentity(process) + ")";
+    }
+
+    private static String processIdentity(Process process) {
+        if (process == null) {
+            return "process handle unavailable";
+        }
+        try {
+            ProcessHandle handle = process.toHandle();
+            String start = handle.info().startInstant().map(Instant::toString).orElse("start time unavailable");
+            return "pid " + handle.pid() + ", " + start;
+        } catch (RuntimeException e) {
+            return "process identity unavailable";
+        }
+    }
+
+    private static List<Mount> mounts(
+            Path candidate,
+            Path acceptedSnapshot,
+            Path evidenceDirectory,
+            Path privateHome,
+            Path privateTemporaryDirectory,
+            ResolvedToolchain toolchain,
+            JdkIdentity jdk)
+            throws IOException {
+        List<Path> systemLibraries = List.of(
+                realDirectory(Path.of("/usr/lib64"), "system library root"));
+        for (Path system : systemLibraries) {
+            if (candidate.startsWith(system) || evidenceDirectory.startsWith(system)) {
+                throw new IOException("Candidate and controller evidence must be outside system library mounts");
+            }
+        }
+        if (candidate.startsWith(evidenceDirectory) || evidenceDirectory.startsWith(candidate)) {
+            throw new IOException("Candidate and controller evidence directories must be disjoint");
+        }
+        List<Mount> mounts = new ArrayList<>();
+        mounts.add(new Mount(systemLibraries.get(0), "/usr/lib64", Access.READ_ONLY));
+        if (jdk.root().startsWith(candidate) || candidate.startsWith(jdk.root())
+                || evidenceDirectory.startsWith(jdk.root())) {
+            throw new IOException("Controller JDK overlaps candidate or controller state");
+        }
+        mounts.add(new Mount(jdk.root(), SANDBOX_JDK, Access.READ_ONLY));
+        mounts.addAll(jdk.externalMounts());
+        mounts.add(new Mount(acceptedSnapshot, SANDBOX_WORKSPACE, Access.READ_ONLY));
+        mounts.add(new Mount(privateHome, SANDBOX_HOME, Access.READ_WRITE));
+        mounts.add(new Mount(privateTemporaryDirectory, SANDBOX_TMP, Access.READ_WRITE));
+        for (Mount mount : toolchain.mounts()) {
+            if (mount.access() != Access.READ_ONLY) {
+                throw new IOException("Controller toolchains must be mounted read-only");
+            }
+            Path source = mount.source();
+            if (source.startsWith(candidate) || candidate.startsWith(source)
+                    || source.equals(evidenceDirectory) || evidenceDirectory.startsWith(source)) {
+                throw new IOException("External toolchain mount overlaps candidate or controller state");
+            }
+            mounts.add(mount);
+        }
+        return List.copyOf(mounts);
+    }
+
+    private static String sandboxWorkingDirectory(Path candidate, Path workingDirectory) {
+        Path relative = candidate.relativize(workingDirectory);
+        if (relative.getNameCount() == 0) {
+            return SANDBOX_WORKSPACE;
+        }
+        StringBuilder value = new StringBuilder(SANDBOX_WORKSPACE);
+        for (Path part : relative) {
+            value.append('/').append(part);
+        }
+        return value.toString();
+    }
+
+    private static void requireExpectedToolchain(EvidenceCommand command, String actual) throws IOException {
+        if (command.requiredToolchainDigest() != null
+                && !command.requiredToolchainDigest().equals(actual)) {
+            throw new IOException("Resolved toolchain differs from the controller-required digest");
+        }
+    }
+
+    private static byte[] readBounded(InputStream input, int maximum) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(maximum, 8192));
+        byte[] bytes = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = input.read(bytes)) != -1) {
+            total = Math.addExact(total, read);
+            if (total > maximum) {
+                throw new IOException("Version output exceeds " + maximum + " bytes");
+            }
+            output.write(bytes, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static Path realDirectory(Path path, String label) throws IOException {
+        if (path == null) {
+            throw new IOException(label + " is required");
+        }
+        Path real = path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (!Files.isDirectory(real, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(real)) {
+            throw new IOException(label + " must be a non-symbolic-link directory: " + path);
+        }
+        return real;
+    }
+
+    private static Path createEvidenceDirectory(Path path) throws IOException {
+        if (path == null) {
+            throw new IOException("Evidence directory is required");
+        }
+        Path absolute = path.toAbsolutePath().normalize();
+        Path current = absolute.getRoot();
+        for (Path part : absolute) {
+            current = current.resolve(part);
+            if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+                Files.createDirectory(current);
+            }
+            if (Files.isSymbolicLink(current) || !Files.isDirectory(current, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Evidence path contains an unsafe component: " + current);
+            }
+        }
+        return privateDirectory(absolute.toRealPath(LinkOption.NOFOLLOW_LINKS));
+    }
+
+    private static Path privateTempDirectory(Path parent, String prefix) throws IOException {
+        Path directory = Files.createTempDirectory(parent, prefix);
+        return privateDirectory(directory);
+    }
+
+    private static Path privateDirectory(Path directory) throws IOException {
+        if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createDirectory(directory);
+        }
+        if (Files.isSymbolicLink(directory) || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Private sandbox path is unsafe: " + directory);
+        }
+        if (Files.getFileAttributeView(directory, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS) == null) {
+            throw new IOException("Evidence storage requires POSIX permission support: " + directory);
+        }
+        Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+        return directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static Path acceptedSnapshot(Path candidate, Path sandboxRoot, EvidenceCommand command)
+            throws IOException {
+        ProjectSnapshot before = ProjectEvidenceFiles.capture(candidate);
+        if (!command.inputDigests().contains(before.digest())) {
+            throw new IOException("Evidence command is not bound to the accepted candidate tree digest");
+        }
+        Path copy = privateDirectory(sandboxRoot.resolve("accepted-snapshot"));
+        ProjectSnapshot copied = ProjectEvidenceFiles.materializeMaterial(candidate, copy);
+        ProjectSnapshot after = ProjectEvidenceFiles.capture(candidate);
+        if (!ProjectEvidenceFiles.unchangedMaterialTree(before, copied)
+                || !ProjectEvidenceFiles.unchanged(before, after)) {
+            throw new IOException("Candidate changed while the accepted evidence snapshot was frozen");
+        }
+        return copy;
+    }
+
+    private static void deleteRelativeFile(Path root, String relative) throws IOException {
+        Path file = controlledPath(root, relative);
+        if (Files.isDirectory(file, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Refusing to delete an evidence directory as a file: " + relative);
+        }
+        Files.deleteIfExists(file);
+    }
+
+    private static void deleteRelativeTree(Path root, String relative) throws IOException {
+        Path directory = controlledPath(root, relative);
+        if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        Files.walkFileTree(directory, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path visited, IOException failure) throws IOException {
+                if (failure != null) {
+                    throw failure;
+                }
+                Files.delete(visited);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void writeBytesAtomically(
+            Path root, String relative, byte[] content, String mode, String temporaryName)
+            throws IOException {
+        Path target = controlledPath(root, relative);
+        Path temporary = controlledPath(root, temporaryName);
+        Files.write(temporary, content, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        boolean moved = false;
+        try {
+            Files.setPosixFilePermissions(temporary, PosixFilePermissions.fromString(mode));
+            Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE);
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private static Path controlledPath(Path requestedRoot, String relative) throws IOException {
+        Path root = requestedRoot.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        String canonical = ShipTreePolicy.requireCanonicalRelativePath(relative);
+        Path path = root.resolve(canonical).normalize();
+        if (!path.startsWith(root)) {
+            throw new IOException("Evidence path escapes its controller-owned root");
+        }
+        Path current = root;
+        Path parent = path.getParent();
+        if (parent != null) {
+            for (Path component : root.relativize(parent)) {
+                current = current.resolve(component);
+                if (Files.isSymbolicLink(current)
+                        || Files.exists(current, LinkOption.NOFOLLOW_LINKS)
+                                && !Files.isDirectory(current, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException("Evidence path contains an unsafe component: " + current);
+                }
+            }
+        }
+        return path;
+    }
+
+    private static Path resolveWorkingDirectory(Path root, String relative) throws IOException {
+        Path directory = relative == null || relative.isBlank() ? root : root.resolve(relative).normalize();
+        if (!directory.startsWith(root)) {
+            throw new IOException("Evidence command working directory escapes the project root");
+        }
+        Path real = directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (!real.startsWith(root) || !Files.isDirectory(real, LinkOption.NOFOLLOW_LINKS)
+                || Files.isSymbolicLink(real)) {
+            throw new IOException("Evidence command working directory is not a safe project directory: " + relative);
+        }
+        return real;
+    }
+
+    private static Path requireExecutable(Path path, String label) throws IOException {
+        if (path == null || Files.isSymbolicLink(path)
+                || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isExecutable(path)) {
+            throw new IOException(label + " executable is missing, symbolic, non-regular, or not executable: " + path);
+        }
+        return path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static JdkIdentity controllerJdk() throws IOException {
+        Path root = realDirectory(Path.of(System.getProperty("java.home", "")), "controller JDK");
+        return jdkIdentity(root);
+    }
+
+    private static JdkIdentity freezeControllerJdk(Path sandboxRoot) throws IOException {
+        return freezeJdk(
+                realDirectory(Path.of(System.getProperty("java.home", "")), "controller JDK"), sandboxRoot);
+    }
+
+    static JdkIdentity freezeJdk(Path liveRoot, Path sandboxRoot) throws IOException {
+        Path source = realDirectory(liveRoot, "controller JDK");
+        JdkIdentity before = jdkIdentity(source);
+        Path snapshot = privateDirectory(sandboxRoot.resolve("jdk-snapshot"));
+        copyTree(source, snapshot);
+
+        List<Mount> externalSnapshots = new ArrayList<>();
+        if (!before.externalMounts().isEmpty()) {
+            Path externalRoot = privateDirectory(sandboxRoot.resolve("jdk-external-snapshots"));
+            int index = 0;
+            for (Mount mount : before.externalMounts()) {
+                Path target = externalRoot.resolve(String.format(Locale.ROOT, "%03d", index++));
+                copyTree(mount.source(), target);
+                externalSnapshots.add(new Mount(target, mount.target(), Access.READ_ONLY));
+            }
+        }
+        JdkIdentity frozen = jdkIdentity(snapshot, externalSnapshots);
+        JdkIdentity after = jdkIdentity(source);
+        if (!before.digest().equals(frozen.digest()) || !before.digest().equals(after.digest())) {
+            throw new IOException("Controller JDK changed while its immutable evidence snapshot was frozen");
+        }
+        return frozen;
+    }
+
+    private static JdkIdentity jdkIdentity(Path root) throws IOException {
+        List<Mount> externalMounts = externalJdkMounts(root);
+        return jdkIdentity(root, externalMounts);
+    }
+
+    private static JdkIdentity jdkIdentity(Path root, List<Mount> externalMounts) throws IOException {
+        MessageDigest digest = sha256();
+        update(digest, "camel-kit.ship.jdk-tree.v1");
+        long[] totals = {0, 0};
+        updateTree(digest, root, SANDBOX_JDK, totals);
+        for (Mount mount : externalMounts) {
+            updateTree(digest, mount.source(), mount.target(), totals);
+        }
+        if (totals[0] == 0 || !Files.isExecutable(root.resolve("bin/java"))) {
+            throw new IOException("Controller JDK tree is incomplete");
+        }
+        return new JdkIdentity(root, digest(digest), externalMounts);
+    }
+
+    private static void copyTree(Path source, Path target) throws IOException {
+        if (Files.isSymbolicLink(source)) {
+            throw new IOException("Controller JDK snapshot source cannot itself be symbolic");
+        }
+        if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
+            copyFile(source, target);
+            return;
+        }
+        if (!Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Controller JDK snapshot source is not regular: " + source);
+        }
+        if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createDirectory(target);
+        }
+        List<Path> directories = new ArrayList<>();
+        try (var paths = Files.walk(source, 64)) {
+            for (Path path : paths.sorted().toList()) {
+                Path relative = source.relativize(path);
+                Path copy = target.resolve(relative.toString()).normalize();
+                if (!copy.startsWith(target) || Files.exists(copy, LinkOption.NOFOLLOW_LINKS)
+                        && !source.equals(path)) {
+                    throw new IOException("Controller JDK snapshot destination is unsafe: " + copy);
+                }
+                if (Files.isSymbolicLink(path)) {
+                    Files.createSymbolicLink(copy, Files.readSymbolicLink(path));
+                } else if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                    if (!source.equals(path)) {
+                        Files.createDirectory(copy);
+                    }
+                    directories.add(path);
+                } else if (Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+                    copyFile(path, copy);
+                } else {
+                    throw new IOException("Controller JDK contains a non-regular object: " + path);
+                }
+            }
+        }
+        for (Path directory : directories.stream()
+                .sorted(Comparator.comparingInt(Path::getNameCount).reversed()).toList()) {
+            copyPermissions(directory, target.resolve(source.relativize(directory).toString()));
+        }
+    }
+
+    private static void copyFile(Path source, Path target) throws IOException {
+        Path parent = target.getParent();
+        if (parent == null || Files.isSymbolicLink(parent)
+                || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Controller JDK snapshot file has an unsafe parent");
+        }
+        try (InputStream input = Files.newInputStream(source, LinkOption.NOFOLLOW_LINKS)) {
+            Files.copy(input, target);
+        }
+        copyPermissions(source, target);
+    }
+
+    private static void copyPermissions(Path source, Path target) throws IOException {
+        if (Files.getFileAttributeView(source, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS) != null
+                && Files.getFileAttributeView(target, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS)
+                   != null) {
+            Files.setPosixFilePermissions(
+                    target, Files.getPosixFilePermissions(source, LinkOption.NOFOLLOW_LINKS));
+        } else if (Files.isExecutable(source) && !target.toFile().setExecutable(true, true)) {
+            throw new IOException("Could not preserve controller JDK executable permission");
+        }
+    }
+
+    private static List<Mount> externalJdkMounts(Path root) throws IOException {
+        TreeMap<String, Path> mounts = new TreeMap<>();
+        Set<String> scanned = new LinkedHashSet<>();
+        scanExternalLinks(root, SANDBOX_JDK, root, mounts);
+        while (true) {
+            Map.Entry<String, Path> next = mounts.entrySet().stream()
+                    .filter(entry -> !scanned.contains(entry.getKey()))
+                    .findFirst().orElse(null);
+            if (next == null) {
+                break;
+            }
+            scanned.add(next.getKey());
+            if (Files.isDirectory(next.getValue(), LinkOption.NOFOLLOW_LINKS)) {
+                scanExternalLinks(next.getValue(), next.getKey(), root, mounts);
+            }
+            if (mounts.size() > 64) {
+                throw new IOException("Controller JDK has too many external link targets");
+            }
+        }
+        return mounts.entrySet().stream()
+                .map(entry -> new Mount(entry.getValue(), entry.getKey(), Access.READ_ONLY))
+                .toList();
+    }
+
+    private static void scanExternalLinks(
+            Path sourceRoot, String sandboxRoot, Path jdkRoot, Map<String, Path> mounts)
+            throws IOException {
+        try (var paths = Files.walk(sourceRoot, 64)) {
+            for (Path path : paths.sorted().toList()) {
+                if (!Files.isSymbolicLink(path)) {
+                    continue;
+                }
+                Path link = Files.readSymbolicLink(path);
+                Path sandboxPath = Path.of(sandboxRoot)
+                        .resolve(sourceRoot.relativize(path).toString()).normalize();
+                Path target = link.isAbsolute()
+                        ? link.normalize()
+                        : sandboxPath.getParent().resolve(link).normalize();
+                if (!target.isAbsolute()) {
+                    throw new IOException("Controller JDK contains an unresolved symbolic link");
+                }
+                Path hostTarget;
+                if (sandboxRoot.equals(SANDBOX_JDK) && target.startsWith(Path.of(SANDBOX_JDK))) {
+                    hostTarget = jdkRoot.resolve(Path.of(SANDBOX_JDK).relativize(target)).normalize();
+                } else {
+                    hostTarget = target;
+                }
+                if (hostTarget.startsWith(jdkRoot)) {
+                    continue;
+                }
+                if (!allowedExternalJdkTarget(target)) {
+                    throw new IOException("Controller JDK symbolic link escapes to an unapproved target: " + target);
+                }
+                Path real = hostTarget.toRealPath();
+                if (!allowedExternalJdkTarget(real)
+                        || Files.isSymbolicLink(real)
+                        || (!Files.isRegularFile(real, LinkOption.NOFOLLOW_LINKS)
+                                && !Files.isDirectory(real, LinkOption.NOFOLLOW_LINKS))) {
+                    throw new IOException("Controller JDK external target is unsafe: " + target);
+                }
+                Path previous = mounts.putIfAbsent(target.toString(), real);
+                if (previous != null && !previous.equals(real)) {
+                    throw new IOException("Controller JDK external target identity is ambiguous: " + target);
+                }
+            }
+        }
+    }
+
+    private static boolean allowedExternalJdkTarget(Path target) {
+        return target.startsWith(Path.of("/etc/java"))
+                || target.startsWith(Path.of("/etc/pki"))
+                || target.startsWith(Path.of("/usr/share/javazi-1.8"));
+    }
+
+    private static void updateTree(
+            MessageDigest digest, Path source, String namespace, long[] totals)
+            throws IOException {
+        if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
+            boundedJdkFile(totals, source);
+            updateFile(digest, namespace, source);
+            return;
+        }
+        try (var paths = Files.walk(source, 64)) {
+            for (Path path : paths.sorted().toList()) {
+                String relative = source.equals(path)
+                        ? ""
+                        : source.relativize(path).toString().replace('\\', '/');
+                String name = relative.isEmpty() ? namespace : namespace + '/' + relative;
+                if (Files.isSymbolicLink(path)) {
+                    update(digest, "link:" + name);
+                    update(digest, Files.readSymbolicLink(path).toString());
+                } else if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                    update(digest, "directory:" + name);
+                } else if (Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+                    boundedJdkFile(totals, path);
+                    updateFile(digest, name, path);
+                } else {
+                    throw new IOException("Controller JDK contains a non-regular object: " + path);
+                }
+            }
+        }
+    }
+
+    private static void boundedJdkFile(long[] totals, Path path) throws IOException {
+        totals[0] = Math.addExact(totals[0], 1);
+        totals[1] = Math.addExact(totals[1], Files.size(path));
+        if (totals[0] > 8_192 || totals[1] > 2L * 1024 * 1024 * 1024) {
+            throw new IOException("Controller JDK tree exceeds the evidence identity bounds");
+        }
+    }
+
+    private static boolean waitForExecution(
+            Process process, Future<?> stdout, Future<?> stderr, Duration timeout)
+            throws InterruptedException, ExecutionException {
+        long deadline = Math.addExact(System.nanoTime(), timeout.toNanos());
+        while (true) {
+            requireHealthy(stdout);
+            requireHealthy(stderr);
+            long remaining = deadline - System.nanoTime();
+            if (remaining <= 0) {
+                return false;
+            }
+            long slice = Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(100));
+            if (process.waitFor(slice, TimeUnit.NANOSECONDS)) {
+                return true;
+            }
+        }
+    }
+
+    private static void requireHealthy(Future<?> pump) throws InterruptedException, ExecutionException {
+        if (pump.isDone()) {
+            pump.get();
+        }
+    }
+
+    private static boolean terminateAndWait(Process process) {
+        List<ProcessHandle> children = descendants(process);
+        children.forEach(ProcessHandle::destroy);
+        process.destroy();
+        if (awaitTermination(process, children, TERMINATION_GRACE)) {
+            return true;
+        }
+        children.forEach(handle -> {
+            if (handle.isAlive()) {
+                handle.destroyForcibly();
+            }
+        });
+        if (process.isAlive()) {
+            process.destroyForcibly();
+        }
+        return awaitTermination(process, children, TERMINATION_TIMEOUT);
+    }
+
+    private static boolean terminateDescendantsAndWait(Process process) {
+        List<ProcessHandle> children = descendants(process);
+        children.forEach(ProcessHandle::destroy);
+        if (awaitHandles(children, TERMINATION_GRACE)) {
+            return true;
+        }
+        children.forEach(handle -> {
+            if (handle.isAlive()) {
+                handle.destroyForcibly();
+            }
+        });
+        return awaitHandles(children, TERMINATION_TIMEOUT);
+    }
+
+    private static boolean awaitTermination(
+            Process process, List<ProcessHandle> children, Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        boolean interrupted = false;
+        try {
+            while (process.isAlive()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    if (!process.waitFor(remaining, TimeUnit.NANOSECONDS)) {
+                        return false;
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    Thread.interrupted();
+                }
+            }
+            return awaitHandles(children, Duration.ofNanos(Math.max(0, deadline - System.nanoTime())));
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static boolean awaitHandles(List<ProcessHandle> handles, Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        boolean interrupted = false;
+        try {
+            for (ProcessHandle handle : handles) {
+                while (handle.isAlive()) {
+                    long remaining = deadline - System.nanoTime();
+                    if (remaining <= 0) {
+                        return false;
+                    }
+                    try {
+                        handle.onExit().get(remaining, TimeUnit.NANOSECONDS);
+                    } catch (InterruptedException e) {
+                        interrupted = true;
+                        Thread.interrupted();
+                    } catch (ExecutionException | TimeoutException e) {
+                        return false;
+                    }
+                }
+            }
+            return handles.stream().noneMatch(ProcessHandle::isAlive);
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static List<ProcessHandle> descendants(Process process) {
+        try {
+            return process.toHandle().descendants()
+                    .sorted(Comparator.comparingLong(ProcessHandle::pid).reversed())
+                    .toList();
+        } catch (UnsupportedOperationException e) {
+            return List.of();
+        }
+    }
+
+    private static LogFile createLog(Path directory, Path sandbox, String suffix) throws IOException {
+        String sandboxName = sandbox.getFileName().toString();
+        if (!sandbox.getParent().equals(directory)
+                || !sandboxName.matches("\\.[a-z0-9][a-z0-9-]*-sandbox-[A-Za-z0-9._-]+")
+                || !(".stdout.log".equals(suffix) || ".stderr.log".equals(suffix))) {
+            throw new IOException("Evidence log is not bound to a recognized sandbox");
+        }
+        Path path = directory.resolve(sandboxName + suffix);
+        Files.createFile(path, PosixFilePermissions.asFileAttribute(
+                PosixFilePermissions.fromString("rw-------")));
+        BasicFileAttributes attributes
+                = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (attributes.isSymbolicLink() || !attributes.isRegularFile()) {
+            throw new IOException("Evidence log is not a regular file: " + path);
+        }
+        return new LogFile(path, attributes.fileKey());
+    }
+
+    private static FileChannel openLog(Path path) throws IOException {
+        return FileChannel.open(path, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static void copy(InputStream input, FileChannel output) throws IOException {
+        byte[] bytes = new byte[8192];
+        long total = 0;
+        int read;
+        while ((read = input.read(bytes)) != -1) {
+            total = Math.addExact(total, read);
+            if (total > MAX_LOG_BYTES) {
+                throw new IOException("Command log exceeds " + MAX_LOG_BYTES + " bytes");
+            }
+            ByteBuffer buffer = ByteBuffer.wrap(bytes, 0, read);
+            while (buffer.hasRemaining()) {
+                output.write(buffer);
+            }
+        }
+    }
+
+    private static void awaitPump(Future<?> pump) throws InterruptedException, ExecutionException, IOException {
+        try {
+            pump.get(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            pump.cancel(true);
+            throw new IOException("Timed out while retaining command logs", e);
+        }
+    }
+
+    private static void verifyLog(LogFile log) throws IOException {
+        BasicFileAttributes attributes
+                = Files.readAttributes(log.path(), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (attributes.isSymbolicLink() || !attributes.isRegularFile()
+                || (log.fileKey() != null && !log.fileKey().equals(attributes.fileKey()))) {
+            throw new IOException("Evidence log identity changed during execution: " + log.path());
+        }
+    }
+
+    private static String appendFailure(String current, String additional) {
+        return current == null ? additional : current + "; " + additional;
+    }
+
+    private static String digest(Path file) throws IOException {
+        MessageDigest digest = sha256();
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return digest(digest);
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static String digest(MessageDigest digest) {
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static void update(MessageDigest digest, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+        digest.update(bytes);
+    }
+
+    @FunctionalInterface
+    interface ToolchainResolver {
+
+        ResolvedToolchain resolve(
+                Path candidate, Path sandboxRoot, EvidenceCommand command, JdkIdentity jdk)
+                throws IOException;
+    }
+
+    @FunctionalInterface
+    interface JdkResolver {
+
+        JdkIdentity freeze(Path sandboxRoot) throws IOException;
+    }
+
+    @FunctionalInterface
+    interface IdentitySource {
+
+        JvmPayloadArchive.Identity identity() throws IOException;
+    }
+
+    record ResolvedToolchain(
+            Path executable,
+            String sandboxExecutable,
+            List<Mount> mounts,
+            String digest,
+            Path snapshot,
+            String snapshotDigest,
+            IdentitySource identitySource) {
+
+        ResolvedToolchain {
+            mounts = List.copyOf(mounts);
+        }
+    }
+
+    private static final class ControllerToolchainResolver implements ToolchainResolver {
+
+        @Override
+        public ResolvedToolchain resolve(
+                Path candidate, Path sandboxRoot, EvidenceCommand command, JdkIdentity jdk)
+                throws IOException {
+            if (!JAVA_EXECUTABLE.equals(command.arguments().get(0))) {
+                throw new IOException(
+                        "Only controller-owned direct JVM evidence is supported; Maven, Camel CLI, JBang, "
+                                      + "Citrus JBang, and candidate executables are forbidden");
+            }
+            JvmPayloadArchive.Identity identity
+                    = JvmPayloadArchive.materialize(sandboxRoot, command.jvmPayload(), jdk.digest());
+            return new ResolvedToolchain(
+                    requireExecutable(jdk.root().resolve("bin/java"), "controller JDK java"),
+                    JAVA_EXECUTABLE,
+                    List.of(new Mount(
+                            identity.archive().getParent(), "/opt/camel-kit/payload", Access.READ_ONLY)),
+                    identity.aggregateDigest(),
+                    identity.archive(),
+                    identity.archiveDigest(),
+                    () -> JvmPayloadArchive.verify(
+                            identity.archive(), command.jvmPayload(),
+                            jdkIdentity(jdk.root(), jdk.externalMounts()).digest()));
+        }
+
+    }
+
+    private static void updateFile(MessageDigest digest, String name, Path file) throws IOException {
+        update(digest, "file:" + name);
+        digest.update(ByteBuffer.allocate(Long.BYTES).putLong(Files.size(file)).array());
+        update(digest, "executable:" + Files.isExecutable(file));
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+    }
+
+    record JdkIdentity(Path root, String digest, List<Mount> externalMounts) {
+
+        JdkIdentity {
+            externalMounts = List.copyOf(externalMounts);
+        }
+    }
+
+    private record VersionResult(String value, boolean reaped, String residualFailure) {
+    }
+
+    private record LogFile(Path path, Object fileKey) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
@@ -575,10 +575,15 @@ public final class EvidenceRunner {
             ResolvedToolchain toolchain,
             JdkIdentity jdk)
             throws IOException {
-        List<Path> systemLibraries = List.of(
-                realDirectory(Path.of("/usr/lib64"), "system library root"));
-        for (Path system : systemLibraries) {
-            if (candidate.startsWith(system) || evidenceDirectory.startsWith(system)) {
+        List<Mount> systemLibraries = List.of(
+                new Mount(
+                        realDirectory(Path.of("/usr/lib"), "system library root"),
+                        "/usr/lib", Access.READ_ONLY),
+                new Mount(
+                        realDirectory(Path.of("/usr/lib64"), "system library root"),
+                        "/usr/lib64", Access.READ_ONLY));
+        for (Mount system : systemLibraries) {
+            if (candidate.startsWith(system.source()) || evidenceDirectory.startsWith(system.source())) {
                 throw new IOException("Candidate and controller evidence must be outside system library mounts");
             }
         }
@@ -586,7 +591,7 @@ public final class EvidenceRunner {
             throw new IOException("Candidate and controller evidence directories must be disjoint");
         }
         List<Mount> mounts = new ArrayList<>();
-        mounts.add(new Mount(systemLibraries.get(0), "/usr/lib64", Access.READ_ONLY));
+        mounts.addAll(systemLibraries);
         if (jdk.root().startsWith(candidate) || candidate.startsWith(jdk.root())
                 || evidenceDirectory.startsWith(jdk.root())) {
             throw new IOException("Controller JDK overlaps candidate or controller state");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
@@ -477,7 +477,7 @@ public final class EvidenceRunner {
 
     private VersionResult readVersion(Invocation invocation, List<String> versionArguments) {
         if (versionArguments.isEmpty()) {
-            return new VersionResult("unreported", true, null);
+            return failedVersionResult("unreported", true, null);
         }
         Invocation versionInvocation = new Invocation(
                 invocation.candidate(), invocation.workingDirectory(), invocation.sandboxWorkingDirectory(),

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceSandboxLauncher.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceSandboxLauncher.java
@@ -1,0 +1,66 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/** Launch boundary for controller-owned evidence commands. */
+interface EvidenceSandboxLauncher {
+
+    Identity identity() throws IOException;
+
+    String profileId();
+
+    Process launch(Invocation invocation) throws IOException;
+
+    record Identity(String provider, Path executable) {
+    }
+
+    record Mount(Path source, String target, Access access) {
+
+        public Mount {
+            source = source.toAbsolutePath().normalize();
+            if (target == null || !target.startsWith("/") || target.contains("..")) {
+                throw new IllegalArgumentException("Sandbox mount target must be absolute and normalized");
+            }
+        }
+
+        boolean exposes(Path hostPath) {
+            Path path = hostPath.toAbsolutePath().normalize();
+            return path.equals(source) || path.startsWith(source);
+        }
+    }
+
+    enum Access {
+        READ_ONLY,
+        READ_WRITE
+    }
+
+    record Invocation(
+            Path candidate,
+            Path workingDirectory,
+            String sandboxWorkingDirectory,
+            Path privateHome,
+            Path privateTemporaryDirectory,
+            Path toolchainExecutable,
+            List<Mount> mounts,
+            List<String> arguments,
+            Map<String, String> environment) {
+
+        public Invocation {
+            candidate = candidate.toAbsolutePath().normalize();
+            workingDirectory = workingDirectory.toAbsolutePath().normalize();
+            privateHome = privateHome.toAbsolutePath().normalize();
+            privateTemporaryDirectory = privateTemporaryDirectory.toAbsolutePath().normalize();
+            toolchainExecutable = toolchainExecutable.toAbsolutePath().normalize();
+            mounts = List.copyOf(mounts);
+            arguments = List.copyOf(arguments);
+            environment = Map.copyOf(environment);
+        }
+
+        boolean exposes(Path hostPath) {
+            return mounts.stream().anyMatch(mount -> mount.exposes(hostPath));
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
@@ -1,0 +1,642 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogExpressionInventory;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCamelMainBootstrap;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCamelYamlValidateMain;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCitrusYamlMain;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain;
+import io.github.luigidemasi.camelkit.ship.expression.ShipExpressionPolicy;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenDependencyExclusion;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenDependencyRoot;
+import io.github.luigidemasi.camelkit.ship.resolver.ResolvedMavenArtifact;
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver;
+
+/** Resolves, freezes, and verifies a single controller-owned nested-JAR JVM payload. */
+public final class JvmPayloadArchive {
+
+    public static final String SANDBOX_ARCHIVE = "/opt/camel-kit/payload/payload.jar";
+    public static final String BOOTSTRAP_CLASS = ShipJvmPayloadBootstrap.class.getName();
+    private static final String CENTRAL = "https://repo.maven.apache.org/maven2/";
+    private static final HttpClient CENTRAL_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(java.time.Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .proxy(new NoProxySelector())
+            .build();
+    private static final int MAX_ARTIFACTS = 512;
+    private static final long MAX_ARTIFACT_BYTES = 128L * 1024 * 1024;
+    private static final long MAX_TOTAL_BYTES = 768L * 1024 * 1024;
+
+    private JvmPayloadArchive() {
+    }
+
+    public static Identity materialize(Path root, JvmPayloadRequest request, String jdkDigest) throws IOException {
+        if (request == null || !request.kind().supported()) {
+            String kind = request == null ? "missing" : request.kind().id();
+            throw new IOException(switch (kind) {
+                case "citrus-yaml" ->
+                    "Direct Citrus YAML evidence fails closed until Citrus and the approved Camel version "
+                                      + "can be resolved into one dependency-aligned immutable payload";
+                case "spring-boot-build", "quarkus-build" ->
+                    "Runtime build evidence fails closed until a direct controller JVM build payload is retained";
+                default -> "Unsupported direct JVM evidence payload: " + kind;
+            });
+        }
+        Path payloadRoot = privateDirectory(root.resolve("jvm-payload"));
+        List<ArtifactFile> artifacts = List.of();
+        if (!request.dependencyRoots().isEmpty()) {
+            Path repository = privateDirectory(root.resolve("resolver-repository"));
+            try (var files = Files.list(repository)) {
+                if (files.findAny().isPresent()) {
+                    throw new IOException("Controller JVM payload resolver repository must start empty");
+                }
+            }
+            artifacts = resolve(repository, request);
+        }
+        Path archive = payloadRoot.resolve("payload.jar");
+        return write(archive, request, jdkDigest, artifacts);
+    }
+
+    static Identity write(
+            Path archive, JvmPayloadRequest request, String jdkDigest, List<ArtifactFile> artifacts)
+            throws IOException {
+        List<SourceEntry> sources = new ArrayList<>();
+        for (Class<?> type : classClosure(ShipJvmPayloadBootstrap.class, JvmPayloadLock.class)) {
+            byte[] bytes = classBytes(type);
+            sources.add(SourceEntry.bytes(
+                    "bootstrap", "class:" + type.getName(), classPath(type), bytes));
+        }
+        Class<?> launcher = launcher(request);
+        byte[] launcherJar = launcherJar(launcher);
+        sources.add(SourceEntry.bytes(
+                "launcher", "class:" + launcher.getName(), "lib/000-controller-launcher.jar", launcherJar));
+
+        List<ArtifactFile> ordered = artifacts.stream()
+                .sorted(Comparator.comparing(ArtifactFile::identity)).toList();
+        for (int index = 0; index < ordered.size(); index++) {
+            ArtifactFile artifact = ordered.get(index);
+            String name = safeName(artifact.artifactId()) + '-' + safeName(artifact.version()) + ".jar";
+            sources.add(SourceEntry.file(
+                    "maven", artifact.identity(),
+                    String.format(Locale.ROOT, "lib/%03d-%s", index + 100, name), artifact.path()));
+        }
+        sources.sort(Comparator.comparing(SourceEntry::path));
+        List<JvmPayloadLock.Entry> entries = sources.stream()
+                .map(SourceEntry::lockEntry).toList();
+        JvmPayloadLock lock = JvmPayloadLock.create(request, jdkDigest, entries);
+        SourceEntry lockEntry = SourceEntry.bytes(
+                "lock", "lock", JvmPayloadLock.LOCK_PATH, lock.encode());
+
+        List<SourceEntry> archiveEntries = new ArrayList<>(sources);
+        archiveEntries.add(lockEntry);
+        archiveEntries.sort(Comparator.comparing(SourceEntry::path));
+        long total = archiveEntries.stream().mapToLong(SourceEntry::size).reduce(0, Math::addExact);
+        if (total > MAX_TOTAL_BYTES) {
+            throw new IOException("Controller JVM payload exceeds " + MAX_TOTAL_BYTES + " bytes");
+        }
+        Files.createDirectories(archive.toAbsolutePath().normalize().getParent());
+        try (ZipOutputStream zip = new ZipOutputStream(
+                Files.newOutputStream(
+                        archive, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE))) {
+            zip.setLevel(0);
+            for (SourceEntry source : archiveEntries) {
+                ZipEntry entry = new ZipEntry(source.path());
+                entry.setMethod(ZipEntry.STORED);
+                entry.setSize(source.size());
+                entry.setCompressedSize(source.size());
+                entry.setCrc(source.crc());
+                entry.setTime(0);
+                zip.putNextEntry(entry);
+                source.writeTo(zip);
+                zip.closeEntry();
+            }
+        }
+        if (Files.getFileAttributeView(archive, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS) != null) {
+            Files.setPosixFilePermissions(archive, PosixFilePermissions.fromString("r--------"));
+        }
+        return verify(archive, request, jdkDigest);
+    }
+
+    public static Identity verify(Path archive, JvmPayloadRequest request, String jdkDigest) throws IOException {
+        Path file = regular(archive, "JVM payload archive");
+        if (Files.size(file) <= 0 || Files.size(file) > MAX_TOTAL_BYTES) {
+            throw new IOException("JVM payload archive has an unsafe size");
+        }
+        String archiveDigest = digest(file);
+        JvmPayloadLock lock;
+        try (ZipFile zip = new ZipFile(file.toFile())) {
+            lock = JvmPayloadLock.parse(read(zip, JvmPayloadLock.LOCK_PATH, 1024 * 1024));
+            lock.requireRequest(request);
+            if (!lock.jdkDigest().equals(jdkDigest)) {
+                throw new IOException("JVM payload JDK digest differs from the accepted controller JDK");
+            }
+            Set<String> expected = new HashSet<>();
+            expected.add(JvmPayloadLock.LOCK_PATH);
+            lock.entries().forEach(entry -> expected.add(entry.path()));
+            Set<String> observed = new HashSet<>();
+            long total = 0;
+            var enumeration = zip.entries();
+            while (enumeration.hasMoreElements()) {
+                ZipEntry entry = enumeration.nextElement();
+                if (entry.isDirectory() || !observed.add(entry.getName()) || !expected.contains(entry.getName())
+                        || entry.getSize() <= 0 || entry.getSize() > MAX_ARTIFACT_BYTES) {
+                    throw new IOException("JVM payload archive contains an unsafe entry: " + entry.getName());
+                }
+                total = Math.addExact(total, entry.getSize());
+                if (total > MAX_TOTAL_BYTES) {
+                    throw new IOException("JVM payload archive exceeds the controller size bound");
+                }
+            }
+            if (!observed.equals(expected)) {
+                throw new IOException("JVM payload archive entries differ from its content lock");
+            }
+            for (JvmPayloadLock.Entry entry : lock.entries()) {
+                byte[] bytes = read(zip, entry.path(), Math.toIntExact(entry.size()));
+                if (bytes.length != entry.size() || !entry.digest().equals(digest(bytes))) {
+                    throw new IOException("JVM payload entry differs from its content lock: " + entry.path());
+                }
+            }
+        }
+        String aggregate = aggregate(lock.contentDigest(), archiveDigest, jdkDigest);
+        return new Identity(file, aggregate, archiveDigest, lock);
+    }
+
+    private static List<ArtifactFile> resolve(Path repository, JvmPayloadRequest request) throws IOException {
+        rejectRepositoryOverrides();
+        try {
+            List<MavenDependencyRoot> roots = request.dependencyRoots().stream()
+                    .map(root -> new MavenDependencyRoot(
+                            MavenCoordinate.jar(root.groupId(), root.artifactId(), root.version()),
+                            root.exclusions().stream()
+                                    .map(exclusion -> new MavenDependencyExclusion(
+                                            exclusion.groupId(), exclusion.artifactId()))
+                                    .toList()))
+                    .toList();
+            List<ResolvedMavenArtifact> artifacts = ShipMavenResolver.resolve(repository, roots);
+            return validateResolved(repository, request, artifacts);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Could not materialize the direct JVM payload: " + safeMessage(e), e);
+        }
+    }
+
+    private static List<ArtifactFile> validateResolved(
+            Path repository, JvmPayloadRequest request, List<ResolvedMavenArtifact> resolved)
+            throws IOException {
+        if (resolved == null || resolved.isEmpty() || resolved.size() > MAX_ARTIFACTS) {
+            throw new IOException("Direct JVM payload resolution returned an unsafe artifact count");
+        }
+        Path root = repository.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        Map<String, String> versions = new HashMap<>();
+        Set<String> coordinates = new HashSet<>();
+        Set<String> roots = new HashSet<>();
+        List<ArtifactFile> result = new ArrayList<>();
+        long total = 0;
+        for (ResolvedMavenArtifact artifact : resolved) {
+            if (artifact == null || artifact.coordinate() == null || artifact.path() == null) {
+                throw new IOException("Direct JVM payload resolver returned an incomplete artifact");
+            }
+            MavenCoordinate coordinate = artifact.coordinate();
+            if (!"jar".equals(coordinate.extension())) {
+                throw new IOException("Direct JVM payload contains a non-JAR or non-release artifact: " + artifact);
+            }
+            String identity = coordinate.resolverString();
+            if (!coordinates.add(identity)) {
+                throw new IOException("Direct JVM payload contains duplicate coordinates: " + identity);
+            }
+            String ga = coordinate.groupId() + ':' + coordinate.artifactId();
+            String previous = versions.putIfAbsent(ga, coordinate.version());
+            if (previous != null && !previous.equals(coordinate.version())) {
+                throw new IOException("Direct JVM payload contains multiple versions of " + ga);
+            }
+            if ("org.apache.camel".equals(coordinate.groupId())
+                    && !request.camelVersion().equals(coordinate.version())) {
+                throw new IOException(
+                        "Direct JVM payload does not align all Camel artifacts to "
+                                      + request.camelVersion());
+            }
+            if ("org.citrusframework".equals(coordinate.groupId()) && request.citrusVersion() != null
+                    && !request.citrusVersion().equals(coordinate.version())) {
+                throw new IOException(
+                        "Direct JVM payload does not align all Citrus artifacts to "
+                                      + request.citrusVersion());
+            }
+            Path file = regular(artifact.path(), "resolved JVM payload artifact");
+            if (!file.startsWith(root)) {
+                throw new IOException("Direct JVM payload artifact escaped its empty private repository");
+            }
+            long size = Files.size(file);
+            if (size <= 0 || size > MAX_ARTIFACT_BYTES) {
+                throw new IOException("Direct JVM payload artifact has an unsafe size: " + identity);
+            }
+            verifyCentralBytes(coordinate, file, size);
+            total = Math.addExact(total, size);
+            if (total > MAX_TOTAL_BYTES) {
+                throw new IOException("Direct JVM payload dependencies exceed the controller size limit");
+            }
+            roots.add(coordinate.gav());
+            result.add(new ArtifactFile(identity, coordinate.artifactId(), coordinate.version(), file));
+        }
+        if (!roots.containsAll(request.roots())) {
+            throw new IOException("Direct JVM payload resolution omitted a controller root");
+        }
+        return List.copyOf(result);
+    }
+
+    private static void rejectRepositoryOverrides() throws IOException {
+        for (String key : List.of(
+                "camel.extra.repos",
+                "camel.default.extra.repos.default.value",
+                "https.proxyHost",
+                "https.proxyPort",
+                "http.proxyHost",
+                "http.proxyPort",
+                "java.net.useSystemProxies",
+                "javax.net.ssl.trustStore",
+                "javax.net.ssl.trustStoreType",
+                "javax.net.ssl.trustStoreProvider")) {
+            if (System.getProperty(key) != null && !System.getProperty(key).isBlank()) {
+                throw new IOException("Controller JVM payload refuses repository override property " + key);
+            }
+        }
+    }
+
+    private static void verifyCentralBytes(
+            MavenCoordinate artifact, Path local, long expectedSize)
+            throws IOException {
+        requireCoordinatePart(artifact.groupId(), "groupId");
+        requireCoordinatePart(artifact.artifactId(), "artifactId");
+        requireCoordinatePart(artifact.version(), "version");
+        if (!artifact.classifier().isBlank()) {
+            requireCoordinatePart(artifact.classifier(), "classifier");
+        }
+        URI uri = URI.create(CENTRAL
+                             + artifact.groupId().replace('.', '/') + '/'
+                             + artifact.artifactId() + '/' + artifact.version() + '/' + artifact.fileName());
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(java.time.Duration.ofSeconds(60))
+                .header("Accept", "application/java-archive")
+                .GET()
+                .build();
+        try {
+            HttpResponse<InputStream> response = centralClient().send(
+                    request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200 || !uri.equals(response.uri())) {
+                response.body().close();
+                throw new IOException("Authenticated Maven Central verification failed for " + artifact);
+            }
+            MessageDigest remoteDigest = sha512();
+            long remoteSize = 0;
+            try (InputStream input = response.body()) {
+                byte[] buffer = new byte[16_384];
+                int count;
+                while ((count = input.read(buffer)) != -1) {
+                    remoteSize = Math.addExact(remoteSize, count);
+                    if (remoteSize > MAX_ARTIFACT_BYTES) {
+                        throw new IOException("Authenticated Maven Central artifact exceeds the size limit");
+                    }
+                    remoteDigest.update(buffer, 0, count);
+                }
+            }
+            if (remoteSize != expectedSize
+                    || !MessageDigest.isEqual(remoteDigest.digest(), digest(local, "SHA-512"))) {
+                throw new IOException("Resolved JVM payload artifact differs from Maven Central: " + artifact);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while verifying authenticated Maven Central bytes", e);
+        } catch (IOException e) {
+            throw new IOException(
+                    "Could not verify authenticated Maven Central bytes for " + artifact + ": " + safeMessage(e),
+                    e);
+        }
+    }
+
+    private static void requireCoordinatePart(String value, String label) throws IOException {
+        if (value == null || !value.matches("[A-Za-z0-9_.-]+")) {
+            throw new IOException("Direct JVM payload has an unsafe Maven " + label);
+        }
+    }
+
+    private static Class<?> launcher(JvmPayloadRequest request) throws IOException {
+        if (ShipMainPackageMain.class.getName().equals(request.launcherClass())) {
+            return ShipMainPackageMain.class;
+        }
+        if (ShipCamelYamlValidateMain.class.getName().equals(request.launcherClass())) {
+            return ShipCamelYamlValidateMain.class;
+        }
+        if (ShipCamelMainBootstrap.class.getName().equals(request.launcherClass())) {
+            return ShipCamelMainBootstrap.class;
+        }
+        if (ShipCitrusYamlMain.class.getName().equals(request.launcherClass())) {
+            return ShipCitrusYamlMain.class;
+        }
+        throw new IOException("JVM payload request names an unknown controller launcher");
+    }
+
+    private static List<Class<?>> classClosure(Class<?>... roots) {
+        Set<Class<?>> result = new LinkedHashSet<>();
+        for (Class<?> root : roots) {
+            collect(root, result);
+        }
+        return result.stream().sorted(Comparator.comparing(Class::getName)).toList();
+    }
+
+    private static void collect(Class<?> type, Set<Class<?>> result) {
+        if (result.add(type)) {
+            for (Class<?> nested : type.getDeclaredClasses()) {
+                collect(nested, result);
+            }
+        }
+    }
+
+    private static byte[] launcherJar(Class<?> launcher) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            zip.setLevel(0);
+            List<Class<?>> types;
+            if (launcher == ShipCitrusYamlMain.class) {
+                types = classClosure(
+                        launcher, ShipCamelMainBootstrap.class,
+                        ShipArtifactLimits.class, ShipExpressionPolicy.class, CatalogExpressionInventory.class);
+            } else if (launcher == ShipCamelMainBootstrap.class) {
+                types = classClosure(
+                        launcher, ShipArtifactLimits.class, ShipExpressionPolicy.class,
+                        CatalogExpressionInventory.class);
+            } else if (launcher == ShipMainPackageMain.class) {
+                types = classClosure(launcher, ShipArtifactLimits.class);
+            } else if (launcher == ShipCamelYamlValidateMain.class) {
+                types = classClosure(launcher, ShipArtifactLimits.class);
+            } else {
+                types = classClosure(launcher);
+            }
+            for (Class<?> type : types) {
+                byte[] content = classBytes(type);
+                ZipEntry entry = storedEntry(classPath(type), content);
+                zip.putNextEntry(entry);
+                zip.write(content);
+                zip.closeEntry();
+            }
+        }
+        return bytes.toByteArray();
+    }
+
+    private static ZipEntry storedEntry(String name, byte[] content) {
+        CRC32 crc = new CRC32();
+        crc.update(content);
+        ZipEntry entry = new ZipEntry(name);
+        entry.setMethod(ZipEntry.STORED);
+        entry.setSize(content.length);
+        entry.setCompressedSize(content.length);
+        entry.setCrc(crc.getValue());
+        entry.setTime(0);
+        return entry;
+    }
+
+    private static byte[] classBytes(Class<?> type) throws IOException {
+        String path = classPath(type);
+        ClassLoader loader = type.getClassLoader();
+        try (InputStream input = loader == null
+                ? ClassLoader.getSystemResourceAsStream(path)
+                : loader.getResourceAsStream(path)) {
+            if (input == null) {
+                throw new IOException("Controller launcher class bytes are unavailable: " + type.getName());
+            }
+            return input.readAllBytes();
+        }
+    }
+
+    private static String classPath(Class<?> type) {
+        return type.getName().replace('.', '/') + ".class";
+    }
+
+    private static byte[] read(ZipFile zip, String name, int maximum) throws IOException {
+        ZipEntry entry = zip.getEntry(name);
+        if (entry == null || entry.isDirectory() || entry.getSize() <= 0 || entry.getSize() > maximum) {
+            throw new IOException("JVM payload archive lacks a bounded entry: " + name);
+        }
+        try (InputStream input = zip.getInputStream(entry)) {
+            byte[] bytes = input.readNBytes(maximum + 1);
+            if (bytes.length > maximum || input.read() != -1) {
+                throw new IOException("JVM payload archive entry exceeds its bound: " + name);
+            }
+            return bytes;
+        }
+    }
+
+    private static Path privateDirectory(Path directory) throws IOException {
+        Files.createDirectory(directory);
+        if (Files.isSymbolicLink(directory) || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("JVM payload directory is unsafe: " + directory);
+        }
+        if (Files.getFileAttributeView(directory, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS) != null) {
+            Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+        }
+        return directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static Path regular(Path path, String label) throws IOException {
+        Path normalized = path.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isRegularFile(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(label + " is missing, symbolic, or non-regular: " + path);
+        }
+        return normalized.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static String safeName(String value) throws IOException {
+        if (value == null || !value.matches("[A-Za-z0-9_.-]+")) {
+            throw new IOException("Unsafe JVM payload artifact name");
+        }
+        return value;
+    }
+
+    private static String aggregate(String contentDigest, String archiveDigest, String jdkDigest) {
+        MessageDigest digest = sha256();
+        update(digest, "camel-kit.ship.jvm-payload-identity.v1");
+        update(digest, contentDigest);
+        update(digest, archiveDigest);
+        update(digest, jdkDigest);
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static String digest(Path file) throws IOException {
+        MessageDigest digest = sha256();
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] buffer = new byte[16_384];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, count);
+            }
+        }
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static byte[] digest(Path file, String algorithm) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(algorithm + " is unavailable", e);
+        }
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] buffer = new byte[16_384];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, count);
+            }
+        }
+        return digest.digest();
+    }
+
+    private static String digest(byte[] bytes) {
+        return "sha256:" + HexFormat.of().formatHex(sha256().digest(bytes));
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static MessageDigest sha512() {
+        try {
+            return MessageDigest.getInstance("SHA-512");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-512 is unavailable", e);
+        }
+    }
+
+    private static void update(MessageDigest digest, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+        digest.update(bytes);
+    }
+
+    private static String safeMessage(Throwable error) {
+        return error.getMessage() == null || error.getMessage().isBlank()
+                ? error.getClass().getSimpleName()
+                : error.getMessage();
+    }
+
+    private static HttpClient centralClient() throws IOException {
+        rejectRepositoryOverrides();
+        return CENTRAL_CLIENT;
+    }
+
+    private static final class NoProxySelector extends ProxySelector {
+
+        @Override
+        public List<java.net.Proxy> select(URI uri) {
+            return List.of(java.net.Proxy.NO_PROXY);
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+            // There is no proxy endpoint to report.
+        }
+    }
+
+    public record Identity(Path archive, String aggregateDigest, String archiveDigest, JvmPayloadLock lock) {
+    }
+
+    record ArtifactFile(String identity, String artifactId, String version, Path path) {
+
+        ArtifactFile {
+            path = path.toAbsolutePath().normalize();
+        }
+    }
+
+    private record SourceEntry(
+            String kind,
+            String identity,
+            String path,
+            long size,
+            String digest,
+            long crc,
+            byte[] bytes,
+            Path file) {
+
+        private static SourceEntry bytes(String kind, String identity, String path, byte[] bytes) {
+            CRC32 crc = new CRC32();
+            crc.update(bytes);
+            return new SourceEntry(
+                    kind, identity, path, bytes.length, JvmPayloadArchive.digest(bytes), crc.getValue(), bytes.clone(),
+                    null);
+        }
+
+        private static SourceEntry file(String kind, String identity, String path, Path file) throws IOException {
+            Path source = regular(file, "JVM payload source");
+            CRC32 crc = new CRC32();
+            MessageDigest digest = sha256();
+            long size = 0;
+            try (InputStream input = Files.newInputStream(source, LinkOption.NOFOLLOW_LINKS)) {
+                byte[] buffer = new byte[16_384];
+                int count;
+                while ((count = input.read(buffer)) != -1) {
+                    size = Math.addExact(size, count);
+                    if (size > MAX_ARTIFACT_BYTES) {
+                        throw new IOException("JVM payload source exceeds the artifact size limit");
+                    }
+                    crc.update(buffer, 0, count);
+                    digest.update(buffer, 0, count);
+                }
+            }
+            return new SourceEntry(
+                    kind, identity, path, size,
+                    "sha256:" + HexFormat.of().formatHex(digest.digest()), crc.getValue(), null, source);
+        }
+
+        private JvmPayloadLock.Entry lockEntry() {
+            return new JvmPayloadLock.Entry(kind, identity, path, size, digest);
+        }
+
+        private void writeTo(ZipOutputStream target) throws IOException {
+            if (bytes != null) {
+                target.write(bytes);
+                return;
+            }
+            try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+                input.transferTo(target);
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadLock.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadLock.java
@@ -1,0 +1,519 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Canonical manifest embedded in every controller-owned JVM payload archive. */
+public final class JvmPayloadLock {
+
+    public static final int SCHEMA_VERSION = 2;
+    public static final String LOCK_PATH = "META-INF/camel-kit/payload.lock";
+    private static final int MAX_ROOTS = 64;
+    private static final int MAX_EXCLUSIONS = 16;
+    private static final int MAX_ENTRIES = 512;
+    private static final int MAX_LOCK_BYTES = 1024 * 1024;
+    private static final Pattern SAFE_VALUE = Pattern.compile("[A-Za-z0-9_.$:/-]+");
+    private static final Pattern SAFE_COORDINATE_PART = Pattern.compile("[A-Za-z0-9_.-]+");
+    private static final Pattern DIGEST = Pattern.compile("sha256:[0-9a-f]{64}");
+
+    private final String kind;
+    private final String camelVersion;
+    private final String citrusVersion;
+    private final String launcherClass;
+    private final String jdkDigest;
+    private final List<Root> dependencyRoots;
+    private final List<Entry> entries;
+    private final String contentDigest;
+
+    private JvmPayloadLock(
+                           String kind,
+                           String camelVersion,
+                           String citrusVersion,
+                           String launcherClass,
+                           String jdkDigest,
+                           List<Root> dependencyRoots,
+                           List<Entry> entries,
+                           String contentDigest)
+                                                 throws IOException {
+        this.kind = requireSafe(kind, "payload kind");
+        this.camelVersion = requireRelease(camelVersion, "Camel version");
+        this.citrusVersion = citrusVersion == null ? null : requireRelease(citrusVersion, "Citrus version");
+        this.launcherClass = requireSafe(launcherClass, "launcher class");
+        this.jdkDigest = requireDigest(jdkDigest, "JDK digest");
+        this.dependencyRoots = dependencyRoots == null
+                ? List.of()
+                : dependencyRoots.stream().sorted(Comparator.comparing(Root::coordinate)).toList();
+        this.entries = entries == null
+                ? List.of()
+                : entries.stream().sorted(Comparator.comparing(Entry::path)).toList();
+        validate();
+        String expected = computeContentDigest();
+        if (contentDigest != null && !expected.equals(contentDigest)) {
+            throw new IOException("JVM payload lock content digest mismatch");
+        }
+        this.contentDigest = expected;
+    }
+
+    public static JvmPayloadLock create(
+            JvmPayloadRequest request, String jdkDigest, List<Entry> entries)
+            throws IOException {
+        if (request == null || !request.kind().supported()) {
+            throw new IOException("Only supported controller JVM payloads can be locked");
+        }
+        return new JvmPayloadLock(
+                request.kind().id(), request.camelVersion(), request.citrusVersion(),
+                request.launcherClass(), jdkDigest, roots(request), entries, null);
+    }
+
+    public static JvmPayloadLock parse(byte[] bytes) throws IOException {
+        if (bytes == null || bytes.length == 0 || bytes.length > MAX_LOCK_BYTES) {
+            throw new IOException("JVM payload lock has an unsafe size");
+        }
+        Map<String, String> values = new LinkedHashMap<>();
+        String text = new String(bytes, StandardCharsets.UTF_8);
+        for (String line : text.split("\\n", -1)) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            int separator = line.indexOf('=');
+            if (separator <= 0 || separator == line.length() - 1
+                    || values.putIfAbsent(line.substring(0, separator), line.substring(separator + 1)) != null) {
+                throw new IOException("JVM payload lock contains malformed or duplicate fields");
+            }
+        }
+        int schema = integer(values.remove("schemaVersion"), "schemaVersion");
+        if (schema != SCHEMA_VERSION) {
+            throw new IOException("Unsupported JVM payload lock schema: " + schema);
+        }
+        String kind = required(values, "kind");
+        String camelVersion = required(values, "camelVersion");
+        String citrusVersion = nullable(required(values, "citrusVersion"));
+        String launcherClass = required(values, "launcherClass");
+        String jdkDigest = required(values, "jdkDigest");
+        int rootCount = boundedCount(values.remove("root.count"), "root.count", MAX_ROOTS);
+        List<Root> roots = new ArrayList<>(rootCount);
+        for (int index = 0; index < rootCount; index++) {
+            String prefix = "root." + formatted(index) + '.';
+            String groupId = required(values, prefix + "groupId");
+            String artifactId = required(values, prefix + "artifactId");
+            String version = required(values, prefix + "version");
+            int exclusionCount = boundedCount(
+                    values.remove(prefix + "exclusion.count"), prefix + "exclusion.count", MAX_EXCLUSIONS);
+            List<Exclusion> exclusions = new ArrayList<>(exclusionCount);
+            for (int exclusion = 0; exclusion < exclusionCount; exclusion++) {
+                String exclusionPrefix = prefix + "exclusion." + formatted(exclusion) + '.';
+                exclusions.add(exclusion(
+                        required(values, exclusionPrefix + "groupId"),
+                        required(values, exclusionPrefix + "artifactId")));
+            }
+            roots.add(root(groupId, artifactId, version, exclusions));
+        }
+        int entryCount = boundedCount(values.remove("entry.count"), "entry.count", MAX_ENTRIES);
+        List<Entry> entries = new ArrayList<>(entryCount);
+        for (int index = 0; index < entryCount; index++) {
+            String prefix = "entry." + formatted(index) + '.';
+            entries.add(entry(
+                    required(values, prefix + "kind"),
+                    required(values, prefix + "identity"),
+                    required(values, prefix + "path"),
+                    longValue(values.remove(prefix + "size"), prefix + "size"),
+                    required(values, prefix + "digest")));
+        }
+        String contentDigest = required(values, "contentDigest");
+        if (!values.isEmpty()) {
+            throw new IOException("JVM payload lock contains unknown fields: " + values.keySet());
+        }
+        return new JvmPayloadLock(
+                kind, camelVersion, citrusVersion, launcherClass, jdkDigest, roots, entries, contentDigest);
+    }
+
+    public byte[] encode() {
+        StringBuilder value = new StringBuilder(4096);
+        field(value, "schemaVersion", Integer.toString(SCHEMA_VERSION));
+        field(value, "kind", kind);
+        field(value, "camelVersion", camelVersion);
+        field(value, "citrusVersion", citrusVersion == null ? "-" : citrusVersion);
+        field(value, "launcherClass", launcherClass);
+        field(value, "jdkDigest", jdkDigest);
+        field(value, "root.count", Integer.toString(dependencyRoots.size()));
+        for (int index = 0; index < dependencyRoots.size(); index++) {
+            Root root = dependencyRoots.get(index);
+            String prefix = "root." + formatted(index) + '.';
+            field(value, prefix + "groupId", root.groupId());
+            field(value, prefix + "artifactId", root.artifactId());
+            field(value, prefix + "version", root.version());
+            field(value, prefix + "exclusion.count", Integer.toString(root.exclusions().size()));
+            for (int exclusion = 0; exclusion < root.exclusions().size(); exclusion++) {
+                Exclusion excluded = root.exclusions().get(exclusion);
+                String exclusionPrefix = prefix + "exclusion." + formatted(exclusion) + '.';
+                field(value, exclusionPrefix + "groupId", excluded.groupId());
+                field(value, exclusionPrefix + "artifactId", excluded.artifactId());
+            }
+        }
+        field(value, "entry.count", Integer.toString(entries.size()));
+        for (int index = 0; index < entries.size(); index++) {
+            Entry entry = entries.get(index);
+            String prefix = "entry." + formatted(index) + '.';
+            field(value, prefix + "kind", entry.kind());
+            field(value, prefix + "identity", entry.identity());
+            field(value, prefix + "path", entry.path());
+            field(value, prefix + "size", Long.toString(entry.size()));
+            field(value, prefix + "digest", entry.digest());
+        }
+        field(value, "contentDigest", contentDigest);
+        return value.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public void requireRequest(JvmPayloadRequest request) throws IOException {
+        if (request == null
+                || !kind.equals(request.kind().id())
+                || !camelVersion.equals(request.camelVersion())
+                || !Objects.equals(citrusVersion, request.citrusVersion())
+                || !launcherClass.equals(request.launcherClass())
+                || !dependencyRoots.equals(roots(request))) {
+            throw new IOException("Retained JVM payload does not match the controller request");
+        }
+    }
+
+    public String kind() {
+        return kind;
+    }
+
+    public String camelVersion() {
+        return camelVersion;
+    }
+
+    public String citrusVersion() {
+        return citrusVersion;
+    }
+
+    public String launcherClass() {
+        return launcherClass;
+    }
+
+    public String jdkDigest() {
+        return jdkDigest;
+    }
+
+    public List<String> roots() {
+        return dependencyRoots.stream().map(Root::coordinate).toList();
+    }
+
+    public List<Root> dependencyRoots() {
+        return dependencyRoots;
+    }
+
+    public List<Entry> entries() {
+        return entries;
+    }
+
+    public String contentDigest() {
+        return contentDigest;
+    }
+
+    private void validate() throws IOException {
+        boolean jdkOnlyPackage = "main-package-inspect".equals(kind);
+        if (dependencyRoots.size() > MAX_ROOTS
+                || dependencyRoots.isEmpty() != jdkOnlyPackage
+                || dependencyRoots.stream().map(Root::coordinate).distinct().count() != dependencyRoots.size()) {
+            throw new IOException("JVM payload lock roots are missing, duplicated, or excessive");
+        }
+        if (entries.size() < 3 || entries.size() > MAX_ENTRIES) {
+            throw new IOException("JVM payload lock entry count is outside controller bounds");
+        }
+        Set<String> paths = new HashSet<>();
+        Map<String, String> gaVersions = new HashMap<>();
+        int launcherCount = 0;
+        boolean bootstrapFound = false;
+        Set<String> resolvedRoots = new HashSet<>();
+        for (Entry entry : entries) {
+            if (!paths.add(entry.path())) {
+                throw new IOException("JVM payload lock contains duplicate paths");
+            }
+            if ("launcher".equals(entry.kind())) {
+                launcherCount++;
+            }
+            bootstrapFound |= "bootstrap".equals(entry.kind());
+            if ("maven".equals(entry.kind())) {
+                MavenIdentity identity = MavenIdentity.parse(entry.identity());
+                String previous = gaVersions.putIfAbsent(identity.ga(), identity.version());
+                if (previous != null && !previous.equals(identity.version())) {
+                    throw new IOException("JVM payload contains multiple versions of " + identity.ga());
+                }
+                if ("org.apache.camel".equals(identity.groupId())
+                        && !camelVersion.equals(identity.version())) {
+                    throw new IOException("JVM payload Camel artifacts are not aligned to " + camelVersion);
+                }
+                if ("org.citrusframework".equals(identity.groupId()) && citrusVersion != null
+                        && !citrusVersion.equals(identity.version())) {
+                    throw new IOException("JVM payload Citrus artifacts are not aligned to " + citrusVersion);
+                }
+                resolvedRoots.add(identity.groupId() + ':' + identity.artifactId() + ':' + identity.version());
+            }
+        }
+        if (launcherCount != 1 || !bootstrapFound) {
+            throw new IOException("JVM payload lock lacks its controller bootstrap or launcher");
+        }
+        if (!resolvedRoots.containsAll(roots())) {
+            throw new IOException("JVM payload lock omits a controller dependency root");
+        }
+    }
+
+    private String computeContentDigest() {
+        MessageDigest digest = sha256();
+        update(digest, "camel-kit.ship.jvm-payload-lock.v2");
+        update(digest, kind);
+        update(digest, camelVersion);
+        update(digest, citrusVersion == null ? "" : citrusVersion);
+        update(digest, launcherClass);
+        update(digest, jdkDigest);
+        update(digest, Integer.toString(dependencyRoots.size()));
+        for (Root root : dependencyRoots) {
+            update(digest, root.groupId());
+            update(digest, root.artifactId());
+            update(digest, root.version());
+            update(digest, Integer.toString(root.exclusions().size()));
+            for (Exclusion exclusion : root.exclusions()) {
+                update(digest, exclusion.groupId());
+                update(digest, exclusion.artifactId());
+            }
+        }
+        for (Entry entry : entries) {
+            update(digest, entry.kind());
+            update(digest, entry.identity());
+            update(digest, entry.path());
+            update(digest, Long.toString(entry.size()));
+            update(digest, entry.digest());
+        }
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static List<Root> roots(JvmPayloadRequest request) {
+        return request.dependencyRoots().stream()
+                .map(root -> new Root(
+                        root.groupId(), root.artifactId(), root.version(),
+                        root.exclusions().stream()
+                                .map(exclusion -> new Exclusion(exclusion.groupId(), exclusion.artifactId()))
+                                .toList()))
+                .sorted(Comparator.comparing(Root::coordinate))
+                .toList();
+    }
+
+    private static Root root(String groupId, String artifactId, String version, List<Exclusion> exclusions)
+            throws IOException {
+        try {
+            return new Root(groupId, artifactId, version, exclusions);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("JVM payload lock contains an unsafe dependency root", e);
+        }
+    }
+
+    private static Exclusion exclusion(String groupId, String artifactId) throws IOException {
+        try {
+            return new Exclusion(groupId, artifactId);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("JVM payload lock contains an unsafe dependency exclusion", e);
+        }
+    }
+
+    private static Entry entry(String kind, String identity, String path, long size, String digest)
+            throws IOException {
+        try {
+            return new Entry(kind, identity, path, size, digest);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("JVM payload lock contains an unsafe entry", e);
+        }
+    }
+
+    private static void field(StringBuilder target, String key, String value) {
+        target.append(key).append('=').append(value).append('\n');
+    }
+
+    private static String required(Map<String, String> values, String key) throws IOException {
+        String value = values.remove(key);
+        if (value == null || value.isBlank()) {
+            throw new IOException("JVM payload lock is missing " + key);
+        }
+        return value;
+    }
+
+    private static String nullable(String value) {
+        return "-".equals(value) ? null : value;
+    }
+
+    private static int boundedCount(String value, String key, int maximum) throws IOException {
+        int count = integer(value, key);
+        if (count < 0 || count > maximum) {
+            throw new IOException("JVM payload lock " + key + " is outside controller bounds");
+        }
+        return count;
+    }
+
+    private static int integer(String value, String key) throws IOException {
+        try {
+            return Integer.parseInt(value);
+        } catch (RuntimeException e) {
+            throw new IOException("JVM payload lock has an invalid " + key, e);
+        }
+    }
+
+    private static long longValue(String value, String key) throws IOException {
+        try {
+            long result = Long.parseLong(value);
+            if (result <= 0) {
+                throw new NumberFormatException("non-positive");
+            }
+            return result;
+        } catch (RuntimeException e) {
+            throw new IOException("JVM payload lock has an invalid " + key, e);
+        }
+    }
+
+    private static String formatted(int index) {
+        return String.format(Locale.ROOT, "%03d", index);
+    }
+
+    private static String requireSafe(String value, String label) throws IOException {
+        if (value == null || !SAFE_VALUE.matcher(value).matches()) {
+            throw new IOException("JVM payload lock has an unsafe " + label);
+        }
+        return value;
+    }
+
+    private static String requireRelease(String value, String label) throws IOException {
+        String release = requireSafe(value, label);
+        String normalized = release.toUpperCase(Locale.ROOT);
+        if (normalized.contains("SNAPSHOT") || "LATEST".equals(normalized) || "RELEASE".equals(normalized)) {
+            throw new IOException("JVM payload lock has a mutable " + label);
+        }
+        return release;
+    }
+
+    private static String requireDigest(String value, String label) throws IOException {
+        if (value == null || !DIGEST.matcher(value).matches()) {
+            throw new IOException("JVM payload lock has an invalid " + label);
+        }
+        return value;
+    }
+
+    private static String coordinatePart(String value, String label) {
+        if (value == null || !SAFE_COORDINATE_PART.matcher(value).matches()) {
+            throw new IllegalArgumentException("JVM payload lock has an unsafe " + label);
+        }
+        return value;
+    }
+
+    private static String coordinatePattern(String value, String label) {
+        return "*".equals(value) ? value : coordinatePart(value, label);
+    }
+
+    private static String release(String value, String label) {
+        try {
+            return requireRelease(value, label);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static void update(MessageDigest digest, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+        digest.update(bytes);
+    }
+
+    public record Root(String groupId, String artifactId, String version, List<Exclusion> exclusions) {
+
+        public Root {
+            groupId = coordinatePart(groupId, "root group ID");
+            artifactId = coordinatePart(artifactId, "root artifact ID");
+            version = release(version, "root version");
+            exclusions = Objects.requireNonNull(exclusions, "exclusions").stream()
+                    .sorted(Comparator.comparing(Exclusion::groupId).thenComparing(Exclusion::artifactId))
+                    .toList();
+            if (exclusions.size() > MAX_EXCLUSIONS || Set.copyOf(exclusions).size() != exclusions.size()) {
+                throw new IllegalArgumentException("JVM payload lock exclusions are duplicated or excessive");
+            }
+        }
+
+        public String coordinate() {
+            return groupId + ':' + artifactId + ':' + version;
+        }
+    }
+
+    public record Exclusion(String groupId, String artifactId) {
+
+        public Exclusion {
+            groupId = coordinatePattern(groupId, "exclusion group ID");
+            artifactId = coordinatePattern(artifactId, "exclusion artifact ID");
+        }
+    }
+
+    public record Entry(String kind, String identity, String path, long size, String digest) {
+
+        public Entry {
+            try {
+                kind = requireSafe(kind, "entry kind");
+                identity = requireSafe(identity, "entry identity");
+                path = requireSafe(path, "entry path");
+                digest = requireDigest(digest, "entry digest");
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+            boolean expectedPath = "bootstrap".equals(kind) && path.endsWith(".class")
+                    || Set.of("launcher", "maven").contains(kind)
+                            && path.startsWith("lib/") && path.endsWith(".jar");
+            if (!Set.of("bootstrap", "launcher", "maven").contains(kind)
+                    || !expectedPath
+                    || path.startsWith("/") || path.contains("..") || size <= 0) {
+                throw new IllegalArgumentException("JVM payload lock entry is unsafe");
+            }
+        }
+    }
+
+    private record MavenIdentity(String groupId, String artifactId, String version) {
+
+        private static MavenIdentity parse(String value) throws IOException {
+            String[] parts = value.split(":", -1);
+            if (parts.length < 3 || parts.length > 5) {
+                throw new IOException("JVM payload contains an invalid Maven identity: " + value);
+            }
+            String groupId = parts[0];
+            String artifactId = parts[1];
+            String version = parts[parts.length - 1];
+            String normalized = version.toUpperCase(Locale.ROOT);
+            if (!SAFE_VALUE.matcher(groupId).matches() || !SAFE_VALUE.matcher(artifactId).matches()
+                    || !SAFE_VALUE.matcher(version).matches() || normalized.contains("SNAPSHOT")
+                    || "LATEST".equals(normalized) || "RELEASE".equals(normalized)) {
+                throw new IOException("JVM payload Maven identity is not an exact release: " + value);
+            }
+            return new MavenIdentity(groupId, artifactId, version);
+        }
+
+        private String ga() {
+            return groupId + ':' + artifactId;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadRequest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadRequest.java
@@ -1,0 +1,510 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCamelMainBootstrap;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCamelYamlValidateMain;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipCitrusYamlMain;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain;
+
+/** Exact controller-owned dependency roots and launcher selected for a JVM evidence command. */
+public record JvmPayloadRequest(
+        Kind kind,
+        String camelVersion,
+        String citrusVersion,
+        String launcherClass,
+        List<DependencyRoot> dependencyRoots) {
+
+    private static final Pattern SAFE_VERSION = Pattern.compile("[A-Za-z0-9_.-]+");
+    private static final Pattern SAFE_COORDINATE_PART = Pattern.compile("[A-Za-z0-9_.-]+");
+    private static final DependencyExclusion ALL_CAMEL = new DependencyExclusion("org.apache.camel", "*");
+    private static final Policy POLICY = Policy.load();
+
+    public JvmPayloadRequest {
+        dependencyRoots = dependencyRoots == null
+                ? List.of()
+                : dependencyRoots.stream()
+                        .sorted(Comparator.comparing(DependencyRoot::coordinate))
+                        .toList();
+        if (kind == null || !exactRelease(camelVersion)) {
+            throw new IllegalArgumentException("JVM payload requires an exact release Camel version");
+        }
+        if (citrusVersion != null && !exactRelease(citrusVersion)) {
+            throw new IllegalArgumentException("JVM payload requires an exact release Citrus version");
+        }
+        if (kind.supported()) {
+            if (launcherClass == null || !launcherClass.matches("[A-Za-z_$][A-Za-z0-9_$.]*")
+                    || kind != Kind.MAIN_PACKAGE_INSPECT && dependencyRoots.isEmpty()) {
+                throw new IllegalArgumentException("A supported JVM payload requires a launcher and roots");
+            }
+        } else if (launcherClass != null) {
+            throw new IllegalArgumentException("An unsupported JVM payload cannot name a launcher");
+        }
+        if (dependencyRoots.size() > 64
+                || dependencyRoots.stream().map(DependencyRoot::coordinate).distinct().count()
+                   != dependencyRoots.size()) {
+            throw new IllegalArgumentException("JVM payload roots must be unique exact GAV coordinates");
+        }
+        requireCanonicalPolicy(kind, camelVersion, citrusVersion, launcherClass, dependencyRoots);
+    }
+
+    public static JvmPayloadRequest yamlValidator(String camelVersion) {
+        return new JvmPayloadRequest(
+                Kind.CAMEL_YAML_VALIDATE,
+                camelVersion,
+                null,
+                ShipCamelYamlValidateMain.class.getName(),
+                yamlValidatorRoots(camelVersion));
+    }
+
+    /** JDK-only deterministic route-resource packaging and immediate archive inspection. */
+    public static JvmPayloadRequest mainPackage(String camelVersion) {
+        return new JvmPayloadRequest(
+                Kind.MAIN_PACKAGE_INSPECT,
+                camelVersion,
+                null,
+                ShipMainPackageMain.class.getName(),
+                List.of());
+    }
+
+    public static JvmPayloadRequest camelMain(String camelVersion) {
+        return camelMain(camelVersion, List.of());
+    }
+
+    public static JvmPayloadRequest camelMain(
+            String camelVersion, List<RuntimeDependency> runtimeDependencies) {
+        return new JvmPayloadRequest(
+                Kind.CAMEL_MAIN_START,
+                camelVersion,
+                null,
+                ShipCamelMainBootstrap.class.getName(),
+                mergeRuntimeRoots(camelMainRoots(camelVersion), runtimeDependencies));
+    }
+
+    public static JvmPayloadRequest citrus(
+            String camelVersion, String citrusVersion, List<String> citrusDependencies) {
+        return citrus(camelVersion, citrusVersion, citrusDependencies, List.of());
+    }
+
+    public static JvmPayloadRequest citrus(
+            String camelVersion,
+            String citrusVersion,
+            List<String> citrusDependencies,
+            List<RuntimeDependency> runtimeDependencies) {
+        java.util.TreeSet<String> declared = new java.util.TreeSet<>(citrusDependencies);
+        Set<String> required = Set.of(
+                "org.citrusframework:citrus-camel:" + citrusVersion,
+                "org.citrusframework:citrus-junit-jupiter:" + citrusVersion,
+                "org.citrusframework:citrus-yaml:" + citrusVersion);
+        if (!declared.equals(required)) {
+            throw new IllegalArgumentException("Direct Citrus requires the exact approved dependency declaration");
+        }
+        return new JvmPayloadRequest(
+                Kind.CITRUS_YAML,
+                camelVersion,
+                citrusVersion,
+                ShipCitrusYamlMain.class.getName(),
+                mergeRuntimeRoots(citrusRoots(camelVersion, citrusVersion), runtimeDependencies));
+    }
+
+    public static JvmPayloadRequest runtimeBuild(String kind, String camelVersion) {
+        return new JvmPayloadRequest(
+                Kind.valueOf(kind.toUpperCase(Locale.ROOT).replace('-', '_') + "_BUILD"),
+                camelVersion,
+                null,
+                null,
+                List.of());
+    }
+
+    /** Canonical exact coordinates retained in the payload lock. */
+    public List<String> roots() {
+        return dependencyRoots.stream().map(DependencyRoot::coordinate).toList();
+    }
+
+    /** Stable digest included in the sandbox policy identity. */
+    public String digest() {
+        MessageDigest digest = sha256();
+        update(digest, "camel-kit.ship.jvm-payload-request.v2");
+        update(digest, kind.id());
+        update(digest, camelVersion);
+        update(digest, citrusVersion == null ? "" : citrusVersion);
+        update(digest, launcherClass == null ? "" : launcherClass);
+        update(digest, Integer.toString(dependencyRoots.size()));
+        for (DependencyRoot root : dependencyRoots) {
+            update(digest, root.groupId());
+            update(digest, root.artifactId());
+            update(digest, root.version());
+            update(digest, Integer.toString(root.exclusions().size()));
+            for (DependencyExclusion exclusion : root.exclusions()) {
+                update(digest, exclusion.groupId());
+                update(digest, exclusion.artifactId());
+            }
+        }
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static List<DependencyRoot> yamlValidatorRoots(String camelVersion) {
+        List<DependencyRoot> roots = new ArrayList<>(launcherYamlRoots());
+        roots.add(root(
+                "com.networknt", "json-schema-validator", POLICY.jsonSchemaValidatorVersion(camelVersion)));
+        roots.add(root("com.ethlo.time", "itu", POLICY.networkntItuVersion()));
+        roots.add(root("org.slf4j", "slf4j-api", POLICY.networkntSlf4jVersion()));
+        roots.add(root("org.apache.camel", "camel-yaml-dsl-validator", camelVersion));
+        roots.add(root("org.apache.camel", "camel-yaml-dsl", camelVersion));
+        return roots.stream().sorted(Comparator.comparing(DependencyRoot::coordinate)).toList();
+    }
+
+    private static List<DependencyRoot> camelMainRoots(String camelVersion) {
+        List<DependencyRoot> roots = new ArrayList<>(launcherYamlRoots());
+        roots.addAll(List.of(
+                root("org.apache.camel", "camel-direct", camelVersion),
+                root("org.apache.camel", "camel-main", camelVersion),
+                root("org.apache.camel", "camel-stub", camelVersion),
+                root("org.apache.camel", "camel-yaml-dsl", camelVersion)));
+        return roots.stream().sorted(Comparator.comparing(DependencyRoot::coordinate)).toList();
+    }
+
+    private static List<DependencyRoot> launcherYamlRoots() {
+        return List.of(
+                root("com.fasterxml.jackson.core", "jackson-annotations", POLICY.jacksonYamlVersion()),
+                root("com.fasterxml.jackson.core", "jackson-core", POLICY.jacksonYamlVersion()),
+                root("com.fasterxml.jackson.core", "jackson-databind", POLICY.jacksonYamlVersion()),
+                root("com.fasterxml.jackson.dataformat", "jackson-dataformat-yaml", POLICY.jacksonYamlVersion()),
+                root("org.yaml", "snakeyaml", POLICY.snakeyamlVersion()));
+    }
+
+    private static List<DependencyRoot> citrusRoots(String camelVersion, String citrusVersion) {
+        List<DependencyRoot> roots = new ArrayList<>(camelMainRoots(camelVersion));
+        for (String artifact : List.of("camel-catalog", "camel-core", "camel-spring", "camel-spring-xml")) {
+            roots.add(root("org.apache.camel", artifact, camelVersion));
+        }
+        for (String artifact : List.of("citrus-camel", "citrus-junit-jupiter", "citrus-yaml")) {
+            roots.add(new DependencyRoot(
+                    "org.citrusframework", artifact, citrusVersion, List.of(ALL_CAMEL)));
+        }
+        return roots.stream().sorted(Comparator.comparing(DependencyRoot::coordinate)).toList();
+    }
+
+    private static DependencyRoot root(String groupId, String artifactId, String version) {
+        return new DependencyRoot(groupId, artifactId, version, List.of());
+    }
+
+    private static void requireCanonicalPolicy(
+            Kind kind,
+            String camelVersion,
+            String citrusVersion,
+            String launcherClass,
+            List<DependencyRoot> roots) {
+        if (!kind.supported()) {
+            if (citrusVersion != null || !roots.isEmpty()) {
+                throw new IllegalArgumentException("An unsupported JVM payload cannot name dependencies");
+            }
+            return;
+        }
+        POLICY.requireYamlValidator(camelVersion);
+        String expectedLauncher;
+        List<DependencyRoot> expectedRoots;
+        switch (kind) {
+            case MAIN_PACKAGE_INSPECT -> {
+                if (citrusVersion != null) {
+                    throw new IllegalArgumentException("Camel Main packaging cannot name a Citrus version");
+                }
+                expectedLauncher = ShipMainPackageMain.class.getName();
+                expectedRoots = List.of();
+            }
+            case CAMEL_YAML_VALIDATE -> {
+                if (citrusVersion != null) {
+                    throw new IllegalArgumentException("Camel YAML validation cannot name a Citrus version");
+                }
+                expectedLauncher = ShipCamelYamlValidateMain.class.getName();
+                expectedRoots = yamlValidatorRoots(camelVersion);
+            }
+            case CAMEL_MAIN_START -> {
+                if (citrusVersion != null) {
+                    throw new IllegalArgumentException("Camel Main startup cannot name a Citrus version");
+                }
+                expectedLauncher = ShipCamelMainBootstrap.class.getName();
+                expectedRoots = camelMainRoots(camelVersion);
+            }
+            case CITRUS_YAML -> {
+                POLICY.requireCitrus(camelVersion, citrusVersion);
+                expectedLauncher = ShipCitrusYamlMain.class.getName();
+                expectedRoots = citrusRoots(camelVersion, citrusVersion);
+            }
+            default -> throw new IllegalArgumentException("Unsupported JVM payload kind");
+        }
+        boolean allowRuntimeRoots = kind == Kind.CAMEL_MAIN_START || kind == Kind.CITRUS_YAML;
+        if (!expectedLauncher.equals(launcherClass)
+                || !canonicalRoots(expectedRoots, roots, allowRuntimeRoots)) {
+            throw new IllegalArgumentException("JVM payload dependencies differ from the packaged controller policy");
+        }
+    }
+
+    private static boolean canonicalRoots(
+            List<DependencyRoot> base, List<DependencyRoot> actual, boolean allowRuntimeRoots) {
+        Map<String, DependencyRoot> required = new java.util.HashMap<>();
+        base.forEach(root -> required.put(root.groupId() + ':' + root.artifactId(), root));
+        Set<String> seen = new HashSet<>();
+        for (DependencyRoot root : actual) {
+            String ga = root.groupId() + ':' + root.artifactId();
+            if (!seen.add(ga)) {
+                return false;
+            }
+            DependencyRoot expected = required.get(ga);
+            if (expected != null) {
+                if (!expected.equals(root)) {
+                    return false;
+                }
+                continue;
+            }
+            if (!allowRuntimeRoots || !(root.groupId().equals("org.apache.camel")
+                    || root.groupId().equals("org.apache.camel.springboot")
+                    || root.groupId().equals("org.apache.camel.quarkus"))
+                    || !root.artifactId().startsWith("camel-") || !root.exclusions().isEmpty()) {
+                return false;
+            }
+        }
+        Set<String> actualGa = actual.stream()
+                .map(root -> root.groupId() + ':' + root.artifactId()).collect(java.util.stream.Collectors.toSet());
+        return actualGa.containsAll(required.keySet());
+    }
+
+    private static List<DependencyRoot> mergeRuntimeRoots(
+            List<DependencyRoot> base, List<RuntimeDependency> runtimeDependencies) {
+        Objects.requireNonNull(runtimeDependencies, "runtimeDependencies must not be null");
+        Map<String, DependencyRoot> roots = new java.util.HashMap<>();
+        for (DependencyRoot root : base) {
+            roots.put(root.groupId() + ':' + root.artifactId(), root);
+        }
+        for (RuntimeDependency dependency : runtimeDependencies) {
+            Objects.requireNonNull(dependency, "runtimeDependencies must not contain null");
+            DependencyRoot root = root(dependency.groupId(), dependency.artifactId(), dependency.version());
+            String ga = root.groupId() + ':' + root.artifactId();
+            DependencyRoot previous = roots.putIfAbsent(ga, root);
+            if (previous != null && !previous.equals(root)) {
+                throw new IllegalArgumentException("Catalog runtime root conflicts with controller payload: " + ga);
+            }
+        }
+        return roots.values().stream().sorted(Comparator.comparing(DependencyRoot::coordinate)).toList();
+    }
+
+    private static boolean exactRelease(String value) {
+        if (value == null || !SAFE_VERSION.matcher(value).matches()) {
+            return false;
+        }
+        String normalized = value.toUpperCase(Locale.ROOT);
+        return !normalized.contains("SNAPSHOT")
+                && !"LATEST".equals(normalized)
+                && !"RELEASE".equals(normalized);
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static void update(MessageDigest digest, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+        digest.update(bytes);
+    }
+
+    public record DependencyRoot(
+            String groupId,
+            String artifactId,
+            String version,
+            List<DependencyExclusion> exclusions) {
+
+        public DependencyRoot {
+            requireCoordinatePart(groupId, "group ID");
+            requireCoordinatePart(artifactId, "artifact ID");
+            if (!exactRelease(version)) {
+                throw new IllegalArgumentException("JVM payload roots require exact release versions");
+            }
+            exclusions = Objects.requireNonNull(exclusions, "exclusions").stream()
+                    .sorted(Comparator.comparing(DependencyExclusion::groupId)
+                            .thenComparing(DependencyExclusion::artifactId))
+                    .toList();
+            if (exclusions.size() > 16 || Set.copyOf(exclusions).size() != exclusions.size()) {
+                throw new IllegalArgumentException("JVM payload root exclusions are duplicated or excessive");
+            }
+        }
+
+        public String coordinate() {
+            return groupId + ':' + artifactId + ':' + version;
+        }
+    }
+
+    public record DependencyExclusion(String groupId, String artifactId) {
+
+        public DependencyExclusion {
+            requireCoordinatePattern(groupId, "exclusion group ID");
+            requireCoordinatePattern(artifactId, "exclusion artifact ID");
+        }
+    }
+
+    private static void requireCoordinatePart(String value, String label) {
+        if (value == null || !SAFE_COORDINATE_PART.matcher(value).matches()) {
+            throw new IllegalArgumentException("JVM payload has an unsafe " + label);
+        }
+    }
+
+    private static void requireCoordinatePattern(String value, String label) {
+        if (!"*".equals(value)) {
+            requireCoordinatePart(value, label);
+        }
+    }
+
+    private record Policy(
+            List<String> yamlValidatorVersions,
+            Properties properties,
+            String jacksonYamlVersion,
+            String snakeyamlVersion) {
+
+        private static final String VALIDATOR_VERSIONS = "ship.evidence.camel-yaml-validator.supported";
+        private static final String JACKSON_VERSION = "ship.evidence.jackson-yaml.version";
+        private static final String SNAKEYAML_VERSION = "ship.evidence.snakeyaml.version";
+        private static final String NETWORKNT_ITU_VERSION = "ship.evidence.camel-yaml-validator.networknt-itu.version";
+        private static final String NETWORKNT_SLF4J_VERSION
+                = "ship.evidence.camel-yaml-validator.networknt-slf4j.version";
+
+        private static Policy load() {
+            Properties properties = new Properties();
+            try (InputStream input = JvmPayloadRequest.class.getClassLoader()
+                    .getResourceAsStream("distribution.properties")) {
+                if (input == null) {
+                    throw new IllegalStateException("Packaged distribution.properties is unavailable");
+                }
+                properties.load(input);
+            } catch (IOException e) {
+                throw new IllegalStateException("Could not read the packaged Ship payload policy", e);
+            }
+            List<String> versions = versionList(properties, VALIDATOR_VERSIONS, true);
+            versions.forEach(version -> requiredRelease(properties, jsonSchemaValidatorKey(version)));
+            String defaultCamel = requiredRelease(properties, "camel.main.version");
+            if (!versions.contains(defaultCamel)) {
+                throw new IllegalStateException("Ship validator policy excludes the distribution's default Camel");
+            }
+            String defaultCitrus = requiredRelease(properties, "citrus.version");
+            List<String> citrusCamel = versionList(properties, citrusKey(defaultCitrus), true);
+            if (!citrusCamel.contains(defaultCamel)) {
+                throw new IllegalStateException("Ship Citrus policy excludes the distribution's default Camel");
+            }
+            return new Policy(
+                    versions,
+                    properties,
+                    requiredRelease(properties, JACKSON_VERSION),
+                    requiredRelease(properties, SNAKEYAML_VERSION));
+        }
+
+        private void requireYamlValidator(String camelVersion) {
+            if (!yamlValidatorVersions.contains(camelVersion)) {
+                throw new IllegalArgumentException(
+                        "Camel " + camelVersion + " has no certified direct YAML validator payload; supported: "
+                                                   + yamlValidatorVersions);
+            }
+        }
+
+        private String jsonSchemaValidatorVersion(String camelVersion) {
+            requireYamlValidator(camelVersion);
+            return requiredRelease(properties, jsonSchemaValidatorKey(camelVersion));
+        }
+
+        private String networkntItuVersion() {
+            return requiredRelease(properties, NETWORKNT_ITU_VERSION);
+        }
+
+        private String networkntSlf4jVersion() {
+            return requiredRelease(properties, NETWORKNT_SLF4J_VERSION);
+        }
+
+        private void requireCitrus(String camelVersion, String citrusVersion) {
+            if (citrusVersion == null
+                    || !versionList(properties, citrusKey(citrusVersion), false).contains(camelVersion)) {
+                throw new IllegalArgumentException(
+                        "Citrus " + citrusVersion + " with Camel " + camelVersion
+                                                   + " has no certified direct evidence payload");
+            }
+        }
+
+        private static String citrusKey(String citrusVersion) {
+            return "ship.evidence.citrus." + citrusVersion + ".camel.supported";
+        }
+
+        private static String jsonSchemaValidatorKey(String camelVersion) {
+            return "ship.evidence.camel-yaml-validator." + camelVersion
+                   + ".json-schema-validator.version";
+        }
+
+        private static List<String> versionList(Properties properties, String key, boolean required) {
+            String value = properties.getProperty(key);
+            if (value == null || value.isBlank()) {
+                if (!required) {
+                    return List.of();
+                }
+                throw new IllegalStateException("Packaged Ship payload policy is missing " + key);
+            }
+            Set<String> unique = new HashSet<>();
+            for (String version : value.split(",", -1)) {
+                String normalized = version.trim();
+                if (!exactRelease(normalized) || !unique.add(normalized)) {
+                    throw new IllegalStateException("Packaged Ship payload policy has an invalid " + key);
+                }
+            }
+            return unique.stream().sorted().toList();
+        }
+
+        private static String requiredRelease(Properties properties, String key) {
+            String value = properties.getProperty(key);
+            if (!exactRelease(value)) {
+                throw new IllegalStateException("Packaged Ship payload policy has an invalid " + key);
+            }
+            return value;
+        }
+    }
+
+    public enum Kind {
+        MAIN_PACKAGE_INSPECT("main-package-inspect", true),
+        CAMEL_YAML_VALIDATE("camel-yaml-validate", true),
+        CAMEL_MAIN_START("camel-main-start", true),
+        CITRUS_YAML("citrus-yaml", true),
+        SPRING_BOOT_BUILD("spring-boot-build", false),
+        QUARKUS_BUILD("quarkus-build", false);
+
+        private final String id;
+        private final boolean supported;
+
+        Kind(String id, boolean supported) {
+            this.id = id;
+            this.supported = supported;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public boolean supported() {
+            return supported;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipJvmPayloadBootstrap.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipJvmPayloadBootstrap.java
@@ -44,7 +44,7 @@ public final class ShipJvmPayloadBootstrap {
 
         Path extraction = Files.createTempDirectory("camel-kit-ship-payload-");
         try {
-            List<URL> urls = extract(archive, extraction, classpath);
+            List<URL> urls = extract(extraction, classpath);
             try (URLClassLoader loader = new URLClassLoader(
                     urls.toArray(URL[]::new), ClassLoader.getPlatformClassLoader())) {
                 Class<?> launcher = Class.forName(lock.launcherClass(), true, loader);
@@ -144,20 +144,18 @@ public final class ShipJvmPayloadBootstrap {
         }
     }
 
-    private static List<URL> extract(Path archive, Path root, List<PayloadEntry> entries) throws IOException {
+    private static List<URL> extract(Path root, List<PayloadEntry> entries) throws IOException {
         List<URL> result = new ArrayList<>();
-        try (ZipFile zip = new ZipFile(archive.toFile())) {
-            for (PayloadEntry payload : entries) {
-                Path target = root.resolve(Path.of(payload.entry().path()).getFileName().toString()).normalize();
-                if (!target.getParent().equals(root)) {
-                    throw new IOException("JVM payload extraction path escaped its private directory");
-                }
-                Files.write(target, payload.bytes(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
-                if (!payload.entry().digest().equals(digest(Files.readAllBytes(target)))) {
-                    throw new IOException("Extracted JVM payload entry failed digest verification");
-                }
-                result.add(target.toUri().toURL());
+        for (PayloadEntry payload : entries) {
+            Path target = root.resolve(Path.of(payload.entry().path()).getFileName().toString()).normalize();
+            if (!target.getParent().equals(root)) {
+                throw new IOException("JVM payload extraction path escaped its private directory");
             }
+            Files.write(target, payload.bytes(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            if (!payload.entry().digest().equals(digest(Files.readAllBytes(target)))) {
+                throw new IOException("Extracted JVM payload entry failed digest verification");
+            }
+            result.add(target.toUri().toURL());
         }
         return List.copyOf(result);
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipJvmPayloadBootstrap.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipJvmPayloadBootstrap.java
@@ -1,0 +1,198 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/** Minimal JDK-only bootstrap for a content-locked nested-JAR evidence payload. */
+public final class ShipJvmPayloadBootstrap {
+
+    private static final int MAX_ARCHIVE_ENTRIES = 1_024;
+    private static final long MAX_ENTRY_BYTES = 128L * 1024 * 1024;
+    private static final long MAX_TOTAL_BYTES = 768L * 1024 * 1024;
+
+    private ShipJvmPayloadBootstrap() {
+    }
+
+    public static void main(String[] arguments) throws Throwable {
+        Path archive = archive();
+        JvmPayloadLock lock;
+        List<PayloadEntry> classpath;
+        try (ZipFile zip = new ZipFile(archive.toFile())) {
+            lock = JvmPayloadLock.parse(read(zip, JvmPayloadLock.LOCK_PATH, 1024 * 1024));
+            requireJdk(lock);
+            classpath = verify(zip, lock);
+        }
+
+        Path extraction = Files.createTempDirectory("camel-kit-ship-payload-");
+        try {
+            List<URL> urls = extract(archive, extraction, classpath);
+            try (URLClassLoader loader = new URLClassLoader(
+                    urls.toArray(URL[]::new), ClassLoader.getPlatformClassLoader())) {
+                Class<?> launcher = Class.forName(lock.launcherClass(), true, loader);
+                if (launcher.getClassLoader() != loader) {
+                    throw new SecurityException("Evidence launcher escaped the isolated payload classloader");
+                }
+                Method main = launcher.getMethod("main", String[].class);
+                Thread thread = Thread.currentThread();
+                ClassLoader previous = thread.getContextClassLoader();
+                thread.setContextClassLoader(loader);
+                try {
+                    main.invoke(null, (Object) arguments);
+                } catch (InvocationTargetException e) {
+                    throw e.getCause();
+                } finally {
+                    thread.setContextClassLoader(previous);
+                }
+            }
+        } finally {
+            deleteTree(extraction);
+        }
+    }
+
+    private static Path archive() throws Exception {
+        Path path = Path.of(ShipJvmPayloadBootstrap.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI())
+                .toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(path) || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("JVM payload bootstrap must run from one regular archive");
+        }
+        return path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static void requireJdk(JvmPayloadLock lock) {
+        String actual = System.getenv("CAMEL_KIT_JDK_DIGEST");
+        if (!lock.jdkDigest().equals(actual)) {
+            throw new SecurityException("JVM payload JDK identity differs from its content lock");
+        }
+    }
+
+    private static List<PayloadEntry> verify(ZipFile zip, JvmPayloadLock lock) throws IOException {
+        Set<String> expected = new HashSet<>();
+        expected.add(JvmPayloadLock.LOCK_PATH);
+        lock.entries().forEach(entry -> expected.add(entry.path()));
+        Set<String> observed = new HashSet<>();
+        long total = 0;
+        int count = 0;
+        var enumeration = zip.entries();
+        while (enumeration.hasMoreElements()) {
+            ZipEntry entry = enumeration.nextElement();
+            if (++count > MAX_ARCHIVE_ENTRIES || entry.isDirectory() || !observed.add(entry.getName())
+                    || !expected.contains(entry.getName()) || entry.getSize() <= 0
+                    || entry.getSize() > MAX_ENTRY_BYTES) {
+                throw new IOException("JVM payload archive contains an unsafe entry: " + entry.getName());
+            }
+            total = Math.addExact(total, entry.getSize());
+            if (total > MAX_TOTAL_BYTES) {
+                throw new IOException("JVM payload archive exceeds the controller size limit");
+            }
+        }
+        if (!observed.equals(expected)) {
+            throw new IOException("JVM payload archive entries differ from its content lock");
+        }
+
+        List<PayloadEntry> result = new ArrayList<>();
+        for (JvmPayloadLock.Entry entry : lock.entries()) {
+            byte[] bytes = read(zip, entry.path(), Math.toIntExact(Math.min(entry.size(), Integer.MAX_VALUE)));
+            if (bytes.length != entry.size() || !entry.digest().equals(digest(bytes))) {
+                throw new IOException("JVM payload entry differs from its content lock: " + entry.path());
+            }
+            if ("launcher".equals(entry.kind()) || "maven".equals(entry.kind())) {
+                result.add(new PayloadEntry(entry, bytes));
+            }
+        }
+        result.sort(Comparator.comparing(payload -> payload.entry().path()));
+        return List.copyOf(result);
+    }
+
+    private static byte[] read(ZipFile zip, String name, int maximum) throws IOException {
+        ZipEntry entry = zip.getEntry(name);
+        if (entry == null || entry.isDirectory() || entry.getSize() <= 0 || entry.getSize() > maximum) {
+            throw new IOException("JVM payload archive lacks a bounded entry: " + name);
+        }
+        try (InputStream input = zip.getInputStream(entry)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream((int) entry.getSize());
+            byte[] buffer = new byte[16_384];
+            int total = 0;
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                total = Math.addExact(total, count);
+                if (total > maximum) {
+                    throw new IOException("JVM payload entry exceeds its bound: " + name);
+                }
+                output.write(buffer, 0, count);
+            }
+            return output.toByteArray();
+        }
+    }
+
+    private static List<URL> extract(Path archive, Path root, List<PayloadEntry> entries) throws IOException {
+        List<URL> result = new ArrayList<>();
+        try (ZipFile zip = new ZipFile(archive.toFile())) {
+            for (PayloadEntry payload : entries) {
+                Path target = root.resolve(Path.of(payload.entry().path()).getFileName().toString()).normalize();
+                if (!target.getParent().equals(root)) {
+                    throw new IOException("JVM payload extraction path escaped its private directory");
+                }
+                Files.write(target, payload.bytes(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+                if (!payload.entry().digest().equals(digest(Files.readAllBytes(target)))) {
+                    throw new IOException("Extracted JVM payload entry failed digest verification");
+                }
+                result.add(target.toUri().toURL());
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (root == null || !Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                if (Files.isSymbolicLink(path)) {
+                    throw new IOException("Private JVM payload extraction contained a symbolic link");
+                }
+                Files.delete(path);
+            }
+        }
+    }
+
+    private static String digest(byte[] bytes) {
+        try {
+            return "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private record PayloadEntry(JvmPayloadLock.Entry entry, byte[] bytes) {
+
+        private PayloadEntry {
+            bytes = bytes.clone();
+        }
+
+        @Override
+        public byte[] bytes() {
+            return bytes.clone();
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrap.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrap.java
@@ -1,0 +1,520 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.component.stub.StubComponent;
+import org.apache.camel.main.Main;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogExpressionInventory;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.events.AliasEvent;
+import org.yaml.snakeyaml.events.CollectionStartEvent;
+import org.yaml.snakeyaml.events.DocumentStartEvent;
+import org.yaml.snakeyaml.events.NodeEvent;
+import org.yaml.snakeyaml.events.ScalarEvent;
+import org.yaml.snakeyaml.parser.ParserImpl;
+import org.yaml.snakeyaml.reader.StreamReader;
+
+/** Starts only the accepted YAML routes with every non-direct endpoint replaced by Camel Stub. */
+public final class ShipCamelMainBootstrap {
+
+    static final String TEST_ENTRY_PREFIX = "direct:camel-kit-ship-test-";
+    private static final Pattern URI_SCHEME = Pattern.compile("[A-Za-z][A-Za-z0-9+.-]*");
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{\\{([A-Za-z0-9_.-]+)}}");
+    private static final Pattern APPLICATION_CONFIGURATION = Pattern.compile(
+            "application[^/]*\\.(?:properties|ya?ml)", Pattern.CASE_INSENSITIVE);
+    private static final Set<String> ENDPOINT_KEYS = Set.of(
+            "from", "to", "tod", "enrich", "pollenrich", "wiretap", "interceptsendtoendpoint", "uri");
+    private static final Set<String> FORBIDDEN_KEYS = Set.of(
+            "bean", "beans", "script", "scripts", "groovy", "javascript", "js", "python", "kotlin",
+            "routepolicy", "routeconfiguration", "routeconfigurations", "templatedroute", "routetemplate",
+            "rest", "rests", "kamelet", "process", "exec");
+    private static final List<String> FORBIDDEN_VALUES = List.of(
+            "${bean:", "${type:", "${ref:", "#bean:", "#class:", "java.lang.runtime",
+            "processbuilder", "script:", "$simple{", ".class", "::", "runtime.exec");
+    private static final Set<String> ALTERNATE_BUILD_OR_LAUNCH_FILES = Set.of(
+            "build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts",
+            "gradlew", "gradlew.bat", "build.xml", "jbang-catalog.json", "dockerfile",
+            "docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml");
+    private static final Set<String> MAVEN_MODEL_HOOKS = Set.of(
+            ".mvn/extensions.xml", ".mvn/maven.config", ".mvn/jvm.config");
+    private static final Set<String> CAMEL_CONFIGURATION_FILES = Set.of(
+            "camel.properties", "camel.yaml", "camel.yml",
+            "camel-main.properties", "camel-main.yaml", "camel-main.yml");
+    private static final Set<String> SCRIPT_SUFFIXES = Set.of(
+            ".sh", ".bash", ".zsh", ".ksh", ".jsh", ".py", ".rb", ".groovy", ".js");
+    private static final ObjectMapper YAML = new ObjectMapper(
+            YAMLFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(100)
+                            .maxStringLength(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES)
+                            .build())
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build());
+
+    private ShipCamelMainBootstrap() {
+    }
+
+    public static void main(String[] arguments) throws Exception {
+        if (arguments.length == 1 && "--payload-version".equals(arguments[0])) {
+            System.out.println("Camel direct Main bootstrap " + camelVersion());
+            return;
+        }
+        TreeSet<String> routes = new TreeSet<>();
+        TreeSet<String> routeIds = new TreeSet<>();
+        for (String argument : arguments) {
+            if (argument.startsWith("--route=")) {
+                if (!routes.add(argument.substring("--route=".length()))) {
+                    throw new IOException("A route path was supplied more than once");
+                }
+            } else if (argument.startsWith("--expected-route=")) {
+                String id = argument.substring("--expected-route=".length());
+                if (id.isBlank() || !routeIds.add(id)) {
+                    throw new IOException("An expected route ID is blank or duplicated");
+                }
+            } else {
+                throw new IOException("Unknown direct Main bootstrap argument");
+            }
+        }
+        start(Path.of("/workspace"), routes.stream().map(Path::of).toList(), routeIds);
+    }
+
+    public static void start(Path acceptedRoot, List<Path> requestedRoutes, Set<String> expectedRouteIds)
+            throws Exception {
+        withStarted(acceptedRoot, requestedRoutes, expectedRouteIds, context -> {
+            // Reaching the callback proves that every accepted route is started.
+        });
+    }
+
+    public static void withStarted(
+            Path acceptedRoot,
+            List<Path> requestedRoutes,
+            Set<String> expectedRouteIds,
+            StartedAction action)
+            throws Exception {
+        withStarted(acceptedRoot, requestedRoutes, expectedRouteIds, null, action);
+    }
+
+    /** Starts one accepted route after replacing its consumer with a reserved in-memory test entry. */
+    static void withTestEntryPoint(
+            Path acceptedRoot,
+            List<Path> requestedRoutes,
+            Set<String> expectedRouteIds,
+            String testRouteId,
+            StartedAction action)
+            throws Exception {
+        if (requestedRoutes == null || requestedRoutes.size() != 1
+                || expectedRouteIds == null || expectedRouteIds.size() != 1
+                || !expectedRouteIds.contains(testRouteId)) {
+            throw new IOException("Direct Citrus requires exactly one accepted target route");
+        }
+        withStarted(acceptedRoot, requestedRoutes, expectedRouteIds, testRouteId, action);
+    }
+
+    private static void withStarted(
+            Path acceptedRoot,
+            List<Path> requestedRoutes,
+            Set<String> expectedRouteIds,
+            String testRouteId,
+            StartedAction action)
+            throws Exception {
+        Path root = acceptedRoot.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (Files.isSymbolicLink(root) || !Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)
+                || requestedRoutes == null || requestedRoutes.isEmpty()
+                || expectedRouteIds == null || expectedRouteIds.isEmpty()) {
+            throw new IOException("Direct Main startup requires accepted routes and exact route IDs");
+        }
+
+        TreeSet<Path> routes = new TreeSet<>();
+        TreeSet<String> schemes = new TreeSet<>();
+        for (Path requested : requestedRoutes) {
+            Path route = requested.toAbsolutePath().normalize();
+            if (!route.startsWith(root) || Files.isSymbolicLink(route)
+                    || !Files.isRegularFile(route, LinkOption.NOFOLLOW_LINKS)
+                    || Files.size(route) <= 0
+                    || Files.size(route) > ShipArtifactLimits.MAX_ROUTE_YAML_BYTES) {
+                throw new IOException("Route is outside the accepted snapshot or unsafe: " + requested);
+            }
+            route = route.toRealPath(LinkOption.NOFOLLOW_LINKS);
+            if (!route.startsWith(root) || !routes.add(route)) {
+                throw new IOException("Route escaped or was supplied more than once: " + requested);
+            }
+            inspect(route, schemes);
+        }
+        validateLaunchSurface(root, List.copyOf(routes));
+
+        Main main = new Main();
+        main.setDefaultPropertyPlaceholderLocation("false");
+        main.configure().setAutoConfigurationEnabled(false);
+        main.configure().setAutoConfigurationEnvironmentVariablesEnabled(false);
+        main.configure().setAutoConfigurationSystemPropertiesEnabled(false);
+        main.configure().setBasePackageScanEnabled(false);
+        main.configure().setModeline(false);
+        main.configure().setRoutesReloadEnabled(false);
+        main.configure().setJmxEnabled(false);
+        main.configure().setLoadHealthChecks(false);
+        main.configure().setDevConsoleEnabled(false);
+        main.configure().setAutoStartup(testRouteId == null);
+        main.configure().setRoutesIncludePattern(routes.stream()
+                .map(path -> path.toUri().toString())
+                .collect(Collectors.joining(",")));
+        Properties properties = new Properties();
+        main.setInitialProperties(properties);
+        for (String scheme : schemes) {
+            if (!"direct".equals(scheme)) {
+                main.bind(scheme, new StubComponent());
+            }
+        }
+
+        try {
+            main.start();
+            CamelContext context = main.getCamelContext();
+            Set<String> actualIds = Set.copyOf(context.getRouteIds());
+            if (!actualIds.equals(Set.copyOf(expectedRouteIds))) {
+                throw new IOException("Started route IDs differ from the approved manifest: " + actualIds);
+            }
+            if (testRouteId != null) {
+                AdviceWith.adviceWith(
+                        context, testRouteId,
+                        route -> route.replaceFromWith(testEntryUri(testRouteId)));
+                context.getRouteController().startRoute(testRouteId);
+            }
+            for (String routeId : expectedRouteIds) {
+                ServiceStatus status = context.getRouteController().getRouteStatus(routeId);
+                if (status == null || !status.isStarted()) {
+                    throw new IOException("Approved route did not reach Started: " + routeId);
+                }
+            }
+            Set<String> unexpectedComponents = new HashSet<>(context.getComponentNames());
+            unexpectedComponents.removeAll(schemes);
+            unexpectedComponents.remove("direct");
+            unexpectedComponents.remove("stub");
+            unexpectedComponents.remove("properties");
+            if (!unexpectedComponents.isEmpty()) {
+                throw new IOException("Main loaded components outside the stub policy: " + unexpectedComponents);
+            }
+            if (action == null) {
+                throw new IOException("Direct Main startup requires a controller action");
+            }
+            action.run(context);
+        } finally {
+            main.stop();
+        }
+    }
+
+    static String testEntryUri(String routeId) throws IOException {
+        if (routeId == null || !routeId.matches("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")) {
+            throw new IOException("Route ID cannot form a safe controller test entry");
+        }
+        return TEST_ENTRY_PREFIX + routeId;
+    }
+
+    public static void validatePolicy(Path route) throws IOException {
+        inspect(route, new TreeSet<>());
+    }
+
+    /**
+     * Rejects candidate-controlled launch inputs outside Ship v1's exact, configuration-free Main route bundle. The
+     * evidence launcher repeats this check even though the controller performs it before execution.
+     */
+    public static void validateLaunchSurface(Path acceptedRoot, List<Path> requestedRoutes) throws IOException {
+        Path root = acceptedRoot.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (Files.isSymbolicLink(root) || !Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)
+                || requestedRoutes == null || requestedRoutes.isEmpty()) {
+            throw new IOException("Main launch-surface validation requires an accepted root and routes");
+        }
+
+        Set<Path> acceptedRoutes = new HashSet<>();
+        for (Path requested : requestedRoutes) {
+            if (requested == null) {
+                throw new IOException("Main launch-surface validation received a null route");
+            }
+            Path route = requested.isAbsolute()
+                    ? requested.toAbsolutePath().normalize()
+                    : root.resolve(requested).normalize();
+            if (!route.startsWith(root) || Files.isSymbolicLink(route)
+                    || !Files.isRegularFile(route, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Accepted route is absent or unsafe: " + requested);
+            }
+            route = route.toRealPath(LinkOption.NOFOLLOW_LINKS);
+            if (!route.startsWith(root) || !acceptedRoutes.add(route)) {
+                throw new IOException("Accepted route escaped or was duplicated: " + requested);
+            }
+        }
+
+        try (var entries = Files.walk(root)) {
+            for (Path entry : entries.sorted().toList()) {
+                if (entry.equals(root)) {
+                    continue;
+                }
+                if (Files.isSymbolicLink(entry)) {
+                    throw new IOException(
+                            "Candidate launch surface contains a symbolic link: "
+                                          + relative(root, entry));
+                }
+                if (Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS)) {
+                    continue;
+                }
+                if (!Files.isRegularFile(entry, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException(
+                            "Candidate launch surface contains a non-regular entry: "
+                                          + relative(root, entry));
+                }
+                Path real = entry.toRealPath(LinkOption.NOFOLLOW_LINKS);
+                if (!real.startsWith(root)) {
+                    throw new IOException("Candidate launch surface escaped its accepted root");
+                }
+                if (acceptedRoutes.contains(real)) {
+                    continue;
+                }
+                rejectUnapprovedLaunchInput(root, entry);
+            }
+        }
+    }
+
+    private static void rejectUnapprovedLaunchInput(Path root, Path entry) throws IOException {
+        String relative = relative(root, entry);
+        String lower = relative.toLowerCase(Locale.ROOT);
+        String fileName = entry.getFileName().toString();
+        String lowerName = fileName.toLowerCase(Locale.ROOT);
+
+        if (lower.endsWith(".camel.yaml") || lower.endsWith(".camel.yml")) {
+            throw launchSurfaceError(relative, "an undeclared Camel YAML route");
+        }
+        if (lower.endsWith(".camel.xml") || lower.endsWith(".pipe.yaml") || lower.endsWith(".pipe.yml")
+                || lower.endsWith(".kamelet.yaml") || lower.endsWith(".kamelet.yml")) {
+            throw launchSurfaceError(relative, "an alternate Camel route source");
+        }
+        if (APPLICATION_CONFIGURATION.matcher(fileName).matches()
+                || CAMEL_CONFIGURATION_FILES.contains(lowerName)) {
+            throw launchSurfaceError(relative, "candidate runtime configuration");
+        }
+        if (lower.startsWith("src/main/resources/")) {
+            throw launchSurfaceError(relative, "an undeclared Main runtime resource");
+        }
+        if (lower.startsWith("src/main/java/") || lower.startsWith("src/main/kotlin/")
+                || lower.startsWith("src/main/groovy/")) {
+            throw launchSurfaceError(relative, "candidate runtime code");
+        }
+        if (lower.startsWith("meta-inf/services/") || lower.contains("/meta-inf/services/")
+                || lower.startsWith("meta-inf/spring/") || lower.contains("/meta-inf/spring/")
+                || lower.endsWith("/meta-inf/spring.factories") || lower.equals("meta-inf/spring.factories")) {
+            throw launchSurfaceError(relative, "a candidate service-loader or runtime extension");
+        }
+        if (lower.endsWith(".jar") || lower.endsWith(".class")) {
+            throw launchSurfaceError(relative, "candidate-controlled JVM bytecode");
+        }
+        if (MAVEN_MODEL_HOOKS.contains(lower)) {
+            throw launchSurfaceError(relative, "an unbound Maven model hook");
+        }
+        if (ALTERNATE_BUILD_OR_LAUNCH_FILES.contains(lowerName)) {
+            throw launchSurfaceError(relative, "an alternate build or launch model");
+        }
+        boolean launchDirectory = lower.startsWith("bin/") || lower.startsWith("scripts/")
+                || lower.startsWith("src/main/scripts/");
+        boolean rootScript = !relative.contains("/") && !Set.of("mvnw", "mvnw.cmd").contains(lowerName);
+        if ((launchDirectory || rootScript)
+                && SCRIPT_SUFFIXES.stream().anyMatch(lowerName::endsWith)) {
+            throw launchSurfaceError(relative, "a candidate-controlled launch script");
+        }
+    }
+
+    private static IOException launchSurfaceError(String relative, String kind) {
+        return new IOException("Ship v1 Main launch surface contains " + kind + ": " + relative);
+    }
+
+    private static String relative(Path root, Path path) {
+        return root.relativize(path.toAbsolutePath().normalize()).toString().replace('\\', '/');
+    }
+
+    private static void inspect(Path route, Set<String> schemes) throws IOException {
+        long size = Files.size(route);
+        if (size <= 0 || size > ShipArtifactLimits.MAX_ROUTE_YAML_BYTES) {
+            throw new IOException("Route YAML exceeds the deterministic byte limit");
+        }
+        rejectYamlReferences(route);
+        JsonNode document;
+        try (InputStream input = Files.newInputStream(route, LinkOption.NOFOLLOW_LINKS)) {
+            document = YAML.readTree(input);
+        } catch (RuntimeException e) {
+            throw new IOException("Could not safely inspect route YAML", e);
+        }
+        if (document == null || (!document.isArray() && !document.isObject())) {
+            throw new IOException("Route YAML must contain a mapping or sequence");
+        }
+        visit(document, null, schemes);
+    }
+
+    private static void visit(JsonNode node, String parentKey, Set<String> schemes) throws IOException {
+        if (node == null || node.isNull()) {
+            return;
+        }
+        if (node.isArray()) {
+            for (JsonNode child : node) {
+                visit(child, parentKey, schemes);
+            }
+            return;
+        }
+        if (node.isObject()) {
+            requireSingleExpressionSelector(node);
+            for (Map.Entry<String, JsonNode> field : node.properties()) {
+                String rawKey = field.getKey();
+                String key = normalize(rawKey);
+                if (CatalogExpressionInventory.SIMPLE.equals(rawKey)) {
+                    if (!field.getValue().isTextual()
+                            || !CatalogExpressionInventory.isSafeSimple(field.getValue().asText())) {
+                        throw new IOException("Only scalar allowlisted Simple expressions are supported");
+                    }
+                    continue;
+                }
+                if (CatalogExpressionInventory.GENERIC.equals(rawKey)) {
+                    requireGenericSimple(field.getValue());
+                    continue;
+                }
+                if (CatalogExpressionInventory.isRejectedAlias(rawKey)) {
+                    throw new IOException(
+                            "Ship v1 permits only the Simple expression language: " + field.getKey());
+                }
+                if (CatalogExpressionInventory.isNonExactAlias(rawKey)) {
+                    throw new IOException("Camel expression uses an unsupported non-exact alias: " + rawKey);
+                }
+                if (FORBIDDEN_KEYS.contains(key)) {
+                    throw new IOException("Route YAML contains an unsafe startup construct: " + field.getKey());
+                }
+                visit(field.getValue(), key, schemes);
+            }
+            return;
+        }
+        if (!node.isTextual()) {
+            return;
+        }
+        String value = node.asText().trim();
+        String lower = value.toLowerCase(Locale.ROOT);
+        if (FORBIDDEN_VALUES.stream().anyMatch(lower::contains)) {
+            throw new IOException("Route YAML contains an unsafe startup value");
+        }
+        String resolved = rejectPlaceholders(value);
+        if (parentKey != null && ENDPOINT_KEYS.contains(parentKey)) {
+            int colon = resolved.indexOf(':');
+            if (colon <= 0 || resolved.substring(0, colon).contains("{")
+                    || resolved.substring(0, colon).contains("$")) {
+                throw new IOException("Endpoint URI has no static safe component scheme");
+            }
+            String scheme = resolved.substring(0, colon).toLowerCase(Locale.ROOT);
+            if (!URI_SCHEME.matcher(scheme).matches()) {
+                throw new IOException("Endpoint URI has an unsafe component scheme");
+            }
+            if (resolved.toLowerCase(Locale.ROOT).startsWith(TEST_ENTRY_PREFIX)) {
+                throw new IOException("Route uses the controller-reserved test endpoint namespace");
+            }
+            schemes.add(scheme);
+        }
+    }
+
+    private static void requireSingleExpressionSelector(JsonNode node) throws IOException {
+        int selected = 0;
+        for (Map.Entry<String, JsonNode> field : node.properties()) {
+            if (CatalogExpressionInventory.isKnownAlias(field.getKey())) {
+                selected++;
+            }
+        }
+        if (selected > 1) {
+            throw new IOException("Camel expression must select exactly one unambiguous language alias");
+        }
+    }
+
+    private static void requireGenericSimple(JsonNode value) throws IOException {
+        if (value == null || !value.isObject() || value.size() != 2
+                || !value.has(CatalogExpressionInventory.GENERIC) || !value.has("expression")) {
+            throw new IOException(
+                    "Generic Camel language expressions must contain exactly language and expression");
+        }
+        JsonNode language = value.get(CatalogExpressionInventory.GENERIC);
+        JsonNode expression = value.get("expression");
+        if (!language.isTextual() || !CatalogExpressionInventory.SIMPLE.equals(language.asText())) {
+            throw new IOException("Ship v1 generic Camel expressions must select exactly Simple");
+        }
+        if (!expression.isTextual() || !CatalogExpressionInventory.isSafeSimple(expression.asText())) {
+            throw new IOException("Only scalar allowlisted Simple expressions are supported");
+        }
+    }
+
+    static void rejectYamlReferences(Path yaml) throws IOException {
+        LoaderOptions options = new LoaderOptions();
+        options.setAllowDuplicateKeys(false);
+        options.setMaxAliasesForCollections(0);
+        options.setNestingDepthLimit(100);
+        options.setCodePointLimit(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES);
+        try (var reader = Files.newBufferedReader(yaml)) {
+            ParserImpl parser = new ParserImpl(new StreamReader(reader), options);
+            int documents = 0;
+            while (parser.peekEvent() != null) {
+                var event = parser.getEvent();
+                if (event instanceof DocumentStartEvent && ++documents > 1) {
+                    throw new IOException("YAML must contain exactly one document");
+                }
+                if (event instanceof AliasEvent
+                        || event instanceof NodeEvent node && node.getAnchor() != null
+                        || event instanceof ScalarEvent scalar && scalar.getTag() != null
+                        || event instanceof CollectionStartEvent collection && collection.getTag() != null) {
+                    throw new IOException("YAML aliases, anchors, and explicit tags are forbidden");
+                }
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new IOException("Could not inspect YAML parser events safely", e);
+        }
+    }
+
+    private static String rejectPlaceholders(String value) throws IOException {
+        Matcher matcher = PLACEHOLDER.matcher(value);
+        if (matcher.find() || value.contains("{{") || value.contains("}}")) {
+            throw new IOException(
+                    "Route placeholders are unsupported until bound to an approved runtime-property contract");
+        }
+        if (value.contains("${") && !CatalogExpressionInventory.isSafeSimple(value)) {
+            throw new IOException("Route contains an unsupported dynamic placeholder");
+        }
+        return value;
+    }
+
+    private static String normalize(String value) {
+        return value.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+    }
+
+    private static String camelVersion() {
+        String version = CamelContext.class.getPackage().getImplementationVersion();
+        return version == null || version.isBlank() ? "unknown" : version;
+    }
+
+    @FunctionalInterface
+    public interface StartedAction {
+
+        void run(CamelContext context) throws Exception;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrap.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrap.java
@@ -48,7 +48,9 @@ public final class ShipCamelMainBootstrap {
     private static final Pattern APPLICATION_CONFIGURATION = Pattern.compile(
             "application[^/]*\\.(?:properties|ya?ml)", Pattern.CASE_INSENSITIVE);
     private static final Set<String> ENDPOINT_KEYS = Set.of(
-            "from", "to", "tod", "enrich", "pollenrich", "wiretap", "interceptsendtoendpoint", "uri");
+            "from", "to", "tod", "enrich", "pollenrich", "wiretap", "uri", "afteruri");
+    private static final Set<String> ENDPOINT_SELECTOR_KEYS = Set.of(
+            "interceptfrom", "interceptsendtoendpoint");
     private static final Set<String> FORBIDDEN_KEYS = Set.of(
             "bean", "beans", "script", "scripts", "groovy", "javascript", "js", "python", "kotlin",
             "routepolicy", "routeconfiguration", "routeconfigurations", "templatedroute", "routetemplate",
@@ -380,6 +382,15 @@ public final class ShipCamelMainBootstrap {
             return;
         }
         if (node.isObject()) {
+            if (isEndpointSelector(parentKey)) {
+                JsonNode uriPattern = node.get("uri");
+                if (uriPattern == null && "interceptsendtoendpoint".equals(parentKey)) {
+                    throw new IOException("interceptSendToEndpoint requires a URI pattern");
+                }
+                if (uriPattern != null && !uriPattern.isTextual()) {
+                    throw new IOException("Endpoint selector URI pattern must be textual");
+                }
+            }
             requireSingleExpressionSelector(node);
             for (Map.Entry<String, JsonNode> field : node.properties()) {
                 String rawKey = field.getKey();
@@ -405,7 +416,9 @@ public final class ShipCamelMainBootstrap {
                 if (FORBIDDEN_KEYS.contains(key)) {
                     throw new IOException("Route YAML contains an unsafe startup construct: " + field.getKey());
                 }
-                visit(field.getValue(), key, schemes);
+                visit(field.getValue(),
+                        isEndpointSelector(parentKey) && "uri".equals(key) ? parentKey : key,
+                        schemes);
             }
             return;
         }
@@ -416,6 +429,9 @@ public final class ShipCamelMainBootstrap {
         String lower = value.toLowerCase(Locale.ROOT);
         if (FORBIDDEN_VALUES.stream().anyMatch(lower::contains)) {
             throw new IOException("Route YAML contains an unsafe startup value");
+        }
+        if (isEndpointSelector(parentKey) && value.contains("${")) {
+            throw new IOException("Endpoint selector pattern cannot be dynamic");
         }
         String resolved = rejectPlaceholders(value);
         if (parentKey != null && ENDPOINT_KEYS.contains(parentKey)) {
@@ -505,6 +521,10 @@ public final class ShipCamelMainBootstrap {
 
     private static String normalize(String value) {
         return value.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isEndpointSelector(String key) {
+        return key != null && ENDPOINT_SELECTOR_KEYS.contains(key);
     }
 
     private static String camelVersion() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelYamlValidateMain.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelYamlValidateMain.java
@@ -1,0 +1,66 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.dsl.yaml.validator.CamelYamlParser;
+import org.apache.camel.dsl.yaml.validator.YamlValidator;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+
+/** Direct, controller-owned Camel YAML schema and parser validation entry point. */
+public final class ShipCamelYamlValidateMain {
+
+    private ShipCamelYamlValidateMain() {
+    }
+
+    public static void main(String[] arguments) throws Exception {
+        if (arguments.length == 1 && "--payload-version".equals(arguments[0])) {
+            new YamlValidator().init();
+            System.out.println("Camel direct YAML validator " + camelVersion());
+            return;
+        }
+        validate(Path.of("/workspace"), List.of(arguments));
+    }
+
+    public static void validate(Path acceptedRoot, List<String> routeArguments) throws Exception {
+        Path root = acceptedRoot.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (Files.isSymbolicLink(root) || !Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)
+                || routeArguments == null || routeArguments.isEmpty()) {
+            throw new IOException("YAML validation requires an accepted route snapshot");
+        }
+        Set<Path> routes = new HashSet<>();
+        for (String value : routeArguments) {
+            Path route = Path.of(value).toAbsolutePath().normalize();
+            if (!route.startsWith(root) || Files.isSymbolicLink(route)
+                    || !Files.isRegularFile(route, LinkOption.NOFOLLOW_LINKS)
+                    || Files.size(route) <= 0
+                    || Files.size(route) > ShipArtifactLimits.MAX_ROUTE_YAML_BYTES) {
+                throw new IOException("YAML route is outside the accepted snapshot or unsafe: " + value);
+            }
+            route = route.toRealPath(LinkOption.NOFOLLOW_LINKS);
+            if (!route.startsWith(root) || !routes.add(route)) {
+                throw new IOException("YAML route escaped or was supplied more than once: " + value);
+            }
+            List<?> schemaErrors = new YamlValidator().validate(route.toFile());
+            if (!schemaErrors.isEmpty()) {
+                throw new IOException("Camel YAML schema validation failed for " + value + ": " + schemaErrors);
+            }
+            List<?> parserErrors = new CamelYamlParser().parse(route.toFile());
+            if (!parserErrors.isEmpty()) {
+                throw new IOException("Camel YAML parser validation failed for " + value + ": " + parserErrors);
+            }
+        }
+    }
+
+    private static String camelVersion() {
+        String version = CamelContext.class.getPackage().getImplementationVersion();
+        return version == null || version.isBlank() ? "unknown" : version;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCitrusYamlMain.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCitrusYamlMain.java
@@ -1,0 +1,404 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import org.apache.camel.CamelContext;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/** Runs one allowlisted Citrus YAML behavior test through one accepted Camel route. */
+public final class ShipCitrusYamlMain {
+
+    static final int MAX_CASES = 32;
+    static final int MAX_ACTIONS = MAX_CASES * 2;
+    static final int MAX_HEADERS_PER_ACTION = 32;
+    static final int MAX_BODY_CHARS = 256 * 1024;
+    static final int MAX_HEADER_VALUE_CHARS = 4096;
+    private static final Pattern TEST_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}");
+    private static final Pattern ENDPOINT = Pattern.compile("camel:sync:direct:[A-Za-z0-9_.-]+");
+    private static final Pattern HEADER_NAME = Pattern.compile("[A-Za-z][A-Za-z0-9_.-]{0,127}");
+    private static final Set<String> TOP_LEVEL = Set.of("name", "actions");
+    private static final Set<String> ACTION_FIELDS = Set.of("endpoint", "message");
+    private static final Set<String> MESSAGE_FIELDS = Set.of("body", "headers");
+    private static final Set<String> HEADER_FIELDS = Set.of("name", "value");
+    private static final Pattern CITRUS_FUNCTION = Pattern.compile(
+            "(?i)citrus:[A-Za-z][A-Za-z0-9]*\\s*\\(");
+    private static final ObjectMapper YAML = new ObjectMapper(
+            YAMLFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(50)
+                            .maxStringLength(ShipArtifactLimits.MAX_CITRUS_YAML_BYTES)
+                            .build())
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build());
+
+    private ShipCitrusYamlMain() {
+    }
+
+    public static void main(String[] arguments) throws Exception {
+        if (arguments.length == 1 && "--payload-version".equals(arguments[0])) {
+            System.out.println("Citrus direct YAML " + citrusVersion() + " with Camel " + camelVersion());
+            return;
+        }
+        TreeSet<Path> routes = new TreeSet<>();
+        TreeSet<String> routeIds = new TreeSet<>();
+        Path test = null;
+        for (String argument : arguments) {
+            if (argument.startsWith("--route=")) {
+                routes.add(Path.of(argument.substring("--route=".length())));
+            } else if (argument.startsWith("--expected-route=")) {
+                routeIds.add(argument.substring("--expected-route=".length()));
+            } else if (argument.startsWith("--test=") && test == null) {
+                test = Path.of(argument.substring("--test=".length()));
+            } else {
+                throw new IOException("Unknown or duplicate direct Citrus argument");
+            }
+        }
+        if (routes.size() != 1 || routeIds.size() != 1 || test == null) {
+            throw new IOException("Direct Citrus requires exactly one route, route ID, and YAML test");
+        }
+        Path acceptedRoot = Path.of("/workspace");
+        Path acceptedTest = acceptedFile(
+                acceptedRoot, test, ShipArtifactLimits.MAX_CITRUS_YAML_BYTES, "Citrus YAML test");
+        String routeId = routeIds.first();
+        TestContract contract = inspect(acceptedTest, routeId);
+        ShipCamelMainBootstrap.withTestEntryPoint(
+                acceptedRoot, List.copyOf(routes), routeIds, routeId,
+                context -> run(context, acceptedTest, contract));
+    }
+
+    static TestContract inspect(Path test, String expectedRouteId) throws IOException {
+        long size = Files.size(test);
+        if (size <= 0 || size > ShipArtifactLimits.MAX_CITRUS_YAML_BYTES) {
+            throw new IOException("Citrus YAML exceeds the deterministic byte limit");
+        }
+        ShipCamelMainBootstrap.rejectYamlReferences(test);
+        JsonNode document;
+        try (InputStream input = Files.newInputStream(test, LinkOption.NOFOLLOW_LINKS)) {
+            document = YAML.readTree(input);
+        } catch (RuntimeException e) {
+            throw new IOException("Could not safely inspect Citrus YAML", e);
+        }
+        if (document == null || !document.isObject()) {
+            throw new IOException("Citrus YAML must be one mapping");
+        }
+        for (Map.Entry<String, JsonNode> field : document.properties()) {
+            if (!TOP_LEVEL.contains(field.getKey())) {
+                throw new IOException("Citrus YAML top-level field is outside the controller allowlist");
+            }
+        }
+        rejectDynamicText(document);
+        JsonNode name = document.get("name");
+        JsonNode actions = document.get("actions");
+        if (name == null || !name.isTextual() || !TEST_NAME.matcher(name.asText()).matches()
+                || actions == null || !actions.isArray()) {
+            throw new IOException("Citrus YAML must name exactly one bounded behavior test");
+        }
+        if (actions.size() < 2 || actions.size() > MAX_ACTIONS || actions.size() % 2 != 0
+                || actions.size() / 2 > MAX_CASES) {
+            throw new IOException(
+                    "Citrus YAML requires 1-" + MAX_CASES
+                                  + " complete send/receive cases and at most " + MAX_ACTIONS + " actions");
+        }
+        String expectedEndpoint = "camel:sync:" + ShipCamelMainBootstrap.testEntryUri(expectedRouteId);
+        List<BehaviorCase> cases = new ArrayList<>(actions.size() / 2);
+        for (int index = 0; index < actions.size(); index += 2) {
+            Action send = action(actions.get(index), "send");
+            Action receive = action(actions.get(index + 1), "receive");
+            if (!send.endpoint().equals(receive.endpoint())) {
+                throw new IOException("Each Citrus send and assertion must address the same Camel endpoint");
+            }
+            if (!expectedEndpoint.equals(send.endpoint())) {
+                throw new IOException("Every Citrus endpoint must address the controller test entry for its route");
+            }
+            cases.add(new BehaviorCase(
+                    send.body(), send.headers(), receive.body(), receive.headers()));
+        }
+        return new TestContract(name.asText(), expectedEndpoint, cases);
+    }
+
+    public static void validatePolicy(Path test, String expectedRouteId) throws IOException {
+        inspect(test, expectedRouteId);
+    }
+
+    private static Action action(JsonNode node, String expected) throws IOException {
+        if (node == null || !node.isObject() || node.size() != 1 || !node.has(expected)) {
+            throw new IOException("Citrus actions must be exactly send followed by receive");
+        }
+        JsonNode action = node.get(expected);
+        if (!action.isObject()) {
+            throw new IOException("Citrus action must be a mapping");
+        }
+        for (Map.Entry<String, JsonNode> field : action.properties()) {
+            if (!ACTION_FIELDS.contains(field.getKey())) {
+                throw new IOException("Citrus action field is outside the controller allowlist");
+            }
+        }
+        if (action.size() != ACTION_FIELDS.size()) {
+            throw new IOException("Citrus action requires only endpoint and message");
+        }
+        String endpoint = textualEndpoint(action.get("endpoint"));
+        JsonNode message = action.get("message");
+        if (message == null || !message.isObject() || !message.has("body")
+                || message.size() < 1 || message.size() > MESSAGE_FIELDS.size()) {
+            throw new IOException("Citrus message requires one inline body and optional literal headers");
+        }
+        for (Map.Entry<String, JsonNode> field : message.properties()) {
+            if (!MESSAGE_FIELDS.contains(field.getKey())) {
+                throw new IOException("Citrus message field is outside the controller allowlist");
+            }
+        }
+        JsonNode body = message.get("body");
+        if (body == null || !body.isObject() || body.size() != 1 || !body.has("data")
+                || !body.get("data").isTextual() || body.get("data").asText().isBlank()
+                || body.get("data").asText().length() > MAX_BODY_CHARS) {
+            throw new IOException("Citrus message body must contain one bounded nonblank inline literal");
+        }
+        return new Action(endpoint, body.get("data").asText(), headers(message.get("headers")));
+    }
+
+    private static List<Header> headers(JsonNode node) throws IOException {
+        if (node == null) {
+            return List.of();
+        }
+        if (!node.isArray() || node.isEmpty() || node.size() > MAX_HEADERS_PER_ACTION) {
+            throw new IOException("Citrus headers must contain 1-" + MAX_HEADERS_PER_ACTION + " literal entries");
+        }
+        List<Header> headers = new ArrayList<>(node.size());
+        Set<String> names = new HashSet<>();
+        for (JsonNode entry : node) {
+            if (!entry.isObject() || entry.size() != HEADER_FIELDS.size()
+                    || !entry.has("name") || !entry.has("value")) {
+                throw new IOException("Each Citrus header requires exactly one name and value");
+            }
+            for (Map.Entry<String, JsonNode> field : entry.properties()) {
+                if (!HEADER_FIELDS.contains(field.getKey())) {
+                    throw new IOException("Citrus header field is outside the controller allowlist");
+                }
+            }
+            JsonNode nameNode = entry.get("name");
+            JsonNode valueNode = entry.get("value");
+            if (!nameNode.isTextual() || !HEADER_NAME.matcher(nameNode.asText()).matches()) {
+                throw new IOException("Citrus header name is not a safe application header name");
+            }
+            String name = nameNode.asText();
+            String normalizedName = name.toLowerCase(Locale.ROOT);
+            if (normalizedName.startsWith("camel") || normalizedName.startsWith("citrus")
+                    || !names.add(normalizedName)) {
+                throw new IOException("Citrus headers must be unique application-owned names");
+            }
+            if (!valueNode.isTextual() || valueNode.asText().length() > MAX_HEADER_VALUE_CHARS
+                    || valueNode.asText().chars().anyMatch(Character::isISOControl)) {
+                throw new IOException("Citrus header value must be one bounded literal string");
+            }
+            headers.add(new Header(name, valueNode.asText()));
+        }
+        return List.copyOf(headers);
+    }
+
+    private static String textualEndpoint(JsonNode value) throws IOException {
+        String endpoint;
+        if (value != null && value.isTextual()) {
+            endpoint = value.asText();
+        } else {
+            throw new IOException("Citrus endpoint must be one literal URI");
+        }
+        if (!ENDPOINT.matcher(endpoint).matches()) {
+            throw new IOException("Citrus may address only a literal synchronous direct Camel endpoint");
+        }
+        return endpoint;
+    }
+
+    private static void rejectDynamicText(JsonNode node) throws IOException {
+        if (node.isContainerNode()) {
+            for (JsonNode child : node) {
+                rejectDynamicText(child);
+            }
+        } else if (node.isTextual()) {
+            String value = node.asText();
+            if (value.contains("${") || value.contains("#{") || value.contains("{{")
+                    || CITRUS_FUNCTION.matcher(value).find()
+                    || value.length() >= 2 && value.startsWith("@") && value.endsWith("@")) {
+                throw new IOException("Citrus YAML contains a variable, function, or validation matcher");
+            }
+        }
+    }
+
+    private static void run(CamelContext camelContext, Path test, TestContract contract) throws Exception {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        Class<?> resolverType = Class.forName(
+                "org.citrusframework.camel.context.CamelReferenceResolver", true, loader);
+        Object resolver = resolverType.getConstructor(CamelContext.class).newInstance(camelContext);
+        Class<?> referenceResolver = Class.forName("org.citrusframework.spi.ReferenceResolver", true, loader);
+        Class<?> builderType = Class.forName("org.citrusframework.CitrusContext$Builder", true, loader);
+        Object builder = builderType.getMethod("defaultContext").invoke(null);
+        builderType.getMethod("referenceResolver", referenceResolver).invoke(builder, resolver);
+        Object citrusContext = builderType.getMethod("build").invoke(builder);
+
+        Class<?> manager = Class.forName("org.citrusframework.CitrusInstanceManager", true, loader);
+        Class<?> strategy = Class.forName("org.citrusframework.CitrusInstanceStrategy", true, loader);
+        Object singleton = strategy.getField("SINGLETON").get(null);
+        manager.getMethod("reset").invoke(null);
+        manager.getMethod("mode", strategy).invoke(null, singleton);
+        Class<?> provider = Class.forName("org.citrusframework.CitrusContextProvider", true, loader);
+        Object contextProvider = Proxy.newProxyInstance(loader, new Class<?>[]{provider}, (proxy, method, args) -> {
+            if ("create".equals(method.getName()) && method.getParameterCount() == 0) {
+                return citrusContext;
+            }
+            if ("toString".equals(method.getName())) {
+                return "controller-owned-citrus-context";
+            }
+            if ("hashCode".equals(method.getName())) {
+                return System.identityHashCode(proxy);
+            }
+            if ("equals".equals(method.getName())) {
+                return proxy == args[0];
+            }
+            throw new UnsupportedOperationException("Unexpected Citrus context provider method");
+        });
+
+        try {
+            Class<?> citrus = Class.forName("org.citrusframework.Citrus", true, loader);
+            Object citrusInstance = citrus.getMethod("newInstance", provider).invoke(null, contextProvider);
+            Object actualContext = citrus.getMethod("getCitrusContext").invoke(citrusInstance);
+            if (actualContext != citrusContext
+                    || resolverType.getMethod("getCamelContext").invoke(resolver) != camelContext) {
+                throw new IOException("Citrus did not bind to the preloaded accepted CamelContext");
+            }
+
+            Class<?> configurationType = Class.forName(
+                    "org.citrusframework.main.TestRunConfiguration", true, loader);
+            Object configuration = configurationType.getConstructor().newInstance();
+            configurationType.getMethod("setEngine", String.class).invoke(configuration, "junit-jupiter");
+            Class<?> sourceType = Class.forName("org.citrusframework.TestSource", true, loader);
+            Object source = sourceType.getConstructor(String.class, String.class, String.class)
+                    .newInstance("yaml", contract.name(), test.toString());
+            configurationType.getMethod("setTestSources", List.class)
+                    .invoke(configuration, List.of(source));
+            configurationType.getMethod("setPackages", List.class).invoke(configuration, List.of());
+            configurationType.getMethod("setIncludes", String[].class).invoke(configuration, (Object) new String[0]);
+            configurationType.getMethod("setModules", Set.class).invoke(configuration, Set.of());
+            configurationType.getMethod("setDependencies", Set.class).invoke(configuration, Set.of());
+            configurationType.getMethod("setDefaultProperties", Map.class).invoke(configuration, Map.of());
+            configurationType.getMethod("setVerbose", boolean.class).invoke(configuration, false);
+            configurationType.getMethod("setReset", boolean.class).invoke(configuration, false);
+
+            Class<?> engineType = Class.forName("org.citrusframework.main.TestEngine", true, loader);
+            Object engine = engineType.getMethod("lookup", configurationType).invoke(null, configuration);
+            if (!"org.citrusframework.junit.jupiter.JUnitJupiterEngine".equals(engine.getClass().getName())) {
+                throw new IOException("Citrus resolved an unexpected test engine");
+            }
+            Class<?> listenerType = Class.forName(
+                    "org.junit.platform.launcher.TestExecutionListener", true, loader);
+            Class<?> summaryListenerType = Class.forName(
+                    "org.junit.platform.launcher.listeners.SummaryGeneratingListener", true, loader);
+            Object listener = summaryListenerType.getConstructor().newInstance();
+            engine.getClass().getMethod("addTestListener", listenerType).invoke(engine, listener);
+            engineType.getMethod("run").invoke(engine);
+            Object summary = summaryListenerType.getMethod("getSummary").invoke(listener);
+            Class<?> summaryType = Class.forName(
+                    "org.junit.platform.launcher.listeners.TestExecutionSummary", true, loader);
+            requireCount(summary, summaryType, "getTestsFoundCount", 1);
+            requireCount(summary, summaryType, "getTestsStartedCount", 1);
+            requireCount(summary, summaryType, "getTestsSucceededCount", 1);
+            requireCount(summary, summaryType, "getTestsFailedCount", 0);
+            requireCount(summary, summaryType, "getTestsSkippedCount", 0);
+            requireCount(summary, summaryType, "getTestsAbortedCount", 0);
+
+            Method resultsMethod = citrusContext.getClass().getMethod("getTestResults");
+            Object results = resultsMethod.invoke(citrusContext);
+            Class<?> resultsType = resultsMethod.getReturnType();
+            requireCount(results, resultsType, "getSize", 1);
+            requireCount(results, resultsType, "getSuccess", 1);
+            requireCount(results, resultsType, "getFailed", 0);
+            requireCount(results, resultsType, "getSkipped", 0);
+        } finally {
+            manager.getMethod("reset").invoke(null);
+        }
+    }
+
+    private static void requireCount(Object target, Class<?> publicType, String method, long expected)
+            throws Exception {
+        if (!publicType.isInstance(target)) {
+            throw new IOException("Direct Citrus result has an unexpected implementation");
+        }
+        Number actual = (Number) publicType.getMethod(method).invoke(target);
+        if (actual.longValue() != expected) {
+            throw new IOException("Direct Citrus result " + method + " was " + actual + ", expected " + expected);
+        }
+    }
+
+    private static Path acceptedFile(Path rootValue, Path value, long maximum, String label) throws IOException {
+        Path root = rootValue.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        Path file = value.toAbsolutePath().normalize();
+        if (!file.startsWith(root) || Files.isSymbolicLink(file)
+                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
+                || Files.size(file) <= 0 || Files.size(file) > maximum) {
+            throw new IOException(label + " is outside the accepted snapshot or unsafe");
+        }
+        file = file.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (!file.startsWith(root)) {
+            throw new IOException(label + " escaped the accepted snapshot");
+        }
+        return file;
+    }
+
+    private static String citrusVersion() {
+        try {
+            Class<?> citrus = Class.forName("org.citrusframework.Citrus");
+            return String.valueOf(citrus.getMethod("getVersion").invoke(null));
+        } catch (ReflectiveOperationException e) {
+            return "unknown";
+        }
+    }
+
+    private static String camelVersion() {
+        String version = CamelContext.class.getPackage().getImplementationVersion();
+        return version == null || version.isBlank() ? "unknown" : version;
+    }
+
+    public record TestContract(String name, String endpoint, List<BehaviorCase> cases) {
+
+        public TestContract {
+            cases = List.copyOf(cases);
+        }
+    }
+
+    public record BehaviorCase(
+            String requestBody,
+            List<Header> requestHeaders,
+            String responseBody,
+            List<Header> responseHeaders) {
+
+        public BehaviorCase {
+            requestHeaders = List.copyOf(requestHeaders);
+            responseHeaders = List.copyOf(responseHeaders);
+        }
+    }
+
+    public record Header(String name, String value) {
+    }
+
+    private record Action(String endpoint, String body, List<Header> headers) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipMainPackageMain.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipMainPackageMain.java
@@ -1,0 +1,649 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+
+/** Builds and inspects the exact accepted Camel Main route-resource JAR using only the JDK. */
+public final class ShipMainPackageMain {
+
+    public static final String PAYLOAD_VERSION = "Camel Kit deterministic Main package 1";
+
+    private static final int SCHEMA_VERSION = 1;
+    static final int MAX_ROUTES = 64;
+    private static final int MAX_ROUTE_BYTES = ShipArtifactLimits.MAX_ROUTE_YAML_BYTES;
+    static final int MAX_ROUTE_PATH_CHARACTERS = 4_096;
+    private static final int MAX_ROUTE_PATH_UTF8_BYTES = MAX_ROUTE_PATH_CHARACTERS * 4;
+    private static final long MAX_ZIP_METADATA_BYTES_PER_ROUTE
+            = 2L * MAX_ROUTE_PATH_UTF8_BYTES + 1_024;
+    static final long MAX_PACKAGE_BYTES = (long) MAX_ROUTES
+                                          * (MAX_ROUTE_BYTES + MAX_ZIP_METADATA_BYTES_PER_ROUTE) + 65_536;
+    public static final int MAX_SUMMARY_BYTES = 2 * 1024 * 1024;
+    private static final int MAX_SUMMARY_FIELDS = 9 + MAX_ROUTES * 3;
+    private static final Pattern DIGEST = Pattern.compile("sha256:[0-9a-f]{64}");
+
+    private ShipMainPackageMain() {
+    }
+
+    public static void main(String[] arguments) throws Exception {
+        if (arguments.length == 1 && "--payload-version".equals(arguments[0])) {
+            System.out.println(PAYLOAD_VERSION);
+            return;
+        }
+        Path temporary = Files.createTempDirectory("camel-kit-ship-main-package-");
+        Path archive = temporary.resolve("main-routes.jar");
+        try {
+            Summary summary = packageAndInspect(Path.of("/workspace"), archive, List.of(arguments));
+            System.out.write(summary.encode());
+        } finally {
+            deletePackage(temporary, archive);
+        }
+    }
+
+    /** Creates a deterministic JAR and immediately verifies every archive entry against the accepted routes. */
+    public static Summary packageAndInspect(
+            Path acceptedRoot, Path archive, List<String> arguments)
+            throws IOException {
+        Request request = Request.parse(arguments);
+        Path root = safeRoot(acceptedRoot);
+        List<RouteBytes> routes = loadRoutes(root, request.routes());
+        requireExactRouteSurface(root, routes);
+        writeArchive(archive, routes);
+        Summary summary = inspectPackage(root, archive, request, routes);
+        requireExactRouteSurface(root, routes);
+        for (RouteBytes route : routes) {
+            route.requireSourceUnchanged();
+        }
+        return summary;
+    }
+
+    /** Reopens an existing package and verifies that it contains only the exact authenticated route resources. */
+    public static Summary inspectPackage(
+            Path acceptedRoot, Path archive, List<String> arguments)
+            throws IOException {
+        Request request = Request.parse(arguments);
+        Path root = safeRoot(acceptedRoot);
+        List<RouteBytes> routes = loadRoutes(root, request.routes());
+        requireExactRouteSurface(root, routes);
+        return inspectPackage(root, archive, request, routes);
+    }
+
+    /** Parses and validates the machine-readable stdout retained by controller command evidence. */
+    public static Summary verifySummary(
+            byte[] encoded, Path acceptedRoot, List<String> arguments)
+            throws IOException {
+        Request request = Request.parse(arguments);
+        Path root = safeRoot(acceptedRoot);
+        List<RouteBytes> routes = loadRoutes(root, request.routes());
+        requireExactRouteSurface(root, routes);
+        Summary summary = Summary.parse(encoded);
+        summary.requireRequest(request, routes);
+        return summary;
+    }
+
+    private static void writeArchive(Path requestedArchive, List<RouteBytes> routes) throws IOException {
+        Path archive = requestedArchive.toAbsolutePath().normalize();
+        Path parent = archive.getParent();
+        if (parent == null || Files.isSymbolicLink(parent)
+                || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)
+                || Files.exists(archive, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(archive)) {
+            throw new IOException("Deterministic Main package output is absent or unsafe");
+        }
+        Path realParent = parent.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (!archive.getParent().equals(realParent)) {
+            throw new IOException("Deterministic Main package output parent contains a symbolic-link alias");
+        }
+        try (ZipOutputStream zip = new ZipOutputStream(
+                Files.newOutputStream(
+                        archive, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS))) {
+            zip.setLevel(0);
+            for (RouteBytes route : routes) {
+                CRC32 crc = new CRC32();
+                crc.update(route.bytes());
+                ZipEntry entry = new ZipEntry(route.path());
+                entry.setMethod(ZipEntry.STORED);
+                entry.setSize(route.bytes().length);
+                entry.setCompressedSize(route.bytes().length);
+                entry.setCrc(crc.getValue());
+                entry.setTime(0);
+                zip.putNextEntry(entry);
+                zip.write(route.bytes());
+                zip.closeEntry();
+            }
+        }
+        if (Files.isSymbolicLink(archive) || !Files.isRegularFile(archive, LinkOption.NOFOLLOW_LINKS)
+                || Files.size(archive) <= 0 || Files.size(archive) > MAX_PACKAGE_BYTES) {
+            throw new IOException("Deterministic Main package output has an unsafe type or size");
+        }
+    }
+
+    private static Summary inspectPackage(
+            Path root, Path requestedArchive, Request request, List<RouteBytes> routes)
+            throws IOException {
+        Path archive = requestedArchive.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(archive) || !Files.isRegularFile(archive, LinkOption.NOFOLLOW_LINKS)
+                || Files.size(archive) <= 0 || Files.size(archive) > MAX_PACKAGE_BYTES) {
+            throw new IOException("Deterministic Main package is absent, symbolic, or outside its byte limit");
+        }
+        archive = archive.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        Map<String, RouteBytes> expected = new LinkedHashMap<>();
+        routes.forEach(route -> expected.put(route.path(), route));
+        List<EntrySummary> entries = new ArrayList<>();
+        Set<String> observed = new HashSet<>();
+        try (ZipFile zip = new ZipFile(archive.toFile())) {
+            if (zip.getComment() != null) {
+                throw new IOException("Deterministic Main package cannot contain an archive comment");
+            }
+            var enumeration = zip.entries();
+            while (enumeration.hasMoreElements()) {
+                ZipEntry entry = enumeration.nextElement();
+                String name = safeRoutePath(entry.getName());
+                RouteBytes route = expected.get(name);
+                CRC32 expectedCrc = new CRC32();
+                expectedCrc.update(route == null ? new byte[0] : route.bytes());
+                if (entry.isDirectory() || !observed.add(name) || route == null
+                        || entry.getMethod() != ZipEntry.STORED || entry.getTime() != 0
+                        || entry.getComment() != null || entry.getCrc() != expectedCrc.getValue()
+                        || entry.getSize() != route.bytes().length
+                        || entry.getCompressedSize() != route.bytes().length) {
+                    throw new IOException("Deterministic Main package contains an unsafe entry: " + name);
+                }
+                byte[] bytes = read(zip, entry, MAX_ROUTE_BYTES);
+                if (!MessageDigest.isEqual(route.bytes(), bytes)
+                        || !route.digest().equals(digest(bytes))) {
+                    throw new IOException("Deterministic Main package entry differs from its accepted route: " + name);
+                }
+                entries.add(new EntrySummary(name, bytes.length, route.digest()));
+            }
+        }
+        List<String> expectedOrder = routes.stream().map(RouteBytes::path).toList();
+        if (!observed.equals(expected.keySet())
+                || !entries.stream().map(EntrySummary::path).toList().equals(expectedOrder)) {
+            throw new IOException("Deterministic Main package entries differ from the accepted route manifest");
+        }
+        long size = Files.size(archive);
+        String packageDigest = digest(archive);
+        Summary summary = new Summary(
+                SCHEMA_VERSION,
+                request.candidateDigest(), request.manifestDigest(), request.catalogUsageDigest(),
+                request.pomDigest(), request.mainPayloadDigest(), packageDigest, size, entries);
+        summary.requireRequest(request, routes);
+        return summary;
+    }
+
+    private static List<RouteBytes> loadRoutes(Path root, List<RouteInput> inputs) throws IOException {
+        if (inputs.isEmpty() || inputs.size() > MAX_ROUTES) {
+            throw new IOException("Deterministic Main packaging requires between 1 and " + MAX_ROUTES + " routes");
+        }
+        List<RouteBytes> routes = new ArrayList<>();
+        Set<String> paths = new HashSet<>();
+        for (RouteInput input : inputs.stream().sorted(Comparator.comparing(RouteInput::path)).toList()) {
+            String relative = safeRoutePath(input.path());
+            if (!paths.add(relative)) {
+                throw new IOException("A deterministic Main package route was supplied more than once: " + relative);
+            }
+            Path path = root.resolve(relative).normalize();
+            requireContainedPath(root, path, relative);
+            BasicFileAttributes before = Files.readAttributes(
+                    path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!before.isRegularFile() || before.isSymbolicLink()
+                    || before.size() <= 0 || before.size() > MAX_ROUTE_BYTES) {
+                throw new IOException("Accepted package route has an unsafe type or size: " + relative);
+            }
+            byte[] bytes;
+            try (InputStream inputStream = Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS)) {
+                bytes = inputStream.readNBytes(MAX_ROUTE_BYTES + 1);
+            }
+            if (bytes.length != before.size() || bytes.length > MAX_ROUTE_BYTES
+                    || !input.digest().equals(digest(bytes))) {
+                throw new IOException("Accepted package route differs from its authenticated digest: " + relative);
+            }
+            BasicFileAttributes after = Files.readAttributes(
+                    path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!sameFile(before, after)) {
+                throw new IOException("Accepted package route changed while it was read: " + relative);
+            }
+            routes.add(new RouteBytes(relative, input.digest(), path, before.fileKey(), bytes));
+        }
+        return List.copyOf(routes);
+    }
+
+    private static void requireExactRouteSurface(Path root, List<RouteBytes> routes) throws IOException {
+        Set<String> expected = routes.stream().map(RouteBytes::path).collect(java.util.stream.Collectors.toSet());
+        Set<String> observed = new TreeSet<>();
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.sorted().toList()) {
+                if (path.equals(root)) {
+                    continue;
+                }
+                String relative = root.relativize(path.toAbsolutePath().normalize()).toString().replace('\\', '/');
+                if (Files.isSymbolicLink(path)) {
+                    throw new IOException("Accepted package surface contains a symbolic link: " + relative);
+                }
+                if (!Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)
+                        && !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException("Accepted package surface contains a non-regular entry: " + relative);
+                }
+                if (Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+                        && relative.endsWith(".camel.yaml")) {
+                    observed.add(safeRoutePath(relative));
+                }
+            }
+        }
+        if (!observed.equals(expected)) {
+            throw new IOException("Accepted package route surface differs from the authenticated manifest");
+        }
+    }
+
+    private static void requireContainedPath(Path root, Path path, String label) throws IOException {
+        if (!path.startsWith(root)) {
+            throw new IOException("Accepted package route escaped its root: " + label);
+        }
+        Path current = root;
+        for (Path segment : root.relativize(path)) {
+            current = current.resolve(segment);
+            if (Files.isSymbolicLink(current)) {
+                throw new IOException("Accepted package route contains a symbolic-link component: " + label);
+            }
+        }
+        if (!path.toRealPath(LinkOption.NOFOLLOW_LINKS).startsWith(root)) {
+            throw new IOException("Accepted package route escaped its real root: " + label);
+        }
+    }
+
+    private static Path safeRoot(Path requested) throws IOException {
+        if (requested == null || Files.isSymbolicLink(requested)
+                || !Files.isDirectory(requested, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Deterministic Main package requires a safe accepted root");
+        }
+        return requested.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static String safeRoutePath(String value) throws IOException {
+        if (value == null || value.isBlank() || value.length() > MAX_ROUTE_PATH_CHARACTERS
+                || value.startsWith("/")
+                || value.endsWith("/") || value.indexOf('\\') >= 0 || value.indexOf('\0') >= 0
+                || !value.endsWith(".camel.yaml")) {
+            throw new IOException("Deterministic Main package route path is unsafe");
+        }
+        Path path;
+        try {
+            path = Path.of(value);
+        } catch (RuntimeException e) {
+            throw new IOException("Deterministic Main package route path is invalid", e);
+        }
+        if (path.isAbsolute() || !path.equals(path.normalize()) || path.getNameCount() == 0) {
+            throw new IOException("Deterministic Main package route path is non-canonical");
+        }
+        for (Path segment : path) {
+            String name = segment.toString();
+            if (name.isEmpty() || ".".equals(name) || "..".equals(name)
+                    || name.getBytes(StandardCharsets.UTF_8).length > 255) {
+                throw new IOException("Deterministic Main package route path contains an unsafe segment");
+            }
+        }
+        String canonical = path.toString().replace('\\', '/');
+        if (!canonical.equals(value)) {
+            throw new IOException("Deterministic Main package route path is not canonical POSIX form");
+        }
+        return canonical;
+    }
+
+    private static byte[] read(ZipFile zip, ZipEntry entry, int maximum) throws IOException {
+        try (InputStream input = zip.getInputStream(entry)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream(Math.toIntExact(entry.getSize()));
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                total = Math.addExact(total, count);
+                if (total > maximum) {
+                    throw new IOException("Deterministic Main package entry exceeds its byte limit");
+                }
+                output.write(buffer, 0, count);
+            }
+            return output.toByteArray();
+        }
+    }
+
+    private static boolean sameFile(BasicFileAttributes before, BasicFileAttributes after) {
+        return before.isRegularFile() == after.isRegularFile()
+                && before.size() == after.size()
+                && java.util.Objects.equals(before.fileKey(), after.fileKey())
+                && before.lastModifiedTime().equals(after.lastModifiedTime());
+    }
+
+    private static void deletePackage(Path directory, Path archive) throws IOException {
+        IOException failure = null;
+        for (Path path : List.of(archive, directory)) {
+            try {
+                if (Files.isSymbolicLink(path)) {
+                    throw new IOException("Private deterministic package output became symbolic");
+                }
+                Files.deleteIfExists(path);
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private static String digest(Path file) throws IOException {
+        MessageDigest digest = sha256();
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] buffer = new byte[8192];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, count);
+            }
+        }
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static String digest(byte[] bytes) {
+        return "sha256:" + HexFormat.of().formatHex(sha256().digest(bytes));
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static void requireDigest(String value, String label) throws IOException {
+        if (value == null || !DIGEST.matcher(value).matches()) {
+            throw new IOException("Deterministic Main package has an invalid " + label);
+        }
+    }
+
+    private record Request(
+            String candidateDigest,
+            String manifestDigest,
+            String catalogUsageDigest,
+            String pomDigest,
+            String mainPayloadDigest,
+            List<RouteInput> routes) {
+
+        private static Request parse(List<String> arguments) throws IOException {
+            if (arguments == null) {
+                throw new IOException("Deterministic Main package arguments are missing");
+            }
+            Map<String, String> bindings = new LinkedHashMap<>();
+            List<RouteInput> routes = new ArrayList<>();
+            String pendingRoute = null;
+            for (String argument : arguments) {
+                if (argument == null) {
+                    throw new IOException("Deterministic Main package argument is null");
+                }
+                if (argument.startsWith("--route=")) {
+                    if (pendingRoute != null) {
+                        throw new IOException("Deterministic Main package route lacks its digest");
+                    }
+                    pendingRoute = safeRoutePath(argument.substring("--route=".length()));
+                } else if (argument.startsWith("--route-digest=")) {
+                    if (pendingRoute == null) {
+                        throw new IOException("Deterministic Main package route digest lacks its route");
+                    }
+                    String digest = argument.substring("--route-digest=".length());
+                    requireDigest(digest, "route digest");
+                    routes.add(new RouteInput(pendingRoute, digest));
+                    pendingRoute = null;
+                } else if (argument.startsWith("--") && argument.indexOf('=') > 2) {
+                    int separator = argument.indexOf('=');
+                    String key = argument.substring(2, separator);
+                    String value = argument.substring(separator + 1);
+                    if (!Set.of(
+                            "candidate-digest", "manifest-digest", "catalog-usage-digest",
+                            "pom-digest", "main-payload-digest").contains(key)
+                            || bindings.putIfAbsent(key, value) != null) {
+                        throw new IOException("Unknown or duplicate deterministic Main package binding: " + key);
+                    }
+                    requireDigest(value, key);
+                } else {
+                    throw new IOException("Unknown deterministic Main package argument");
+                }
+            }
+            if (pendingRoute != null || routes.isEmpty() || routes.size() > MAX_ROUTES
+                    || bindings.size() != 5) {
+                throw new IOException("Deterministic Main package arguments are incomplete or excessive");
+            }
+            return new Request(
+                    bindings.get("candidate-digest"), bindings.get("manifest-digest"),
+                    bindings.get("catalog-usage-digest"), bindings.get("pom-digest"),
+                    bindings.get("main-payload-digest"), List.copyOf(routes));
+        }
+    }
+
+    private record RouteInput(String path, String digest) {
+    }
+
+    private record RouteBytes(
+            String path, String digest, Path source, Object fileKey, byte[] bytes) {
+
+        private RouteBytes {
+            bytes = bytes.clone();
+        }
+
+        @Override
+        public byte[] bytes() {
+            return bytes.clone();
+        }
+
+        private void requireSourceUnchanged() throws IOException {
+            if (Files.isSymbolicLink(source) || !Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)
+                    || !java.util.Objects.equals(
+                            fileKey,
+                            Files.readAttributes(source, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)
+                                    .fileKey())
+                    || !digest.equals(ShipMainPackageMain.digest(source))) {
+                throw new IOException("Accepted package route changed during packaging: " + path);
+            }
+        }
+    }
+
+    public record EntrySummary(String path, long size, String digest) {
+
+        public EntrySummary {
+            if (size <= 0 || size > MAX_ROUTE_BYTES) {
+                throw new IllegalArgumentException("Package summary entry has an unsafe size");
+            }
+            try {
+                path = safeRoutePath(path);
+                requireDigest(digest, "summary entry digest");
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+        }
+    }
+
+    /** Exact package output binding retained as the command's content-addressed stdout. */
+    public record Summary(
+            int schemaVersion,
+            String candidateDigest,
+            String manifestDigest,
+            String catalogUsageDigest,
+            String pomDigest,
+            String mainPayloadDigest,
+            String packageDigest,
+            long packageSize,
+            List<EntrySummary> entries) {
+
+        public Summary {
+            entries = entries == null ? List.of() : List.copyOf(entries);
+            if (schemaVersion != SCHEMA_VERSION || entries.isEmpty() || entries.size() > MAX_ROUTES
+                    || packageSize <= 0 || packageSize > MAX_PACKAGE_BYTES) {
+                throw new IllegalArgumentException("Deterministic Main package summary is outside its bounds");
+            }
+            try {
+                requireDigest(candidateDigest, "candidate digest");
+                requireDigest(manifestDigest, "manifest digest");
+                requireDigest(catalogUsageDigest, "catalog usage digest");
+                requireDigest(pomDigest, "POM digest");
+                requireDigest(mainPayloadDigest, "Main payload digest");
+                requireDigest(packageDigest, "package digest");
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+            if (entries.stream().map(EntrySummary::path).distinct().count() != entries.size()
+                    || !entries.equals(entries.stream().sorted(Comparator.comparing(EntrySummary::path)).toList())) {
+                throw new IllegalArgumentException("Deterministic Main package entries are duplicated or unsorted");
+            }
+        }
+
+        public byte[] encode() {
+            StringBuilder value = new StringBuilder(2048);
+            field(value, "schemaVersion", Integer.toString(schemaVersion));
+            field(value, "candidateDigest", candidateDigest);
+            field(value, "manifestDigest", manifestDigest);
+            field(value, "catalogUsageDigest", catalogUsageDigest);
+            field(value, "pomDigest", pomDigest);
+            field(value, "mainPayloadDigest", mainPayloadDigest);
+            field(value, "packageDigest", packageDigest);
+            field(value, "packageSize", Long.toString(packageSize));
+            field(value, "entry.count", Integer.toString(entries.size()));
+            for (int index = 0; index < entries.size(); index++) {
+                EntrySummary entry = entries.get(index);
+                String prefix = "entry." + String.format(java.util.Locale.ROOT, "%03d", index) + '.';
+                field(value, prefix + "pathBase64", Base64.getUrlEncoder().withoutPadding()
+                        .encodeToString(entry.path().getBytes(StandardCharsets.UTF_8)));
+                field(value, prefix + "size", Long.toString(entry.size()));
+                field(value, prefix + "digest", entry.digest());
+            }
+            byte[] encoded = value.toString().getBytes(StandardCharsets.UTF_8);
+            if (encoded.length > MAX_SUMMARY_BYTES) {
+                throw new IllegalStateException("Deterministic Main package summary exceeds its byte limit");
+            }
+            return encoded;
+        }
+
+        public static Summary parse(byte[] encoded) throws IOException {
+            if (encoded == null || encoded.length == 0 || encoded.length > MAX_SUMMARY_BYTES) {
+                throw new IOException("Deterministic Main package summary has an unsafe size");
+            }
+            Map<String, String> values = new LinkedHashMap<>();
+            for (String line : new String(encoded, StandardCharsets.UTF_8).split("\\n", -1)) {
+                if (line.isEmpty()) {
+                    continue;
+                }
+                int separator = line.indexOf('=');
+                if (separator <= 0 || separator == line.length() - 1
+                        || values.putIfAbsent(
+                                line.substring(0, separator), line.substring(separator + 1))
+                           != null) {
+                    throw new IOException("Deterministic Main package summary is malformed or duplicated");
+                }
+                if (values.size() > MAX_SUMMARY_FIELDS) {
+                    throw new IOException("Deterministic Main package summary contains too many fields");
+                }
+            }
+            try {
+                int schema = Integer.parseInt(required(values, "schemaVersion"));
+                String candidate = required(values, "candidateDigest");
+                String manifest = required(values, "manifestDigest");
+                String usage = required(values, "catalogUsageDigest");
+                String pom = required(values, "pomDigest");
+                String payload = required(values, "mainPayloadDigest");
+                String packageDigest = required(values, "packageDigest");
+                long packageSize = Long.parseLong(required(values, "packageSize"));
+                int count = Integer.parseInt(required(values, "entry.count"));
+                if (count <= 0 || count > MAX_ROUTES) {
+                    throw new IOException("Deterministic Main package summary entry count is outside its bounds");
+                }
+                List<EntrySummary> entries = new ArrayList<>();
+                for (int index = 0; index < count; index++) {
+                    String prefix = "entry." + String.format(java.util.Locale.ROOT, "%03d", index) + '.';
+                    entries.add(new EntrySummary(
+                            decodePath(required(values, prefix + "pathBase64")),
+                            Long.parseLong(required(values, prefix + "size")),
+                            required(values, prefix + "digest")));
+                }
+                if (!values.isEmpty()) {
+                    throw new IOException(
+                            "Deterministic Main package summary contains unknown fields: "
+                                          + values.keySet());
+                }
+                return new Summary(
+                        schema, candidate, manifest, usage, pom, payload,
+                        packageDigest, packageSize, entries);
+            } catch (IOException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new IOException("Deterministic Main package summary contains an invalid value", e);
+            }
+        }
+
+        private void requireRequest(Request request, List<RouteBytes> routes) throws IOException {
+            List<EntrySummary> expected = routes.stream()
+                    .map(route -> new EntrySummary(route.path(), route.bytes().length, route.digest()))
+                    .toList();
+            if (!candidateDigest.equals(request.candidateDigest())
+                    || !manifestDigest.equals(request.manifestDigest())
+                    || !catalogUsageDigest.equals(request.catalogUsageDigest())
+                    || !pomDigest.equals(request.pomDigest())
+                    || !mainPayloadDigest.equals(request.mainPayloadDigest())
+                    || !entries.equals(expected)) {
+                throw new IOException("Deterministic Main package summary is not bound to the accepted inputs");
+            }
+        }
+
+        private static void field(StringBuilder target, String key, String value) {
+            target.append(key).append('=').append(value).append('\n');
+        }
+
+        private static String required(Map<String, String> values, String key) throws IOException {
+            String value = values.remove(key);
+            if (value == null || value.isBlank()) {
+                throw new IOException("Deterministic Main package summary is missing " + key);
+            }
+            return value;
+        }
+
+        private static String decodePath(String encoded) throws IOException {
+            try {
+                byte[] bytes = Base64.getUrlDecoder().decode(encoded);
+                String path = new String(bytes, StandardCharsets.UTF_8);
+                String canonical = Base64.getUrlEncoder().withoutPadding()
+                        .encodeToString(path.getBytes(StandardCharsets.UTF_8));
+                if (!canonical.equals(encoded)) {
+                    throw new IOException("Deterministic Main package summary path encoding is non-canonical");
+                }
+                return path;
+            } catch (IllegalArgumentException e) {
+                throw new IOException("Deterministic Main package summary path encoding is invalid", e);
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/DecisionLedger.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/DecisionLedger.java
@@ -1,0 +1,171 @@
+package io.github.luigidemasi.camelkit.ship.ledger;
+
+import java.util.List;
+
+/**
+ * Revisioned requirements and decision ledger proposed by a bounded discovery worker.
+ *
+ * <p>
+ * The controller validates this record before persisting it. A worker cannot mark the run ready merely by setting
+ * {@link Completeness#gapReviewStatus()} to {@link GapReviewStatus#PASSED}.
+ */
+public record DecisionLedger(
+        int schemaVersion,
+        long revision,
+        List<Entry> facts,
+        List<Entry> decisions,
+        List<Conflict> conflicts,
+        List<Assumption> assumptions,
+        List<CatalogEvidence> catalogEvidence,
+        List<Question> openQuestions,
+        List<Category> completeness,
+        List<String> blockingOpenItemIds,
+        GapReviewStatus gapReviewStatus,
+        RequirementsPolicy requirementsPolicy) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public DecisionLedger {
+        facts = immutable(facts);
+        decisions = immutable(decisions);
+        conflicts = immutable(conflicts);
+        assumptions = immutable(assumptions);
+        catalogEvidence = immutable(catalogEvidence);
+        openQuestions = immutable(openQuestions);
+        completeness = immutable(completeness);
+        blockingOpenItemIds = immutable(blockingOpenItemIds);
+    }
+
+    private static <T> List<T> immutable(List<T> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+
+    /** Exact evidence excerpt bound to one controller-owned initial-context or interaction source. */
+    public record SourceRef(String sourceId, String locator, String digest, String excerpt) {
+    }
+
+    public record Entry(
+            String id,
+            String category,
+            String value,
+            LedgerStatus status,
+            List<SourceRef> sourceRefs,
+            String rationale) {
+
+        public Entry {
+            sourceRefs = immutable(sourceRefs);
+        }
+    }
+
+    public record Claim(String value, SourceRef sourceRef) {
+    }
+
+    public record Conflict(
+            String id,
+            String category,
+            List<Claim> claims,
+            LedgerStatus status,
+            String rationale) {
+
+        public Conflict {
+            claims = immutable(claims);
+        }
+    }
+
+    public record Assumption(
+            String id,
+            String category,
+            String proposedValue,
+            LedgerStatus status,
+            List<SourceRef> sourceRefs,
+            String rationale) {
+
+        public Assumption {
+            sourceRefs = immutable(sourceRefs);
+        }
+    }
+
+    /** Raw catalog observation accepted only when bound to an exact controller-issued discovery capability. */
+    public record CatalogEvidence(
+            String id,
+            long prerequisiteLedgerRevision,
+            String requestAttemptId,
+            String requestPolicyDigest,
+            CatalogKind kind,
+            String tool,
+            String subject,
+            String runtime,
+            String camelVersion,
+            String platformVersion,
+            String springBootVersion,
+            String platformBom,
+            boolean verified,
+            String response,
+            String responseDigest) {
+    }
+
+    public record Question(
+            String id,
+            String openItemId,
+            String prompt,
+            List<String> options,
+            String recommendation,
+            LedgerStatus status) {
+
+        public Question {
+            options = immutable(options);
+        }
+    }
+
+    public record Category(String id, LedgerStatus status, String rationale, List<SourceRef> sourceRefs) {
+
+        public Category {
+            sourceRefs = immutable(sourceRefs);
+        }
+    }
+
+    /** Exact implementation policy derived before design approval and enforced on execution output. */
+    public record RequirementsPolicy(
+            String runtime,
+            String camelVersion,
+            String platformVersion,
+            String springBootVersion,
+            String routeDsl,
+            String expressionLanguage,
+            String citrusVersion,
+            List<String> citrusDependencies,
+            JavaPolicy javaPolicy,
+            List<String> approvedJavaExceptions,
+            List<RouteContract> routes,
+            boolean citrusTestsRequired,
+            boolean oneCitrusTestPerRoute) {
+
+        public RequirementsPolicy {
+            citrusDependencies = immutable(citrusDependencies);
+            approvedJavaExceptions = immutable(approvedJavaExceptions);
+            routes = immutable(routes);
+        }
+    }
+
+    public record RouteContract(String routeId, String routePath, String citrusTestPath) {
+    }
+
+    public enum JavaPolicy {
+        FORBIDDEN,
+        JUSTIFICATION_REQUIRED,
+        ALLOWED
+    }
+
+    public enum CatalogKind {
+        COMPONENT,
+        EIP,
+        DATAFORMAT,
+        LANGUAGE
+    }
+
+    public enum GapReviewStatus {
+        NOT_RUN,
+        FAILED,
+        PASSED
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerStatus.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerStatus.java
@@ -1,0 +1,10 @@
+package io.github.luigidemasi.camelkit.ship.ledger;
+
+/** Status of a requirements-ledger item. */
+public enum LedgerStatus {
+    OPEN,
+    NEEDS_USER_DECISION,
+    RESOLVED,
+    NOT_APPLICABLE,
+    SUPERSEDED
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerValidationException.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerValidationException.java
@@ -1,0 +1,18 @@
+package io.github.luigidemasi.camelkit.ship.ledger;
+
+import java.util.List;
+
+/** Raised when a discovery worker proposes an invalid or incomplete ledger. */
+public class LedgerValidationException extends IllegalArgumentException {
+
+    private final List<String> violations;
+
+    public LedgerValidationException(List<String> violations) {
+        super(String.join("; ", violations));
+        this.violations = List.copyOf(violations);
+    }
+
+    public List<String> violations() {
+        return violations;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerValidator.java
@@ -1,0 +1,623 @@
+package io.github.luigidemasi.camelkit.ship.ledger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Assumption;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Category;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Conflict;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Entry;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Question;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RouteContract;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.SourceRef;
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction;
+
+/** Deterministic structural and completeness policy for discovery output. */
+public final class LedgerValidator {
+
+    public static final int MAX_SOURCE_EXCERPT_CHARS = 16 * 1024;
+    public static final Set<String> REQUIRED_CATEGORIES = Set.of(
+            "business-purpose",
+            "flows",
+            "message-contracts",
+            "routing-rules",
+            "runtime",
+            "camel-version",
+            "deployment",
+            "dsl",
+            "expression-language",
+            "java-policy",
+            "error-handling",
+            "security",
+            "observability",
+            "acceptance-criteria",
+            "integration-tests",
+            "citrus-version",
+            "citrus-dependencies");
+    private static final Set<String> SINGLE_VALUED_CATEGORIES = Set.of(
+            "runtime",
+            "camel-version",
+            "platform-version",
+            "spring-boot-version",
+            "dsl",
+            "expression-language",
+            "java-policy",
+            "citrus-version",
+            "citrus-dependencies");
+    private static final Pattern VERSION = Pattern.compile("[0-9]+(?:\\.[0-9A-Za-z_-]+)+(?:[-+.][0-9A-Za-z_.-]+)?");
+    private static final Pattern ROUTE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}");
+
+    private LedgerValidator() {
+    }
+
+    public static void validateAnalysis(DecisionLedger ledger) {
+        List<String> violations = validateCommon(ledger);
+        if (ledger == null) {
+            throwIfAny(violations);
+            return;
+        }
+        if (ledger.openQuestions().size() > 1) {
+            violations.add("At most one blocking discovery question may be proposed");
+        }
+        if (ledger.openQuestions().size() == 1) {
+            Question question = ledger.openQuestions().get(0);
+            if (question.status() != LedgerStatus.OPEN
+                    && question.status() != LedgerStatus.NEEDS_USER_DECISION) {
+                violations.add("The pending discovery question must be open");
+            }
+            if (!allOpenItemIds(ledger).contains(question.openItemId())) {
+                violations.add("Question " + question.id() + " does not reference an open ledger item");
+            }
+        }
+        throwIfAny(violations);
+    }
+
+    /**
+     * Validates the controller gate that must be satisfied before a discovery worker can query a runtime-dependent
+     * catalog.
+     */
+    public static void validateCatalogPrerequisites(DecisionLedger ledger) {
+        List<String> violations = validateCommon(ledger);
+        if (ledger != null) {
+            validateCatalogPrerequisitePolicy(ledger, violations);
+        }
+        throwIfAny(violations);
+    }
+
+    public static void validateReady(DecisionLedger ledger) {
+        validateReady(ledger, DecisionLedger.GapReviewStatus.PASSED);
+    }
+
+    /** Validates a complete candidate before the independent gap-review attempt. */
+    public static void validateCandidateReady(DecisionLedger ledger) {
+        validateReady(ledger, DecisionLedger.GapReviewStatus.NOT_RUN);
+    }
+
+    private static void validateReady(DecisionLedger ledger, DecisionLedger.GapReviewStatus requiredReviewStatus) {
+        List<String> violations = validateCommon(ledger);
+        if (ledger == null) {
+            throwIfAny(violations);
+            return;
+        }
+        if (!ledger.openQuestions().isEmpty()) {
+            violations.add("A requirements-ready ledger cannot contain a pending question");
+        }
+        if (!ledger.blockingOpenItemIds().isEmpty()) {
+            violations.add("Blocking ledger items remain: " + String.join(", ", ledger.blockingOpenItemIds()));
+        }
+        if (!allOpenItemIds(ledger).isEmpty()) {
+            violations.add("Open or undecided ledger items remain");
+        }
+        Map<String, Category> categories = categoriesById(ledger, violations);
+        for (String required : REQUIRED_CATEGORIES) {
+            Category category = categories.get(required);
+            if (category == null) {
+                violations.add("Missing completeness category: " + required);
+                continue;
+            }
+            if (category.status() != LedgerStatus.RESOLVED
+                    && category.status() != LedgerStatus.NOT_APPLICABLE) {
+                violations.add("Completeness category is unresolved: " + required);
+            }
+            if (category.status() == LedgerStatus.NOT_APPLICABLE && isBlank(category.rationale())) {
+                violations.add("Not-applicable category requires a rationale: " + required);
+            }
+            if (category.status() == LedgerStatus.RESOLVED && !hasResolvedValue(ledger, required)) {
+                violations.add("Resolved completeness category has no resolved fact or decision: " + required);
+            }
+        }
+        if (ledger.gapReviewStatus() != requiredReviewStatus) {
+            violations.add(requiredReviewStatus == DecisionLedger.GapReviewStatus.PASSED
+                    ? "A fresh-context gap review must pass before requirements are ready"
+                    : "Discovery cannot self-attest its fresh-context gap review");
+        }
+        validateRequirementsPolicy(ledger, violations);
+        throwIfAny(violations);
+    }
+
+    private static List<String> validateCommon(DecisionLedger ledger) {
+        List<String> violations = new ArrayList<>();
+        if (ledger == null) {
+            return List.of("Decision ledger is required");
+        }
+        if (ledger.schemaVersion() != DecisionLedger.SCHEMA_VERSION) {
+            violations.add("Unsupported decision-ledger schema version: " + ledger.schemaVersion());
+        }
+        if (ledger.revision() < 1) {
+            violations.add("Decision-ledger revision must be positive");
+        }
+
+        Set<String> ids = new HashSet<>();
+        ledger.facts().forEach(entry -> validateEntry("fact", entry, ids, violations));
+        ledger.decisions().forEach(entry -> validateEntry("decision", entry, ids, violations));
+        ledger.conflicts().forEach(entry -> validateConflict(entry, ids, violations));
+        ledger.assumptions().forEach(entry -> validateAssumption(entry, ids, violations));
+        ledger.openQuestions().forEach(entry -> validateQuestion(entry, ids, violations));
+        validateCatalogEvidence(ledger, violations);
+        validateConclusiveCategories(ledger, violations);
+
+        Set<String> blockers = new HashSet<>();
+        for (String id : ledger.blockingOpenItemIds()) {
+            if (isBlank(id)) {
+                violations.add("Blocking open-item IDs must not be blank");
+            } else if (!blockers.add(id)) {
+                violations.add("Duplicate blocking open-item ID: " + id);
+            } else if (!allItemIds(ledger).contains(id)) {
+                violations.add("Unknown blocking open-item ID: " + id);
+            }
+        }
+        categoriesById(ledger, violations);
+        return violations;
+    }
+
+    private static void validateCatalogEvidence(DecisionLedger ledger, List<String> violations) {
+        if (!ledger.catalogEvidence().isEmpty()) {
+            violations.add("Workers cannot author catalog evidence in the decision ledger");
+        }
+    }
+
+    /**
+     * Prevents a worker from bypassing an earlier answer by creating a fresh open item ID in the same single-valued
+     * category. These categories describe one exact implementation choice, so they cannot contain competing conclusions
+     * or become open again without an explicit requirements-change transition.
+     */
+    private static void validateConclusiveCategories(DecisionLedger ledger, List<String> violations) {
+        for (String category : SINGLE_VALUED_CATEGORIES) {
+            long resolved = java.util.stream.Stream.concat(ledger.facts().stream(), ledger.decisions().stream())
+                    .filter(entry -> entry != null
+                            && category.equals(entry.category())
+                            && entry.status() == LedgerStatus.RESOLVED)
+                    .count();
+            long open = java.util.stream.Stream.of(
+                    ledger.facts().stream().map(entry -> new CategoryStatus(entry.category(), entry.status())),
+                    ledger.decisions().stream().map(entry -> new CategoryStatus(entry.category(), entry.status())),
+                    ledger.conflicts().stream().map(entry -> new CategoryStatus(entry.category(), entry.status())),
+                    ledger.assumptions().stream().map(entry -> new CategoryStatus(entry.category(), entry.status())))
+                    .flatMap(stream -> stream)
+                    .filter(entry -> category.equals(entry.category()) && isOpen(entry.status()))
+                    .count();
+            if (resolved > 1) {
+                violations.add("Single-valued category has multiple resolved conclusions: " + category);
+            }
+            if (resolved > 0 && open > 0) {
+                violations.add("Resolved single-valued category cannot be reopened with another item: " + category);
+            } else if (open > 1) {
+                violations.add("Single-valued category has multiple open items: " + category);
+            }
+        }
+    }
+
+    private static Map<String, Category> categoriesById(DecisionLedger ledger, List<String> violations) {
+        Map<String, Category> categories = new HashMap<>();
+        for (Category category : ledger.completeness()) {
+            if (category == null || isBlank(category.id()) || category.status() == null) {
+                violations.add("Completeness categories require an ID and status");
+                continue;
+            }
+            if (categories.putIfAbsent(category.id(), category) != null) {
+                violations.add("Duplicate completeness category: " + category.id());
+            }
+            validateSourceRefs("category " + category.id(), category.sourceRefs(), violations);
+        }
+        return categories;
+    }
+
+    private static void validateEntry(
+            String type, Entry entry, Set<String> ids, List<String> violations) {
+        if (entry == null || !validateIdentity(type, entry == null ? null : entry.id(),
+                entry == null ? null : entry.category(), ids, violations)) {
+            return;
+        }
+        if (entry.status() == null) {
+            violations.add(type + " " + entry.id() + " is missing status");
+        }
+        if (entry.status() == LedgerStatus.RESOLVED && isBlank(entry.value())) {
+            violations.add(type + " " + entry.id() + " is resolved without a value");
+        }
+        if (entry.status() == LedgerStatus.RESOLVED && entry.sourceRefs().isEmpty()) {
+            violations.add(type + " " + entry.id() + " is resolved without provenance");
+        }
+        if (entry.status() == LedgerStatus.NOT_APPLICABLE && isBlank(entry.rationale())) {
+            violations.add(type + " " + entry.id() + " is not applicable without a rationale");
+        }
+        validateSourceRefs(type + " " + entry.id(), entry.sourceRefs(), violations);
+    }
+
+    private static void validateConflict(Conflict entry, Set<String> ids, List<String> violations) {
+        if (entry == null || !validateIdentity("conflict", entry == null ? null : entry.id(),
+                entry == null ? null : entry.category(), ids, violations)) {
+            return;
+        }
+        if (entry.status() == null) {
+            violations.add("conflict " + entry.id() + " is missing status");
+        } else if (!isOpen(entry.status())) {
+            violations.add("conflict " + entry.id()
+                           + " must remain open until a controller-recorded answer replaces it");
+        }
+        if (entry.claims().size() < 2) {
+            violations.add("conflict " + entry.id() + " must contain at least two claims");
+        }
+        entry.claims().forEach(claim -> {
+            if (claim == null || isBlank(claim.value()) || claim.sourceRef() == null) {
+                violations.add("conflict " + entry.id() + " contains an invalid claim");
+            } else {
+                validateSourceRef("conflict " + entry.id(), claim.sourceRef(), violations);
+            }
+        });
+    }
+
+    private static void validateAssumption(Assumption entry, Set<String> ids, List<String> violations) {
+        if (entry == null || !validateIdentity("assumption", entry == null ? null : entry.id(),
+                entry == null ? null : entry.category(), ids, violations)) {
+            return;
+        }
+        if (entry.status() == null) {
+            violations.add("assumption " + entry.id() + " is missing status");
+        } else if (!isOpen(entry.status())) {
+            violations.add("assumption " + entry.id()
+                           + " must remain open until a controller-recorded answer replaces it");
+        }
+        if (isBlank(entry.proposedValue())) {
+            violations.add("assumption " + entry.id() + " is missing its proposed value");
+        }
+        validateSourceRefs("assumption " + entry.id(), entry.sourceRefs(), violations);
+    }
+
+    private static void validateQuestion(Question entry, Set<String> ids, List<String> violations) {
+        if (entry == null || !validateIdentity("question", entry == null ? null : entry.id(),
+                entry == null ? null : entry.openItemId(), ids, violations)) {
+            return;
+        }
+        if (isBlank(entry.prompt())) {
+            violations.add("question " + entry.id() + " is missing its prompt");
+        } else if (entry.prompt().length() > Interaction.MAX_PROMPT_CHARS) {
+            violations.add("question " + entry.id() + " prompt exceeds "
+                           + Interaction.MAX_PROMPT_CHARS + " characters");
+        }
+        if (entry.status() == null) {
+            violations.add("question " + entry.id() + " is missing status");
+        }
+        if (new HashSet<>(entry.options()).size() != entry.options().size()) {
+            violations.add("question " + entry.id() + " contains duplicate options");
+        }
+        if (entry.options().size() > Interaction.MAX_OPTIONS) {
+            violations.add("question " + entry.id() + " has too many options");
+        }
+        for (String option : entry.options()) {
+            if (isBlank(option) || option.length() > Interaction.MAX_OPTION_CHARS) {
+                violations.add("question " + entry.id() + " contains a blank or oversized option");
+            }
+        }
+        if (entry.recommendation() != null
+                && entry.recommendation().length() > Interaction.MAX_OPTION_CHARS) {
+            violations.add("question " + entry.id() + " recommendation is oversized");
+        }
+    }
+
+    private static boolean validateIdentity(
+            String type, String id, String category, Set<String> ids, List<String> violations) {
+        if (isBlank(id) || isBlank(category)) {
+            violations.add(type + " entries require stable IDs and categories");
+            return false;
+        }
+        if (!ids.add(id)) {
+            violations.add("Duplicate ledger item ID: " + id);
+        }
+        return true;
+    }
+
+    private static Set<String> allItemIds(DecisionLedger ledger) {
+        Set<String> ids = new LinkedHashSet<>();
+        ledger.facts().forEach(entry -> ids.add(entry.id()));
+        ledger.decisions().forEach(entry -> ids.add(entry.id()));
+        ledger.conflicts().forEach(entry -> ids.add(entry.id()));
+        ledger.assumptions().forEach(entry -> ids.add(entry.id()));
+        return ids;
+    }
+
+    private static Set<String> allOpenItemIds(DecisionLedger ledger) {
+        Set<String> ids = new LinkedHashSet<>();
+        ledger.facts().stream().filter(entry -> isOpen(entry.status())).forEach(entry -> ids.add(entry.id()));
+        ledger.decisions().stream().filter(entry -> isOpen(entry.status())).forEach(entry -> ids.add(entry.id()));
+        ledger.conflicts().stream().filter(entry -> isOpen(entry.status())).forEach(entry -> ids.add(entry.id()));
+        ledger.assumptions().stream().filter(entry -> isOpen(entry.status())).forEach(entry -> ids.add(entry.id()));
+        return ids;
+    }
+
+    private static boolean isOpen(LedgerStatus status) {
+        return status == LedgerStatus.OPEN || status == LedgerStatus.NEEDS_USER_DECISION;
+    }
+
+    private static boolean hasResolvedValue(DecisionLedger ledger, String category) {
+        return java.util.stream.Stream.concat(ledger.facts().stream(), ledger.decisions().stream())
+                .anyMatch(entry -> category.equals(entry.category())
+                        && entry.status() == LedgerStatus.RESOLVED
+                        && !isBlank(entry.value()));
+    }
+
+    private static void validateRequirementsPolicy(DecisionLedger ledger, List<String> violations) {
+        RequirementsPolicy policy = ledger.requirementsPolicy();
+        String runtime = validateCatalogPrerequisitePolicy(ledger, violations);
+        if (policy == null) {
+            return;
+        }
+        if (!"yaml".equals(normalize(policy.routeDsl()))) {
+            violations.add("Ship protocol v1 supports only the YAML route DSL");
+        }
+        if (!"simple".equals(normalize(policy.expressionLanguage()))) {
+            violations.add("Ship protocol v1 supports only the Simple expression language");
+        }
+        List<String> citrusViolations = CitrusDependencyPolicy.violations(
+                policy.citrusVersion(), policy.citrusDependencies());
+        violations.addAll(citrusViolations);
+        if ("main".equals(runtime) && citrusViolations.isEmpty()) {
+            try {
+                JvmPayloadRequest.citrus(
+                        policy.camelVersion(), policy.citrusVersion(), policy.citrusDependencies());
+            } catch (IllegalArgumentException e) {
+                violations.add("Ship protocol v1 has no direct Citrus evidence payload for Camel "
+                               + policy.camelVersion() + " and Citrus " + policy.citrusVersion());
+            }
+        }
+        if (policy.javaPolicy() == null) {
+            violations.add("Implementation policy requires a Java policy");
+        }
+        if ("main".equals(runtime) && policy.javaPolicy() != null
+                && policy.javaPolicy() != DecisionLedger.JavaPolicy.FORBIDDEN) {
+            violations.add("Ship protocol v1 requires Java policy FORBIDDEN for Camel Main because its mandatory "
+                           + "startup evidence does not compile Java sources");
+        }
+        if (policy.javaPolicy() != DecisionLedger.JavaPolicy.JUSTIFICATION_REQUIRED
+                && !policy.approvedJavaExceptions().isEmpty()) {
+            violations.add("Java exceptions are valid only under justification-required policy");
+        }
+        Set<String> paths = new HashSet<>();
+        for (String exception : policy.approvedJavaExceptions()) {
+            if (!safeRelative(exception) || !exception.endsWith(".java") || !paths.add(exception)) {
+                violations.add("Invalid or duplicate approved Java exception: " + exception);
+            }
+        }
+        if (policy.routes().isEmpty()) {
+            violations.add("Implementation policy requires at least one route contract");
+        }
+        Set<String> routeIds = new HashSet<>();
+        for (RouteContract route : policy.routes()) {
+            if (route == null || !safeFileSegment(route.routeId()) || !routeIds.add(route.routeId())) {
+                violations.add("Implementation policy contains an invalid or duplicate route ID");
+                continue;
+            }
+            if (!safeRelative(route.routePath()) || !route.routePath().endsWith(".camel.yaml")
+                    || !paths.add(route.routePath())) {
+                violations.add("Invalid or duplicate route contract path: " + route.routePath());
+            } else if (!hasFileName(route.routePath(), route.routeId() + ".camel.yaml")) {
+                violations.add("Route contract path must be named exactly " + route.routeId() + ".camel.yaml");
+            }
+            if (!safeRelative(route.citrusTestPath()) || !route.citrusTestPath().endsWith(".camel.it.yaml")
+                    || !paths.add(route.citrusTestPath())) {
+                violations.add("Invalid or duplicate Citrus contract path: " + route.citrusTestPath());
+            } else if (!("test/" + route.routeId() + ".camel.it.yaml").equals(route.citrusTestPath())) {
+                violations.add(
+                        "Citrus contract path must be exactly test/" + route.routeId() + ".camel.it.yaml");
+            }
+        }
+        if (!policy.citrusTestsRequired() || !policy.oneCitrusTestPerRoute()) {
+            violations.add("Ship protocol v1 requires Citrus YAML coverage for every route");
+        }
+        requirePolicyValue(ledger, "dsl", policy.routeDsl(), violations);
+        requirePolicyValue(ledger, "expression-language", policy.expressionLanguage(), violations);
+        requirePolicyValue(ledger, "citrus-version", policy.citrusVersion(), violations);
+        requirePolicyCsvValues(ledger, "citrus-dependencies", policy.citrusDependencies(), violations);
+        if (policy.javaPolicy() != null) {
+            requirePolicyValue(ledger, "java-policy",
+                    policy.javaPolicy().name().toLowerCase(java.util.Locale.ROOT).replace('_', '-'), violations);
+        }
+    }
+
+    private static String validateCatalogPrerequisitePolicy(
+            DecisionLedger ledger, List<String> violations) {
+        RequirementsPolicy policy = ledger.requirementsPolicy();
+        if (policy == null) {
+            violations.add("Catalog access requires an exact runtime and version policy");
+            return "";
+        }
+
+        String runtime = normalize(policy.runtime());
+        boolean supportedRuntime = Set.of("main", "spring-boot", "quarkus").contains(runtime);
+        if (!supportedRuntime) {
+            violations.add("Implementation policy runtime must be main, spring-boot, or quarkus");
+        }
+        boolean validCamelVersion = !isBlank(policy.camelVersion())
+                && VERSION.matcher(policy.camelVersion()).matches();
+        if (!validCamelVersion) {
+            violations.add("Implementation policy requires an explicit Camel version");
+        }
+        boolean requiresPlatform = "spring-boot".equals(runtime) || "quarkus".equals(runtime);
+        boolean validPlatformVersion = !requiresPlatform
+                || (!isBlank(policy.platformVersion()) && VERSION.matcher(policy.platformVersion()).matches());
+        if (!validPlatformVersion) {
+            violations.add("Spring Boot and Quarkus policies require an explicit platform version");
+        }
+        boolean validSpringBootVersion = !"spring-boot".equals(runtime)
+                || (!isBlank(policy.springBootVersion()) && VERSION.matcher(policy.springBootVersion()).matches());
+        if (!validSpringBootVersion) {
+            violations.add("Spring Boot policies require an explicit Spring Boot version");
+        }
+        if (!"spring-boot".equals(runtime) && !isBlank(policy.springBootVersion())) {
+            violations.add("Spring Boot version is valid only for the spring-boot runtime");
+        }
+
+        if (supportedRuntime && !"main".equals(runtime)) {
+            violations.add("Ship protocol v1 has direct startup evidence only for the Camel Main runtime");
+        } else if ("main".equals(runtime) && validCamelVersion) {
+            try {
+                JvmPayloadRequest.yamlValidator(policy.camelVersion());
+                JvmPayloadRequest.camelMain(policy.camelVersion());
+            } catch (IllegalArgumentException e) {
+                violations.add("Ship protocol v1 has no direct YAML/startup evidence payload for Camel "
+                               + policy.camelVersion());
+            }
+        }
+
+        if (supportedRuntime) {
+            requireCatalogCategoryResolved(ledger, "runtime", violations);
+            requirePolicyValue(ledger, "runtime", runtime, violations);
+        }
+        if (validCamelVersion) {
+            requireCatalogCategoryResolved(ledger, "camel-version", violations);
+            requirePolicyValue(ledger, "camel-version", policy.camelVersion(), violations);
+        }
+        if (requiresPlatform && validPlatformVersion) {
+            requireCatalogCategoryResolved(ledger, "platform-version", violations);
+            requirePolicyValue(ledger, "platform-version", policy.platformVersion(), violations);
+        }
+        if ("spring-boot".equals(runtime) && validSpringBootVersion) {
+            requireCatalogCategoryResolved(ledger, "spring-boot-version", violations);
+            requirePolicyValue(ledger, "spring-boot-version", policy.springBootVersion(), violations);
+        }
+        return runtime;
+    }
+
+    private record CategoryStatus(String category, LedgerStatus status) {
+    }
+
+    private static void requireCatalogCategoryResolved(
+            DecisionLedger ledger, String category, List<String> violations) {
+        List<Category> projections = ledger.completeness().stream()
+                .filter(candidate -> candidate != null && category.equals(candidate.id()))
+                .toList();
+        if (projections.size() != 1 || projections.get(0).status() != LedgerStatus.RESOLVED) {
+            violations.add("Catalog prerequisite category must be resolved: " + category);
+        }
+        boolean unresolvedItem = ledger.facts().stream()
+                .anyMatch(entry -> entry != null
+                        && category.equals(entry.category()) && isOpen(entry.status()))
+                || ledger.decisions().stream()
+                        .anyMatch(entry -> entry != null
+                                && category.equals(entry.category()) && isOpen(entry.status()))
+                || ledger.conflicts().stream()
+                        .anyMatch(entry -> entry != null
+                                && category.equals(entry.category()) && isOpen(entry.status()))
+                || ledger.assumptions().stream()
+                        .anyMatch(entry -> entry != null
+                                && category.equals(entry.category()) && isOpen(entry.status()));
+        if (unresolvedItem) {
+            violations.add("Catalog prerequisite contains an unresolved ledger item: " + category);
+        }
+    }
+
+    private static void requirePolicyValue(
+            DecisionLedger ledger, String category, String expected, List<String> violations) {
+        Set<String> values = java.util.stream.Stream.concat(ledger.facts().stream(), ledger.decisions().stream())
+                .filter(entry -> category.equals(entry.category()) && entry.status() == LedgerStatus.RESOLVED)
+                .map(entry -> normalize(entry.value()))
+                .collect(java.util.stream.Collectors.toSet());
+        if (!values.equals(Set.of(normalize(expected)))) {
+            violations.add("Implementation policy " + category + " does not match the resolved ledger value");
+        }
+    }
+
+    private static void requirePolicyCsvValues(
+            DecisionLedger ledger, String category, List<String> expected, List<String> violations) {
+        List<String> projections = java.util.stream.Stream.concat(
+                ledger.facts().stream(), ledger.decisions().stream())
+                .filter(entry -> category.equals(entry.category()) && entry.status() == LedgerStatus.RESOLVED)
+                .map(Entry::value)
+                .toList();
+        List<String> actual = projections.size() == 1 && projections.get(0) != null
+                ? java.util.Arrays.stream(projections.get(0).split(",", -1))
+                        .map(LedgerValidator::normalize)
+                        .toList()
+                : List.of();
+        List<String> normalizedExpected = expected.stream().map(LedgerValidator::normalize).toList();
+        if (!actual.equals(normalizedExpected)) {
+            violations.add("Implementation policy " + category + " does not match the resolved ledger values");
+        }
+    }
+
+    private static void validateSourceRefs(String owner, List<SourceRef> references, List<String> violations) {
+        for (SourceRef reference : references) {
+            validateSourceRef(owner, reference, violations);
+        }
+    }
+
+    private static void validateSourceRef(String owner, SourceRef reference, List<String> violations) {
+        if (reference == null || isBlank(reference.sourceId()) || isBlank(reference.locator())
+                || reference.digest() == null || !reference.digest().matches("sha256:[0-9a-f]{64}")
+                || isBlank(reference.excerpt())
+                || reference.excerpt().length() > MAX_SOURCE_EXCERPT_CHARS
+                || reference.excerpt().indexOf('\0') >= 0) {
+            violations.add(owner + " contains an invalid source reference");
+        }
+    }
+
+    private static boolean safeRelative(String value) {
+        if (isBlank(value)) {
+            return false;
+        }
+        try {
+            java.nio.file.Path path = java.nio.file.Path.of(value);
+            return value.indexOf('\\') < 0
+                    && !path.isAbsolute()
+                    && path.equals(path.normalize())
+                    && !path.startsWith("..");
+        } catch (java.nio.file.InvalidPathException e) {
+            return false;
+        }
+    }
+
+    private static boolean safeFileSegment(String value) {
+        return value != null && ROUTE_ID.matcher(value).matches();
+    }
+
+    private static boolean hasFileName(String value, String expected) {
+        try {
+            java.nio.file.Path name = java.nio.file.Path.of(value).getFileName();
+            return name != null && expected.equals(name.toString());
+        } catch (java.nio.file.InvalidPathException e) {
+            return false;
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static void throwIfAny(List<String> violations) {
+        if (!violations.isEmpty()) {
+            throw new LedgerValidationException(violations);
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/Interaction.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/Interaction.java
@@ -1,5 +1,10 @@
 package io.github.luigidemasi.camelkit.ship.protocol;
 
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -13,6 +18,10 @@ import io.github.luigidemasi.camelkit.ship.ShipDigest;
  * <p>
  * Principal and UI-profile values are authenticated only after the later protected controller service observes and
  * signs them. Merely constructing one of these wire records grants no controller authority.
+ *
+ * <p>
+ * Every {@code *MacFields} result is MAC input only after it is encoded by {@link #canonicalMacBytes(String[])}.
+ * Delimiter joining or any other serialization is forbidden because interaction text may contain arbitrary separators.
  */
 public final class Interaction {
 
@@ -403,6 +412,34 @@ public final class Interaction {
         DENY
     }
 
+    /**
+     * Encodes ordered MAC fields as a field count followed by signed, four-byte big-endian UTF-8 byte lengths and
+     * values. A length of {@code -1} represents null and {@code 0} represents the empty string.
+     */
+    public static byte[] canonicalMacBytes(String[] fields) {
+        if (fields == null || fields.length == 0 || fields[0] == null || fields[0].isBlank()) {
+            throw new IllegalArgumentException("Interaction MAC fields require a domain");
+        }
+        byte[][] encoded = new byte[fields.length][];
+        int size = Integer.BYTES;
+        for (int index = 0; index < fields.length; index++) {
+            encoded[index] = fields[index] == null ? null : utf8(fields[index]);
+            size = Math.addExact(size, Integer.BYTES);
+            if (encoded[index] != null) {
+                size = Math.addExact(size, encoded[index].length);
+            }
+        }
+        ByteBuffer output = ByteBuffer.allocate(size).putInt(encoded.length);
+        for (byte[] value : encoded) {
+            if (value == null) {
+                output.putInt(-1);
+            } else {
+                output.putInt(value.length).put(value);
+            }
+        }
+        return output.array();
+    }
+
     /** Canonical, type-separated fields covered by a discovery-challenge MAC. */
     public static String[] discoveryChallengeMacFields(
             String runId,
@@ -709,6 +746,20 @@ public final class Interaction {
             fields[index + 1] = value == null ? null : value instanceof Enum<?> item ? item.name() : value.toString();
         }
         return fields;
+    }
+
+    private static byte[] utf8(String value) {
+        try {
+            ByteBuffer encoded = StandardCharsets.UTF_8.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .encode(CharBuffer.wrap(value));
+            byte[] result = new byte[encoded.remaining()];
+            encoded.get(result);
+            return result;
+        } catch (CharacterCodingException e) {
+            throw new IllegalArgumentException("Interaction MAC fields must contain valid Unicode", e);
+        }
     }
 
     private static void requireCommon(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/Interaction.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/Interaction.java
@@ -1,0 +1,820 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+
+/**
+ * Typed controller-owned user interaction messages.
+ *
+ * <p>
+ * Principal and UI-profile values are authenticated only after the later protected controller service observes and
+ * signs them. Merely constructing one of these wire records grants no controller authority.
+ */
+public final class Interaction {
+
+    public static final int SCHEMA_VERSION = 1;
+    public static final int MAX_ID_CHARS = 256;
+    public static final int MAX_PROMPT_CHARS = 16 * 1024;
+    public static final int MAX_OPTIONS = 32;
+    public static final int MAX_OPTION_CHARS = 4 * 1024;
+    public static final int MAX_RESPONSE_CHARS = 64 * 1024;
+    public static final int MAX_CHANNEL_CHARS = 128;
+    public static final int MAX_REFERENCE_CHARS = 4 * 1024;
+    private static final int NONCE_CHARS = 43;
+
+    private Interaction() {
+    }
+
+    public record DiscoveryChallenge(
+            int schemaVersion,
+            String runId,
+            long ledgerRevision,
+            String questionId,
+            String openItemId,
+            String prompt,
+            List<String> options,
+            String recommendation,
+            String nonce,
+            String mac) {
+
+        public DiscoveryChallenge {
+            options = options == null ? List.of() : List.copyOf(options);
+            requireCommon(schemaVersion, runId, ledgerRevision, questionId, nonce, mac, "discovery challenge");
+            requireText(openItemId, MAX_ID_CHARS, "Discovery challenge open-item ID");
+            requireText(prompt, MAX_PROMPT_CHARS, "Discovery challenge prompt");
+            if (options.size() > MAX_OPTIONS) {
+                throw new IllegalArgumentException("Discovery challenge has too many options");
+            }
+            HashSet<String> unique = new HashSet<>();
+            for (String option : options) {
+                requireText(option, MAX_OPTION_CHARS, "Discovery challenge option");
+                if (!unique.add(option)) {
+                    throw new IllegalArgumentException("Discovery challenge options must be unique");
+                }
+            }
+            requireOptionalText(recommendation, MAX_OPTION_CHARS, "Discovery challenge recommendation");
+            recommendation = recommendation == null || recommendation.isBlank() ? null : recommendation;
+        }
+    }
+
+    public record DiscoveryAnswer(
+            int schemaVersion,
+            String runId,
+            long ledgerRevision,
+            String questionId,
+            String openItemId,
+            String nonce,
+            String response,
+            String channel,
+            Instant answeredAt,
+            String mac) {
+
+        public DiscoveryAnswer {
+            requireCommon(schemaVersion, runId, ledgerRevision, questionId, nonce, mac, "discovery answer");
+            requireText(openItemId, MAX_ID_CHARS, "Discovery answer open-item ID");
+            requireText(response, MAX_RESPONSE_CHARS, "Discovery answer response");
+            requireText(channel, MAX_CHANNEL_CHARS, "Discovery answer channel");
+            if (answeredAt == null) {
+                throw new IllegalArgumentException("Discovery answer timestamp is required");
+            }
+        }
+    }
+
+    /** Consent to read one exact external document locally. */
+    public record DocumentConsentChallenge(
+            int schemaVersion,
+            String runId,
+            String requestId,
+            int sourceOrdinal,
+            String canonicalPath,
+            String purpose,
+            String physicalIdentityDigest,
+            String nonce,
+            String mac) {
+
+        public DocumentConsentChallenge {
+            requireEnvelope(schemaVersion, runId, requestId, nonce, mac, "document-consent challenge");
+            if (sourceOrdinal < 0) {
+                throw new IllegalArgumentException("Document-consent source ordinal must not be negative");
+            }
+            requireText(canonicalPath, MAX_REFERENCE_CHARS, "Document-consent canonical path");
+            requireText(purpose, MAX_REFERENCE_CHARS, "Document-consent purpose");
+            requireDigest(physicalIdentityDigest, "Document-consent physical-identity digest");
+        }
+    }
+
+    public record DocumentConsentResponse(
+            int schemaVersion,
+            String runId,
+            String requestId,
+            int sourceOrdinal,
+            String canonicalPath,
+            String purpose,
+            String physicalIdentityDigest,
+            String nonce,
+            ConsentDecision decision,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt,
+            String mac) {
+
+        public DocumentConsentResponse {
+            requireEnvelope(schemaVersion, runId, requestId, nonce, mac, "document-consent response");
+            if (sourceOrdinal < 0) {
+                throw new IllegalArgumentException("Document-consent source ordinal must not be negative");
+            }
+            requireText(canonicalPath, MAX_REFERENCE_CHARS, "Document-consent canonical path");
+            requireText(purpose, MAX_REFERENCE_CHARS, "Document-consent purpose");
+            requireDigest(physicalIdentityDigest, "Document-consent physical-identity digest");
+            requireDecision(decision, "Document-consent response");
+            requireResponder(controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt,
+                    "Document-consent response");
+        }
+    }
+
+    /** Separate consent to send exact content to one remote provider/model scope. */
+    public record RemoteProviderConsentChallenge(
+            int schemaVersion,
+            String runId,
+            String requestId,
+            ShipStage stage,
+            String purpose,
+            String contentDigest,
+            String provenanceDigest,
+            String provider,
+            String model,
+            String brokerProfile,
+            String scope,
+            String nonce,
+            String mac) {
+
+        public RemoteProviderConsentChallenge {
+            requireEnvelope(schemaVersion, runId, requestId, nonce, mac, "remote-provider consent challenge");
+            requireDecision(stage, "Remote-provider consent stage");
+            requireText(purpose, MAX_REFERENCE_CHARS, "Remote-provider consent purpose");
+            requireDigest(contentDigest, "Remote-provider consent content digest");
+            requireDigest(provenanceDigest, "Remote-provider consent provenance digest");
+            requireText(provider, MAX_ID_CHARS, "Remote-provider consent provider");
+            requireText(model, MAX_ID_CHARS, "Remote-provider consent model");
+            requireText(brokerProfile, MAX_REFERENCE_CHARS, "Remote-provider consent broker profile");
+            requireText(scope, MAX_REFERENCE_CHARS, "Remote-provider consent scope");
+        }
+    }
+
+    public record RemoteProviderConsentResponse(
+            int schemaVersion,
+            String runId,
+            String requestId,
+            ShipStage stage,
+            String purpose,
+            String contentDigest,
+            String provenanceDigest,
+            String provider,
+            String model,
+            String brokerProfile,
+            String scope,
+            String nonce,
+            ConsentDecision decision,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt,
+            String mac) {
+
+        public RemoteProviderConsentResponse {
+            requireEnvelope(schemaVersion, runId, requestId, nonce, mac, "remote-provider consent response");
+            requireDecision(stage, "Remote-provider consent stage");
+            requireText(purpose, MAX_REFERENCE_CHARS, "Remote-provider consent purpose");
+            requireDigest(contentDigest, "Remote-provider consent content digest");
+            requireDigest(provenanceDigest, "Remote-provider consent provenance digest");
+            requireText(provider, MAX_ID_CHARS, "Remote-provider consent provider");
+            requireText(model, MAX_ID_CHARS, "Remote-provider consent model");
+            requireText(brokerProfile, MAX_REFERENCE_CHARS, "Remote-provider consent broker profile");
+            requireText(scope, MAX_REFERENCE_CHARS, "Remote-provider consent scope");
+            requireDecision(decision, "Remote-provider consent response");
+            requireResponder(controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt,
+                    "Remote-provider consent response");
+        }
+    }
+
+    /** Approval challenge for the exact safely displayed design and all of its authoritative inputs. */
+    public record DesignChallenge(
+            int schemaVersion,
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String designDigest,
+            String designReference,
+            String nonce,
+            String mac) {
+
+        public DesignChallenge {
+            requireApprovalBindings(schemaVersion, runId, contextDigest, ledgerRevision, ledgerDigest,
+                    requirementsDigest, policyDigest, baselineDigest, nonce, mac, "design challenge");
+            requireDigest(designDigest, "Design challenge design digest");
+            requireText(designReference, MAX_REFERENCE_CHARS, "Design challenge reference");
+        }
+    }
+
+    public record DesignResponse(
+            int schemaVersion,
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String designDigest,
+            String nonce,
+            DesignDecision decision,
+            String requestedChanges,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt,
+            String mac) {
+
+        public DesignResponse {
+            requireApprovalBindings(schemaVersion, runId, contextDigest, ledgerRevision, ledgerDigest,
+                    requirementsDigest, policyDigest, baselineDigest, nonce, mac, "design response");
+            requireDigest(designDigest, "Design response design digest");
+            requireDecision(decision, "Design response");
+            requestedChanges = requireRequestedChanges(
+                    requestedChanges,
+                    decision == DesignDecision.REQUEST_DESIGN_CHANGES
+                            || decision == DesignDecision.REQUEST_REQUIREMENTS_CHANGES,
+                    "Design response");
+            requireResponder(controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt,
+                    "Design response");
+        }
+    }
+
+    /** Separate approval challenge for the exact plan produced from one approved design. */
+    public record PlanChallenge(
+            int schemaVersion,
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String approvedDesignDigest,
+            String planDigest,
+            String planReference,
+            String nonce,
+            String mac) {
+
+        public PlanChallenge {
+            requireApprovalBindings(schemaVersion, runId, contextDigest, ledgerRevision, ledgerDigest,
+                    requirementsDigest, policyDigest, baselineDigest, nonce, mac, "plan challenge");
+            requireDigest(approvedDesignDigest, "Plan challenge approved-design digest");
+            requireDigest(planDigest, "Plan challenge plan digest");
+            requireText(planReference, MAX_REFERENCE_CHARS, "Plan challenge reference");
+        }
+    }
+
+    public record PlanResponse(
+            int schemaVersion,
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String approvedDesignDigest,
+            String planDigest,
+            String nonce,
+            PlanDecision decision,
+            String requestedChanges,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt,
+            String mac) {
+
+        public PlanResponse {
+            requireApprovalBindings(schemaVersion, runId, contextDigest, ledgerRevision, ledgerDigest,
+                    requirementsDigest, policyDigest, baselineDigest, nonce, mac, "plan response");
+            requireDigest(approvedDesignDigest, "Plan response approved-design digest");
+            requireDigest(planDigest, "Plan response plan digest");
+            requireDecision(decision, "Plan response");
+            requestedChanges = requireRequestedChanges(
+                    requestedChanges, decision != PlanDecision.APPROVE && decision != PlanDecision.ABORT,
+                    "Plan response");
+            requireResponder(controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt,
+                    "Plan response");
+        }
+    }
+
+    /** Controller-generated, safely displayable subject for one policy-eligible failure waiver. */
+    public record WaiverChallenge(
+            int schemaVersion,
+            String runId,
+            String checkId,
+            String evidenceDigest,
+            String eligibilityPolicyDigest,
+            String subjectDigest,
+            String subjectReference,
+            String risk,
+            String consequence,
+            String nonce,
+            String mac) {
+
+        public WaiverChallenge {
+            requireEnvelope(schemaVersion, runId, checkId, nonce, mac, "waiver challenge");
+            requireDigest(evidenceDigest, "Waiver challenge evidence digest");
+            requireDigest(eligibilityPolicyDigest, "Waiver challenge eligibility-policy digest");
+            requireDigest(subjectDigest, "Waiver challenge subject digest");
+            requireText(subjectReference, MAX_REFERENCE_CHARS, "Waiver challenge subject reference");
+            requireText(risk, MAX_PROMPT_CHARS, "Waiver challenge risk");
+            requireText(consequence, MAX_PROMPT_CHARS, "Waiver challenge consequence");
+        }
+    }
+
+    public record WaiverResponse(
+            int schemaVersion,
+            String runId,
+            String checkId,
+            String evidenceDigest,
+            String eligibilityPolicyDigest,
+            String subjectDigest,
+            String nonce,
+            WaiverDecision decision,
+            String reason,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt,
+            String mac) {
+
+        public WaiverResponse {
+            requireEnvelope(schemaVersion, runId, checkId, nonce, mac, "waiver response");
+            requireDigest(evidenceDigest, "Waiver response evidence digest");
+            requireDigest(eligibilityPolicyDigest, "Waiver response eligibility-policy digest");
+            requireDigest(subjectDigest, "Waiver response subject digest");
+            requireDecision(decision, "Waiver response");
+            requireOptionalText(reason, MAX_RESPONSE_CHARS, "Waiver response reason");
+            if (decision == WaiverDecision.WAIVE && (reason == null || reason.isBlank())) {
+                throw new IllegalArgumentException("An approved waiver requires a reason");
+            }
+            if (decision == WaiverDecision.DENY && reason != null && !reason.isBlank()) {
+                throw new IllegalArgumentException("A denied waiver cannot carry an approval reason");
+            }
+            reason = decision == WaiverDecision.WAIVE ? reason : "";
+            requireResponder(controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt,
+                    "Waiver response");
+        }
+    }
+
+    public enum ConsentDecision {
+        AUTHORIZE,
+        DENY
+    }
+
+    public enum DesignDecision {
+        APPROVE,
+        REQUEST_DESIGN_CHANGES,
+        REQUEST_REQUIREMENTS_CHANGES,
+        ABORT
+    }
+
+    public enum PlanDecision {
+        APPROVE,
+        REQUEST_PLAN_CHANGES,
+        REQUEST_DESIGN_CHANGES,
+        REQUEST_REQUIREMENTS_CHANGES,
+        ABORT
+    }
+
+    public enum WaiverDecision {
+        WAIVE,
+        DENY
+    }
+
+    /** Canonical, type-separated fields covered by a discovery-challenge MAC. */
+    public static String[] discoveryChallengeMacFields(
+            String runId,
+            long ledgerRevision,
+            String questionId,
+            String openItemId,
+            String prompt,
+            List<String> options,
+            String recommendation,
+            String nonce) {
+        List<String> fields = new ArrayList<>(9 + (options == null ? 0 : options.size()));
+        fields.add("discovery-challenge-v1");
+        fields.add(runId);
+        fields.add(Long.toString(ledgerRevision));
+        fields.add(questionId);
+        fields.add(openItemId);
+        fields.add(prompt);
+        List<String> values = options == null ? List.of() : options;
+        fields.add(Integer.toString(values.size()));
+        fields.addAll(values);
+        fields.add(recommendation);
+        fields.add(nonce);
+        return fields.toArray(String[]::new);
+    }
+
+    /** Canonical, type-separated fields covered by a discovery-answer MAC. */
+    public static String[] discoveryAnswerMacFields(DiscoveryAnswer answer) {
+        return discoveryAnswerMacFields(
+                answer.runId(), answer.ledgerRevision(), answer.questionId(), answer.openItemId(), answer.nonce(),
+                answer.response(), answer.channel(), answer.answeredAt());
+    }
+
+    public static String[] discoveryAnswerMacFields(
+            String runId,
+            long ledgerRevision,
+            String questionId,
+            String openItemId,
+            String nonce,
+            String response,
+            String channel,
+            Instant answeredAt) {
+        return new String[]{
+                "discovery-answer-v1", runId, Long.toString(ledgerRevision), questionId, openItemId, nonce,
+                response, channel, answeredAt.toString()
+        };
+    }
+
+    public static String[] documentConsentChallengeMacFields(DocumentConsentChallenge challenge) {
+        return documentConsentChallengeMacFields(
+                challenge.runId(), challenge.requestId(), challenge.sourceOrdinal(), challenge.canonicalPath(),
+                challenge.purpose(), challenge.physicalIdentityDigest(), challenge.nonce());
+    }
+
+    public static String[] documentConsentChallengeMacFields(
+            String runId,
+            String requestId,
+            int sourceOrdinal,
+            String canonicalPath,
+            String purpose,
+            String physicalIdentityDigest,
+            String nonce) {
+        return macFields("document-consent-challenge-v1", runId, requestId, sourceOrdinal, canonicalPath, purpose,
+                physicalIdentityDigest, nonce);
+    }
+
+    public static String[] documentConsentResponseMacFields(DocumentConsentResponse response) {
+        return documentConsentResponseMacFields(
+                response.runId(), response.requestId(), response.sourceOrdinal(), response.canonicalPath(),
+                response.purpose(), response.physicalIdentityDigest(), response.nonce(), response.decision(),
+                response.controllerObservedProcessPrincipal(), response.declaredCliUiProfile(), response.channel(),
+                response.answeredAt());
+    }
+
+    public static String[] documentConsentResponseMacFields(
+            String runId,
+            String requestId,
+            int sourceOrdinal,
+            String canonicalPath,
+            String purpose,
+            String physicalIdentityDigest,
+            String nonce,
+            ConsentDecision decision,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt) {
+        return macFields("document-consent-response-v1", runId, requestId, sourceOrdinal, canonicalPath, purpose,
+                physicalIdentityDigest, nonce, decision, controllerObservedProcessPrincipal, declaredCliUiProfile,
+                channel, answeredAt);
+    }
+
+    public static String[] remoteProviderConsentChallengeMacFields(RemoteProviderConsentChallenge challenge) {
+        return remoteProviderConsentChallengeMacFields(
+                challenge.runId(), challenge.requestId(), challenge.stage(), challenge.purpose(),
+                challenge.contentDigest(), challenge.provenanceDigest(), challenge.provider(), challenge.model(),
+                challenge.brokerProfile(), challenge.scope(), challenge.nonce());
+    }
+
+    public static String[] remoteProviderConsentChallengeMacFields(
+            String runId,
+            String requestId,
+            ShipStage stage,
+            String purpose,
+            String contentDigest,
+            String provenanceDigest,
+            String provider,
+            String model,
+            String brokerProfile,
+            String scope,
+            String nonce) {
+        return macFields("remote-provider-consent-challenge-v1", runId, requestId, stage, purpose, contentDigest,
+                provenanceDigest, provider, model, brokerProfile, scope, nonce);
+    }
+
+    public static String[] remoteProviderConsentResponseMacFields(RemoteProviderConsentResponse response) {
+        return remoteProviderConsentResponseMacFields(
+                response.runId(), response.requestId(), response.stage(), response.purpose(), response.contentDigest(),
+                response.provenanceDigest(), response.provider(), response.model(), response.brokerProfile(),
+                response.scope(), response.nonce(), response.decision(),
+                response.controllerObservedProcessPrincipal(), response.declaredCliUiProfile(), response.channel(),
+                response.answeredAt());
+    }
+
+    public static String[] remoteProviderConsentResponseMacFields(
+            String runId,
+            String requestId,
+            ShipStage stage,
+            String purpose,
+            String contentDigest,
+            String provenanceDigest,
+            String provider,
+            String model,
+            String brokerProfile,
+            String scope,
+            String nonce,
+            ConsentDecision decision,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt) {
+        return macFields("remote-provider-consent-response-v1", runId, requestId, stage, purpose, contentDigest,
+                provenanceDigest, provider, model, brokerProfile, scope, nonce, decision,
+                controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt);
+    }
+
+    public static String[] designChallengeMacFields(DesignChallenge challenge) {
+        return designChallengeMacFields(
+                challenge.runId(), challenge.contextDigest(), challenge.ledgerRevision(), challenge.ledgerDigest(),
+                challenge.requirementsDigest(), challenge.policyDigest(), challenge.baselineDigest(),
+                challenge.designDigest(), challenge.designReference(), challenge.nonce());
+    }
+
+    public static String[] designChallengeMacFields(
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String designDigest,
+            String designReference,
+            String nonce) {
+        return macFields("design-challenge-v1", runId, contextDigest, ledgerRevision, ledgerDigest,
+                requirementsDigest, policyDigest, baselineDigest, designDigest, designReference, nonce);
+    }
+
+    public static String[] designResponseMacFields(DesignResponse response) {
+        return designResponseMacFields(
+                response.runId(), response.contextDigest(), response.ledgerRevision(), response.ledgerDigest(),
+                response.requirementsDigest(), response.policyDigest(), response.baselineDigest(),
+                response.designDigest(), response.nonce(), response.decision(), response.requestedChanges(),
+                response.controllerObservedProcessPrincipal(), response.declaredCliUiProfile(), response.channel(),
+                response.answeredAt());
+    }
+
+    public static String[] designResponseMacFields(
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String designDigest,
+            String nonce,
+            DesignDecision decision,
+            String requestedChanges,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt) {
+        return macFields("design-response-v1", runId, contextDigest, ledgerRevision, ledgerDigest,
+                requirementsDigest, policyDigest, baselineDigest, designDigest, nonce, decision, requestedChanges,
+                controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt);
+    }
+
+    public static String[] planChallengeMacFields(PlanChallenge challenge) {
+        return planChallengeMacFields(
+                challenge.runId(), challenge.contextDigest(), challenge.ledgerRevision(), challenge.ledgerDigest(),
+                challenge.requirementsDigest(), challenge.policyDigest(), challenge.baselineDigest(),
+                challenge.approvedDesignDigest(), challenge.planDigest(), challenge.planReference(), challenge.nonce());
+    }
+
+    public static String[] planChallengeMacFields(
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String approvedDesignDigest,
+            String planDigest,
+            String planReference,
+            String nonce) {
+        return macFields("plan-challenge-v1", runId, contextDigest, ledgerRevision, ledgerDigest, requirementsDigest,
+                policyDigest, baselineDigest, approvedDesignDigest, planDigest, planReference, nonce);
+    }
+
+    public static String[] planResponseMacFields(PlanResponse response) {
+        return planResponseMacFields(
+                response.runId(), response.contextDigest(), response.ledgerRevision(), response.ledgerDigest(),
+                response.requirementsDigest(), response.policyDigest(), response.baselineDigest(),
+                response.approvedDesignDigest(), response.planDigest(), response.nonce(), response.decision(),
+                response.requestedChanges(), response.controllerObservedProcessPrincipal(),
+                response.declaredCliUiProfile(), response.channel(), response.answeredAt());
+    }
+
+    public static String[] planResponseMacFields(
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String approvedDesignDigest,
+            String planDigest,
+            String nonce,
+            PlanDecision decision,
+            String requestedChanges,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt) {
+        return macFields("plan-response-v1", runId, contextDigest, ledgerRevision, ledgerDigest, requirementsDigest,
+                policyDigest, baselineDigest, approvedDesignDigest, planDigest, nonce, decision, requestedChanges,
+                controllerObservedProcessPrincipal, declaredCliUiProfile, channel, answeredAt);
+    }
+
+    public static String[] waiverChallengeMacFields(WaiverChallenge challenge) {
+        return waiverChallengeMacFields(
+                challenge.runId(), challenge.checkId(), challenge.evidenceDigest(),
+                challenge.eligibilityPolicyDigest(), challenge.subjectDigest(), challenge.subjectReference(),
+                challenge.risk(), challenge.consequence(), challenge.nonce());
+    }
+
+    public static String[] waiverChallengeMacFields(
+            String runId,
+            String checkId,
+            String evidenceDigest,
+            String eligibilityPolicyDigest,
+            String subjectDigest,
+            String subjectReference,
+            String risk,
+            String consequence,
+            String nonce) {
+        return macFields("waiver-challenge-v1", runId, checkId, evidenceDigest, eligibilityPolicyDigest,
+                subjectDigest, subjectReference, risk, consequence, nonce);
+    }
+
+    public static String[] waiverResponseMacFields(WaiverResponse response) {
+        return waiverResponseMacFields(
+                response.runId(), response.checkId(), response.evidenceDigest(),
+                response.eligibilityPolicyDigest(), response.subjectDigest(), response.nonce(), response.decision(),
+                response.reason(), response.controllerObservedProcessPrincipal(), response.declaredCliUiProfile(),
+                response.channel(), response.answeredAt());
+    }
+
+    public static String[] waiverResponseMacFields(
+            String runId,
+            String checkId,
+            String evidenceDigest,
+            String eligibilityPolicyDigest,
+            String subjectDigest,
+            String nonce,
+            WaiverDecision decision,
+            String reason,
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt) {
+        return macFields("waiver-response-v1", runId, checkId, evidenceDigest, eligibilityPolicyDigest,
+                subjectDigest, nonce, decision, reason, controllerObservedProcessPrincipal, declaredCliUiProfile,
+                channel, answeredAt);
+    }
+
+    private static String[] macFields(String domain, Object... values) {
+        String[] fields = new String[values.length + 1];
+        fields[0] = domain;
+        for (int index = 0; index < values.length; index++) {
+            Object value = values[index];
+            fields[index + 1] = value == null ? null : value instanceof Enum<?> item ? item.name() : value.toString();
+        }
+        return fields;
+    }
+
+    private static void requireCommon(
+            int schemaVersion,
+            String runId,
+            long ledgerRevision,
+            String identity,
+            String nonce,
+            String mac,
+            String label) {
+        requireEnvelope(schemaVersion, runId, identity, nonce, mac, label);
+        if (ledgerRevision < 1) {
+            throw new IllegalArgumentException("Interaction ledger revision must be positive");
+        }
+    }
+
+    private static void requireEnvelope(
+            int schemaVersion,
+            String runId,
+            String identity,
+            String nonce,
+            String mac,
+            String label) {
+        if (schemaVersion != SCHEMA_VERSION) {
+            throw new IllegalArgumentException("Unsupported " + label + " schema: " + schemaVersion);
+        }
+        requireText(runId, MAX_ID_CHARS, "Interaction run ID");
+        requireText(identity, MAX_ID_CHARS, "Interaction identity");
+        if (nonce == null || nonce.length() != NONCE_CHARS || !nonce.matches("[A-Za-z0-9_-]+")) {
+            throw new IllegalArgumentException("Interaction nonce must be a 32-byte base64url value");
+        }
+        if (!ShipDigest.isHmacSha256(mac)) {
+            throw new IllegalArgumentException("Interaction MAC must be an HMAC-SHA-256 value");
+        }
+    }
+
+    private static void requireApprovalBindings(
+            int schemaVersion,
+            String runId,
+            String contextDigest,
+            long ledgerRevision,
+            String ledgerDigest,
+            String requirementsDigest,
+            String policyDigest,
+            String baselineDigest,
+            String nonce,
+            String mac,
+            String label) {
+        requireEnvelope(schemaVersion, runId, label, nonce, mac, label);
+        if (ledgerRevision < 1) {
+            throw new IllegalArgumentException("Interaction ledger revision must be positive");
+        }
+        requireDigest(contextDigest, "Interaction context digest");
+        requireDigest(ledgerDigest, "Interaction ledger digest");
+        requireDigest(requirementsDigest, "Interaction requirements digest");
+        requireDigest(policyDigest, "Interaction policy digest");
+        requireDigest(baselineDigest, "Interaction baseline digest");
+    }
+
+    private static void requireResponder(
+            String controllerObservedProcessPrincipal,
+            String declaredCliUiProfile,
+            String channel,
+            Instant answeredAt,
+            String label) {
+        requireText(controllerObservedProcessPrincipal, MAX_REFERENCE_CHARS,
+                label + " controller-observed process principal");
+        requireText(declaredCliUiProfile, MAX_REFERENCE_CHARS, label + " declared CLI UI profile");
+        requireText(channel, MAX_CHANNEL_CHARS, label + " channel");
+        if (answeredAt == null) {
+            throw new IllegalArgumentException(label + " timestamp is required");
+        }
+    }
+
+    private static void requireDecision(Object decision, String label) {
+        if (decision == null) {
+            throw new IllegalArgumentException(label + " decision is required");
+        }
+    }
+
+    private static String requireRequestedChanges(String value, boolean required, String label) {
+        requireOptionalText(value, MAX_RESPONSE_CHARS, label + " requested changes");
+        if (required && (value == null || value.isBlank())) {
+            throw new IllegalArgumentException(label + " change request requires requested changes");
+        }
+        if (!required && value != null && !value.isBlank()) {
+            throw new IllegalArgumentException(label + " requested changes require a change-request decision");
+        }
+        return required ? value : "";
+    }
+
+    private static void requireDigest(String value, String label) {
+        if (!ShipDigest.isSha256(value)) {
+            throw new IllegalArgumentException(label + " must be a SHA-256 content address");
+        }
+    }
+
+    private static void requireText(String value, int maximum, String label) {
+        if (value == null || value.isBlank() || value.length() > maximum) {
+            throw new IllegalArgumentException(label + " must contain between 1 and " + maximum + " characters");
+        }
+    }
+
+    private static void requireOptionalText(String value, int maximum, String label) {
+        if (value != null && value.length() > maximum) {
+            throw new IllegalArgumentException(label + " must contain at most " + maximum + " characters");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/ProducedArtifact.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/ProducedArtifact.java
@@ -1,0 +1,5 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+/** A staged worker output. The controller computes and verifies its content digest. */
+public record ProducedArtifact(String kind, String relativePath, String digest, long size) {
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/ShipStage.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/ShipStage.java
@@ -1,0 +1,11 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+/** A bounded worker stage selected exclusively by the Ship controller. */
+public enum ShipStage {
+    DISCOVERY,
+    DESIGN,
+    PLAN,
+    EXECUTE,
+    VALIDATE,
+    REVIEW
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageCapability.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageCapability.java
@@ -1,0 +1,41 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.util.List;
+
+/** Controller-issued filesystem and operation envelope for one worker attempt. */
+public record StageCapability(
+        RepositoryAccess repositoryAccess,
+        List<String> readRoots,
+        List<String> writeRoots,
+        List<Operation> allowedOperations,
+        boolean mayLaunchChildren,
+        boolean mayInvokeLaterStages) {
+
+    public StageCapability {
+        readRoots = readRoots == null ? List.of() : List.copyOf(readRoots);
+        writeRoots = writeRoots == null ? List.of() : List.copyOf(writeRoots);
+        allowedOperations = allowedOperations == null ? List.of() : List.copyOf(allowedOperations);
+        if (mayLaunchChildren) {
+            throw new IllegalArgumentException("A bounded Ship worker may never launch child processes");
+        }
+        if (mayInvokeLaterStages) {
+            throw new IllegalArgumentException("A bounded Ship worker may never invoke a later stage");
+        }
+        if (repositoryAccess == RepositoryAccess.READ_ONLY && !writeRoots.isEmpty()) {
+            throw new IllegalArgumentException("A read-only capability cannot contain writable roots");
+        }
+    }
+
+    public enum RepositoryAccess {
+        READ_ONLY,
+        READ_WITH_STAGED_OUTPUT,
+        DECLARED_EXECUTION_PATHS
+    }
+
+    public enum Operation {
+        READ,
+        SEARCH,
+        WRITE_STAGED_ARTIFACT,
+        RETURN_STRUCTURED_RESULT
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageRequest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageRequest.java
@@ -1,0 +1,39 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.util.List;
+
+/** Immutable request for exactly one controller-managed worker attempt. */
+public record StageRequest(
+        int schemaVersion,
+        String runId,
+        ShipStage stage,
+        String attemptId,
+        int attempt,
+        String idempotencyKey,
+        String challenge,
+        String inputDigest,
+        String policyDigest,
+        String sourceDirectory,
+        String sourceSnapshotReference,
+        String projectSourceManifestReference,
+        String contextReference,
+        String ledgerReference,
+        String catalogEvidenceReference,
+        String approvedDesignReference,
+        String planReference,
+        String interactionReference,
+        String artifactManifestReference,
+        String candidateDirectory,
+        List<String> evidenceReferences,
+        String failureCode,
+        String failureMessage,
+        String workerContractReference,
+        String outputDirectory,
+        StageCapability capability) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public StageRequest {
+        evidenceReferences = evidenceReferences == null ? List.of() : List.copyOf(evidenceReferences);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResult.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResult.java
@@ -1,0 +1,42 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Structured result returned by a bounded worker. It contains no requested next state. */
+public record StageResult(
+        @JsonProperty(value = "schemaVersion", required = true) int schemaVersion,
+        @JsonProperty(value = "runId", required = true) String runId,
+        @JsonProperty(value = "stage", required = true) ShipStage stage,
+        @JsonProperty(value = "attemptId", required = true) String attemptId,
+        @JsonProperty(value = "challenge", required = true) String challenge,
+        @JsonProperty(value = "inputDigest", required = true) String inputDigest,
+        @JsonProperty(value = "outcome", required = true) Outcome outcome,
+        @JsonProperty(value = "ledger", required = true) DecisionLedger ledger,
+        @JsonProperty(value = "question", required = true) DecisionLedger.Question question,
+        @JsonProperty(value = "catalogRequests", required = true) List<CatalogSubject> catalogRequests,
+        @JsonProperty(value = "artifacts", required = true) List<ProducedArtifact> artifacts,
+        @JsonProperty(value = "artifactManifest", required = true) ArtifactManifest artifactManifest,
+        @JsonProperty(value = "failureCode", required = true) String failureCode,
+        @JsonProperty(value = "failureMessage", required = true) String failureMessage) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public StageResult {
+        catalogRequests = List.copyOf(Objects.requireNonNull(catalogRequests, "catalogRequests"));
+        artifacts = List.copyOf(Objects.requireNonNull(artifacts, "artifacts"));
+    }
+
+    public enum Outcome {
+        COMPLETED,
+        NEEDS_USER_INPUT,
+        NEEDS_DISCOVERY,
+        FAILED
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidationException.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidationException.java
@@ -1,0 +1,18 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.util.List;
+
+/** Raised when a worker result violates its controller-issued stage contract. */
+public class StageResultValidationException extends IllegalArgumentException {
+
+    private final List<String> violations;
+
+    public StageResultValidationException(List<String> violations) {
+        super(String.join("; ", violations));
+        this.violations = List.copyOf(violations);
+    }
+
+    public List<String> violations() {
+        return violations;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.java
@@ -1,0 +1,337 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
+import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidationException;
+import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidator;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+
+/** Validates worker identity, outcome shape, and staged output before the controller can commit a result. */
+public final class StageResultValidator {
+
+    private StageResultValidator() {
+    }
+
+    public static void validate(StageRequest request, StageResult result, Path attemptOutputDirectory) {
+        validate(request, result, attemptOutputDirectory, true);
+    }
+
+    /** Revalidates an authenticated historical result without consulting mutable worker output. */
+    public static void validateRecorded(StageRequest request, StageResult result) {
+        validate(request, result, null, false);
+    }
+
+    private static void validate(
+            StageRequest request, StageResult result, Path attemptOutputDirectory, boolean verifyFiles) {
+        List<String> violations = new ArrayList<>();
+        if (request == null || result == null) {
+            throw new StageResultValidationException(List.of("Stage request and result are required"));
+        }
+        requireEqual("schema version", StageResult.SCHEMA_VERSION, result.schemaVersion(), violations);
+        requireEqual("run ID", request.runId(), result.runId(), violations);
+        requireEqual("stage", request.stage(), result.stage(), violations);
+        requireEqual("attempt ID", request.attemptId(), result.attemptId(), violations);
+        requireEqual("challenge", request.challenge(), result.challenge(), violations);
+        requireEqual("input digest", request.inputDigest(), result.inputDigest(), violations);
+        if (result.outcome() == null) {
+            violations.add("Stage outcome is required");
+        } else {
+            validateOutcome(request.stage(), result, violations);
+        }
+        validateCatalogRequests(request.stage(), result, violations);
+        validateArtifacts(result.artifacts(), attemptOutputDirectory, verifyFiles, violations);
+        if (!violations.isEmpty()) {
+            throw new StageResultValidationException(violations);
+        }
+    }
+
+    private static void validateCatalogRequests(
+            ShipStage stage, StageResult result, List<String> violations) {
+        List<CatalogSubject> requests = result.catalogRequests();
+        if (requests.size() > 512) {
+            violations.add("A discovery continuation may request at most 512 catalog subjects");
+        }
+        if (new HashSet<>(requests).size() != requests.size()) {
+            violations.add("Catalog requests must be unique");
+        }
+
+        boolean catalogContinuation = stage == ShipStage.DISCOVERY
+                && result.outcome() == StageResult.Outcome.NEEDS_DISCOVERY;
+        if (catalogContinuation && requests.isEmpty()) {
+            violations.add("A discovery continuation requires at least one catalog request");
+        } else if (!catalogContinuation && !requests.isEmpty()) {
+            violations.add("Only discovery may return catalog requests for a discovery continuation");
+        }
+    }
+
+    private static void validateOutcome(ShipStage stage, StageResult result, List<String> violations) {
+        switch (result.outcome()) {
+            case FAILED -> {
+                if (isBlank(result.failureCode()) || isBlank(result.failureMessage())
+                        || !result.failureCode().matches("[a-z][a-z0-9-]{0,127}")
+                        || result.failureMessage().length() > Interaction.MAX_RESPONSE_CHARS) {
+                    violations.add("A failed result requires a failure code and message");
+                }
+                if (result.ledger() != null || result.question() != null) {
+                    violations.add("A failed result cannot contain discovery analysis");
+                }
+                requireNoArtifacts(result, violations);
+            }
+            case NEEDS_USER_INPUT -> validateNeedsInput(stage, result, violations);
+            case NEEDS_DISCOVERY -> validateNeedsDiscovery(stage, result, violations);
+            case COMPLETED -> validateCompleted(stage, result, violations);
+            default -> violations.add("Unsupported stage outcome: " + result.outcome());
+        }
+    }
+
+    private static void validateNeedsDiscovery(
+            ShipStage stage, StageResult result, List<String> violations) {
+        if (stage != ShipStage.DISCOVERY && stage != ShipStage.DESIGN && stage != ShipStage.REVIEW) {
+            violations.add("Only discovery, design, or gap review may request another discovery attempt");
+        }
+        validateLedgerAnalysis(result, violations);
+        if (result.question() != null) {
+            violations.add("A discovery continuation cannot contain a user question");
+        }
+        if (!isBlank(result.failureCode()) || !isBlank(result.failureMessage())) {
+            violations.add("A discovery continuation cannot contain failure details");
+        }
+        requireNoArtifacts(result, violations);
+    }
+
+    private static void validateNeedsInput(ShipStage stage, StageResult result, List<String> violations) {
+        if (stage != ShipStage.DISCOVERY) {
+            violations.add("Only discovery may request user input");
+        }
+        validateLedgerAnalysis(result, violations);
+        if (result.question() == null) {
+            violations.add("A needs-user-input result requires exactly one question");
+        } else if (result.ledger() != null
+                && (result.ledger().openQuestions().size() != 1
+                        || !result.question().id().equals(result.ledger().openQuestions().get(0).id()))) {
+            violations.add("The returned question must be the ledger's single pending question");
+        }
+        if (!isBlank(result.failureCode()) || !isBlank(result.failureMessage())) {
+            violations.add("A needs-user-input result cannot contain failure details");
+        }
+        requireNoArtifacts(result, violations);
+    }
+
+    private static void validateLedgerAnalysis(StageResult result, List<String> violations) {
+        if (result.ledger() == null) {
+            violations.add("Discovery analysis requires a decision ledger");
+            return;
+        }
+        try {
+            LedgerValidator.validateAnalysis(result.ledger());
+        } catch (LedgerValidationException e) {
+            violations.addAll(e.violations());
+        }
+    }
+
+    private static void validateCompleted(ShipStage stage, StageResult result, List<String> violations) {
+        if (!isBlank(result.failureCode()) || !isBlank(result.failureMessage())) {
+            violations.add("A completed result cannot contain failure details");
+        }
+        if (result.question() != null) {
+            violations.add("A completed result cannot contain a pending question");
+        }
+        if (stage != ShipStage.DISCOVERY && stage != ShipStage.REVIEW && result.ledger() != null) {
+            violations.add("Only completed discovery or gap review may return a decision ledger");
+        }
+        switch (stage) {
+            case DISCOVERY -> {
+                if (result.ledger() == null) {
+                    violations.add("Completed discovery requires a decision ledger");
+                } else {
+                    try {
+                        LedgerValidator.validateCandidateReady(result.ledger());
+                    } catch (LedgerValidationException e) {
+                        violations.addAll(e.violations());
+                    }
+                }
+                requireNoArtifacts(result, violations);
+            }
+            case DESIGN -> requireArtifactKind(result, "design", violations);
+            case PLAN -> requireArtifactKind(result, "plan", violations);
+            case EXECUTE -> {
+                if (result.artifactManifest() == null) {
+                    violations.add("Completed execution requires an artifact manifest");
+                }
+                if (result.artifacts().isEmpty()) {
+                    violations.add("Completed execution requires staged artifacts");
+                }
+            }
+            case VALIDATE -> requireArtifactKind(result, "validation", violations);
+            case REVIEW -> {
+                if (result.ledger() == null) {
+                    violations.add("Completed gap review requires a decision ledger");
+                } else {
+                    try {
+                        LedgerValidator.validateReady(result.ledger());
+                    } catch (LedgerValidationException e) {
+                        violations.addAll(e.violations());
+                    }
+                }
+                requireNoArtifacts(result, violations);
+            }
+            default -> violations.add("Unsupported completed stage: " + stage);
+        }
+    }
+
+    private static void requireNoArtifacts(StageResult result, List<String> violations) {
+        if (!result.artifacts().isEmpty() || result.artifactManifest() != null) {
+            violations.add("This stage may not return implementation artifacts");
+        }
+    }
+
+    private static void requireArtifactKind(StageResult result, String kind, List<String> violations) {
+        if (result.artifacts().size() != 1
+                || result.artifacts().get(0) == null
+                || !kind.equals(result.artifacts().get(0).kind())) {
+            violations.add("Completed stage requires exactly one " + kind + " artifact");
+        }
+        if (result.artifactManifest() != null) {
+            violations.add("Only execution may return the implementation artifact manifest");
+        }
+    }
+
+    private static void validateArtifacts(
+            List<ProducedArtifact> artifacts,
+            Path outputDirectory,
+            boolean verifyFiles,
+            List<String> violations) {
+        if (artifacts.isEmpty()) {
+            return;
+        }
+        ShipTreePolicy policy = ShipTreePolicy.current();
+        if (artifacts.size() > policy.maxFileCount()) {
+            violations.add("Stage result exceeds the " + policy.maxFileCount() + " artifact limit");
+            return;
+        }
+        if (verifyFiles && outputDirectory == null) {
+            violations.add("Attempt output directory is required when artifacts are returned");
+            return;
+        }
+        Path root = verifyFiles ? outputDirectory.toAbsolutePath().normalize() : null;
+        Set<String> paths = new HashSet<>();
+        long aggregateSize = 0;
+        for (ProducedArtifact artifact : artifacts) {
+            if (artifact == null
+                    || artifact.kind() == null
+                    || !artifact.kind().matches("[a-z][a-z0-9-]{0,63}")
+                    || !safeRelativePath(artifact.relativePath())
+                    || !ShipDigest.isSha256(artifact.digest())
+                    || artifact.size() < 0) {
+                violations.add("Produced artifacts require a canonical kind, portable relative path, "
+                               + "SHA-256 digest, and nonnegative size");
+                continue;
+            }
+            if (artifact.size() > policy.maxFileBytes()) {
+                violations.add("Produced artifact exceeds the per-file limit: " + artifact.relativePath());
+                continue;
+            }
+            try {
+                aggregateSize = Math.addExact(aggregateSize, artifact.size());
+            } catch (ArithmeticException e) {
+                aggregateSize = Long.MAX_VALUE;
+            }
+            if (aggregateSize > policy.maxAggregateBytes()) {
+                violations.add("Stage result exceeds the aggregate artifact-byte limit");
+                return;
+            }
+            if (!paths.add(artifact.relativePath())) {
+                violations.add("Duplicate produced artifact path: " + artifact.relativePath());
+            }
+            if (!verifyFiles) {
+                continue;
+            }
+            Path relative = Path.of(artifact.relativePath());
+            Path file = root.resolve(relative).normalize();
+            if (relative.isAbsolute() || !file.startsWith(root)) {
+                violations.add("Produced artifact escapes the attempt output directory: " + artifact.relativePath());
+                continue;
+            }
+            if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+                violations.add("Produced artifact is missing, symbolic, or not regular: " + artifact.relativePath());
+                continue;
+            }
+            try {
+                ContentIdentity identity = identity(file, policy.maxFileBytes());
+                if (identity.size() != artifact.size()) {
+                    violations.add("Produced artifact size mismatch: " + artifact.relativePath());
+                }
+                if (!identity.digest().equals(artifact.digest())) {
+                    violations.add("Produced artifact digest mismatch: " + artifact.relativePath());
+                }
+            } catch (IOException e) {
+                violations.add("Could not verify produced artifact " + artifact.relativePath() + ": " + e.getMessage());
+            }
+        }
+    }
+
+    private static ContentIdentity identity(Path file, long maximumBytes) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            long size = 0;
+            try (var input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    size = Math.addExact(size, read);
+                    if (size > maximumBytes) {
+                        throw new IOException("Produced artifact exceeds the per-file limit");
+                    }
+                    digest.update(buffer, 0, read);
+                }
+            }
+            return new ContentIdentity(
+                    "sha256:" + java.util.HexFormat.of().formatHex(digest.digest()), size);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static void requireEqual(String field, Object expected, Object actual, List<String> violations) {
+        if (expected == null ? actual != null : !expected.equals(actual)) {
+            violations.add("Stage result " + field + " does not match the active attempt");
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static boolean safeRelativePath(String value) {
+        if (value == null || value.isBlank() || value.length() > Interaction.MAX_REFERENCE_CHARS
+                || value.startsWith("/") || value.startsWith("\\") || value.contains("\\")) {
+            return false;
+        }
+        String[] segments = value.split("/", -1);
+        for (String segment : segments) {
+            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+                return false;
+            }
+        }
+        try {
+            Path relative = Path.of(value);
+            return !relative.isAbsolute() && relative.normalize().equals(relative);
+        } catch (java.nio.file.InvalidPathException e) {
+            return false;
+        }
+    }
+
+    private record ContentIdentity(String digest, long size) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.java
@@ -442,18 +442,35 @@ public final class StageResultValidator {
                     lexical = lexical.resolve(name);
                     String description = "Attempt output path " + lexical;
                     BasicFileAttributes basic = attributes(current, name);
-                    UnixIdentity expected = sampleUnix(lexical, basic.fileKey(), description);
-                    requireDirectory(basic, expected, null,
-                            "Attempt output path contains a non-directory or symbolic entry");
+                    boolean attemptRoot = lexical.equals(path);
+                    UnixIdentity expected = null;
+                    if (attemptRoot) {
+                        expected = sampleUnix(lexical, basic.fileKey(), description);
+                        requireDirectory(basic, expected, null,
+                                "Attempt output path contains a non-directory or symbolic entry");
+                    } else {
+                        // Shared ancestors may change contents; only their opened identity must remain stable.
+                        requireBasicDirectory(
+                                basic, "Attempt output path contains a non-directory or symbolic entry");
+                    }
 
                     SecureDirectoryStream<Path> child = null;
                     try {
                         child = current.newDirectoryStream(name, LinkOption.NOFOLLOW_LINKS);
-                        requireDirectory(attributes(child, null), expected, null,
-                                "Attempt output directory changed while it was opened");
-                        UnixIdentity rebound = sampleUnix(lexical, expected.fileKey(), description);
-                        if (!expected.equals(rebound)) {
-                            throw new IOException("Attempt output directory changed while it was opened");
+                        BasicFileAttributes childAttributes = attributes(child, null);
+                        if (attemptRoot) {
+                            requireDirectory(childAttributes, expected, null,
+                                    "Attempt output directory changed while it was opened");
+                            UnixIdentity rebound = sampleUnix(lexical, expected.fileKey(), description);
+                            if (!expected.equals(rebound)) {
+                                throw new IOException("Attempt output directory changed while it was opened");
+                            }
+                        } else {
+                            requireBasicDirectory(
+                                    childAttributes, "Attempt output directory changed while it was opened");
+                            if (!basic.fileKey().equals(childAttributes.fileKey())) {
+                                throw new IOException("Attempt output directory changed while it was opened");
+                            }
                         }
                     } catch (IOException | RuntimeException e) {
                         if (child != null) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.java
@@ -1,56 +1,75 @@
 package io.github.luigidemasi.camelkit.ship.protocol;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
 import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidationException;
 import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidator;
+import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.Operation;
+import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.RepositoryAccess;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 
-/** Validates worker identity, outcome shape, and staged output before the controller can commit a result. */
+/** Validates worker identity, outcome shape, and the live staged bytes observed during one non-certifying preflight. */
 public final class StageResultValidator {
 
     private StageResultValidator() {
     }
 
-    public static void validate(StageRequest request, StageResult result, Path attemptOutputDirectory) {
-        validate(request, result, attemptOutputDirectory, true);
-    }
-
-    /** Revalidates an authenticated historical result without consulting mutable worker output. */
-    public static void validateRecorded(StageRequest request, StageResult result) {
-        validate(request, result, null, false);
-    }
-
-    private static void validate(
-            StageRequest request, StageResult result, Path attemptOutputDirectory, boolean verifyFiles) {
+    /**
+     * Performs a live preflight over one stopped worker's output.
+     *
+     * <p>
+     * The controller must own and protect the attempt-output ancestry from worker replacement while this method runs.
+     * Passing preflight does not authorize a later reopen or commit: the protected controller added in the next slice
+     * must hash while importing the same opened stream into controller-owned quarantine/CAS and commit only that copy.
+     */
+    public static void validatePreflight(StageRequest request, StageResult result, Path attemptOutputDirectory) {
         List<String> violations = new ArrayList<>();
         if (request == null || result == null) {
             throw new StageResultValidationException(List.of("Stage request and result are required"));
         }
-        requireEqual("schema version", StageResult.SCHEMA_VERSION, result.schemaVersion(), violations);
+        requireEqual("request schema version", StageRequest.SCHEMA_VERSION, request.schemaVersion(), violations);
+        requireEqual("result schema version", StageResult.SCHEMA_VERSION, result.schemaVersion(), violations);
+        requireEqual("schema version", request.schemaVersion(), result.schemaVersion(), violations);
         requireEqual("run ID", request.runId(), result.runId(), violations);
         requireEqual("stage", request.stage(), result.stage(), violations);
         requireEqual("attempt ID", request.attemptId(), result.attemptId(), violations);
         requireEqual("challenge", request.challenge(), result.challenge(), violations);
         requireEqual("input digest", request.inputDigest(), result.inputDigest(), violations);
+        if (request.stage() == null) {
+            violations.add("Stage request stage is required");
+        }
         if (result.outcome() == null) {
             violations.add("Stage outcome is required");
-        } else {
+        } else if (request.stage() != null) {
             validateOutcome(request.stage(), result, violations);
         }
         validateCatalogRequests(request.stage(), result, violations);
-        validateArtifacts(result.artifacts(), attemptOutputDirectory, verifyFiles, violations);
+        validateResultAuthority(request, result.artifacts(), attemptOutputDirectory, violations);
+        validateArtifacts(result.artifacts(), attemptOutputDirectory, violations);
         if (!violations.isEmpty()) {
             throw new StageResultValidationException(violations);
         }
@@ -119,7 +138,7 @@ public final class StageResultValidator {
             violations.add("A needs-user-input result requires exactly one question");
         } else if (result.ledger() != null
                 && (result.ledger().openQuestions().size() != 1
-                        || !result.question().id().equals(result.ledger().openQuestions().get(0).id()))) {
+                        || !result.question().equals(result.ledger().openQuestions().get(0)))) {
             violations.add("The returned question must be the ledger's single pending question");
         }
         if (!isBlank(result.failureCode()) || !isBlank(result.failureMessage())) {
@@ -210,7 +229,6 @@ public final class StageResultValidator {
     private static void validateArtifacts(
             List<ProducedArtifact> artifacts,
             Path outputDirectory,
-            boolean verifyFiles,
             List<String> violations) {
         if (artifacts.isEmpty()) {
             return;
@@ -220,18 +238,13 @@ public final class StageResultValidator {
             violations.add("Stage result exceeds the " + policy.maxFileCount() + " artifact limit");
             return;
         }
-        if (verifyFiles && outputDirectory == null) {
-            violations.add("Attempt output directory is required when artifacts are returned");
-            return;
-        }
-        Path root = verifyFiles ? outputDirectory.toAbsolutePath().normalize() : null;
         Set<String> paths = new HashSet<>();
         long aggregateSize = 0;
         for (ProducedArtifact artifact : artifacts) {
             if (artifact == null
                     || artifact.kind() == null
                     || !artifact.kind().matches("[a-z][a-z0-9-]{0,63}")
-                    || !safeRelativePath(artifact.relativePath())
+                    || !safeRelativePath(artifact.relativePath(), policy)
                     || !ShipDigest.isSha256(artifact.digest())
                     || artifact.size() < 0) {
                 violations.add("Produced artifacts require a canonical kind, portable relative path, "
@@ -254,52 +267,100 @@ public final class StageResultValidator {
             if (!paths.add(artifact.relativePath())) {
                 violations.add("Duplicate produced artifact path: " + artifact.relativePath());
             }
-            if (!verifyFiles) {
-                continue;
-            }
-            Path relative = Path.of(artifact.relativePath());
-            Path file = root.resolve(relative).normalize();
-            if (relative.isAbsolute() || !file.startsWith(root)) {
-                violations.add("Produced artifact escapes the attempt output directory: " + artifact.relativePath());
-                continue;
-            }
-            if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
-                violations.add("Produced artifact is missing, symbolic, or not regular: " + artifact.relativePath());
-                continue;
-            }
-            try {
-                ContentIdentity identity = identity(file, policy.maxFileBytes());
-                if (identity.size() != artifact.size()) {
-                    violations.add("Produced artifact size mismatch: " + artifact.relativePath());
+        }
+        if (!violations.isEmpty()) {
+            return;
+        }
+        if (outputDirectory == null) {
+            violations.add("Attempt output directory is required when artifacts are returned");
+            return;
+        }
+        try (SecureArtifactRoot root = SecureArtifactRoot.open(outputDirectory)) {
+            for (ProducedArtifact artifact : artifacts) {
+                try {
+                    ContentIdentity identity = root.identity(artifact.relativePath(), policy.maxFileBytes());
+                    if (identity.size() != artifact.size()) {
+                        violations.add("Produced artifact size mismatch: " + artifact.relativePath());
+                    }
+                    if (!identity.digest().equals(artifact.digest())) {
+                        violations.add("Produced artifact digest mismatch: " + artifact.relativePath());
+                    }
+                } catch (IOException e) {
+                    violations.add(
+                            "Could not verify produced artifact " + artifact.relativePath() + ": " + e.getMessage());
                 }
-                if (!identity.digest().equals(artifact.digest())) {
-                    violations.add("Produced artifact digest mismatch: " + artifact.relativePath());
-                }
-            } catch (IOException e) {
-                violations.add("Could not verify produced artifact " + artifact.relativePath() + ": " + e.getMessage());
             }
+        } catch (IOException e) {
+            violations.add("Could not securely bind the attempt output directory: " + e.getMessage());
         }
     }
 
-    private static ContentIdentity identity(Path file, long maximumBytes) throws IOException {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            long size = 0;
-            try (var input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
-                byte[] buffer = new byte[8192];
-                int read;
-                while ((read = input.read(buffer)) != -1) {
-                    size = Math.addExact(size, read);
-                    if (size > maximumBytes) {
-                        throw new IOException("Produced artifact exceeds the per-file limit");
-                    }
-                    digest.update(buffer, 0, read);
-                }
+    private static void validateResultAuthority(
+            StageRequest request,
+            List<ProducedArtifact> artifacts,
+            Path activeOutputDirectory,
+            List<String> violations) {
+        StageCapability capability = request.capability();
+        if (capability == null || capability.repositoryAccess() == null) {
+            violations.add("Stage results require a controller-issued capability envelope");
+            return;
+        }
+        if (!capability.allowedOperations().contains(Operation.RETURN_STRUCTURED_RESULT)) {
+            violations.add("The controller-issued capability must authorize returning a structured result");
+        }
+        if (artifacts.isEmpty()) {
+            return;
+        }
+        if (!repositoryAccessAllowsArtifacts(request.stage(), capability.repositoryAccess())
+                || !capability.allowedOperations().contains(Operation.WRITE_STAGED_ARTIFACT)) {
+            violations.add(
+                    "Produced artifacts require stage-compatible controller-issued staged-artifact write authority");
+            return;
+        }
+        Path declaredOutput = absoluteCanonicalPath(request.outputDirectory());
+        if (declaredOutput == null) {
+            violations.add("Produced artifacts require a canonical absolute request output directory");
+            return;
+        }
+        boolean invalidWriteRoot = false;
+        boolean outputCovered = false;
+        for (String value : capability.writeRoots()) {
+            Path root = absoluteCanonicalPath(value);
+            if (root == null) {
+                invalidWriteRoot = true;
+            } else if (declaredOutput.startsWith(root)) {
+                outputCovered = true;
             }
-            return new ContentIdentity(
-                    "sha256:" + java.util.HexFormat.of().formatHex(digest.digest()), size);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+        if (invalidWriteRoot || !outputCovered) {
+            violations.add("The request output directory must be covered by a canonical capability write root");
+        }
+        if (activeOutputDirectory == null
+                || !declaredOutput.equals(activeOutputDirectory.toAbsolutePath().normalize())) {
+            violations.add("The active attempt output directory does not match the request capability envelope");
+        }
+    }
+
+    private static boolean repositoryAccessAllowsArtifacts(ShipStage stage, RepositoryAccess access) {
+        if (stage == null) {
+            return false;
+        }
+        return switch (stage) {
+            case DESIGN, PLAN, VALIDATE -> access == RepositoryAccess.READ_WITH_STAGED_OUTPUT;
+            case EXECUTE -> access == RepositoryAccess.DECLARED_EXECUTION_PATHS;
+            default -> false;
+        };
+    }
+
+    private static Path absoluteCanonicalPath(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            Path path = Path.of(value);
+            return path.isAbsolute() && path.getNameCount() > 0 && path.normalize().equals(path) ? path : null;
+        } catch (InvalidPathException e) {
+            return null;
         }
     }
 
@@ -313,25 +374,354 @@ public final class StageResultValidator {
         return value == null || value.isBlank();
     }
 
-    private static boolean safeRelativePath(String value) {
-        if (value == null || value.isBlank() || value.length() > Interaction.MAX_REFERENCE_CHARS
-                || value.startsWith("/") || value.startsWith("\\") || value.contains("\\")) {
-            return false;
-        }
-        String[] segments = value.split("/", -1);
-        for (String segment : segments) {
-            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
-                return false;
-            }
-        }
+    private static boolean safeRelativePath(String value, ShipTreePolicy policy) {
         try {
+            ShipTreePolicy.requireCanonicalRelativePath(value);
             Path relative = Path.of(value);
-            return !relative.isAbsolute() && relative.normalize().equals(relative);
-        } catch (java.nio.file.InvalidPathException e) {
+            return !relative.isAbsolute()
+                    && relative.normalize().equals(relative)
+                    && relative.getNameCount() - 1 <= policy.maxDepth();
+        } catch (IllegalArgumentException e) {
             return false;
         }
     }
 
     private record ContentIdentity(String digest, long size) {
+    }
+
+    private record UnixIdentity(
+            Object fileKey,
+            long device,
+            long inode,
+            long linkCount,
+            long size,
+            long modifiedNanos,
+            long changedNanos,
+            int mode) {
+    }
+
+    /** Held, descriptor-relative attempt output root used only during live preflight. */
+    private static final class SecureArtifactRoot implements AutoCloseable {
+
+        private static final String UNIX_ATTRIBUTES = "unix:dev,ino,nlink,size,lastModifiedTime,ctime,mode";
+        private static final int FILE_TYPE_MASK = 0170000;
+        private static final int DIRECTORY_TYPE = 0040000;
+        private static final int REGULAR_FILE_TYPE = 0100000;
+        private static final Set<OpenOption> READ_OPTIONS = Set.of(
+                StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+
+        private final Path path;
+        private final SecureDirectoryStream<Path> root;
+        private final UnixIdentity identity;
+
+        private SecureArtifactRoot(
+                                   Path path, SecureDirectoryStream<Path> root, UnixIdentity identity) {
+            this.path = path;
+            this.root = root;
+            this.identity = identity;
+        }
+
+        private static SecureArtifactRoot open(Path requested) throws IOException {
+            Path path = requested.toAbsolutePath().normalize();
+            if (path.getRoot() == null || path.getNameCount() == 0) {
+                throw new IOException("Attempt output root must be a non-root absolute directory");
+            }
+            DirectoryStream<Path> opened = Files.newDirectoryStream(path.getRoot());
+            if (!(opened instanceof SecureDirectoryStream<?> stream)) {
+                opened.close();
+                throw new IOException("Attempt output filesystem does not provide SecureDirectoryStream");
+            }
+            @SuppressWarnings("unchecked")
+            SecureDirectoryStream<Path> current = (SecureDirectoryStream<Path>) stream;
+            Path lexical = path.getRoot();
+            try {
+                requireBasicDirectory(
+                        attributes(current, null), "Filesystem root is not a stable real directory");
+                for (Path component : path) {
+                    Path name = Path.of(component.toString());
+                    lexical = lexical.resolve(name);
+                    String description = "Attempt output path " + lexical;
+                    BasicFileAttributes basic = attributes(current, name);
+                    UnixIdentity expected = sampleUnix(lexical, basic.fileKey(), description);
+                    requireDirectory(basic, expected, null,
+                            "Attempt output path contains a non-directory or symbolic entry");
+
+                    SecureDirectoryStream<Path> child = null;
+                    try {
+                        child = current.newDirectoryStream(name, LinkOption.NOFOLLOW_LINKS);
+                        requireDirectory(attributes(child, null), expected, null,
+                                "Attempt output directory changed while it was opened");
+                        UnixIdentity rebound = sampleUnix(lexical, expected.fileKey(), description);
+                        if (!expected.equals(rebound)) {
+                            throw new IOException("Attempt output directory changed while it was opened");
+                        }
+                    } catch (IOException | RuntimeException e) {
+                        if (child != null) {
+                            try {
+                                child.close();
+                            } catch (IOException closeFailure) {
+                                e.addSuppressed(closeFailure);
+                            }
+                        }
+                        throw e;
+                    }
+                    try {
+                        current.close();
+                    } catch (IOException e) {
+                        try {
+                            child.close();
+                        } catch (IOException closeFailure) {
+                            e.addSuppressed(closeFailure);
+                        }
+                        throw e;
+                    }
+                    current = child;
+                }
+                BasicFileAttributes held = attributes(current, null);
+                UnixIdentity identity = sampleUnix(path, held.fileKey(), "Attempt output root");
+                requireDirectory(held, identity, null, "Attempt output root is not a stable real directory");
+                return new SecureArtifactRoot(path, current, identity);
+            } catch (IOException | RuntimeException e) {
+                try {
+                    current.close();
+                } catch (IOException closeFailure) {
+                    e.addSuppressed(closeFailure);
+                }
+                throw e;
+            }
+        }
+
+        private ContentIdentity identity(String relativePath, long maximumBytes) throws IOException {
+            String[] components = relativePath.split("/");
+            return identity(root, path, components, 0, maximumBytes);
+        }
+
+        private ContentIdentity identity(
+                SecureDirectoryStream<Path> directory,
+                Path lexicalDirectory,
+                String[] components,
+                int index,
+                long maximumBytes)
+                throws IOException {
+            Path name = Path.of(components[index]);
+            Path lexical = lexicalDirectory.resolve(name);
+            String description = "Produced artifact " + lexical;
+            BasicFileAttributes basicBefore = attributes(directory, name);
+            UnixIdentity before = sampleUnix(lexical, basicBefore.fileKey(), description);
+            if (index < components.length - 1) {
+                requireDirectory(basicBefore, before, identity.device(),
+                        "Produced artifact path contains a non-directory or symbolic entry");
+                try (SecureDirectoryStream<Path> child
+                        = directory.newDirectoryStream(name, LinkOption.NOFOLLOW_LINKS)) {
+                    requireDirectory(attributes(child, null), before, identity.device(),
+                            "Produced artifact directory changed while it was opened");
+                    UnixIdentity rebound = sampleUnix(lexical, before.fileKey(), description);
+                    if (!before.equals(rebound)) {
+                        throw new IOException("Produced artifact directory changed while it was opened");
+                    }
+                    ContentIdentity result = identity(child, lexical, components, index + 1, maximumBytes);
+                    BasicFileAttributes basicAfter = attributes(directory, name);
+                    UnixIdentity after = sampleUnix(lexical, before.fileKey(), description);
+                    requireDirectory(basicAfter, after, identity.device(),
+                            "Produced artifact directory changed while it was read");
+                    if (!before.equals(after)) {
+                        throw new IOException("Produced artifact directory changed while it was read");
+                    }
+                    return result;
+                }
+            }
+            requireRegular(basicBefore, before, identity.device(),
+                    "Produced artifact is missing, symbolic, hard-linked, or not regular");
+            MessageDigest digest = messageDigest();
+            long size = 0;
+            // Java 17 exposes no fstat-style identity from this channel. This preflight
+            // therefore cannot authorize reopening or committing the path later.
+            try (SeekableByteChannel input = directory.newByteChannel(name, READ_OPTIONS)) {
+                ByteBuffer buffer = ByteBuffer.allocate(8192);
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    if (read == 0) {
+                        continue;
+                    }
+                    size = Math.addExact(size, read);
+                    if (size > maximumBytes) {
+                        throw new IOException("Produced artifact exceeds the per-file limit");
+                    }
+                    buffer.flip();
+                    digest.update(buffer);
+                    buffer.clear();
+                }
+            }
+            BasicFileAttributes basicAfter = attributes(directory, name);
+            UnixIdentity after = sampleUnix(lexical, before.fileKey(), description);
+            requireRegular(basicAfter, after, identity.device(), "Produced artifact changed while it was read");
+            if (!before.equals(after) || size != before.size()) {
+                throw new IOException("Produced artifact changed while it was read");
+            }
+            return new ContentIdentity("sha256:" + HexFormat.of().formatHex(digest.digest()), size);
+        }
+
+        private static BasicFileAttributes attributes(SecureDirectoryStream<Path> directory, Path name)
+                throws IOException {
+            BasicFileAttributeView view = name == null
+                    ? directory.getFileAttributeView(BasicFileAttributeView.class)
+                    : directory.getFileAttributeView(
+                            name, BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+            if (view == null) {
+                throw new IOException("Attempt output filesystem does not expose descriptor-relative attributes");
+            }
+            return view.readAttributes();
+        }
+
+        private static UnixIdentity sampleUnix(Path path, Object expectedFileKey, String description)
+                throws IOException {
+            if (expectedFileKey == null) {
+                throw new IOException(description + " lacks a stable file key");
+            }
+            try {
+                BasicFileAttributes basicBefore = Files.readAttributes(
+                        path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                if (!expectedFileKey.equals(basicBefore.fileKey())) {
+                    throw new IOException(description + " changed before Unix identity sampling");
+                }
+                Map<String, Object> values = Files.readAttributes(
+                        path, UNIX_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
+                BasicFileAttributes basicAfter = Files.readAttributes(
+                        path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                if (!expectedFileKey.equals(basicAfter.fileKey())) {
+                    throw new IOException(description + " changed during Unix identity sampling");
+                }
+                UnixIdentity identity = new UnixIdentity(
+                        expectedFileKey,
+                        requiredLong(values, "dev", description),
+                        requiredLong(values, "ino", description),
+                        requiredLong(values, "nlink", description),
+                        requiredLong(values, "size", description),
+                        requiredTime(values, "lastModifiedTime", description).to(TimeUnit.NANOSECONDS),
+                        requiredTime(values, "ctime", description).to(TimeUnit.NANOSECONDS),
+                        requiredInt(values, "mode", description));
+                requireBasicBinding(basicBefore, identity, description);
+                requireBasicBinding(basicAfter, identity, description);
+                return identity;
+            } catch (UnsupportedOperationException | IllegalArgumentException e) {
+                throw new IOException(description + " filesystem lacks stable Unix identity metadata", e);
+            }
+        }
+
+        private static long requiredLong(Map<String, Object> values, String name, String description)
+                throws IOException {
+            Object value = values.get(name);
+            if (!(value instanceof Number number)) {
+                throw new IOException(description + " lacks Unix attribute " + name);
+            }
+            return number.longValue();
+        }
+
+        private static int requiredInt(Map<String, Object> values, String name, String description)
+                throws IOException {
+            long value = requiredLong(values, name, description);
+            if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+                throw new IOException(description + " has an invalid Unix attribute " + name);
+            }
+            return (int) value;
+        }
+
+        private static FileTime requiredTime(Map<String, Object> values, String name, String description)
+                throws IOException {
+            Object value = values.get(name);
+            if (!(value instanceof FileTime time)) {
+                throw new IOException(description + " lacks Unix attribute " + name);
+            }
+            return time;
+        }
+
+        private static void requireBasicDirectory(BasicFileAttributes attributes, String message)
+                throws IOException {
+            if (!attributes.isDirectory() || attributes.isSymbolicLink() || attributes.fileKey() == null) {
+                throw new IOException(message);
+            }
+        }
+
+        private static void requireDirectory(
+                BasicFileAttributes basic,
+                UnixIdentity unix,
+                Long requiredDevice,
+                String message)
+                throws IOException {
+            if (!basic.isDirectory() || basic.isSymbolicLink() || basic.fileKey() == null
+                    || (unix.mode() & FILE_TYPE_MASK) != DIRECTORY_TYPE) {
+                throw new IOException(message);
+            }
+            requireBasicBinding(basic, unix, message);
+            requireDevice(unix, requiredDevice, message);
+        }
+
+        private static void requireRegular(
+                BasicFileAttributes basic,
+                UnixIdentity unix,
+                long requiredDevice,
+                String message)
+                throws IOException {
+            if (!basic.isRegularFile() || basic.isSymbolicLink() || basic.fileKey() == null
+                    || (unix.mode() & FILE_TYPE_MASK) != REGULAR_FILE_TYPE
+                    || unix.linkCount() != 1) {
+                throw new IOException(message);
+            }
+            requireBasicBinding(basic, unix, message);
+            requireDevice(unix, requiredDevice, message);
+        }
+
+        private static void requireBasicBinding(
+                BasicFileAttributes basic, UnixIdentity unix, String description)
+                throws IOException {
+            if (!unix.fileKey().equals(basic.fileKey())
+                    || unix.size() != basic.size()
+                    || unix.modifiedNanos() != basic.lastModifiedTime().to(TimeUnit.NANOSECONDS)) {
+                throw new IOException(description);
+            }
+        }
+
+        private static void requireDevice(UnixIdentity unix, Long requiredDevice, String message)
+                throws IOException {
+            if (requiredDevice != null && unix.device() != requiredDevice) {
+                throw new IOException(message + ": filesystem device crossing");
+            }
+        }
+
+        private static MessageDigest messageDigest() {
+            try {
+                return MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("SHA-256 is not available", e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOException failure = null;
+            try {
+                BasicFileAttributes held = attributes(root, null);
+                UnixIdentity rebound = sampleUnix(path, identity.fileKey(), "Attempt output root");
+                requireDirectory(held, rebound, null,
+                        "Attempt output root changed while artifacts were verified");
+                if (!identity.equals(rebound)) {
+                    throw new IOException("Attempt output root changed while artifacts were verified");
+                }
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                root.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
@@ -1,0 +1,35 @@
+package io.github.luigidemasi.camelkit.ship.security;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Purpose-bound secure filesystem operations used to collect controller-owned evidence. */
+public final class ProjectEvidenceFiles {
+
+    private ProjectEvidenceFiles() {
+    }
+
+    public static ProjectSnapshot capture(Path projectRoot) throws IOException {
+        return new ProjectSnapshotService().capture(projectRoot);
+    }
+
+    public static ProjectSnapshot captureSealed(Path sealedRoot) throws IOException {
+        return new ProjectSnapshotService().captureSealed(sealedRoot);
+    }
+
+    public static boolean unchanged(ProjectSnapshot before, ProjectSnapshot after) {
+        return new ProjectSnapshotService().unchanged(before, after);
+    }
+
+    public static boolean unchangedMaterialTree(ProjectSnapshot before, ProjectSnapshot after) {
+        return new ProjectSnapshotService().unchangedMaterialTree(before, after);
+    }
+
+    public static ProjectSnapshot materializeMaterial(Path sourceRoot, Path targetRoot) throws IOException {
+        return new ProjectSnapshotService().materializeMaterial(sourceRoot, targetRoot);
+    }
+
+    public static byte[] readMaterial(Path root, String relativePath, int maximumBytes) throws IOException {
+        return new ProjectSnapshotService().readMaterial(root, relativePath, maximumBytes);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
@@ -1,7 +1,11 @@
 package io.github.luigidemasi.camelkit.ship.security;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -67,6 +71,99 @@ final class ProjectSnapshotService {
                 compareMaps(
                         materialDirectories(before.directories()),
                         materialDirectories(after.directories())));
+    }
+
+    boolean unchanged(ProjectSnapshot before, ProjectSnapshot after) {
+        return compare(before, after).unchanged();
+    }
+
+    boolean unchangedMaterialTree(ProjectSnapshot before, ProjectSnapshot after) {
+        return compareMaterialTree(before, after).unchanged();
+    }
+
+    /** Copies an authenticated material snapshot into an empty controller-owned directory. */
+    ProjectSnapshot materializeMaterial(Path sourceRoot, Path targetRoot) throws IOException {
+        ProjectSnapshot expected = capture(sourceRoot);
+        Path target = requireEmptyTarget(targetRoot);
+        try (SecureRoot source = ShipSecureFilesystem.open(sourceRoot, "Ship baseline source", policy)) {
+            ProjectSnapshot before = source.snapshot();
+            if (!compare(before, expected).unchanged()) {
+                throw new ShipFilesystemException(
+                        ShipFilesystemException.CONCURRENT_MUTATION,
+                        "Ship project differs from the accepted baseline before materialization");
+            }
+            for (Map.Entry<String, DirectoryEntry> item : before.directories().entrySet()) {
+                if (item.getValue().classification() == Classification.MATERIAL) {
+                    Path directory = target.resolve(item.getKey());
+                    Files.createDirectory(directory);
+                }
+            }
+            for (Map.Entry<String, FileEntry> item : before.files().entrySet()) {
+                if (item.getValue().classification() != Classification.MATERIAL) {
+                    continue;
+                }
+                byte[] content = source.readMaterialBytes(
+                        item.getKey(), Math.max(1, Math.toIntExact(item.getValue().size())));
+                Path file = target.resolve(item.getKey());
+                Files.write(file, content, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+                setMode(file, item.getValue().unixMode());
+            }
+            for (Map.Entry<String, DirectoryEntry> item : before.directories().entrySet().stream()
+                    .sorted(Map.Entry.<String, DirectoryEntry>comparingByKey().reversed())
+                    .toList()) {
+                if (item.getValue().classification() == Classification.MATERIAL) {
+                    setMode(target.resolve(item.getKey()), item.getValue().unixMode());
+                }
+            }
+            ProjectSnapshot after = source.snapshot();
+            if (!compare(before, after).unchanged()) {
+                throw new ShipFilesystemException(
+                        ShipFilesystemException.CONCURRENT_MUTATION,
+                        "Ship project changed while its accepted baseline was materialized");
+            }
+        }
+        ProjectSnapshot materialized = captureSealed(target);
+        if (!compareMaterialTree(expected, materialized).unchanged()) {
+            throw new ShipFilesystemException(
+                    ShipFilesystemException.CONCURRENT_MUTATION,
+                    "Materialized Ship workspace differs from its accepted baseline");
+        }
+        return materialized;
+    }
+
+    /** Reads one bounded material file through the descriptor-relative project boundary. */
+    byte[] readMaterial(Path root, String relativePath, int maximumBytes) throws IOException {
+        try (SecureRoot secure = ShipSecureFilesystem.open(root, "Ship material read", policy)) {
+            return secure.readMaterialBytes(relativePath, maximumBytes);
+        }
+    }
+
+    private static Path requireEmptyTarget(Path targetRoot) throws IOException {
+        Path target = targetRoot.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(target) || !Files.isDirectory(target, LinkOption.NOFOLLOW_LINKS)
+                || !target.toRealPath(LinkOption.NOFOLLOW_LINKS).equals(target)) {
+            throw new IOException("Ship materialized workspace must be a real directory");
+        }
+        try (var entries = Files.newDirectoryStream(target)) {
+            if (entries.iterator().hasNext()) {
+                throw new IOException("Ship materialized workspace must be empty");
+            }
+        }
+        return target;
+    }
+
+    private static void setMode(Path path, int unixMode) throws IOException {
+        int permissions = unixMode & 0777;
+        String mode = "---------";
+        char[] chars = mode.toCharArray();
+        int[] bits = {0400, 0200, 0100, 0040, 0020, 0010, 0004, 0002, 0001};
+        char[] values = {'r', 'w', 'x', 'r', 'w', 'x', 'r', 'w', 'x'};
+        for (int index = 0; index < bits.length; index++) {
+            if ((permissions & bits[index]) != 0) {
+                chars[index] = values[index];
+            }
+        }
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(new String(chars)));
     }
 
     private void requireCompatible(ProjectSnapshot before, ProjectSnapshot after) {

--- a/camel-kit-core/src/main/resources/maven/.mvn/wrapper/maven-wrapper.properties
+++ b/camel-kit-core/src/main/resources/maven/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionSha256Sum=305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipExpressionPolicyConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipExpressionPolicyConsistencyTest.java
@@ -2,6 +2,7 @@ package io.github.luigidemasi.camelkit.ship;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -21,6 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShipExpressionPolicyConsistencyTest {
 
+    /**
+     * Non-classpath version rows are externally reviewed exact-artifact pins. Schema digests cover the raw JAR entry
+     * bytes. Catalog-language digests cover the UTF-8 {@code languages.properties} names normalized to lexical order,
+     * one name per line, with one final LF. The default classpath schema receives the additional live content check
+     * below; historical rows intentionally do not add dependencies or network access to unit tests.
+     */
     private static final String INVENTORY = "ship/expression-policy/catalog-yaml-inventory.json";
     private static final String EXPRESSION_DEFINITION = "org.apache.camel.model.language.ExpressionDefinition";
     private static final String GENERIC_DEFINITION = "org.apache.camel.model.language.LanguageExpression";
@@ -56,8 +63,14 @@ class ShipExpressionPolicyConsistencyTest {
             assertEquals(Set.of("expression"), textSet(inventory.path("simple").path("required")), version);
             assertEquals(Set.of("beanType", "id", "method", "ref", "resultType", "scope", "trim", "validate"),
                     textSet(inventory.path("method").path("properties")), version);
+            assertEquals("org.apache.camel:camel-yaml-dsl:" + version + "!/schema/camelYamlDsl.json",
+                    inventory.path("yamlSchemaArtifact").asText(), version);
             assertTrue(ShipDigest.isSha256(inventory.path("yamlSchemaSha256").asText()), version);
-            assertTrue(ShipDigest.isSha256(inventory.path("catalogLanguagesSha256").asText()), version);
+            assertEquals("org.apache.camel:camel-catalog:" + version
+                         + "!/org/apache/camel/catalog/languages.properties",
+                    inventory.path("catalogLanguagesArtifact").asText(), version);
+            assertEquals(inventory.path("catalogLanguagesSha256").asText(),
+                    digestLines(textSet(inventory.path("catalogLanguages"))), version);
         }
     }
 
@@ -187,6 +200,11 @@ class ShipExpressionPolicyConsistencyTest {
         TreeSet<String> result = new TreeSet<>();
         array.forEach(value -> result.add(value.asText()));
         return result;
+    }
+
+    private static String digestLines(Set<String> values) {
+        return ShipDigest.sha256((String.join("\n", new TreeSet<>(values)) + '\n')
+                .getBytes(StandardCharsets.UTF_8));
     }
 
     private static Map<String, String> textMap(JsonNode object) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipExpressionPolicyConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipExpressionPolicyConsistencyTest.java
@@ -1,0 +1,197 @@
+package io.github.luigidemasi.camelkit.ship;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogExpressionInventory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipExpressionPolicyConsistencyTest {
+
+    private static final String INVENTORY = "ship/expression-policy/catalog-yaml-inventory.json";
+    private static final String EXPRESSION_DEFINITION = "org.apache.camel.model.language.ExpressionDefinition";
+    private static final String GENERIC_DEFINITION = "org.apache.camel.model.language.LanguageExpression";
+    private static final String SIMPLE_DEFINITION = "org.apache.camel.model.language.SimpleExpression";
+    private static final String METHOD_DEFINITION = "org.apache.camel.model.language.MethodCallExpression";
+    private static final String REF_PREFIX = "#/items/definitions/";
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void everyCertifiedCamelLineHasAnExactClosedCatalogAndYamlInventory() throws Exception {
+        Properties distribution = distribution();
+        Set<String> certified = csv(distribution.getProperty(
+                "ship.evidence.camel-yaml-validator.supported"));
+        JsonNode versions = resourceJson(INVENTORY).path("versions");
+
+        assertEquals(certified, fieldNames(versions),
+                "A certified Camel version needs a reviewed expression inventory before it can ship");
+        for (String version : certified) {
+            JsonNode inventory = versions.path(version);
+            Map<String, String> aliases = textMap(inventory.path("yamlAliases"));
+            assertEquals(CatalogExpressionInventory.yamlAliases(), aliases.keySet(), version);
+            assertEquals(CatalogExpressionInventory.catalogLanguages(), textSet(inventory.path("catalogLanguages")),
+                    version);
+            assertEquals(GENERIC_DEFINITION, aliases.get(CatalogExpressionInventory.GENERIC), version);
+            assertEquals(SIMPLE_DEFINITION, aliases.get(CatalogExpressionInventory.SIMPLE), version);
+            assertEquals(METHOD_DEFINITION, aliases.get(CatalogExpressionInventory.METHOD), version);
+            assertEquals(Set.of("expression", "id", "language", "trim"),
+                    textSet(inventory.path("generic").path("properties")), version);
+            assertEquals(Set.of("expression", "language"),
+                    textSet(inventory.path("generic").path("required")), version);
+            assertEquals(Set.of("expression", "id", "nested", "pretty", "resultType", "trim", "trimResult"),
+                    textSet(inventory.path("simple").path("properties")), version);
+            assertEquals(Set.of("expression"), textSet(inventory.path("simple").path("required")), version);
+            assertEquals(Set.of("beanType", "id", "method", "ref", "resultType", "scope", "trim", "validate"),
+                    textSet(inventory.path("method").path("properties")), version);
+            assertTrue(ShipDigest.isSha256(inventory.path("yamlSchemaSha256").asText()), version);
+            assertTrue(ShipDigest.isSha256(inventory.path("catalogLanguagesSha256").asText()), version);
+        }
+    }
+
+    @Test
+    void defaultCamelSchemasMatchTheReviewedInventoryWithoutAnUnclassifiedAlias() throws Exception {
+        Properties distribution = distribution();
+        String version = distribution.getProperty("camel.main.version");
+        JsonNode inventory = resourceJson(INVENTORY).path("versions").path(version);
+        assertFalse(inventory.isMissingNode(), "Default Camel lacks an expression inventory: " + version);
+
+        byte[] schemaBytes = resourceBytes("schema/camelYamlDsl.json");
+        assertEquals(inventory.path("yamlSchemaSha256").asText(), ShipDigest.sha256(schemaBytes));
+        assertSchemaInventory(JSON.readTree(schemaBytes), inventory);
+        assertSchemaInventory(resourceJson("schema/camelYamlDsl-canonical.json"), inventory);
+        assertEquals(version, resourceJson("yaml-dsl.json").path("other").path("version").asText());
+    }
+
+    private static void assertSchemaInventory(JsonNode schema, JsonNode inventory) {
+        JsonNode definitions = schema.path("items").path("definitions");
+        JsonNode expression = definitions.path(EXPRESSION_DEFINITION);
+        Map<String, String> aliases = new TreeMap<>();
+        if (expression.has("anyOf")) {
+            for (JsonNode alternative : expression.path("anyOf").path(0).path("oneOf")) {
+                assertEquals(1, alternative.path("required").size());
+                String alias = alternative.path("required").path(0).asText();
+                String ref = alternative.path("properties").path(alias).path("$ref").asText();
+                addAlias(aliases, alias, ref);
+                assertEquals(1, alternative.path("properties").size(), alias);
+            }
+        } else {
+            assertEquals("object", expression.path("type").asText());
+            assertFalse(expression.path("additionalProperties").asBoolean(true));
+            expression.path("properties").properties()
+                    .forEach(field -> addAlias(aliases, field.getKey(), field.getValue().path("$ref").asText()));
+        }
+        assertEquals(textMap(inventory.path("yamlAliases")), aliases);
+        assertEquals(aliases.keySet(), fieldNames(expression.path("properties")));
+
+        JsonNode generic = definitions.path(GENERIC_DEFINITION);
+        assertEquals("object", generic.path("type").asText());
+        assertFalse(generic.path("additionalProperties").asBoolean(true));
+        assertEquals(textSet(inventory.path("generic").path("properties")),
+                fieldNames(generic.path("properties")));
+        assertEquals(textSet(inventory.path("generic").path("required")), textSet(generic.path("required")));
+
+        assertExpressionObject(definitions.path(SIMPLE_DEFINITION), inventory.path("simple"), true);
+        assertExpressionObject(definitions.path(METHOD_DEFINITION), inventory.path("method"), false);
+    }
+
+    private static void addAlias(Map<String, String> aliases, String alias, String ref) {
+        assertTrue(ref.startsWith(REF_PREFIX), alias);
+        assertFalse(aliases.containsKey(alias), alias);
+        aliases.put(alias, ref.substring(REF_PREFIX.length()));
+    }
+
+    private static void assertExpressionObject(JsonNode definition, JsonNode inventory, boolean required) {
+        JsonNode object;
+        if (definition.has("oneOf")) {
+            Set<String> types = new TreeSet<>();
+            object = null;
+            for (JsonNode alternative : definition.path("oneOf")) {
+                types.add(alternative.path("type").asText());
+                if (alternative.has("properties")) {
+                    object = alternative;
+                }
+            }
+            assertEquals(Set.of("object", "string"), types);
+            assertNotNull(object);
+        } else {
+            assertEquals("object", definition.path("type").asText());
+            object = definition;
+        }
+        assertFalse(object.path("additionalProperties").asBoolean(true));
+        assertEquals(textSet(inventory.path("properties")), fieldNames(object.path("properties")));
+        if (required) {
+            assertEquals(textSet(inventory.path("required")), textSet(definition.path("required")));
+        }
+    }
+
+    private static Properties distribution() throws IOException {
+        Properties properties = new Properties();
+        try (InputStream input = resource("distribution.properties")) {
+            properties.load(input);
+        }
+        return properties;
+    }
+
+    private static JsonNode resourceJson(String name) throws IOException {
+        try (InputStream input = resource(name)) {
+            return JSON.readTree(input);
+        }
+    }
+
+    private static byte[] resourceBytes(String name) throws IOException {
+        try (InputStream input = resource(name)) {
+            return input.readAllBytes();
+        }
+    }
+
+    private static InputStream resource(String name) throws IOException {
+        InputStream input = ShipExpressionPolicyConsistencyTest.class.getClassLoader().getResourceAsStream(name);
+        if (input == null) {
+            throw new IOException("Missing test resource: " + name);
+        }
+        return input;
+    }
+
+    private static Set<String> csv(String value) {
+        TreeSet<String> result = new TreeSet<>();
+        if (value != null) {
+            for (String item : value.split(",")) {
+                if (!item.isBlank()) {
+                    result.add(item.trim());
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Set<String> fieldNames(JsonNode object) {
+        TreeSet<String> result = new TreeSet<>();
+        object.properties().forEach(field -> result.add(field.getKey()));
+        return result;
+    }
+
+    private static Set<String> textSet(JsonNode array) {
+        TreeSet<String> result = new TreeSet<>();
+        array.forEach(value -> result.add(value.asText()));
+        return result;
+    }
+
+    private static Map<String, String> textMap(JsonNode object) {
+        TreeMap<String, String> result = new TreeMap<>();
+        object.properties().forEach(field -> result.put(field.getKey(), field.getValue().asText()));
+        return result;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipFoundationBoundaryTest.java
@@ -25,6 +25,7 @@ import io.github.luigidemasi.camelkit.ship.context.ContextFilesystemPolicy;
 import io.github.luigidemasi.camelkit.ship.context.ContextResolution;
 import io.github.luigidemasi.camelkit.ship.context.InitialContext;
 import io.github.luigidemasi.camelkit.ship.security.ProjectContextFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 
@@ -92,6 +93,18 @@ class ShipFoundationBoundaryTest {
     private static final Set<String> HELD_ROOT_METHODS = Set.of(
             "close()->void throws java.io.IOException",
             "toString()->java.lang.String");
+    private static final Set<String> PROJECT_EVIDENCE_METHODS = Set.of(
+            "static capture(java.nio.file.Path)->" + SECURITY_PACKAGE
+                                                                       + "ProjectSnapshot throws java.io.IOException",
+            "static captureSealed(java.nio.file.Path)->" + SECURITY_PACKAGE
+                                                                                                                       + "ProjectSnapshot throws java.io.IOException",
+            "static unchanged(" + SECURITY_PACKAGE + "ProjectSnapshot," + SECURITY_PACKAGE
+                                                                                                                                                                       + "ProjectSnapshot)->boolean",
+            "static unchangedMaterialTree(" + SECURITY_PACKAGE + "ProjectSnapshot," + SECURITY_PACKAGE
+                                                                                                                                                                                                      + "ProjectSnapshot)->boolean",
+            "static materializeMaterial(java.nio.file.Path,java.nio.file.Path)->" + SECURITY_PACKAGE
+                                                                                                                                                                                                                                     + "ProjectSnapshot throws java.io.IOException",
+            "static readMaterial(java.nio.file.Path,java.lang.String,int)->byte[] throws java.io.IOException");
     private static final Set<String> ALLOWED_CONTEXT_FILE_DEPENDENCIES = Set.of(
             "java.io.FileNotFoundException",
             "java.io.IOException",
@@ -715,6 +728,16 @@ class ShipFoundationBoundaryTest {
                 .map(ShipFoundationBoundaryTest::signature)
                 .collect(java.util.stream.Collectors.toUnmodifiableSet());
         assertEquals(HELD_ROOT_METHODS, heldRootMethods);
+
+        assertTrue(Modifier.isPublic(ProjectEvidenceFiles.class.getModifiers()));
+        assertTrue(Modifier.isFinal(ProjectEvidenceFiles.class.getModifiers()));
+        assertEquals(0, ProjectEvidenceFiles.class.getConstructors().length);
+        assertEquals(0, ProjectEvidenceFiles.class.getFields().length);
+        Set<String> evidenceMethods = Arrays.stream(ProjectEvidenceFiles.class.getDeclaredMethods())
+                .filter(method -> Modifier.isPublic(method.getModifiers()))
+                .map(ShipFoundationBoundaryTest::signature)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        assertEquals(PROJECT_EVIDENCE_METHODS, evidenceMethods);
     }
 
     private static String signature(java.lang.reflect.Method method) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorCatalogDependencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorCatalogDependencyTest.java
@@ -1,0 +1,217 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.ArtifactEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactValidatorCatalogDependencyTest {
+
+    @TempDir
+    Path project;
+
+    @Test
+    void exactMainPomAcceptsOnlyLiteralControllerAndCatalogRoots() throws Exception {
+        writePom("", "", "4.21.0");
+
+        ArtifactValidator.CatalogDependencyBinding binding = binding();
+
+        assertTrue(binding.validation().passed(), () -> binding.validation().findings().toString());
+        assertTrue(binding.runtimeDependencies().stream()
+                .anyMatch(dependency -> "camel-direct".equals(dependency.artifactId())));
+        assertEquals(ShipDigest.sha256(Files.readAllBytes(project.resolve("pom.xml"))), binding.pomDigest());
+    }
+
+    @Test
+    void exactMainPomRejectsEveryMavenExecutionOrPublicationSection() throws Exception {
+        for (String section : List.of(
+                "<build><resources/></build>",
+                "<reporting><plugins><plugin><artifactId>maven-project-info-reports-plugin</artifactId>"
+                                               + "</plugin></plugins></reporting>",
+                "<distributionManagement><repository><id>releases</id>"
+                                                                                    + "<url>https://example.invalid</url></repository></distributionManagement>")) {
+            writePom("", section, "4.21.0");
+            assertFinding("catalog-runtime-pom-policy");
+        }
+    }
+
+    @Test
+    void exactMainPomRejectsResolvedPropertyExpressions() throws Exception {
+        writePom("", "", "${project.version}");
+
+        assertFalse(binding().validation().passed());
+        assertFinding("catalog-runtime-pom-policy");
+    }
+
+    @Test
+    void exactMainPomRejectsForeignXmlNamespacesAndDuplicateRoots() throws Exception {
+        writePom("", "<evil:dependencies xmlns:evil=\"urn:evil\"/>", "4.21.0");
+        assertFinding("catalog-runtime-pom-policy");
+
+        writePom("""
+                <dependency><groupId>org.apache.camel</groupId>
+                  <artifactId>camel-direct</artifactId><version>4.21.0</version></dependency>
+                """, "", "4.21.0");
+        assertFalse(binding().validation().passed());
+    }
+
+    @Test
+    void exactMainPomRejectsNonJarPackaging() throws Exception {
+        writePom("", "<packaging>pom</packaging>", "4.21.0");
+
+        assertFalse(binding().validation().passed());
+        assertFinding("catalog-runtime-pom-policy");
+    }
+
+    @Test
+    void exactMainPomRequiresOneLiteralModelVersionAndDependenciesContainer() throws Exception {
+        String valid = validPom();
+        String model = "<modelVersion>4.0.0</modelVersion>";
+        String dependencies = validDependencies("4.21.0", "");
+        for (String invalid : List.of(
+                valid.replace(model, ""),
+                valid.replace(model, "<modelVersion>3.0.0</modelVersion>"),
+                valid.replace(model, model + model),
+                valid.replace(dependencies, ""),
+                valid.replace(dependencies, dependencies + dependencies))) {
+            writeRawPom(invalid);
+            assertFinding("catalog-runtime-pom-policy");
+        }
+    }
+
+    @Test
+    void exactMainPomRejectsUnknownRootAndDependencyFields() throws Exception {
+        writePom("", "<name>orders</name>", "4.21.0");
+        assertFinding("catalog-runtime-pom-policy");
+
+        writeRawPom(validPom().replace(
+                "<artifactId>camel-direct</artifactId>",
+                "<artifactId>camel-direct</artifactId><systemPath>/tmp/escape.jar</systemPath>"));
+        assertFinding("catalog-runtime-pom-policy");
+
+        writeRawPom(validPom().replace(
+                "<groupId>example</groupId>",
+                "<groupId>example<name>hidden</name></groupId>"));
+        assertFinding("catalog-runtime-pom-policy");
+    }
+
+    @Test
+    void exactMainPomRejectsProjectCoordinateExpressions() throws Exception {
+        writeRawPom(validPom().replace("<version>4.21.0</version>\n  <dependencies>",
+                "<version>${revision}</version>\n  <dependencies>"));
+        assertFinding("catalog-runtime-pom-policy");
+
+        writeRawPom(validPom().replace(
+                "<groupId>example</groupId>", "<groupId>${env.HOME}</groupId>"));
+        assertFinding("catalog-runtime-pom-policy");
+    }
+
+    @Test
+    void exactMainPomRequiresOnlyTheDefaultMavenNamespaceAndNoAttributes() throws Exception {
+        String valid = validPom();
+        for (String invalid : List.of(
+                valid.replace("<project xmlns=\"http://maven.apache.org/POM/4.0.0\">", "<project>"),
+                valid.replace("<project xmlns=\"http://maven.apache.org/POM/4.0.0\">",
+                        "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:evil=\"urn:evil\">"),
+                valid.replace("<project xmlns=\"http://maven.apache.org/POM/4.0.0\">",
+                        "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" id=\"hidden\">"),
+                valid.replace("<modelVersion>", "<modelVersion id=\"hidden\">"),
+                valid.replace("<dependency>", "<dependency id=\"hidden\">"))) {
+            writeRawPom(invalid);
+            assertFinding("catalog-runtime-pom-policy");
+        }
+    }
+
+    @Test
+    void exactMainPomRejectsCommentsAndProcessingInstructions() throws Exception {
+        for (String markup : List.of("<!-- hidden -->", "<?ship hidden?>")) {
+            writeRawPom(validPom().replace("<dependencies>", markup + "<dependencies>"));
+            assertFinding("catalog-runtime-pom-policy");
+        }
+    }
+
+    private ArtifactValidator.CatalogDependencyBinding binding() {
+        return ArtifactValidator.bindCatalogDependencies(project, policy(), evidence());
+    }
+
+    private void assertFinding(String code) {
+        assertTrue(binding().validation().findings().stream().anyMatch(finding -> code.equals(finding.code())),
+                () -> binding().validation().findings().toString());
+    }
+
+    private void writePom(String dependencyExtra, String projectExtra, String directVersion) throws Exception {
+        writeRawPom(String.format(Locale.ROOT, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>4.21.0</version>
+                  %s
+                %s
+                </project>
+                """, validDependencies(directVersion, dependencyExtra), projectExtra));
+    }
+
+    private String validPom() {
+        return String.format(Locale.ROOT, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>4.21.0</version>
+                  %s
+                </project>
+                """, validDependencies("4.21.0", ""));
+    }
+
+    private static String validDependencies(String directVersion, String dependencyExtra) {
+        return String.format(Locale.ROOT, """
+                <dependencies>
+                  <dependency><groupId>org.apache.camel</groupId>
+                    <artifactId>camel-main</artifactId><version>4.21.0</version></dependency>
+                  <dependency><groupId>org.apache.camel</groupId>
+                    <artifactId>camel-yaml-dsl</artifactId><version>4.21.0</version></dependency>
+                  <dependency><groupId>org.apache.camel</groupId>
+                    <artifactId>camel-direct</artifactId><version>%s</version></dependency>
+                  %s
+                </dependencies>
+                """, directVersion, dependencyExtra).stripTrailing();
+    }
+
+    private void writeRawPom(String pom) throws Exception {
+        Files.writeString(project.resolve("pom.xml"), pom);
+    }
+
+    private static RequirementsPolicy policy() {
+        return new RequirementsPolicy(
+                "main", "4.21.0", null, null, "yaml", "simple", "5.0.0-M2",
+                CitrusDependencyPolicy.required("5.0.0-M2"),
+                DecisionLedger.JavaPolicy.FORBIDDEN, List.of(), List.of(), true, true);
+    }
+
+    private static CatalogEvidenceSet evidence() {
+        CatalogSubject direct = new CatalogSubject(CatalogSubject.Kind.COMPONENT, "direct");
+        MavenCoordinate catalog = MavenCoordinate.jar("org.apache.camel", "camel-catalog", "4.21.0");
+        String catalogDigest = "sha256:" + "a".repeat(64);
+        return CatalogEvidenceSet.create(
+                new CatalogTarget("main", "4.21.0", null, null), catalog,
+                List.of(new ArtifactEvidence(catalog, catalogDigest, 1)),
+                List.of(new SubjectEvidence(
+                        direct, catalog, catalogDigest,
+                        "org/apache/camel/catalog/components/direct.json", "sha256:" + "b".repeat(64),
+                        "org.apache.camel", "camel-direct", "4.21.0", false)));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorTest.java
@@ -1,0 +1,887 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.DeclaredArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.TestArtifact;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RouteContract;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArtifactValidatorTest {
+
+    private static final String CITRUS_VERSION = "5.0.0-M2";
+    private static final List<String> CITRUS_DEPENDENCIES = CitrusDependencyPolicy.required(CITRUS_VERSION);
+
+    @TempDir
+    Path project;
+
+    @Test
+    void acceptsYamlSimpleProjectWithOneCitrusTestPerRoute() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", mainConfiguration());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        digest("src/main/resources/routes/orders.camel.yaml"))),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml",
+                        digest("test/orders.camel.it.yaml"))),
+                JavaPolicy.FORBIDDEN,
+                List.of()));
+
+        assertTrue(result.passed(), () -> result.findings().toString());
+    }
+
+    @Test
+    void rejectsLegacyCitrusJbangConfiguration() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", mainConfiguration());
+        ArtifactManifest approved = manifest(
+                "main",
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        digest("src/main/resources/routes/orders.camel.yaml"))),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml",
+                        digest("test/orders.camel.it.yaml"))),
+                JavaPolicy.FORBIDDEN,
+                List.of());
+        write(CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH,
+                "run.deps=org.citrusframework:citrus-yaml:" + CITRUS_VERSION + '\n');
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, approved);
+
+        assertTrue(hasError(result, "citrus-jbang-forbidden", CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH));
+    }
+
+    @Test
+    void rejectsDeclaredCitrusJbangConfigurationArtifact() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", mainConfiguration());
+        writeCitrusConfiguration();
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        digest("src/main/resources/routes/orders.camel.yaml"))),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml",
+                        digest("test/orders.camel.it.yaml"))),
+                JavaPolicy.FORBIDDEN,
+                List.of(),
+                List.of()));
+
+        assertTrue(hasError(result, "citrus-jbang-forbidden", CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH));
+    }
+
+    @Test
+    void citrusTestMustUseControllerOwnedTestLocation() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("src/test/resources/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "src/test/resources/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN,
+                List.of()));
+
+        assertTrue(hasError(result, "citrus-test-location", "src/test/resources/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void discoversWrongSuffixInsteadOfIgnoringRoute() throws Exception {
+        write("src/main/resources/routes/orders.yaml", "- route:\n    id: orders\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.yaml", null)),
+                List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertFalse(result.passed());
+        assertTrue(hasError(result, "route-suffix", "src/main/resources/routes/orders.yaml"));
+    }
+
+    @Test
+    void discoversStructuralRouteOutsideTheConventionalDirectoryAndWithoutBlockRegexShape() throws Exception {
+        write("config/hidden.yml", "{\"route\": {\"id\": \"hidden\", \"from\": {\"uri\": \"direct:start\"}}}\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-suffix", "config/hidden.yml"));
+    }
+
+    @Test
+    void discoversTopLevelFromAndPluralRestDefinitionsWithWrongSuffixes() throws Exception {
+        write("config/from.yml", "- from:\n    uri: direct:start\n    steps: []\n");
+        write("config/rests.yaml", "rests:\n  - rest:\n      path: /orders\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-suffix", "config/from.yml"));
+        assertTrue(hasError(result, "route-suffix", "config/rests.yaml"));
+    }
+
+    @Test
+    void alternatePipeAndKameletDefinitionsCannotHideBehindTheirOwnSuffixes() throws Exception {
+        write("config/orders.pipe.yaml", "apiVersion: camel.apache.org/v1\nkind: Pipe\nspec: {}\n");
+        write("config/enrich.kamelet.yaml", "apiVersion: camel.apache.org/v1\nkind: Kamelet\nspec: {}\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-suffix", "config/orders.pipe.yaml"));
+        assertTrue(hasError(result, "route-suffix", "config/enrich.kamelet.yaml"));
+    }
+
+    @Test
+    void uninspectableOrMultiDocumentYamlFailsClosedOutsideTheRouteDirectory() throws Exception {
+        write("config/broken.yaml", "route: [\n");
+        write("config/multiple.yaml", "service:\n  name: orders\n---\nroute:\n  id: hidden\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-scan-parse", "config/broken.yaml"));
+        assertTrue(hasError(result, "route-scan-parse", "config/multiple.yaml"));
+    }
+
+    @Test
+    void oversizedYamlCannotBypassWrongSuffixInspection() throws Exception {
+        write("config/hidden.yaml", "route:\n  id: hidden\n#" + "x".repeat(2 * 1024 * 1024));
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-scan-size", "config/hidden.yaml"));
+    }
+
+    @Test
+    void genericArtifactDeclarationCannotMasqueradeAsADeclaredRoute() throws Exception {
+        write("config/hidden.camel.yaml", "- route:\n    id: hidden\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of(),
+                List.of(new DeclaredArtifact(
+                        "config", "config/hidden.camel.yaml", digest("config/hidden.camel.yaml"), true))));
+
+        assertTrue(hasError(result, "route-undeclared", "config/hidden.camel.yaml"));
+    }
+
+    @Test
+    void unrelatedBoundedYamlIsNotMisclassifiedAsARoute() throws Exception {
+        write("config/application.yaml", "service:\n  name: orders\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(), List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertFalse(hasError(result, "route-suffix", "config/application.yaml"));
+        assertFalse(hasError(result, "route-scan-size", "config/application.yaml"));
+    }
+
+    @Test
+    void missingCitrusTestsAreFailureNotSkip() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "citrus-tests-missing", null));
+        assertTrue(hasError(result, "citrus-route-uncovered", null));
+    }
+
+    @Test
+    void rejectsCitrusEndpointBoundToAnotherRoute() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest().replace(
+                "camel-kit-ship-test-orders", "camel-kit-ship-test-other"));
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "citrus-yaml-policy", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void routePlaceholdersCannotBeSatisfiedByControllerGuesses() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", """
+                - route:
+                    id: orders
+                    from:
+                      uri: kafka:{{orders.topic}}
+                      steps:
+                        - delay:
+                            constant: "{{orders.threshold}}"
+                """);
+        write("test/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-yaml-parse", "src/main/resources/routes/orders.camel.yaml"));
+    }
+
+    @Test
+    void emptyCitrusTestCannotSatisfyRequiredIntegrationCoverage() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", "name: orders-test\nactions: []\n");
+        write(".camel-kit/config.properties", mainConfiguration());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        digest("src/main/resources/routes/orders.camel.yaml"))),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml",
+                        digest("test/orders.camel.it.yaml"))),
+                JavaPolicy.FORBIDDEN,
+                List.of()));
+
+        assertTrue(hasError(result, "citrus-yaml-policy", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void citrusTestMayUseJbangTextAsLiteralBodyData() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", """
+                name: orders-test
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: camel.jbang
+                """);
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertFalse(hasError(result, "citrus-yaml-policy", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void citrusTestCannotAddressAnExternalEndpoint() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest().replace(
+                "camel:sync:direct:camel-kit-ship-test-orders", "https://example.test/orders"));
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "citrus-yaml-policy", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void citrusTestMayUseOnlyTheControllerOwnedCamelDirectEndpointShape() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertFalse(hasError(result, "citrus-yaml-policy", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void citrusTestMayUseBoundedLiteralCasesAndApplicationHeaders() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusMatrixTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertFalse(hasError(result, "citrus-yaml-policy", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void undeclaredRouteIsRejected() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("src/main/resources/routes/hidden.camel.yaml", "- route:\n    id: hidden\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-undeclared", "src/main/resources/routes/hidden.camel.yaml"));
+    }
+
+    @Test
+    void forbiddenJavaCannotHideBesideYamlRoute() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write("src/main/java/example/HiddenProcessor.java", "package example; class HiddenProcessor {}\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "java-forbidden", "src/main/java/example/HiddenProcessor.java"));
+    }
+
+    @Test
+    void justificationPolicyRequiresExactApprovedPath() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write("src/main/java/example/Approved.java", "package example; class Approved {}\n");
+        write("src/main/java/example/Hidden.java", "package example; class Hidden {}\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "spring-boot",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.JUSTIFICATION_REQUIRED,
+                List.of("src/main/java/example/Approved.java")));
+
+        assertFalse(hasError(result, "java-unapproved", "src/main/java/example/Approved.java"));
+        assertTrue(hasError(result, "java-unapproved", "src/main/java/example/Hidden.java"));
+    }
+
+    @Test
+    void camelMainRejectsJavaPoliciesWithoutCompilationEvidence() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", mainConfiguration());
+
+        for (JavaPolicy javaPolicy : List.of(JavaPolicy.ALLOWED, JavaPolicy.JUSTIFICATION_REQUIRED)) {
+            ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                    "main",
+                    List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                    List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                    javaPolicy, List.of()));
+
+            assertTrue(hasError(result, "main-java-policy", null),
+                    () -> javaPolicy + " findings: " + result.findings());
+        }
+    }
+
+    @Test
+    void runtimeConfigurationMismatchFails() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", mainConfiguration().replace("main", "spring-boot"));
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "runtime-config-mismatch", ".camel-kit/config.properties"));
+    }
+
+    @Test
+    void artifactPathCannotEscapeProject() throws Exception {
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main", List.of(new RouteArtifact("orders", "../orders.camel.yaml", null)),
+                List.of(), JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "artifact-path", "../orders.camel.yaml"));
+    }
+
+    @Test
+    void requiredRouteAndTestDigestsCannotBeOmitted() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN,
+                List.of()));
+
+        assertTrue(hasError(result, "artifact-digest-missing", "src/main/resources/routes/orders.camel.yaml"));
+        assertTrue(hasError(result, "artifact-digest-missing", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void routeAndCitrusBasenamesMustMatchRouteIdExactly() throws Exception {
+        write("src/main/resources/routes/order-route.camel.yaml", "- route:\n    id: orders\n");
+        write("test/order-test.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/order-route.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/order-test.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-name", "src/main/resources/routes/order-route.camel.yaml"));
+        assertTrue(hasError(result, "citrus-test-name", "test/order-test.camel.it.yaml"));
+    }
+
+    @Test
+    void routeYamlIdMustMatchManifestRouteId() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: hidden\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-yaml-id-mismatch", "src/main/resources/routes/orders.camel.yaml"));
+    }
+
+    @Test
+    void malformedOrDuplicateKeyRouteYamlIsRejected() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    id: hidden\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact("orders", "src/main/resources/routes/orders.camel.yaml", null)),
+                List.of(new TestArtifact("orders", "test/orders.camel.it.yaml", null)),
+                JavaPolicy.FORBIDDEN, List.of()));
+
+        assertTrue(hasError(result, "route-yaml-parse", "src/main/resources/routes/orders.camel.yaml"));
+    }
+
+    @Test
+    void acceptsApprovedSpringPomWithResolvedVersionProperties() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(result.passed(), () -> result.findings().toString());
+    }
+
+    @Test
+    void rejectsCitrusVersionThatDiffersFromApprovedPolicy() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy("5.0.0-M3"));
+
+        assertTrue(hasError(result, "approved-policy-citrus-version", null));
+        assertTrue(hasError(result, "approved-policy-citrus-dependencies", null));
+    }
+
+    @Test
+    void rejectsSpringPluginVersionThatDiffersFromApprovedPolicy() throws Exception {
+        writeSpringProject("4.0.0");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-pom-version", "pom.xml"));
+    }
+
+    @Test
+    void rejectsMavenModelsThatCanTurnTestIntoANoOp() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        Path pom = project.resolve("pom.xml");
+        String original = Files.readString(pom);
+
+        Files.writeString(pom, original.replace(
+                "<properties>", "<packaging>pom</packaging><properties><skipTests>true</skipTests>"));
+        ArtifactValidationResult disabled = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(disabled, "runtime-pom-packaging", "pom.xml"));
+        assertTrue(hasError(disabled, "runtime-pom-test-skip", "pom.xml"));
+    }
+
+    @Test
+    void rejectsUninspectedMavenModelSourcesAndStartupHooks() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        Path pom = project.resolve("pom.xml");
+        Files.writeString(pom, Files.readString(pom).replace(
+                "</project>",
+                "<profiles><profile><id>hidden</id></profile></profiles>"
+                              + "<pluginRepositories><pluginRepository><id>hidden</id>"
+                              + "<url>https://example.invalid</url></pluginRepository></pluginRepositories>"
+                              + "</project>"));
+        write(".mvn/extensions.xml", "<extensions/>\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-pom-dynamic-model", "pom.xml"));
+        assertTrue(hasError(result, "runtime-maven-hook", ".mvn/extensions.xml"));
+    }
+
+    @Test
+    void rejectsUnapprovedBuildPlugins() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        Path pom = project.resolve("pom.xml");
+        Files.writeString(pom, Files.readString(pom).replace(
+                "<build><plugins>",
+                "<build><plugins><plugin><groupId>org.codehaus.mojo</groupId>"
+                                    + "<artifactId>exec-maven-plugin</artifactId><version>3.5.0</version></plugin>"));
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-pom-plugin", "pom.xml"));
+    }
+
+    @Test
+    void commentsCannotSpoofRequiredSpringCoordinates() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        write("pom.xml", """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <!-- camel-spring-boot-bom spring-boot-maven-plugin -->
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>1</version>
+                </project>
+                """);
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-pom-coordinate", "pom.xml"));
+    }
+
+    @Test
+    void pomDoctypeAndExternalEntityAreRejected() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        write("pom.xml", """
+                <?xml version="1.0"?>
+                <!DOCTYPE project [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>&xxe;</artifactId><version>1</version>
+                </project>
+                """);
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-pom-parse", "pom.xml"));
+    }
+
+    @Test
+    void duplicateRuntimeConfigurationKeysAreRejected() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        write(".camel-kit/config.properties", """
+                project.runtime=spring-boot
+                project.runtime=main
+                project.camelVersion=4.21.0
+                project.platformBomVersion=4.21.0
+                project.springBootVersion=4.1.0
+                citrus.version=5.0.0-M2
+                """);
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-config-read", ".camel-kit/config.properties"));
+    }
+
+    @Test
+    void validatesApprovedQuarkusBomsPluginAndManagedExtension() throws Exception {
+        writeQuarkusProject(null);
+
+        ArtifactValidationResult accepted = ArtifactValidator.validate(
+                project, quarkusManifest(), quarkusPolicy());
+        assertTrue(accepted.passed(), () -> accepted.findings().toString());
+
+        writeQuarkusProject("4.18.2");
+        ArtifactValidationResult explicitExtensionVersion = ArtifactValidator.validate(
+                project, quarkusManifest(), quarkusPolicy());
+        assertTrue(hasError(explicitExtensionVersion, "runtime-pom-version", "pom.xml"));
+    }
+
+    private void writeSpringProject(String pluginVersion) throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", """
+                project.runtime=spring-boot
+                project.camelVersion=4.21.0
+                project.platformBomVersion=4.21.0
+                project.springBootVersion=4.1.0
+                citrus.version=5.0.0-M2
+                """);
+        write("pom.xml", String.format(Locale.ROOT, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>1</version>
+                  <properties>
+                    <camel.platform.version>4.21.0</camel.platform.version>
+                    <spring.boot.version>4.1.0</spring.boot.version>
+                  </properties>
+                  <dependencyManagement><dependencies><dependency>
+                    <groupId>org.apache.camel.springboot</groupId>
+                    <artifactId>camel-spring-boot-bom</artifactId>
+                    <version>${camel.platform.version}</version><type>pom</type><scope>import</scope>
+                  </dependency></dependencies></dependencyManagement>
+                  <dependencies>
+                    <dependency><groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter</artifactId></dependency>
+                    <dependency><groupId>org.apache.camel.springboot</groupId>
+                      <artifactId>camel-spring-boot-starter</artifactId></dependency>
+                  </dependencies>
+                  <build><plugins><plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>%s</version>
+                  </plugin></plugins></build>
+                </project>
+                """, pluginVersion));
+    }
+
+    private ArtifactManifest springManifest() throws Exception {
+        return new ArtifactManifest(
+                1, "spring-boot", "4.21.0", "4.21.0", "4.1.0", "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES,
+                JavaPolicy.FORBIDDEN, List.of(),
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        digest("src/main/resources/routes/orders.camel.yaml"))),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml",
+                        digest("test/orders.camel.it.yaml"))),
+                List.of(), true, true);
+    }
+
+    private static RequirementsPolicy springPolicy() {
+        return springPolicy(CITRUS_VERSION);
+    }
+
+    private static RequirementsPolicy springPolicy(String citrusVersion) {
+        return new RequirementsPolicy(
+                "spring-boot", "4.21.0", "4.21.0", "4.1.0", "yaml", "simple",
+                citrusVersion, CitrusDependencyPolicy.required(citrusVersion),
+                DecisionLedger.JavaPolicy.FORBIDDEN, List.of(),
+                List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+    }
+
+    private void writeQuarkusProject(String extensionVersion) throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml",
+                "- route:\n    id: orders\n    from:\n      uri: direct:start\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        write(".camel-kit/config.properties", """
+                project.runtime=quarkus
+                project.camelVersion=4.18.2
+                project.platformBomVersion=3.33.1
+                citrus.version=5.0.0-M2
+                """);
+        String versionElement = extensionVersion == null ? "" : "<version>" + extensionVersion + "</version>";
+        write("pom.xml", String.format(Locale.ROOT, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>1</version>
+                  <properties>
+                    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+                    <quarkus.platform.version>3.33.1</quarkus.platform.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency><groupId>${quarkus.platform.group-id}</groupId>
+                      <artifactId>quarkus-bom</artifactId><version>${quarkus.platform.version}</version>
+                      <type>pom</type><scope>import</scope></dependency>
+                    <dependency><groupId>${quarkus.platform.group-id}</groupId>
+                      <artifactId>quarkus-camel-bom</artifactId><version>${quarkus.platform.version}</version>
+                      <type>pom</type><scope>import</scope></dependency>
+                  </dependencies></dependencyManagement>
+                  <dependencies><dependency>
+                    <groupId>org.apache.camel.quarkus</groupId><artifactId>camel-quarkus-direct</artifactId>%s
+                  </dependency></dependencies>
+                  <build><plugins><plugin>
+                    <groupId>io.quarkus</groupId><artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                  </plugin></plugins></build>
+                </project>
+                """, versionElement));
+    }
+
+    private ArtifactManifest quarkusManifest() throws Exception {
+        return new ArtifactManifest(
+                1, "quarkus", "4.18.2", "3.33.1", null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES,
+                JavaPolicy.FORBIDDEN, List.of(),
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        digest("src/main/resources/routes/orders.camel.yaml"))),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml",
+                        digest("test/orders.camel.it.yaml"))),
+                List.of(), true, true);
+    }
+
+    private static RequirementsPolicy quarkusPolicy() {
+        return new RequirementsPolicy(
+                "quarkus", "4.18.2", "3.33.1", null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES,
+                DecisionLedger.JavaPolicy.FORBIDDEN, List.of(),
+                List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+    }
+
+    private ArtifactManifest manifest(
+            String runtime,
+            List<RouteArtifact> routes,
+            List<TestArtifact> tests,
+            JavaPolicy javaPolicy,
+            List<String> exceptions)
+            throws Exception {
+        return manifest(runtime, routes, tests, javaPolicy, exceptions, List.of());
+    }
+
+    private static ArtifactManifest manifest(
+            String runtime,
+            List<RouteArtifact> routes,
+            List<TestArtifact> tests,
+            JavaPolicy javaPolicy,
+            List<String> exceptions,
+            List<DeclaredArtifact> artifacts) {
+        return new ArtifactManifest(
+                1, runtime, "4.21.0", null, null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, javaPolicy, exceptions,
+                routes, tests, artifacts, true, true);
+    }
+
+    private static String citrusTest() {
+        return """
+                name: orders-test
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                """;
+    }
+
+    private static String citrusMatrixTest() {
+        return """
+                name: orders-matrix
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        headers:
+                          - name: requestId
+                            value: req-1
+                          - name: timestamp
+                            value: "2026-07-17T10:15:30Z"
+                          - name: strategy
+                            value: priority
+                        body:
+                          data: priority-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        headers:
+                          - name: requestId
+                            value: req-1
+                        body:
+                          data: accepted-priority
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: standard-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: accepted-standard
+                """;
+    }
+
+    private static String mainConfiguration() {
+        return """
+                project.runtime=main
+                project.camelVersion=4.21.0
+                project.platformBomVersion=4.21.0
+                citrus.version=5.0.0-M2
+                """;
+    }
+
+    private void writeCitrusConfiguration() throws Exception {
+        write(CitrusDependencyPolicy.FORBIDDEN_JBANG_PROPERTIES_PATH,
+                "run.deps=" + String.join(",", CITRUS_DEPENDENCIES) + '\n');
+    }
+
+    private void write(String relative, String content) throws Exception {
+        Path file = project.resolve(relative);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    private String digest(String relative) throws Exception {
+        byte[] content = Files.readAllBytes(project.resolve(relative));
+        return "sha256:" + java.util.HexFormat.of().formatHex(
+                java.security.MessageDigest.getInstance("SHA-256").digest(content));
+    }
+
+    private static boolean hasError(ArtifactValidationResult result, String code, String path) {
+        return result.findings().stream()
+                .anyMatch(finding -> finding.severity() == ArtifactFinding.Severity.ERROR
+                        && code.equals(finding.code())
+                        && (path == null || path.equals(finding.path())));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorTest.java
@@ -454,6 +454,27 @@ class ArtifactValidatorTest {
     }
 
     @Test
+    void staleAndMalformedArtifactDigestsFailClosed() throws Exception {
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n");
+        write("test/orders.camel.it.yaml", citrusTest());
+        String approvedRouteDigest = digest("src/main/resources/routes/orders.camel.yaml");
+        write("src/main/resources/routes/orders.camel.yaml", "- route:\n    id: orders\n# edited after approval\n");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(project, manifest(
+                "main",
+                List.of(new RouteArtifact(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        approvedRouteDigest)),
+                List.of(new TestArtifact(
+                        "orders", "test/orders.camel.it.yaml", "sha256:not-a-digest")),
+                JavaPolicy.FORBIDDEN,
+                List.of()));
+
+        assertTrue(hasError(result, "artifact-digest", "src/main/resources/routes/orders.camel.yaml"));
+        assertTrue(hasError(result, "artifact-digest-format", "test/orders.camel.it.yaml"));
+    }
+
+    @Test
     void routeAndCitrusBasenamesMustMatchRouteIdExactly() throws Exception {
         write("src/main/resources/routes/order-route.camel.yaml", "- route:\n    id: orders\n");
         write("test/order-test.camel.it.yaml", citrusTest());
@@ -544,6 +565,22 @@ class ArtifactValidatorTest {
     }
 
     @Test
+    void rejectsMavenControlsThatIgnoreTestFailures() throws Exception {
+        for (String control : List.of("maven.test.failure.ignore", "testFailureIgnore")) {
+            writeSpringProject("${spring.boot.version}");
+            Path pom = project.resolve("pom.xml");
+            Files.writeString(pom, Files.readString(pom).replace(
+                    "<properties>",
+                    "<properties><" + control + ">true</" + control + ">"));
+
+            ArtifactValidationResult result = ArtifactValidator.validate(
+                    project, springManifest(), springPolicy());
+
+            assertTrue(hasError(result, "runtime-pom-test-skip", "pom.xml"), control);
+        }
+    }
+
+    @Test
     void rejectsUninspectedMavenModelSourcesAndStartupHooks() throws Exception {
         writeSpringProject("${spring.boot.version}");
         Path pom = project.resolve("pom.xml");
@@ -605,6 +642,21 @@ class ArtifactValidatorTest {
                   <groupId>example</groupId><artifactId>&xxe;</artifactId><version>1</version>
                 </project>
                 """);
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project, springManifest(), springPolicy());
+
+        assertTrue(hasError(result, "runtime-pom-parse", "pom.xml"));
+    }
+
+    @Test
+    void deeplyNestedPomFailsClosedBeforeDomTraversal() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+        write("pom.xml", """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>1</version>
+                """ + "<nested>".repeat(150) + "value" + "</nested>".repeat(150) + "</project>");
 
         ArtifactValidationResult result = ArtifactValidator.validate(
                 project, springManifest(), springPolicy());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
@@ -1,0 +1,365 @@
+package io.github.luigidemasi.camelkit.ship.catalog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelYamlCatalogUsageExtractorTest {
+
+    @TempDir
+    Path project;
+
+    @Test
+    void extractsComponentsEipsDataformatsAndSimple() throws Exception {
+        Path route = write("""
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:start
+                      steps:
+                        - set-body:
+                            simple: ${body}
+                        - split:
+                            simple: ${body}
+                            steps:
+                              - marshal:
+                                  csv: {}
+                              - to:
+                                  uri: kafka:orders
+                """);
+
+        List<CatalogSubject> result = extractor().extract(route, available());
+
+        assertEquals(List.of(
+                subject(Kind.COMPONENT, "direct"),
+                subject(Kind.COMPONENT, "kafka"),
+                subject(Kind.EIP, "from"),
+                subject(Kind.EIP, "marshal"),
+                subject(Kind.EIP, "route"),
+                subject(Kind.EIP, "setBody"),
+                subject(Kind.EIP, "split"),
+                subject(Kind.EIP, "to"),
+                subject(Kind.DATAFORMAT, "csv"),
+                subject(Kind.LANGUAGE, "simple")), result);
+    }
+
+    @Test
+    void genericSimpleIsRecordedAsTheExactSimpleCatalogSubject() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                        - setBody:
+                            language:
+                              language: simple
+                              expression: ${body}
+                """);
+
+        List<CatalogSubject> result = extractor().extract(route, available());
+
+        assertTrue(result.contains(subject(Kind.LANGUAGE, "simple")));
+    }
+
+    @Test
+    void rejectsDottedSimpleLookupKeysThatCamelCouldExecuteAsOgnl() throws Exception {
+        for (String expression : List.of(
+                "${header.control.stop}",
+                "${exchangeProperty.control.stop}",
+                "${exchangeProperties.clear}",
+                "${exchangeProperties.size}",
+                "${exchangeProperties.toString}",
+                "${variable.control.stop}")) {
+            Path route = write(String.format(Locale.ROOT, """
+                    - route:
+                        id: orders
+                        from:
+                          uri: direct:orders
+                          steps:
+                            - setBody:
+                                simple: "%s"
+                    """, expression));
+
+            assertThrows(IOException.class, () -> extractor().extract(route, available()), expression);
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void genericConstantMethodAndEveryDirectAlternativeFailClosed() throws Exception {
+        List<String> alternatives = new ArrayList<>(
+                List.of(
+                        "language:\n  language: constant\n  expression: accepted-order",
+                        "method: ordersBean"));
+        CatalogExpressionInventory.catalogLanguages().stream()
+                .filter(language -> !CatalogExpressionInventory.SIMPLE.equals(language))
+                .map(language -> language + ": accepted-order")
+                .forEach(alternatives::add);
+        for (String expression : alternatives) {
+            Path route = expressionRoute(expression);
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> extractor().extract(route, available()), expression);
+            assertTrue(failure.getMessage().contains("Simple expression language")
+                    || failure.getMessage().contains("select exactly Simple"), failure::getMessage);
+        }
+    }
+
+    @Test
+    void malformedAmbiguousAndUnsafeGenericExpressionsFailClosed() throws Exception {
+        for (String expression : List.of(
+                "language: simple",
+                "language:\n  language: simple",
+                "language:\n  expression: accepted-order",
+                "language:\n  language: [simple]\n  expression: accepted-order",
+                "language:\n  language: simple\n  expression: [accepted-order]",
+                "language:\n  language: simple\n  expression: accepted-order\n  trim: true",
+                "language:\n  language: simple\n  expression: accepted-order\nsimple: hidden",
+                "Language:\n  language: simple\n  expression: accepted-order",
+                "language:\n  language: simple\n  expression: \"${body.class}\"")) {
+            Path route = expressionRoute(expression);
+
+            assertThrows(IOException.class, () -> extractor().extract(route, available()), expression);
+        }
+    }
+
+    @Test
+    void endpointParametersCannotManufactureFalseCatalogUsage() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                        - to:
+                            uri: kafka:orders
+                            parameters:
+                              split: enabled
+                              simple: not-an-expression
+                """);
+
+        List<CatalogSubject> result = extractor().extract(route, available());
+
+        assertFalse(result.contains(subject(Kind.EIP, "split")));
+        assertFalse(result.contains(subject(Kind.LANGUAGE, "simple")));
+    }
+
+    @Test
+    void unknownComponentFailsClosed() throws Exception {
+        Path route = write("- route:\n    from:\n      uri: unknown:thing\n");
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extract(route, available()));
+
+        assertTrue(error.getMessage().contains("unavailable in the resolved catalog"));
+    }
+
+    @Test
+    void dynamicComponentSchemeFailsClosed() throws Exception {
+        Path route = write("- route:\n    from:\n      uri: '{{source.scheme}}:thing'\n");
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extract(route, available()));
+
+        assertTrue(error.getMessage().contains("dynamic or unsafe"));
+    }
+
+    @Test
+    void duplicateYamlKeysAreRejected() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      uri: kafka:orders
+                """);
+
+        assertThrows(IOException.class, () -> extractor().extract(route, available()));
+    }
+
+    @Test
+    void unknownStepGrammarFailsClosed() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                        - invented-step:
+                            value: ignored-before-catalog-binding
+                """);
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extract(route, available()));
+
+        assertTrue(error.getMessage().contains("Unknown Camel YAML step"));
+    }
+
+    @Test
+    void pluralRoutesContainerPreservesStepClassification() throws Exception {
+        Path route = write("""
+                routes:
+                  - route:
+                      from:
+                        uri: direct:start
+                """);
+
+        List<CatalogSubject> result = extractor().extract(route, available());
+
+        assertTrue(result.contains(subject(Kind.EIP, "route")));
+        assertTrue(result.contains(subject(Kind.EIP, "from")));
+        assertTrue(result.contains(subject(Kind.COMPONENT, "direct")));
+    }
+
+    @Test
+    void oversizedYamlIsRejectedBeforeParsing() throws Exception {
+        Path route = project.resolve("route.camel.yaml");
+        Files.writeString(route, " ".repeat(2 * 1024 * 1024 + 1));
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extract(route, available()));
+
+        assertTrue(error.getMessage().contains("unsafe size"));
+    }
+
+    @Test
+    void exactComponentMetadataProvesStaticUriAndYamlOptions() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start?block=true
+                      endpointParameters:
+                        timeout: 50
+                """);
+
+        CamelYamlCatalogUsageExtractor.Extraction result = extractor().extractBound(
+                route, available(), List.of(directModel()));
+
+        assertEquals(1, result.endpoints().size());
+        CatalogUsageRecord.EndpointUsage endpoint = result.endpoints().get(0);
+        assertEquals(1, endpoint.pathParameterCount());
+        assertEquals(List.of("block", "timeout"), endpoint.endpointOptions());
+    }
+
+    @Test
+    void endpointOptionAbsentFromFrozenMetadataFailsClosed() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start?invented=true
+                """);
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extractBound(
+                route, available(), List.of(directModel())));
+
+        assertTrue(error.getMessage().contains("absent from frozen component metadata"));
+    }
+
+    @Test
+    void endpointOptionTypeAndDynamicValuesFailClosed() throws Exception {
+        Path invalidType = write("""
+                - route:
+                    from:
+                      uri: direct:start?block=perhaps
+                """);
+        assertThrows(IOException.class, () -> extractor().extractBound(
+                invalidType, available(), List.of(directModel())));
+
+        Path dynamic = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      endpointParameters:
+                        timeout: "${header.timeout}"
+                """);
+        IOException error = assertThrows(IOException.class, () -> extractor().extractBound(
+                dynamic, available(), List.of(directModel())));
+        assertTrue(error.getMessage().contains("Dynamic or unsafe"));
+    }
+
+    @Test
+    void marshalMustSelectExactlyOneStaticDataformat() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                        - marshal: {}
+                """);
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extract(route, available()));
+
+        assertTrue(error.getMessage().contains("exactly one static data format"));
+    }
+
+    private CamelYamlCatalogUsageExtractor extractor() {
+        return new CamelYamlCatalogUsageExtractor();
+    }
+
+    private Path write(String content) throws IOException {
+        Path route = project.resolve("route.camel.yaml");
+        Files.writeString(route, content);
+        return route;
+    }
+
+    private Path expressionRoute(String expression) throws IOException {
+        String indented = expression.lines()
+                .map(line -> "            " + line)
+                .reduce((left, right) -> left + '\n' + right)
+                .orElseThrow();
+        return write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                        - setBody:
+                """ + indented + '\n');
+    }
+
+    private static List<CatalogSubject> available() {
+        return List.of(
+                subject(Kind.COMPONENT, "direct"),
+                subject(Kind.COMPONENT, "kafka"),
+                subject(Kind.EIP, "route"),
+                subject(Kind.EIP, "from"),
+                subject(Kind.EIP, "to"),
+                subject(Kind.EIP, "setBody"),
+                subject(Kind.EIP, "split"),
+                subject(Kind.EIP, "marshal"),
+                subject(Kind.DATAFORMAT, "csv"),
+                subject(Kind.LANGUAGE, "simple"),
+                subject(Kind.LANGUAGE, "jsonpath"));
+    }
+
+    private static CatalogSubject subject(Kind kind, String name) {
+        return new CatalogSubject(kind, name);
+    }
+
+    private static CatalogComponentModel directModel() {
+        CatalogSubject direct = subject(Kind.COMPONENT, "direct");
+        SubjectEvidence evidence = new SubjectEvidence(
+                direct, MavenCoordinate.jar("org.apache.camel", "camel-catalog", "4.21.0"),
+                "sha256:" + "a".repeat(64),
+                "org/apache/camel/catalog/components/direct.json", "sha256:" + "b".repeat(64),
+                "org.apache.camel", "camel-direct", "4.21.0", false);
+        return new CatalogComponentModel(
+                evidence, "direct:name", false, List.of(
+                        new CatalogComponentModel.Option(
+                                "name", CatalogComponentModel.Scope.ENDPOINT, CatalogComponentModel.Kind.PATH,
+                                0, "string", "java.lang.String", true, false, null, null, List.of()),
+                        new CatalogComponentModel.Option(
+                                "block", CatalogComponentModel.Scope.ENDPOINT, CatalogComponentModel.Kind.PARAMETER,
+                                1, "boolean", "boolean", false, false, null, null, List.of()),
+                        new CatalogComponentModel.Option(
+                                "timeout", CatalogComponentModel.Scope.ENDPOINT, CatalogComponentModel.Kind.PARAMETER,
+                                2, "integer", "long", false, false, null, null, List.of())));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
@@ -139,7 +139,19 @@ class CamelYamlCatalogUsageExtractorTest {
     }
 
     @Test
-    void endpointParametersCannotManufactureFalseCatalogUsage() throws Exception {
+    void nonExactExpressionAliasesFailClosedWithoutDependingOnCatalogAvailability() throws Exception {
+        for (String alias : List.of("exchange-property", "exchange_property", "Json-Path")) {
+            Path route = expressionRoute(alias + ": order-status");
+
+            IOException error = assertThrows(IOException.class,
+                    () -> extractor().extract(route, available()), alias);
+
+            assertTrue(error.getMessage().contains("non-exact language alias"), error::getMessage);
+        }
+    }
+
+    @Test
+    void endpointParameterValuesCannotManufactureFalseCatalogUsage() throws Exception {
         Path route = write("""
                 - route:
                     from:
@@ -236,7 +248,7 @@ class CamelYamlCatalogUsageExtractorTest {
                 - route:
                     from:
                       uri: direct:start?block=true
-                      endpointParameters:
+                      parameters:
                         timeout: 50
                 """);
 
@@ -247,6 +259,102 @@ class CamelYamlCatalogUsageExtractorTest {
         CatalogUsageRecord.EndpointUsage endpoint = result.endpoints().get(0);
         assertEquals(1, endpoint.pathParameterCount());
         assertEquals(List.of("block", "timeout"), endpoint.endpointOptions());
+    }
+
+    @Test
+    void endpointMetadataScalarsAreNotMisclassifiedAsUris() throws Exception {
+        Path route = write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                        - to:
+                            uri: direct:orders
+                            id: deliver
+                            description: "kafka: orders"
+                            pattern: InOnly
+                """);
+
+        CamelYamlCatalogUsageExtractor.Extraction result = extractor().extractBound(
+                route, available(), List.of(directModel()));
+
+        assertFalse(result.subjects().contains(subject(Kind.COMPONENT, "kafka")));
+        assertEquals(2, result.endpoints().size());
+        assertTrue(result.endpoints().stream()
+                .allMatch(endpoint -> endpoint.component().equals(subject(Kind.COMPONENT, "direct"))));
+    }
+
+    @Test
+    void everyStaticEndpointFieldProducesExactlyValidatedUsage() throws Exception {
+        Path route = write("""
+                - route:
+                    errorHandler:
+                      deadLetterChannel:
+                        deadLetterUri: direct:dead
+                    from:
+                      uri: direct:start
+                      steps:
+                        - saga:
+                            compensation: direct:compensate
+                            completion: direct:complete
+                            steps:
+                              - to: direct:done
+                - interceptFrom:
+                    uri: direct:incoming
+                - interceptSendToEndpoint:
+                    uri: direct:target
+                    afterUri: direct:after
+                    steps: []
+                - endpointTransformer:
+                    uri: direct:transform
+                - endpointValidator:
+                    uri: direct:validate
+                """);
+
+        CamelYamlCatalogUsageExtractor.Extraction result = extractor().extractBound(
+                route, available(), List.of(directModel()));
+
+        assertEquals(10, result.endpoints().size());
+        assertEquals(List.of(subject(Kind.COMPONENT, "direct")), result.subjects().stream()
+                .filter(subject -> subject.kind() == Kind.COMPONENT)
+                .toList());
+    }
+
+    @Test
+    void expressionDrivenAndServiceDiscoveredEndpointEipsFailClosed() throws Exception {
+        for (String endpointStep : List.of(
+                "- dynamicRouter:\n    simple: kafka:orders",
+                "- enrich:\n    simple: kafka:orders",
+                "- pollEnrich:\n    simple: kafka:orders",
+                "- recipientList:\n    simple: kafka:orders",
+                "- routingSlip:\n    simple: kafka:orders",
+                // serviceCall is an endpoint EIP in the certified Camel 4.18.3 schema only.
+                "- serviceCall: orders",
+                "- serviceCall:\n    name: orders\n    component: kafka")) {
+            Path route = endpointStepRoute(endpointStep);
+
+            IOException error = assertThrows(IOException.class, () -> extractor().extractBound(
+                    route, available(), List.of(directModel())), endpointStep);
+
+            assertTrue(error.getMessage().contains("cannot catalog-prove"), error::getMessage);
+        }
+    }
+
+    @Test
+    void endpointFieldsOutsidePrimaryEndpointEipsValidateFrozenOptions() throws Exception {
+        Path route = write("""
+                - route:
+                    errorHandler:
+                      deadLetterChannel:
+                        deadLetterUri: direct:dead?invented=true
+                    from:
+                      uri: direct:start
+                """);
+
+        IOException error = assertThrows(IOException.class, () -> extractor().extractBound(
+                route, available(), List.of(directModel())));
+
+        assertTrue(error.getMessage().contains("absent from frozen component metadata"));
     }
 
     @Test
@@ -277,7 +385,7 @@ class CamelYamlCatalogUsageExtractorTest {
                 - route:
                     from:
                       uri: direct:start
-                      endpointParameters:
+                      parameters:
                         timeout: "${header.timeout}"
                 """);
         IOException error = assertThrows(IOException.class, () -> extractor().extractBound(
@@ -324,15 +432,39 @@ class CamelYamlCatalogUsageExtractorTest {
                 """ + indented + '\n');
     }
 
+    private Path endpointStepRoute(String endpointStep) throws IOException {
+        String indented = endpointStep.lines()
+                .map(line -> "        " + line)
+                .reduce((left, right) -> left + '\n' + right)
+                .orElseThrow();
+        return write("""
+                - route:
+                    from:
+                      uri: direct:start
+                      steps:
+                """ + indented + '\n');
+    }
+
     private static List<CatalogSubject> available() {
         return List.of(
                 subject(Kind.COMPONENT, "direct"),
                 subject(Kind.COMPONENT, "kafka"),
                 subject(Kind.EIP, "route"),
                 subject(Kind.EIP, "from"),
+                subject(Kind.EIP, "dynamicRouter"),
+                subject(Kind.EIP, "enrich"),
+                subject(Kind.EIP, "interceptFrom"),
+                subject(Kind.EIP, "interceptSendToEndpoint"),
+                subject(Kind.EIP, "endpointTransformer"),
+                subject(Kind.EIP, "endpointValidator"),
+                subject(Kind.EIP, "pollEnrich"),
+                subject(Kind.EIP, "recipientList"),
+                subject(Kind.EIP, "routingSlip"),
+                subject(Kind.EIP, "serviceCall"),
                 subject(Kind.EIP, "to"),
                 subject(Kind.EIP, "setBody"),
                 subject(Kind.EIP, "split"),
+                subject(Kind.EIP, "saga"),
                 subject(Kind.EIP, "marshal"),
                 subject(Kind.DATAFORMAT, "csv"),
                 subject(Kind.LANGUAGE, "simple"),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
@@ -314,10 +315,72 @@ class CamelYamlCatalogUsageExtractorTest {
         CamelYamlCatalogUsageExtractor.Extraction result = extractor().extractBound(
                 route, available(), List.of(directModel()));
 
-        assertEquals(10, result.endpoints().size());
+        assertEquals(8, result.endpoints().size());
         assertEquals(List.of(subject(Kind.COMPONENT, "direct")), result.subjects().stream()
                 .filter(subject -> subject.kind() == Kind.COMPONENT)
                 .toList());
+    }
+
+    @Test
+    void endpointSelectorPatternsDoNotManufactureEndpointUsage() throws Exception {
+        Path route = write("- interceptFrom:\n    steps: []\n");
+        CamelYamlCatalogUsageExtractor.Extraction allEndpoints = extractor().extractBound(
+                route, available(), List.of(directModel()));
+        assertEquals(List.of(subject(Kind.EIP, "interceptFrom")), allEndpoints.subjects());
+        assertTrue(allEndpoints.endpoints().isEmpty());
+
+        for (String operation : List.of("interceptFrom", "interceptSendToEndpoint")) {
+            for (String definition : List.of(
+                    "- " + operation + ": jms*",
+                    "- " + operation + ":\n    uri: jms*\n    steps: []")) {
+                route = write(definition + '\n');
+
+                CamelYamlCatalogUsageExtractor.Extraction result = extractor().extractBound(
+                        route, available(), List.of(directModel()));
+
+                assertEquals(List.of(subject(Kind.EIP, operation)), result.subjects(), definition);
+                assertTrue(result.endpoints().isEmpty(), definition);
+            }
+        }
+    }
+
+    @Test
+    void endpointSelectorPatternsRemainStaticAndRequired() throws Exception {
+        for (String operation : List.of("interceptFrom", "interceptSendToEndpoint")) {
+            for (String definition : List.of(
+                    "- " + operation + ": \"{{selector}}\"",
+                    "- " + operation + ":\n    uri: \"{{selector}}\"",
+                    "- " + operation + ":\n    uri: \"${body}\"",
+                    "- " + operation + ":\n    uri: \"#bean:selector\"")) {
+                Path route = write(definition + '\n');
+
+                assertThrows(IOException.class, () -> extractor().extractBound(
+                        route, available(), List.of(directModel())), definition);
+            }
+        }
+
+        Path missingRequiredPattern = write("- interceptSendToEndpoint:\n    steps: []\n");
+        assertThrows(IOException.class, () -> extractor().extractBound(
+                missingRequiredPattern, available(), List.of(directModel())));
+    }
+
+    @Test
+    void interceptSendAfterUriRemainsAConcreteEndpoint() throws Exception {
+        Path route = write("""
+                - interceptSendToEndpoint:
+                    uri: jms*
+                    afterUri: direct:after
+                    steps: []
+                """);
+
+        CamelYamlCatalogUsageExtractor.Extraction result = extractor().extractBound(
+                route, available(), List.of(directModel()));
+
+        assertEquals(1, result.endpoints().size());
+        assertEquals(subject(Kind.COMPONENT, "direct"), result.endpoints().get(0).component());
+        assertEquals(Set.of(
+                subject(Kind.COMPONENT, "direct"),
+                subject(Kind.EIP, "interceptSendToEndpoint")), Set.copyOf(result.subjects()));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogBoundaryTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogBoundaryTest.java
@@ -39,6 +39,12 @@ class ShipCatalogBoundaryTest {
             "com.fasterxml.jackson.databind.DeserializationFeature",
             "com.fasterxml.jackson.databind.JsonNode",
             "com.fasterxml.jackson.databind.ObjectMapper",
+            "com.fasterxml.jackson.databind.ObjectReader",
+            "com.fasterxml.jackson.databind.node.TextNode",
+            "com.fasterxml.jackson.dataformat.yaml.YAMLFactory",
+            "com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder",
+            "io.github.luigidemasi.camelkit.ship.ShipDigest",
+            "io.github.luigidemasi.camelkit.ship.expression.ShipExpressionPolicy",
             "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate",
             "io.github.luigidemasi.camelkit.ship.resolver.ResolvedExactMavenArtifact",
             "io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver",
@@ -65,7 +71,12 @@ class ShipCatalogBoundaryTest {
             CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence",
             CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence",
             CATALOG_PACKAGE + "CatalogComponentModel",
-            CATALOG_PACKAGE + "CatalogComponentModel$Option");
+            CATALOG_PACKAGE + "CatalogComponentModel$Option",
+            CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor$Extraction",
+            CATALOG_PACKAGE + "CatalogUsageRecord",
+            CATALOG_PACKAGE + "CatalogUsageRecord$RouteUsage",
+            CATALOG_PACKAGE + "CatalogUsageRecord$EndpointUsage",
+            CATALOG_PACKAGE + "CatalogUsageRecord$RuntimeDependency");
     private static final Set<String> PUBLIC_ENUMS = Set.of(
             CATALOG_PACKAGE + "CatalogSubject$Kind",
             CATALOG_PACKAGE + "CatalogComponentModel$Scope",
@@ -111,7 +122,28 @@ class ShipCatalogBoundaryTest {
             Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Scope", Set.of()),
             Map.entry(CATALOG_PACKAGE + "CatalogComponentModel$Kind", Set.of()),
             Map.entry(CATALOG_PACKAGE + "ShipCatalogService", Set.of(constructor("java.nio.file.Path"))),
-            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of()));
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor", Set.of("<init>()")),
+            Map.entry(CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor$Extraction", Set.of(constructor(
+                    "java.lang.String", "java.util.List<" + CATALOG_PACKAGE + "CatalogSubject>",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogUsageRecord$EndpointUsage>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogExpressionInventory", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord", Set.of(constructor(
+                    "int", "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String",
+                    "java.lang.String", "java.lang.String", "java.lang.String",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogUsageRecord$RouteUsage>",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogComponentModel>",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogUsageRecord$RuntimeDependency>",
+                    CATALOG_PACKAGE + "CatalogEvidenceSet"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$RouteUsage", Set.of(constructor(
+                    "java.lang.String", "java.lang.String", "java.lang.String",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogSubject>",
+                    "java.util.List<" + CATALOG_PACKAGE + "CatalogUsageRecord$EndpointUsage>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$EndpointUsage", Set.of(constructor(
+                    CATALOG_PACKAGE + "CatalogSubject", "int", "java.util.List<java.lang.String>",
+                    "java.util.List<java.lang.String>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$RuntimeDependency", Set.of(constructor(
+                    "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String"))));
     private static final Map<String, Set<String>> PUBLIC_METHODS = Map.ofEntries(
             Map.entry(CATALOG_PACKAGE + "CatalogTarget", Set.of(
                     method("toString", "java.lang.String"), method("hashCode", "int"),
@@ -137,7 +169,12 @@ class ShipCatalogBoundaryTest {
                                         + "CatalogEvidenceSet$ArtifactEvidence>"),
                     method("subjects", "java.util.List<" + CATALOG_PACKAGE
                                        + "CatalogEvidenceSet$SubjectEvidence>"),
-                    method("digest", "java.lang.String"))),
+                    method("digest", "java.lang.String"),
+                    staticMethod("create", CATALOG_PACKAGE + "CatalogEvidenceSet",
+                            CATALOG_PACKAGE + "CatalogTarget",
+                            "io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate",
+                            "java.util.List<" + CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence>",
+                            "java.util.List<" + CATALOG_PACKAGE + "CatalogEvidenceSet$SubjectEvidence>"))),
             Map.entry(CATALOG_PACKAGE + "CatalogEvidenceSet$ArtifactEvidence", Set.of(
                     method("toString", "java.lang.String"), method("hashCode", "int"),
                     method("equals", "boolean", "java.lang.Object"),
@@ -188,7 +225,63 @@ class ShipCatalogBoundaryTest {
                     throwingMethod("componentModelsFor",
                             "java.util.List<" + CATALOG_PACKAGE + "CatalogComponentModel>", "java.io.IOException",
                             "java.util.Collection<" + CATALOG_PACKAGE + "CatalogSubject>"),
-                    method("toString", "java.lang.String"))));
+                    method("toString", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor", Set.of(
+                    throwingMethod("extract", "java.util.List<" + CATALOG_PACKAGE + "CatalogSubject>",
+                            "java.io.IOException", "java.nio.file.Path",
+                            "java.util.Collection<" + CATALOG_PACKAGE + "CatalogSubject>"),
+                    throwingMethod("extractBound", CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor$Extraction",
+                            "java.io.IOException", "java.nio.file.Path",
+                            "java.util.Collection<" + CATALOG_PACKAGE + "CatalogSubject>"),
+                    throwingMethod("extractBound", CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor$Extraction",
+                            "java.io.IOException", "java.nio.file.Path",
+                            "java.util.Collection<" + CATALOG_PACKAGE + "CatalogSubject>",
+                            "java.util.Collection<" + CATALOG_PACKAGE + "CatalogComponentModel>"))),
+            Map.entry(CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor$Extraction", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("digest", "java.lang.String"),
+                    method("subjects", "java.util.List<" + CATALOG_PACKAGE + "CatalogSubject>"),
+                    method("endpoints", "java.util.List<" + CATALOG_PACKAGE
+                                        + "CatalogUsageRecord$EndpointUsage>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogExpressionInventory", Set.of(
+                    staticMethod("yamlAliases", "java.util.Set<java.lang.String>"),
+                    staticMethod("catalogLanguages", "java.util.Set<java.lang.String>"),
+                    staticMethod("isKnownAlias", "boolean", "java.lang.String"),
+                    staticMethod("isRejectedAlias", "boolean", "java.lang.String"),
+                    staticMethod("isNonExactAlias", "boolean", "java.lang.String"),
+                    staticMethod("isSafeSimple", "boolean", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("schemaVersion", "int"),
+                    method("runId", "java.lang.String"), method("catalogEvidenceDigest", "java.lang.String"),
+                    method("artifactManifestDigest", "java.lang.String"),
+                    method("candidateSnapshotDigest", "java.lang.String"),
+                    method("candidateContentDigest", "java.lang.String"),
+                    method("pomDigest", "java.lang.String"), method("inventoryDigest", "java.lang.String"),
+                    method("routes", "java.util.List<" + CATALOG_PACKAGE + "CatalogUsageRecord$RouteUsage>"),
+                    method("componentModels", "java.util.List<" + CATALOG_PACKAGE + "CatalogComponentModel>"),
+                    method("runtimeDependencies", "java.util.List<" + CATALOG_PACKAGE
+                                                  + "CatalogUsageRecord$RuntimeDependency>"),
+                    method("evidence", CATALOG_PACKAGE + "CatalogEvidenceSet"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$RouteUsage", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("routeId", "java.lang.String"),
+                    method("path", "java.lang.String"), method("routeDigest", "java.lang.String"),
+                    method("subjects", "java.util.List<" + CATALOG_PACKAGE + "CatalogSubject>"),
+                    method("endpoints", "java.util.List<" + CATALOG_PACKAGE
+                                        + "CatalogUsageRecord$EndpointUsage>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$EndpointUsage", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"),
+                    method("component", CATALOG_PACKAGE + "CatalogSubject"),
+                    method("pathParameterCount", "int"),
+                    method("componentOptions", "java.util.List<java.lang.String>"),
+                    method("endpointOptions", "java.util.List<java.lang.String>"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$RuntimeDependency", Set.of(
+                    method("toString", "java.lang.String"), method("hashCode", "int"),
+                    method("equals", "boolean", "java.lang.Object"), method("coordinate", "java.lang.String"),
+                    method("groupId", "java.lang.String"), method("artifactId", "java.lang.String"),
+                    method("version", "java.lang.String"), method("scope", "java.lang.String"))));
     private static final Map<String, Set<String>> PUBLIC_FIELDS = Map.ofEntries(
             Map.entry(CATALOG_PACKAGE + "CatalogTarget", Set.of()),
             Map.entry(CATALOG_PACKAGE + "CatalogSubject", Set.of()),
@@ -210,9 +303,21 @@ class ShipCatalogBoundaryTest {
                     field("PATH", CATALOG_PACKAGE + "CatalogComponentModel$Kind"),
                     field("PARAMETER", CATALOG_PACKAGE + "CatalogComponentModel$Kind"))),
             Map.entry(CATALOG_PACKAGE + "ShipCatalogService", Set.of()),
-            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of()));
+            Map.entry(CATALOG_PACKAGE + "ShipCatalogService$Snapshot", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CamelYamlCatalogUsageExtractor$Extraction", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogExpressionInventory", Set.of(
+                    field("SIMPLE", "java.lang.String"), field("GENERIC", "java.lang.String"),
+                    field("METHOD", "java.lang.String"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord", Set.of(field("SCHEMA_VERSION", "int"))),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$RouteUsage", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$EndpointUsage", Set.of()),
+            Map.entry(CATALOG_PACKAGE + "CatalogUsageRecord$RuntimeDependency", Set.of()));
     private static final Map<String, Map<String, Object>> PUBLIC_CONSTANT_VALUES = Map.of(
-            CATALOG_PACKAGE + "CatalogEvidenceSet", Map.of("SCHEMA_VERSION", 1));
+            CATALOG_PACKAGE + "CatalogEvidenceSet", Map.of("SCHEMA_VERSION", 1),
+            CATALOG_PACKAGE + "CatalogExpressionInventory", Map.of(
+                    "SIMPLE", "simple", "GENERIC", "language", "METHOD", "method"),
+            CATALOG_PACKAGE + "CatalogUsageRecord", Map.of("SCHEMA_VERSION", 1));
 
     @Test
     void compiledCatalogUsesOnlyApprovedModulesAndExactExternalTypes()
@@ -262,7 +367,14 @@ class ShipCatalogBoundaryTest {
                 CatalogComponentModel.Scope.class,
                 CatalogComponentModel.Kind.class,
                 ShipCatalogService.class,
-                ShipCatalogService.Snapshot.class);
+                ShipCatalogService.Snapshot.class,
+                CamelYamlCatalogUsageExtractor.class,
+                CamelYamlCatalogUsageExtractor.Extraction.class,
+                CatalogExpressionInventory.class,
+                CatalogUsageRecord.class,
+                CatalogUsageRecord.RouteUsage.class,
+                CatalogUsageRecord.EndpointUsage.class,
+                CatalogUsageRecord.RuntimeDependency.class);
         Path classes = Path.of(System.getProperty("basedir"), "target", "classes");
         Path catalog = classes.resolve("io/github/luigidemasi/camelkit/ship/catalog");
         Set<Class<?>> actual = new HashSet<>();

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -2,6 +2,7 @@ package io.github.luigidemasi.camelkit.ship.evidence;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -118,6 +119,90 @@ class EvidenceRunnerTest {
     }
 
     @Test
+    void failedVersionQueryCannotLaunchOrPassOnStderrNoise() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        launcher.versionStdout = "misleading version\n";
+        launcher.versionExitCode = 9;
+
+        CommandEvidence result = runner(launcher).run(
+                project, tempDir.resolve("evidence"), command(project, "version-check", Duration.ofSeconds(2)));
+
+        assertFalse(result.passed());
+        assertFalse(result.launched());
+        assertNull(result.exitCode());
+        assertEquals("exit-9", result.executableVersion());
+        assertTrue(result.launchError().contains("Version query failed: exit-9"));
+        assertEquals(1, launcher.invocations.size(), "the evidence command must not launch after a failed query");
+    }
+
+    @Test
+    void zeroExitVersionQueryWithOnlyStderrCannotLaunchOrPass() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        launcher.versionStdout = " \n";
+        launcher.versionStderr = "Picked up JAVA_TOOL_OPTIONS: fixture\n";
+
+        CommandEvidence result = runner(launcher).run(
+                project, tempDir.resolve("evidence"), command(project, "version-check", Duration.ofSeconds(2)));
+
+        assertFalse(result.passed());
+        assertFalse(result.launched());
+        assertNull(result.exitCode());
+        assertEquals("unreported", result.executableVersion());
+        assertTrue(result.launchError().contains("Version query failed: unreported"));
+        assertEquals(1, launcher.invocations.size(), "stderr must not become executable version evidence");
+    }
+
+    @Test
+    void rejectsReuseOfAnotherRunsEvidenceDirectoryWithoutDeletingIt() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path evidenceDirectory = tempDir.resolve("evidence");
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        EvidenceCommand command = command(project, "first-check", Duration.ofSeconds(2));
+        RecordingLauncher firstLauncher = new RecordingLauncher(fakeBubblewrap, null, null);
+        CommandEvidence first = runner(firstLauncher).run(project, evidenceDirectory, command);
+        Path firstSandbox = firstLauncher.invocations.get(1).privateHome().getParent();
+
+        IOException rejected = assertThrows(IOException.class, () -> runner(
+                new RecordingLauncher(fakeBubblewrap, null, null))
+                .run(project, evidenceDirectory, command(project, "sibling-check", Duration.ofSeconds(2))));
+
+        assertTrue(rejected.getMessage().contains("new and exclusive"));
+        assertTrue(Files.isRegularFile(Path.of(first.stdoutLog())));
+        assertTrue(Files.isRegularFile(Path.of(first.stderrLog())));
+        assertTrue(Files.isDirectory(firstSandbox));
+    }
+
+    @Test
+    void midRunAuthorityTamperAlwaysFailsClosed() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        for (AuthorityTamper tamper : AuthorityTamper.values()) {
+            String id = tamper.name().toLowerCase(java.util.Locale.ROOT).replace('_', '-');
+            Path fakeBubblewrap = executable(
+                    tempDir.resolve("fake-bwrap-" + id), "fixture");
+            RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+            launcher.executionTamper = tamper;
+
+            CommandEvidence result = runner(launcher).run(
+                    project,
+                    tempDir.resolve("evidence-" + id),
+                    command(project, "tamper-" + id, Duration.ofSeconds(2)));
+
+            assertFalse(result.passed(), tamper.name());
+            switch (tamper) {
+                case PAYLOAD_ARCHIVE -> assertNull(result.postToolchainDigest());
+                case TOOLCHAIN_EXECUTABLE ->
+                    assertNotEquals(result.executableDigest(), result.postExecutableDigest());
+                case SANDBOX_EXECUTABLE -> assertNotEquals(
+                        result.sandbox().executableDigest(), result.sandbox().postExecutableDigest());
+            }
+        }
+    }
+
+    @Test
     void interruptionStillForciblyReapsAParentThatIgnoresGracefulTermination() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("candidate"));
         Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
@@ -143,7 +228,8 @@ class EvidenceRunnerTest {
     void interruptionReportsAParentThatCannotBeReaped() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("candidate"));
         Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
-        Path evidenceDirectory = tempDir.resolve("evidence");
+        Path evidenceRoot = Files.createDirectory(tempDir.resolve("evidence"));
+        Path evidenceDirectory = evidenceRoot.resolve("unreaped-run");
         RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
         launcher.executionCompletes = false;
         launcher.executionInterruptsWait = true;
@@ -172,12 +258,13 @@ class EvidenceRunnerTest {
 
         RecordingLauncher nextLauncher = new RecordingLauncher(fakeBubblewrap, null, null);
         EvidenceCommand nextCommand = command(project, "next-check", Duration.ofSeconds(2));
-        CommandEvidence next = runner(nextLauncher).run(project, evidenceDirectory, nextCommand);
-        EvidenceRunner.cleanupEphemeral(evidenceDirectory, nextCommand, next);
+        Path nextEvidenceDirectory = evidenceRoot.resolve("next-run");
+        CommandEvidence next = runner(nextLauncher).run(project, nextEvidenceDirectory, nextCommand);
+        EvidenceRunner.cleanupEphemeral(nextEvidenceDirectory, nextCommand, next);
 
-        assertTrue(Files.isDirectory(retainedSandbox), "later pruning must preserve quarantined sandboxes");
-        assertTrue(Files.isRegularFile(retainedStdout), "later pruning must preserve quarantined stdout");
-        assertTrue(Files.isRegularFile(retainedStderr), "later pruning must preserve quarantined stderr");
+        assertTrue(Files.isDirectory(retainedSandbox), "a sibling run must preserve quarantined sandboxes");
+        assertTrue(Files.isRegularFile(retainedStdout), "a sibling run must preserve quarantined stdout");
+        assertTrue(Files.isRegularFile(retainedStderr), "a sibling run must preserve quarantined stderr");
     }
 
     @Test
@@ -262,9 +349,15 @@ class EvidenceRunnerTest {
         assertTrue(frozen.externalMounts().isEmpty());
     }
 
-    private EvidenceRunner runner(RecordingLauncher launcher) {
+    private EvidenceRunner runner(RecordingLauncher launcher) throws IOException {
+        Path libraries = Files.createDirectories(tempDir.resolve("fixture-system-libraries"));
+        Path lib = Files.createDirectories(libraries.resolve("lib"));
+        Path lib64 = Files.createDirectories(libraries.resolve("lib64"));
         return new EvidenceRunner(
-                Clock.systemUTC(), launcher, new FixtureToolchainResolver(), new FixtureJdkResolver());
+                Clock.systemUTC(), launcher, new FixtureToolchainResolver(), new FixtureJdkResolver(),
+                List.of(
+                        new Mount(lib, "/usr/lib", Access.READ_ONLY),
+                        new Mount(lib64, "/usr/lib64", Access.READ_ONLY)));
     }
 
     private EvidenceCommand command(Path project, String id, Duration timeout) throws Exception {
@@ -329,6 +422,9 @@ class EvidenceRunnerTest {
         private final Path controllerSentinel;
         private final List<Invocation> invocations = new ArrayList<>();
         private int executionExitCode;
+        private String versionStdout = "Camel direct YAML validator 4.21.0\n";
+        private String versionStderr = "Picked up JAVA_TOOL_OPTIONS: fixture\n";
+        private int versionExitCode;
         private boolean versionCompletes = true;
         private boolean versionInterruptsWait;
         private boolean versionRequiresForcibleTermination;
@@ -337,6 +433,7 @@ class EvidenceRunnerTest {
         private boolean executionInterruptsWait;
         private boolean executionRequiresForcibleTermination;
         private boolean executionIgnoresForcibleTermination;
+        private AuthorityTamper executionTamper;
         private FakeProcess lastProcess;
 
         private RecordingLauncher(Path executable, Path candidateSentinel, Path controllerSentinel) {
@@ -356,7 +453,7 @@ class EvidenceRunnerTest {
         }
 
         @Override
-        public Process launch(Invocation invocation) {
+        public Process launch(Invocation invocation) throws IOException {
             invocations.add(invocation);
             if (candidateSentinel != null) {
                 assertFalse(invocation.exposes(candidateSentinel));
@@ -365,13 +462,50 @@ class EvidenceRunnerTest {
                 assertFalse(invocation.exposes(controllerSentinel));
             }
             boolean version = invocation.arguments().contains("--payload-version");
+            CheckedAction completionAction = !version && executionTamper != null
+                    ? () -> executionTamper.apply(invocation, executable)
+                    : null;
+            boolean completes = version ? versionCompletes : executionCompletes;
+            if (completionAction != null) {
+                completes = false;
+            }
             lastProcess = new FakeProcess(
-                    version ? "Camel direct YAML validator 4.21.0\n" : "PASS\n",
-                    "", version ? 0 : executionExitCode, version ? versionCompletes : executionCompletes,
+                    version ? versionStdout : "PASS\n",
+                    version ? versionStderr : "", version ? versionExitCode : executionExitCode,
+                    completes,
                     version ? versionInterruptsWait : executionInterruptsWait,
                     version ? versionRequiresForcibleTermination : executionRequiresForcibleTermination,
-                    version ? versionIgnoresForcibleTermination : executionIgnoresForcibleTermination);
+                    version ? versionIgnoresForcibleTermination : executionIgnoresForcibleTermination,
+                    completionAction);
             return lastProcess;
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedAction {
+
+        void run() throws IOException;
+    }
+
+    private enum AuthorityTamper {
+        PAYLOAD_ARCHIVE,
+        TOOLCHAIN_EXECUTABLE,
+        SANDBOX_EXECUTABLE;
+
+        private void apply(Invocation invocation, Path sandboxExecutable) throws IOException {
+            switch (this) {
+                case PAYLOAD_ARCHIVE -> {
+                    Path archive = invocation.mounts().stream()
+                            .filter(mount -> "/opt/camel-kit/payload".equals(mount.target()))
+                            .findFirst().orElseThrow()
+                            .source().resolve("payload.jar");
+                    Files.delete(archive);
+                    Files.writeString(archive, "mutated-payload");
+                }
+                case TOOLCHAIN_EXECUTABLE -> Files.writeString(
+                        invocation.toolchainExecutable(), "mutated-toolchain");
+                case SANDBOX_EXECUTABLE -> Files.writeString(sandboxExecutable, "mutated-sandbox");
+            }
         }
     }
 
@@ -385,6 +519,8 @@ class EvidenceRunnerTest {
         private boolean interruptWait;
         private final boolean requiresForcibleTermination;
         private final boolean ignoresForcibleTermination;
+        private final CheckedAction completionAction;
+        private boolean completionActionRun;
         private boolean forciblyDestroyed;
 
         private FakeProcess(
@@ -394,7 +530,8 @@ class EvidenceRunnerTest {
                             boolean completes,
                             boolean interruptWait,
                             boolean requiresForcibleTermination,
-                            boolean ignoresForcibleTermination) {
+                            boolean ignoresForcibleTermination,
+                            CheckedAction completionAction) {
             this.stdout = new ByteArrayInputStream(stdout.getBytes(StandardCharsets.UTF_8));
             this.stderr = new ByteArrayInputStream(stderr.getBytes(StandardCharsets.UTF_8));
             this.exitCode = exitCode;
@@ -402,6 +539,7 @@ class EvidenceRunnerTest {
             this.interruptWait = interruptWait;
             this.requiresForcibleTermination = requiresForcibleTermination;
             this.ignoresForcibleTermination = ignoresForcibleTermination;
+            this.completionAction = completionAction;
         }
 
         @Override
@@ -433,6 +571,15 @@ class EvidenceRunnerTest {
             }
             if (Thread.interrupted()) {
                 throw new InterruptedException("fixture observed caller interruption");
+            }
+            if (completionAction != null && !completionActionRun) {
+                completionActionRun = true;
+                try {
+                    completionAction.run();
+                } catch (IOException e) {
+                    throw new AssertionError("Could not apply execution-time authority tamper", e);
+                }
+                alive = false;
             }
             return !alive;
         }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -63,6 +63,7 @@ class EvidenceRunnerTest {
                     Files.getPosixFilePermissions(emptyDirectory),
                     Files.getPosixFilePermissions(frozenEmptyDirectory));
             assertTrue(invocation.mounts().stream().noneMatch(mount -> "/usr".equals(mount.target())));
+            assertTrue(invocation.mounts().stream().anyMatch(mount -> "/usr/lib".equals(mount.target())));
             assertTrue(invocation.mounts().stream().anyMatch(mount -> "/usr/lib64".equals(mount.target())));
         }
         assertEquals("Camel direct YAML validator 4.21.0", result.executableVersion());
@@ -76,6 +77,7 @@ class EvidenceRunnerTest {
         assertTrue(bubblewrapArguments.containsAll(List.of(
                 "--unshare-user", "--unshare-pid", "--unshare-ipc", "--unshare-uts",
                 "--unshare-cgroup", "--unshare-net", "--die-with-parent", "--new-session", "--clearenv")));
+        assertTrue(bubblewrapArguments.containsAll(List.of("usr/lib", "/lib", "usr/lib64", "/lib64")));
         assertFalse(bubblewrapArguments.contains("/bin"));
         assertFalse(bubblewrapArguments.contains("/sbin"));
         int separator = bubblewrapArguments.indexOf("--");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -1,0 +1,467 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Access;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Invocation;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Mount;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EvidenceRunnerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void usesOnlyTheFrozenCandidateAndControllerOwnedJvmPayload() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path candidateFile = Files.writeString(project.resolve("route.camel.yaml"), "route fixture");
+        Path emptyDirectory = Files.createDirectories(project.resolve("config/empty"));
+        Files.setPosixFilePermissions(emptyDirectory, PosixFilePermissions.fromString("rwxr-x---"));
+        Path candidateSibling = Files.writeString(tempDir.resolve("candidate-sibling.secret"), "secret");
+        Path controllerRoot = Files.createDirectories(tempDir.resolve("controller/run"));
+        Path controllerSentinel = Files.writeString(controllerRoot.resolve("signing.key"), "secret");
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, candidateSibling, controllerSentinel);
+        EvidenceCommand command = command(project, "route-schema", Duration.ofSeconds(5));
+
+        CommandEvidence result = runner(launcher).run(project, controllerRoot.resolve("evidence"), command);
+
+        assertTrue(result.passed(), result::toString);
+        assertEquals(2, launcher.invocations.size(), "version and evidence commands must both be sandboxed");
+        for (Invocation invocation : launcher.invocations) {
+            assertFalse(invocation.exposes(candidateSibling));
+            assertFalse(invocation.exposes(controllerSentinel));
+            Mount workspace = invocation.mounts().stream()
+                    .filter(mount -> "/workspace".equals(mount.target()))
+                    .findFirst().orElseThrow();
+            assertEquals(Access.READ_ONLY, workspace.access());
+            assertNotEquals(project.toRealPath(), workspace.source());
+            assertEquals(Files.readString(candidateFile),
+                    Files.readString(workspace.source().resolve("route.camel.yaml")));
+            Path frozenEmptyDirectory = workspace.source().resolve("config/empty");
+            assertTrue(Files.isDirectory(frozenEmptyDirectory));
+            assertEquals(
+                    Files.getPosixFilePermissions(emptyDirectory),
+                    Files.getPosixFilePermissions(frozenEmptyDirectory));
+            assertTrue(invocation.mounts().stream().noneMatch(mount -> "/usr".equals(mount.target())));
+            assertTrue(invocation.mounts().stream().anyMatch(mount -> "/usr/lib64".equals(mount.target())));
+        }
+        assertEquals("Camel direct YAML validator 4.21.0", result.executableVersion());
+        assertEquals("PASS\n", Files.readString(Path.of(result.stdoutLog())));
+        assertEquals(result.toolchainDigest(), result.postToolchainDigest());
+        assertNotNull(result.toolchainSnapshot());
+        assertEquals("/home/camel-kit", result.controlledEnvironment().get("HOME"));
+
+        List<String> bubblewrapArguments = BubblewrapSandboxLauncher.arguments(
+                fakeBubblewrap, launcher.invocations.get(1));
+        assertTrue(bubblewrapArguments.containsAll(List.of(
+                "--unshare-user", "--unshare-pid", "--unshare-ipc", "--unshare-uts",
+                "--unshare-cgroup", "--unshare-net", "--die-with-parent", "--new-session", "--clearenv")));
+        assertFalse(bubblewrapArguments.contains("/bin"));
+        assertFalse(bubblewrapArguments.contains("/sbin"));
+        int separator = bubblewrapArguments.indexOf("--");
+        assertEquals(command.arguments(), bubblewrapArguments.subList(separator + 1, bubblewrapArguments.size()));
+        assertFalse(bubblewrapArguments.contains("-c"));
+
+        Path rawStdout = Path.of(result.stdoutLog());
+        Path rawStderr = Path.of(result.stderrLog());
+        EvidenceRunner.cleanupEphemeral(controllerRoot.resolve("evidence"), command, result);
+        assertFalse(Files.exists(rawStdout));
+        assertFalse(Files.exists(rawStderr));
+        try (var entries = Files.list(controllerRoot.resolve("evidence"))) {
+            assertTrue(entries.noneMatch(path -> path.getFileName().toString().contains("-sandbox-")));
+        }
+    }
+
+    @Test
+    void recordsNonzeroAndTimeoutOutcomesFromSandbox() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher nonzero = new RecordingLauncher(fakeBubblewrap, null, null);
+        nonzero.executionExitCode = 7;
+        CommandEvidence failed = runner(nonzero).run(
+                project, tempDir.resolve("evidence-a"), command(project, "build-check", Duration.ofSeconds(2)));
+        assertFalse(failed.passed());
+        assertEquals(7, failed.exitCode());
+
+        RecordingLauncher timeout = new RecordingLauncher(fakeBubblewrap, null, null);
+        timeout.executionCompletes = false;
+        CommandEvidence timedOut = runner(timeout).run(
+                project, tempDir.resolve("evidence-b"), command(project, "slow-check", Duration.ofMillis(10)));
+        assertFalse(timedOut.passed());
+        assertTrue(timedOut.timedOut());
+        assertNull(timedOut.exitCode());
+        assertNotNull(timeout.lastProcess);
+        assertTrue(timeout.lastProcess.destroyed);
+        assertFalse(timeout.lastProcess.isAlive());
+    }
+
+    @Test
+    void interruptionStillForciblyReapsAParentThatIgnoresGracefulTermination() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        launcher.executionCompletes = false;
+        launcher.executionInterruptsWait = true;
+        launcher.executionRequiresForcibleTermination = true;
+
+        CommandEvidence interrupted = runner(launcher).run(
+                project, tempDir.resolve("evidence"), command(project, "interrupted-check", Duration.ofSeconds(2)));
+        boolean interruptPreserved = Thread.interrupted();
+
+        assertFalse(interrupted.passed());
+        assertTrue(interrupted.launchError().contains("Interrupted while waiting for the command"));
+        assertNotNull(launcher.lastProcess);
+        assertTrue(launcher.lastProcess.destroyed);
+        assertTrue(launcher.lastProcess.forciblyDestroyed);
+        assertFalse(launcher.lastProcess.isAlive());
+        assertTrue(interruptPreserved, "the caller's interrupted status must be preserved");
+    }
+
+    @Test
+    void interruptionReportsAParentThatCannotBeReaped() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        Path evidenceDirectory = tempDir.resolve("evidence");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        launcher.executionCompletes = false;
+        launcher.executionInterruptsWait = true;
+        launcher.executionRequiresForcibleTermination = true;
+        launcher.executionIgnoresForcibleTermination = true;
+
+        CommandEvidence interrupted = runner(launcher).run(
+                project, evidenceDirectory, command(project, "unreaped-check", Duration.ofSeconds(2)));
+        boolean interruptPreserved = Thread.interrupted();
+        Path retainedSandbox = launcher.invocations.get(1).privateHome().getParent();
+        Path retainedStdout = Path.of(interrupted.stdoutLog());
+        Path retainedStderr = Path.of(interrupted.stderrLog());
+
+        assertTrue(interrupted.launchError().contains("Interrupted command process tree could not be reaped"));
+        assertTrue(interrupted.launchError().contains("Ephemeral evidence quarantined at"));
+        assertNotNull(launcher.lastProcess);
+        assertTrue(launcher.lastProcess.forciblyDestroyed);
+        assertTrue(launcher.lastProcess.isAlive());
+        assertTrue(interruptPreserved, "the caller's interrupted status must be preserved");
+
+        EvidenceRunner.cleanupEphemeral(
+                evidenceDirectory, command(project, "unreaped-check", Duration.ofSeconds(2)), interrupted);
+        assertTrue(Files.isDirectory(retainedSandbox));
+        assertTrue(Files.isRegularFile(retainedStdout));
+        assertTrue(Files.isRegularFile(retainedStderr));
+
+        RecordingLauncher nextLauncher = new RecordingLauncher(fakeBubblewrap, null, null);
+        EvidenceCommand nextCommand = command(project, "next-check", Duration.ofSeconds(2));
+        CommandEvidence next = runner(nextLauncher).run(project, evidenceDirectory, nextCommand);
+        EvidenceRunner.cleanupEphemeral(evidenceDirectory, nextCommand, next);
+
+        assertTrue(Files.isDirectory(retainedSandbox), "later pruning must preserve quarantined sandboxes");
+        assertTrue(Files.isRegularFile(retainedStdout), "later pruning must preserve quarantined stdout");
+        assertTrue(Files.isRegularFile(retainedStderr), "later pruning must preserve quarantined stderr");
+    }
+
+    @Test
+    void unreapedVersionQueryIsQuarantinedBeforeTheCommandCanLaunch() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        Path evidenceDirectory = tempDir.resolve("evidence");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        launcher.versionCompletes = false;
+        launcher.versionInterruptsWait = true;
+        launcher.versionRequiresForcibleTermination = true;
+        launcher.versionIgnoresForcibleTermination = true;
+        EvidenceCommand evidenceCommand = command(project, "version-check", Duration.ofSeconds(2));
+
+        CommandEvidence result = runner(launcher).run(project, evidenceDirectory, evidenceCommand);
+        boolean interruptPreserved = Thread.interrupted();
+        Path retainedSandbox = launcher.invocations.get(0).privateHome().getParent();
+
+        assertEquals(1, launcher.invocations.size(),
+                "the evidence command must not launch after a residual version process");
+        assertFalse(result.launched());
+        assertTrue(result.launchError().contains("Version query process tree could not be reaped"));
+        assertTrue(result.launchError().contains("Ephemeral evidence quarantined at"));
+        assertTrue(interruptPreserved, "the caller's interrupted status must be preserved");
+
+        EvidenceRunner.cleanupEphemeral(evidenceDirectory, evidenceCommand, result);
+        assertTrue(Files.isDirectory(retainedSandbox));
+        assertTrue(Files.isRegularFile(Path.of(result.stdoutLog())));
+        assertTrue(Files.isRegularFile(Path.of(result.stderrLog())));
+    }
+
+    @Test
+    void failsClosedForMissingSandboxLegacyExecutableAndWorkingDirectoryEscape() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        EvidenceCommand command = command(project, "build-check", Duration.ofSeconds(1));
+        EvidenceRunner missingSandbox = new EvidenceRunner(
+                Clock.systemUTC(), new BubblewrapSandboxLauncher(tempDir.resolve("missing-bwrap")),
+                new FixtureToolchainResolver(), new FixtureJdkResolver());
+        assertThrows(Exception.class, () -> missingSandbox.run(
+                project, tempDir.resolve("evidence-a"), command));
+        try (var entries = Files.list(tempDir.resolve("evidence-a"))) {
+            assertTrue(entries.noneMatch(path -> path.getFileName().toString().contains("-sandbox-")));
+        }
+
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        Exception legacyFailure = assertThrows(IllegalArgumentException.class, () -> new EvidenceCommand(
+                "legacy", List.of("/usr/bin/mvn", "--version"), List.of(), null,
+                Duration.ofSeconds(1), List.of(ProjectEvidenceFiles.capture(project).digest()),
+                Map.of(), List.of(), null, null));
+        assertTrue(legacyFailure.getMessage().contains("direct JVM"));
+
+        EvidenceCommand escaped = new EvidenceCommand(
+                "escaped", command.arguments(), command.versionArguments(), "..", Duration.ofSeconds(1),
+                command.inputDigests(), Map.of(), List.of(), null, command.jvmPayload());
+        assertThrows(Exception.class, () -> runner(launcher)
+                .run(project, tempDir.resolve("evidence-c"), escaped));
+        assertTrue(launcher.invocations.isEmpty());
+    }
+
+    @Test
+    void freezesIndependentExactJdkBytesWithoutFollowingInternalLinks() throws Exception {
+        Path live = Files.createDirectories(tempDir.resolve("live-jdk"));
+        Path bin = Files.createDirectory(live.resolve("bin"));
+        Path java = executable(bin.resolve("java"), "java-bytes");
+        Path lib = Files.createDirectories(live.resolve("lib/security"));
+        Path policy = Files.writeString(lib.resolve("default.policy"), "accepted-policy");
+        Path conf = Files.createDirectory(live.resolve("conf"));
+        Files.createSymbolicLink(conf.resolve("security"), Path.of("../lib/security"));
+        Path sandbox = Files.createDirectory(tempDir.resolve("jdk-sandbox"));
+
+        EvidenceRunner.JdkIdentity frozen = EvidenceRunner.freezeJdk(live, sandbox);
+        Files.writeString(java, "mutated-java");
+        Files.writeString(policy, "mutated-policy");
+
+        assertNotEquals(live.toRealPath(), frozen.root());
+        assertEquals("java-bytes", Files.readString(frozen.root().resolve("bin/java")));
+        assertEquals("accepted-policy", Files.readString(frozen.root().resolve("lib/security/default.policy")));
+        assertTrue(Files.isSymbolicLink(frozen.root().resolve("conf/security")));
+        assertEquals(Path.of("../lib/security"), Files.readSymbolicLink(frozen.root().resolve("conf/security")));
+        assertTrue(frozen.digest().matches("sha256:[0-9a-f]{64}"));
+        assertTrue(frozen.externalMounts().isEmpty());
+    }
+
+    private EvidenceRunner runner(RecordingLauncher launcher) {
+        return new EvidenceRunner(
+                Clock.systemUTC(), launcher, new FixtureToolchainResolver(), new FixtureJdkResolver());
+    }
+
+    private EvidenceCommand command(Path project, String id, Duration timeout) throws Exception {
+        JvmPayloadRequest payload = JvmPayloadRequest.yamlValidator("4.21.0");
+        List<String> arguments = List.of(
+                EvidenceRunner.JAVA_EXECUTABLE, "-cp", JvmPayloadArchive.SANDBOX_ARCHIVE,
+                ShipJvmPayloadBootstrap.class.getName());
+        List<String> version = new ArrayList<>(arguments);
+        version.add("--payload-version");
+        return new EvidenceCommand(
+                id, arguments, version, null, timeout,
+                List.of(ProjectEvidenceFiles.capture(project).digest()),
+                Map.of("LANG", "C", "LC_ALL", "C"), List.of(), null, payload);
+    }
+
+    private static Path executable(Path path, String content) throws Exception {
+        Files.writeString(path, content);
+        assertTrue(path.toFile().setExecutable(true, true) || Files.isExecutable(path));
+        return path.toRealPath();
+    }
+
+    private static final class FixtureToolchainResolver implements EvidenceRunner.ToolchainResolver {
+
+        @Override
+        public EvidenceRunner.ResolvedToolchain resolve(
+                Path candidate,
+                Path sandboxRoot,
+                EvidenceCommand command,
+                EvidenceRunner.JdkIdentity jdk)
+                throws java.io.IOException {
+            String jdkDigest = jdk.digest();
+            JvmPayloadArchive.Identity identity = JvmPayloadTestFixture.create(
+                    sandboxRoot.resolve("fixture-payload"), command.jvmPayload(), jdkDigest);
+            Path java = jdk.root().resolve("bin/java").toRealPath();
+            return new EvidenceRunner.ResolvedToolchain(
+                    java, EvidenceRunner.JAVA_EXECUTABLE,
+                    List.of(new Mount(identity.archive().getParent(), "/opt/camel-kit/payload", Access.READ_ONLY)),
+                    identity.aggregateDigest(), identity.archive(), identity.archiveDigest(),
+                    () -> JvmPayloadArchive.verify(identity.archive(), command.jvmPayload(), jdkDigest));
+        }
+    }
+
+    private static final class FixtureJdkResolver implements EvidenceRunner.JdkResolver {
+
+        @Override
+        public EvidenceRunner.JdkIdentity freeze(Path sandboxRoot) throws java.io.IOException {
+            Path root = Files.createDirectories(sandboxRoot.resolve("fixture-jdk"));
+            Path bin = Files.createDirectory(root.resolve("bin"));
+            Path java = Files.writeString(bin.resolve("java"), "fixture-java");
+            if (!java.toFile().setExecutable(true, true) && !Files.isExecutable(java)) {
+                throw new java.io.IOException("Could not create fixture Java executable");
+            }
+            return new EvidenceRunner.JdkIdentity(
+                    root.toRealPath(), "sha256:" + "3".repeat(64), List.of());
+        }
+    }
+
+    private static final class RecordingLauncher implements EvidenceSandboxLauncher {
+
+        private final Path executable;
+        private final Path candidateSentinel;
+        private final Path controllerSentinel;
+        private final List<Invocation> invocations = new ArrayList<>();
+        private int executionExitCode;
+        private boolean versionCompletes = true;
+        private boolean versionInterruptsWait;
+        private boolean versionRequiresForcibleTermination;
+        private boolean versionIgnoresForcibleTermination;
+        private boolean executionCompletes = true;
+        private boolean executionInterruptsWait;
+        private boolean executionRequiresForcibleTermination;
+        private boolean executionIgnoresForcibleTermination;
+        private FakeProcess lastProcess;
+
+        private RecordingLauncher(Path executable, Path candidateSentinel, Path controllerSentinel) {
+            this.executable = executable;
+            this.candidateSentinel = candidateSentinel;
+            this.controllerSentinel = controllerSentinel;
+        }
+
+        @Override
+        public Identity identity() {
+            return new Identity(EvidenceRunner.SANDBOX_PROVIDER, executable);
+        }
+
+        @Override
+        public String profileId() {
+            return BubblewrapSandboxLauncher.PROFILE_ID;
+        }
+
+        @Override
+        public Process launch(Invocation invocation) {
+            invocations.add(invocation);
+            if (candidateSentinel != null) {
+                assertFalse(invocation.exposes(candidateSentinel));
+            }
+            if (controllerSentinel != null) {
+                assertFalse(invocation.exposes(controllerSentinel));
+            }
+            boolean version = invocation.arguments().contains("--payload-version");
+            lastProcess = new FakeProcess(
+                    version ? "Camel direct YAML validator 4.21.0\n" : "PASS\n",
+                    "", version ? 0 : executionExitCode, version ? versionCompletes : executionCompletes,
+                    version ? versionInterruptsWait : executionInterruptsWait,
+                    version ? versionRequiresForcibleTermination : executionRequiresForcibleTermination,
+                    version ? versionIgnoresForcibleTermination : executionIgnoresForcibleTermination);
+            return lastProcess;
+        }
+    }
+
+    private static final class FakeProcess extends Process {
+
+        private final InputStream stdout;
+        private final InputStream stderr;
+        private final int exitCode;
+        private boolean alive;
+        private boolean destroyed;
+        private boolean interruptWait;
+        private final boolean requiresForcibleTermination;
+        private final boolean ignoresForcibleTermination;
+        private boolean forciblyDestroyed;
+
+        private FakeProcess(
+                            String stdout,
+                            String stderr,
+                            int exitCode,
+                            boolean completes,
+                            boolean interruptWait,
+                            boolean requiresForcibleTermination,
+                            boolean ignoresForcibleTermination) {
+            this.stdout = new ByteArrayInputStream(stdout.getBytes(StandardCharsets.UTF_8));
+            this.stderr = new ByteArrayInputStream(stderr.getBytes(StandardCharsets.UTF_8));
+            this.exitCode = exitCode;
+            this.alive = !completes;
+            this.interruptWait = interruptWait;
+            this.requiresForcibleTermination = requiresForcibleTermination;
+            this.ignoresForcibleTermination = ignoresForcibleTermination;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return new ByteArrayOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return stderr;
+        }
+
+        @Override
+        public int waitFor() {
+            alive = false;
+            return exitCode;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+            if (interruptWait) {
+                interruptWait = false;
+                throw new InterruptedException("fixture interruption");
+            }
+            if (Thread.interrupted()) {
+                throw new InterruptedException("fixture observed caller interruption");
+            }
+            return !alive;
+        }
+
+        @Override
+        public int exitValue() {
+            if (alive)
+                throw new IllegalThreadStateException();
+            return exitCode;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+            if (!requiresForcibleTermination) {
+                alive = false;
+            }
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            forciblyDestroyed = true;
+            if (!ignoresForcibleTermination) {
+                alive = false;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return alive;
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -157,6 +157,28 @@ class EvidenceRunnerTest {
     }
 
     @Test
+    void missingVersionCommandCannotLaunchOrPass() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+        EvidenceCommand configured = command(project, "version-check", Duration.ofSeconds(2));
+        EvidenceCommand missingVersion = new EvidenceCommand(
+                configured.id(), configured.arguments(), List.of(), configured.relativeWorkingDirectory(),
+                configured.timeout(), configured.inputDigests(), configured.environment(),
+                configured.inheritedEnvironmentKeys(), configured.requiredToolchainDigest(), configured.jvmPayload());
+
+        CommandEvidence result = runner(launcher).run(
+                project, tempDir.resolve("evidence"), missingVersion);
+
+        assertFalse(result.passed());
+        assertFalse(result.launched());
+        assertNull(result.exitCode());
+        assertEquals("unreported", result.executableVersion());
+        assertTrue(result.launchError().contains("Version query failed: unreported"));
+        assertTrue(launcher.invocations.isEmpty(), "neither a version query nor the evidence command may launch");
+    }
+
+    @Test
     void rejectsReuseOfAnotherRunsEvidenceDirectoryWithoutDeletingIt() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("candidate"));
         Path evidenceDirectory = tempDir.resolve("evidence");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchiveTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchiveTest.java
@@ -1,0 +1,156 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogExpressionInventory;
+import io.github.luigidemasi.camelkit.ship.expression.ShipExpressionPolicy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JvmPayloadArchiveTest {
+
+    private static final String JDK_DIGEST = "sha256:" + "1".repeat(64);
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void writesAReproducibleSelfVerifyingContentLockedArchive() throws Exception {
+        JvmPayloadRequest request = JvmPayloadRequest.camelMain("4.21.0");
+        JvmPayloadArchive.Identity first = JvmPayloadTestFixture.create(
+                directory.resolve("first"), request, JDK_DIGEST);
+        JvmPayloadArchive.Identity second = JvmPayloadTestFixture.create(
+                directory.resolve("second"), request, JDK_DIGEST);
+
+        assertEquals(first.archiveDigest(), second.archiveDigest());
+        assertEquals(first.aggregateDigest(), second.aggregateDigest());
+        assertArrayEquals(Files.readAllBytes(first.archive()), Files.readAllBytes(second.archive()));
+        assertEquals(request.roots(), first.lock().roots());
+        assertEquals(request.launcherClass(), first.lock().launcherClass());
+        first.lock().requireRequest(request);
+
+        JvmPayloadArchive.Identity verified = JvmPayloadArchive.verify(first.archive(), request, JDK_DIGEST);
+        assertEquals(first.aggregateDigest(), verified.aggregateDigest());
+    }
+
+    @Test
+    void writesAReproducibleJdkOnlyPackagePayloadWithoutMavenRoots() throws Exception {
+        JvmPayloadRequest request = JvmPayloadRequest.mainPackage("4.21.0");
+        JvmPayloadArchive.Identity first = JvmPayloadTestFixture.create(
+                directory.resolve("package-first"), request, JDK_DIGEST);
+        JvmPayloadArchive.Identity second = JvmPayloadTestFixture.create(
+                directory.resolve("package-second"), request, JDK_DIGEST);
+
+        assertTrue(first.lock().roots().isEmpty());
+        assertEquals(first.archiveDigest(), second.archiveDigest());
+        assertArrayEquals(Files.readAllBytes(first.archive()), Files.readAllBytes(second.archive()));
+        first.lock().requireRequest(request);
+    }
+
+    @Test
+    void rejectsRequestJdkAndArchiveTampering() throws Exception {
+        JvmPayloadRequest request = JvmPayloadRequest.yamlValidator("4.21.0");
+        JvmPayloadArchive.Identity identity = JvmPayloadTestFixture.create(
+                directory.resolve("payload"), request, JDK_DIGEST);
+
+        assertThrows(IOException.class, () -> JvmPayloadArchive.verify(
+                identity.archive(), JvmPayloadRequest.yamlValidator("4.18.3"), JDK_DIGEST));
+        assertThrows(IOException.class, () -> JvmPayloadArchive.verify(
+                identity.archive(), request, "sha256:" + "2".repeat(64)));
+
+        makeWritable(identity.archive());
+        Files.write(identity.archive(), new byte[]{0}, StandardOpenOption.WRITE);
+        assertThrows(IOException.class,
+                () -> JvmPayloadArchive.verify(identity.archive(), request, JDK_DIGEST));
+    }
+
+    @Test
+    void lockRejectsUnknownFieldsAndContentDigestChanges() throws Exception {
+        JvmPayloadArchive.Identity identity = JvmPayloadTestFixture.create(
+                directory.resolve("payload"), JvmPayloadRequest.yamlValidator("4.21.0"), JDK_DIGEST);
+        byte[] canonical = identity.lock().encode();
+
+        assertThrows(IOException.class, () -> JvmPayloadLock.parse(
+                (new String(canonical, java.nio.charset.StandardCharsets.UTF_8) + "unknown=value\n")
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        assertThrows(IOException.class, () -> JvmPayloadLock.parse(
+                new String(canonical, java.nio.charset.StandardCharsets.UTF_8)
+                        .replace(identity.lock().contentDigest(), "sha256:" + "0".repeat(64))
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void lockAuthenticatesDependencyExclusions() throws Exception {
+        JvmPayloadArchive.Identity identity = JvmPayloadTestFixture.create(
+                directory.resolve("payload"),
+                JvmPayloadRequest.citrus(
+                        "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2")),
+                JDK_DIGEST);
+        String canonical = new String(identity.lock().encode(), java.nio.charset.StandardCharsets.UTF_8);
+
+        assertTrue(canonical.contains("exclusion.000.groupId=org.apache.camel"));
+        assertThrows(IOException.class, () -> JvmPayloadLock.parse(
+                canonical.replace("exclusion.000.groupId=org.apache.camel",
+                        "exclusion.000.groupId=org.example")
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void isolatedLaunchersContainExactlyTheirApplicationOwnedDependencies() throws Exception {
+        for (JvmPayloadRequest request : java.util.List.of(
+                JvmPayloadRequest.mainPackage("4.21.0"),
+                JvmPayloadRequest.yamlValidator("4.21.0"),
+                JvmPayloadRequest.camelMain("4.21.0"),
+                JvmPayloadRequest.citrus(
+                        "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2")))) {
+            JvmPayloadArchive.Identity identity = JvmPayloadTestFixture.create(
+                    directory.resolve(request.kind().id()), request, JDK_DIGEST);
+
+            Set<String> launcherEntries = new HashSet<>();
+            try (ZipFile payload = new ZipFile(identity.archive().toFile());
+                 ZipInputStream launcher = new ZipInputStream(
+                         payload.getInputStream(payload.getEntry("lib/000-controller-launcher.jar")))) {
+                java.util.zip.ZipEntry entry;
+                while ((entry = launcher.getNextEntry()) != null) {
+                    launcherEntries.add(entry.getName());
+                }
+            }
+
+            assertTrue(launcherEntries.contains(classPath(ShipArtifactLimits.class)), request.kind().id());
+            boolean usesExpressionPolicy = request.kind() == JvmPayloadRequest.Kind.CAMEL_MAIN_START
+                    || request.kind() == JvmPayloadRequest.Kind.CITRUS_YAML;
+            assertEquals(
+                    usesExpressionPolicy,
+                    launcherEntries.contains(classPath(ShipExpressionPolicy.class)), request.kind().id());
+            assertEquals(
+                    usesExpressionPolicy,
+                    launcherEntries.contains(classPath(CatalogExpressionInventory.class)), request.kind().id());
+        }
+    }
+
+    private static String classPath(Class<?> type) {
+        return type.getName().replace('.', '/') + ".class";
+    }
+
+    private static void makeWritable(Path file) throws IOException {
+        if (Files.getFileAttributeView(file, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+        } else if (!file.toFile().setWritable(true, true)) {
+            throw new IOException("Could not make fixture writable");
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
@@ -1,0 +1,269 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarFile;
+
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Access;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Invocation;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceSandboxLauncher.Mount;
+import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Explicit network and bubblewrap conformance for every packaged Ship JVM compatibility row. */
+class JvmPayloadCompatibilityIT {
+
+    private static final String JDK_DIGEST = "sha256:" + "1".repeat(64);
+    private static final String SANDBOX_ARCHIVE = JvmPayloadArchive.SANDBOX_ARCHIVE;
+    private static final String SANDBOX_JAVA = "/opt/camel-kit/jdk/bin/java";
+    private static final Duration PROCESS_TIMEOUT = Duration.ofMinutes(2);
+    private static final Set<Row> FUNCTIONALLY_TESTED_ROWS = Set.of(
+            new Row("4.21.0", "5.0.0-M2"),
+            new Row("4.18.3", "5.0.0-M2"));
+    private static final String RELOCATED_RESOLVER_CLASS
+            = "io/github/luigidemasi/camelkit/ship/resolver/internal/org/eclipse/aether/RepositorySystem.class";
+
+    @TempDir
+    Path directory;
+
+    @BeforeAll
+    static void packagedResolverIsTheResolverUnderTest() throws Exception {
+        String configured = System.getProperty("ship.resolver.jar");
+        assertNotNull(configured, "Compatibility certification requires the packaged resolver path");
+        Path expected = Path.of(configured).toRealPath();
+        assertTrue(Files.isRegularFile(expected), "Packaged resolver is absent: " + expected);
+        assertNotNull(ShipMavenResolver.class.getProtectionDomain().getCodeSource());
+        Path actual = Path.of(ShipMavenResolver.class.getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI())
+                .toRealPath();
+        assertEquals(expected, actual, "Compatibility certification loaded an unshaded reactor resolver");
+        try (JarFile resolver = new JarFile(actual.toFile())) {
+            assertNotNull(resolver.getJarEntry(RELOCATED_RESOLVER_CLASS),
+                    "Compatibility certification resolver lacks its relocated implementation");
+        }
+    }
+
+    @Test
+    void explicitFunctionalRowsCoverTheEntirePackagedPolicy() throws Exception {
+        Properties policy = new Properties();
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("distribution.properties")) {
+            assertNotNull(input, "Missing packaged distribution.properties");
+            policy.load(input);
+        }
+        Set<String> validatorVersions = Set.of(
+                policy.getProperty("ship.evidence.camel-yaml-validator.supported").split(","));
+        Set<Row> citrusRows = policy.stringPropertyNames().stream()
+                .filter(key -> key.startsWith("ship.evidence.citrus."))
+                .filter(key -> key.endsWith(".camel.supported"))
+                .flatMap(key -> {
+                    String citrusVersion = key.substring(
+                            "ship.evidence.citrus.".length(), key.length() - ".camel.supported".length());
+                    return List.of(policy.getProperty(key).split(",")).stream()
+                            .map(camelVersion -> new Row(camelVersion.trim(), citrusVersion));
+                })
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+
+        assertEquals(FUNCTIONALLY_TESTED_ROWS, citrusRows);
+        assertEquals(
+                FUNCTIONALLY_TESTED_ROWS.stream().map(Row::camelVersion).collect(java.util.stream.Collectors.toSet()),
+                validatorVersions);
+    }
+
+    @Test
+    void camel421PayloadsMaterializeAndRunTheirFunctionalEvidenceInIsolation() throws Exception {
+        requirePayloads("4.21.0", "5.0.0-M2");
+    }
+
+    @Test
+    void camel418PayloadsMaterializeAndRunTheirFunctionalEvidenceInIsolation() throws Exception {
+        requirePayloads("4.18.3", "5.0.0-M2");
+    }
+
+    private void requirePayloads(String camelVersion, String citrusVersion) throws Exception {
+        Path workspace = Files.createDirectory(directory.resolve("workspace"));
+        Path route = Files.writeString(workspace.resolve("orders.camel.yaml"), """
+                - route:
+                    id: orders
+                    from:
+                      uri: kafka:orders
+                      steps:
+                        - setBody:
+                            simple: accepted-order
+                """);
+        Files.writeString(workspace.resolve("orders.camel.it.yaml"), """
+                name: orders-behavior
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        headers:
+                          - name: requestId
+                            value: req-1
+                          - name: strategy
+                            value: priority
+                        body:
+                          data: priority-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        headers:
+                          - name: requestId
+                            value: req-1
+                        body:
+                          data: accepted-order
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: standard-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: accepted-order
+                """);
+
+        List<RuntimeDependency> acceptedRuntime = List.of(
+                new RuntimeDependency("org.apache.camel", "camel-kafka", camelVersion, "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-main", camelVersion, "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-yaml-dsl", camelVersion, "compile"));
+        List<JvmPayloadRequest> requests = List.of(
+                JvmPayloadRequest.mainPackage(camelVersion),
+                JvmPayloadRequest.yamlValidator(camelVersion),
+                JvmPayloadRequest.camelMain(camelVersion, acceptedRuntime),
+                JvmPayloadRequest.citrus(
+                        camelVersion, citrusVersion, CitrusDependencyPolicy.required(citrusVersion),
+                        acceptedRuntime));
+        for (JvmPayloadRequest request : requests) {
+            Path root = Files.createDirectory(directory.resolve(request.kind().id()));
+            JvmPayloadArchive.Identity payload = JvmPayloadArchive.materialize(root, request, JDK_DIGEST);
+            requireIsolatedLaunch(payload.archive(), workspace, request, List.of("--payload-version"), true);
+            requireIsolatedLaunch(
+                    payload.archive(), workspace, request, functionalArguments(request, digest(route)), false);
+        }
+    }
+
+    private static List<String> functionalArguments(JvmPayloadRequest request, String routeDigest) {
+        return switch (request.kind()) {
+            case MAIN_PACKAGE_INSPECT -> List.of(
+                    "--candidate-digest=" + digest(1),
+                    "--manifest-digest=" + digest(2),
+                    "--catalog-usage-digest=" + digest(3),
+                    "--pom-digest=" + digest(4),
+                    "--main-payload-digest=" + JvmPayloadRequest.camelMain(
+                            request.camelVersion(), List.of(
+                                    new RuntimeDependency(
+                                            "org.apache.camel", "camel-kafka",
+                                            request.camelVersion(), "compile"),
+                                    new RuntimeDependency(
+                                            "org.apache.camel", "camel-main",
+                                            request.camelVersion(), "compile"),
+                                    new RuntimeDependency(
+                                            "org.apache.camel", "camel-yaml-dsl",
+                                            request.camelVersion(), "compile")))
+                            .digest(),
+                    "--route=orders.camel.yaml", "--route-digest=" + routeDigest);
+            case CAMEL_YAML_VALIDATE -> List.of("/workspace/orders.camel.yaml");
+            case CAMEL_MAIN_START -> List.of(
+                    "--route=/workspace/orders.camel.yaml", "--expected-route=orders");
+            case CITRUS_YAML -> List.of(
+                    "--route=/workspace/orders.camel.yaml", "--expected-route=orders",
+                    "--test=/workspace/orders.camel.it.yaml");
+            default -> throw new IllegalArgumentException("Unsupported compatibility request " + request.kind());
+        };
+    }
+
+    private void requireIsolatedLaunch(
+            Path archive,
+            Path workspace,
+            JvmPayloadRequest request,
+            List<String> launcherArguments,
+            boolean assertVersions)
+            throws Exception {
+        Path javaHome = Path.of(System.getProperty("java.home")).toRealPath();
+        Path java = javaHome.resolve("bin/java").toRealPath();
+        String launch = assertVersions ? "version" : "functional";
+        Path home = Files.createDirectory(directory.resolve(request.kind().id() + "-home-" + launch));
+        Path temporary = Files.createDirectory(
+                directory.resolve(request.kind().id() + "-tmp-" + launch));
+
+        List<Mount> mounts = List.of(
+                new Mount(Path.of("/usr/lib64").toRealPath(), "/usr/lib64", Access.READ_ONLY),
+                new Mount(javaHome, "/opt/camel-kit/jdk", Access.READ_ONLY),
+                new Mount(workspace.toRealPath(), "/workspace", Access.READ_ONLY),
+                new Mount(home.toRealPath(), "/home/camel-kit", Access.READ_WRITE),
+                new Mount(temporary.toRealPath(), "/tmp", Access.READ_WRITE),
+                new Mount(archive.toRealPath(), SANDBOX_ARCHIVE, Access.READ_ONLY));
+        List<String> arguments = new ArrayList<>(
+                List.of(
+                        SANDBOX_JAVA, "-cp", SANDBOX_ARCHIVE,
+                        ShipJvmPayloadBootstrap.class.getName()));
+        arguments.addAll(launcherArguments);
+        Map<String, String> environment = new LinkedHashMap<>();
+        environment.put("HOME", "/home/camel-kit");
+        environment.put("TMPDIR", "/tmp");
+        environment.put("JAVA_HOME", "/opt/camel-kit/jdk");
+        environment.put("JAVA_TOOL_OPTIONS", "-Duser.home=/home/camel-kit -Djava.io.tmpdir=/tmp");
+        environment.put("CAMEL_KIT_JDK_DIGEST", JDK_DIGEST);
+        environment.put("LANG", "C");
+        environment.put("LC_ALL", "C");
+
+        Invocation invocation = new Invocation(
+                workspace, workspace, "/workspace", home, temporary, java,
+                mounts, arguments, environment);
+        Process process = new BubblewrapSandboxLauncher().launch(invocation);
+        boolean exited = process.waitFor(PROCESS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        if (!exited) {
+            process.destroyForcibly();
+            assertTrue(process.waitFor(30, TimeUnit.SECONDS), "Timed-out payload process did not terminate");
+            fail("Timed out launching isolated " + request.kind().id() + " payload");
+        }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8)
+                        + new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.exitValue(), output);
+        if (assertVersions) {
+            if (request.kind() == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT) {
+                assertTrue(output.contains(
+                        io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain.PAYLOAD_VERSION),
+                        output);
+            } else {
+                assertTrue(output.contains(request.camelVersion()), output);
+            }
+            if (request.citrusVersion() != null) {
+                assertTrue(output.contains(request.citrusVersion()), output);
+            }
+        }
+    }
+
+    private static String digest(Path file) throws Exception {
+        return "sha256:" + java.util.HexFormat.of().formatHex(
+                java.security.MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file)));
+    }
+
+    private static String digest(int seed) {
+        return "sha256:" + String.format(Locale.ROOT, "%064x", seed);
+    }
+
+    private record Row(String camelVersion, String citrusVersion) {
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
@@ -208,6 +208,7 @@ class JvmPayloadCompatibilityIT {
                 directory.resolve(request.kind().id() + "-tmp-" + launch));
 
         List<Mount> mounts = List.of(
+                new Mount(Path.of("/usr/lib").toRealPath(), "/usr/lib", Access.READ_ONLY),
                 new Mount(Path.of("/usr/lib64").toRealPath(), "/usr/lib64", Access.READ_ONLY),
                 new Mount(javaHome, "/opt/camel-kit/jdk", Access.READ_ONLY),
                 new Mount(workspace.toRealPath(), "/workspace", Access.READ_ONLY),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
@@ -1,5 +1,7 @@
 package io.github.luigidemasi.camelkit.ship.evidence;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -12,6 +14,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarFile;
 
@@ -35,6 +40,7 @@ class JvmPayloadCompatibilityIT {
     private static final String SANDBOX_ARCHIVE = JvmPayloadArchive.SANDBOX_ARCHIVE;
     private static final String SANDBOX_JAVA = "/opt/camel-kit/jdk/bin/java";
     private static final Duration PROCESS_TIMEOUT = Duration.ofMinutes(2);
+    private static final int MAX_RETAINED_OUTPUT_BYTES = 8 * 1024 * 1024;
     private static final Set<Row> FUNCTIONALLY_TESTED_ROWS = Set.of(
             new Row("4.21.0", "5.0.0-M2"),
             new Row("4.18.3", "5.0.0-M2"));
@@ -46,6 +52,8 @@ class JvmPayloadCompatibilityIT {
 
     @BeforeAll
     static void packagedResolverIsTheResolverUnderTest() throws Exception {
+        assertEquals("Linux", System.getProperty("os.name"),
+                "The linux-ship-certification profile requires Linux and Bubblewrap");
         String configured = System.getProperty("ship.resolver.jar");
         assertNotNull(configured, "Compatibility certification requires the packaged resolver path");
         Path expected = Path.of(configured).toRealPath();
@@ -233,14 +241,30 @@ class JvmPayloadCompatibilityIT {
                 workspace, workspace, "/workspace", home, temporary, java,
                 mounts, arguments, environment);
         Process process = new BubblewrapSandboxLauncher().launch(invocation);
-        boolean exited = process.waitFor(PROCESS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-        if (!exited) {
-            process.destroyForcibly();
-            assertTrue(process.waitFor(30, TimeUnit.SECONDS), "Timed-out payload process did not terminate");
-            fail("Timed out launching isolated " + request.kind().id() + " payload");
+        ExecutorService readers = Executors.newFixedThreadPool(2, runnable -> {
+            Thread thread = new Thread(runnable, "camel-kit-ship-compatibility-output");
+            thread.setDaemon(true);
+            return thread;
+        });
+        Future<CapturedOutput> stdout = readers.submit(() -> drain(process.getInputStream()));
+        Future<CapturedOutput> stderr = readers.submit(() -> drain(process.getErrorStream()));
+        CapturedOutput capturedStdout;
+        CapturedOutput capturedStderr;
+        try {
+            boolean exited = process.waitFor(PROCESS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (!exited) {
+                process.destroyForcibly();
+                assertTrue(process.waitFor(30, TimeUnit.SECONDS), "Timed-out payload process did not terminate");
+                fail("Timed out launching isolated " + request.kind().id() + " payload");
+            }
+            capturedStdout = stdout.get(30, TimeUnit.SECONDS);
+            capturedStderr = stderr.get(30, TimeUnit.SECONDS);
+        } finally {
+            readers.shutdownNow();
         }
-        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8)
-                        + new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        String output = capturedStdout.text() + capturedStderr.text();
+        assertFalse(capturedStdout.truncated() || capturedStderr.truncated(),
+                "Isolated payload output exceeded " + MAX_RETAINED_OUTPUT_BYTES + " bytes per stream\n" + output);
         assertEquals(0, process.exitValue(), output);
         if (assertVersions) {
             if (request.kind() == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT) {
@@ -256,6 +280,21 @@ class JvmPayloadCompatibilityIT {
         }
     }
 
+    private static CapturedOutput drain(InputStream input) throws IOException {
+        ByteArrayOutputStream retained = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        boolean truncated = false;
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+            int remaining = MAX_RETAINED_OUTPUT_BYTES - retained.size();
+            if (remaining > 0) {
+                retained.write(buffer, 0, Math.min(count, remaining));
+            }
+            truncated |= count > remaining;
+        }
+        return new CapturedOutput(retained.toByteArray(), truncated);
+    }
+
     private static String digest(Path file) throws Exception {
         return "sha256:" + java.util.HexFormat.of().formatHex(
                 java.security.MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file)));
@@ -266,5 +305,12 @@ class JvmPayloadCompatibilityIT {
     }
 
     private record Row(String camelVersion, String citrusVersion) {
+    }
+
+    private record CapturedOutput(byte[] bytes, boolean truncated) {
+
+        private String text() {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadRequestTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadRequestTest.java
@@ -1,0 +1,137 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest.DependencyExclusion;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest.DependencyRoot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JvmPayloadRequestTest {
+
+    @Test
+    void selectsOnlyControllerOwnedDirectLaunchersAndExactRoots() {
+        JvmPayloadRequest packager = JvmPayloadRequest.mainPackage("4.21.0");
+        JvmPayloadRequest validator = JvmPayloadRequest.yamlValidator("4.21.0");
+        JvmPayloadRequest main = JvmPayloadRequest.camelMain("4.21.0");
+        JvmPayloadRequest citrus = JvmPayloadRequest.citrus(
+                "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2"));
+
+        assertEquals(JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT, packager.kind());
+        assertTrue(packager.roots().isEmpty());
+        assertEquals(JvmPayloadRequest.Kind.CAMEL_YAML_VALIDATE, validator.kind());
+        assertEquals(JvmPayloadRequest.Kind.CAMEL_MAIN_START, main.kind());
+        assertEquals(JvmPayloadRequest.Kind.CITRUS_YAML, citrus.kind());
+        assertTrue(citrus.roots().contains("org.citrusframework:citrus-junit-jupiter:5.0.0-M2"));
+        assertTrue(citrus.roots().contains("org.citrusframework:citrus-yaml:5.0.0-M2"));
+        assertTrue(citrus.roots().contains("org.citrusframework:citrus-camel:5.0.0-M2"));
+        assertTrue(main.roots().contains("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.2"));
+        assertTrue(main.roots().contains("org.yaml:snakeyaml:2.4"));
+        assertTrue(validator.roots().contains("com.networknt:json-schema-validator:2.0.1"));
+        assertTrue(validator.roots().contains("com.ethlo.time:itu:1.14.0"));
+        assertTrue(validator.roots().contains("org.slf4j:slf4j-api:2.0.17"));
+        assertTrue(JvmPayloadRequest.yamlValidator("4.18.3").roots()
+                .contains("com.networknt:json-schema-validator:1.5.9"));
+        assertTrue(citrus.roots().contains("org.apache.camel:camel-core:4.21.0"));
+        assertTrue(citrus.roots().contains("org.apache.camel:camel-spring:4.21.0"));
+        assertTrue(citrus.dependencyRoots().stream()
+                .filter(root -> "org.citrusframework".equals(root.groupId()))
+                .allMatch(root -> root.exclusions().equals(List.of(
+                        new DependencyExclusion("org.apache.camel", "*")))));
+        assertFalse(citrus.roots().stream().anyMatch(root -> root.contains("testcontainers")));
+        assertFalse(citrus.roots().stream().anyMatch(root -> root.endsWith(":4.20.0")));
+        assertNotEquals(validator.digest(), main.digest());
+        assertNotEquals(packager.digest(), main.digest());
+        assertNotEquals(main.digest(), citrus.digest());
+    }
+
+    @Test
+    void refusesDependencyDriftAliasesSnapshotsAndDuplicateRoots() {
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.citrus(
+                "4.21.0", "5.0.0-M2", List.of(
+                        "org.citrusframework:citrus-camel:5.0.0-M2",
+                        "org.citrusframework:citrus-yaml:5.0.0-M2")));
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.yamlValidator("LATEST"));
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.yamlValidator("4.21.0-SNAPSHOT"));
+        assertThrows(IllegalArgumentException.class, () -> new JvmPayloadRequest(
+                JvmPayloadRequest.Kind.CAMEL_MAIN_START, "4.21.0", null, "example.Launcher",
+                List.of(
+                        new DependencyRoot("g", "a", "1", List.of()),
+                        new DependencyRoot("g", "a", "1", List.of()))));
+    }
+
+    @Test
+    void failsClosedBeforeResolutionOutsideThePackagedCompatibilityMatrix() {
+        assertDoesNotThrow(() -> JvmPayloadRequest.yamlValidator("4.21.0"));
+        assertDoesNotThrow(() -> JvmPayloadRequest.yamlValidator("4.18.3"));
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.yamlValidator("4.14.7"));
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.camelMain("4.14.7"));
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.citrus(
+                "4.21.0", "4.9.2", CitrusDependencyPolicy.required("4.9.2")));
+    }
+
+    @Test
+    void refusesARequestThatChangesTheControllerOwnedExclusionPolicy() {
+        JvmPayloadRequest citrus = JvmPayloadRequest.citrus(
+                "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2"));
+        List<DependencyRoot> changed = citrus.dependencyRoots().stream()
+                .map(root -> "citrus-camel".equals(root.artifactId())
+                        ? new DependencyRoot(root.groupId(), root.artifactId(), root.version(), List.of())
+                        : root)
+                .toList();
+
+        assertThrows(IllegalArgumentException.class, () -> new JvmPayloadRequest(
+                citrus.kind(), citrus.camelVersion(), citrus.citrusVersion(), citrus.launcherClass(), changed));
+    }
+
+    @Test
+    void authenticatedRuntimeRootsExtendMainAndCitrusPayloadLocksExactly() {
+        List<RuntimeDependency> runtime = List.of(
+                new RuntimeDependency("org.apache.camel", "camel-main", "4.21.0", "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-yaml-dsl", "4.21.0", "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-direct", "4.21.0", "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-csv", "4.21.0", "runtime"));
+
+        JvmPayloadRequest fixed = JvmPayloadRequest.camelMain("4.21.0");
+        JvmPayloadRequest main = JvmPayloadRequest.camelMain("4.21.0", runtime);
+        JvmPayloadRequest citrus = JvmPayloadRequest.citrus(
+                "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2"), runtime);
+
+        assertTrue(main.roots().contains("org.apache.camel:camel-csv:4.21.0"));
+        assertTrue(citrus.roots().contains("org.apache.camel:camel-csv:4.21.0"));
+        assertEquals(1, main.roots().stream()
+                .filter("org.apache.camel:camel-direct:4.21.0"::equals).count());
+        assertNotEquals(fixed.digest(), main.digest());
+        assertTrue(citrus.dependencyRoots().stream()
+                .filter(root -> "org.citrusframework".equals(root.groupId()))
+                .allMatch(root -> root.exclusions().equals(List.of(
+                        new DependencyExclusion("org.apache.camel", "*")))));
+    }
+
+    @Test
+    void runtimeRootsCannotConflictWithCoreOrIntroduceUnverifiedGroups() {
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.camelMain(
+                "4.21.0", List.of(new RuntimeDependency(
+                        "org.apache.camel", "camel-main", "4.20.0", "compile"))));
+        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.camelMain(
+                "4.21.0", List.of(new RuntimeDependency(
+                        "com.example", "unverified", "1.0.0", "compile"))));
+    }
+
+    @Test
+    void springBootAndQuarkusBuildsFailClosedInsteadOfFallingBackToMaven() {
+        JvmPayloadRequest spring = JvmPayloadRequest.runtimeBuild("spring-boot", "4.21.0");
+        JvmPayloadRequest quarkus = JvmPayloadRequest.runtimeBuild("quarkus", "4.18.2");
+
+        assertFalse(spring.kind().supported());
+        assertFalse(quarkus.kind().supported());
+        assertNull(spring.launcherClass());
+        assertNull(quarkus.launcherClass());
+        assertTrue(spring.roots().isEmpty());
+        assertTrue(quarkus.roots().isEmpty());
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadTestFixture.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadTestFixture.java
@@ -1,0 +1,33 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipOutputStream;
+
+/** Builds a content-valid, dependency-empty test fixture without consulting a repository. */
+public final class JvmPayloadTestFixture {
+
+    private JvmPayloadTestFixture() {
+    }
+
+    public static JvmPayloadArchive.Identity create(
+            Path directory, JvmPayloadRequest request, String jdkDigest)
+            throws IOException {
+        Files.createDirectories(directory);
+        List<JvmPayloadArchive.ArtifactFile> artifacts = new ArrayList<>();
+        int index = 0;
+        for (String root : request.roots()) {
+            String[] parts = root.split(":", -1);
+            Path jar = directory.resolve("root-" + index++ + ".jar");
+            try (ZipOutputStream ignored = new ZipOutputStream(Files.newOutputStream(jar))) {
+                // A valid empty JAR is enough: production verification validates real Central bytes.
+            }
+            artifacts.add(new JvmPayloadArchive.ArtifactFile(
+                    parts[0] + ':' + parts[1] + ":jar:" + parts[2], parts[1], parts[2], jar));
+        }
+        return JvmPayloadArchive.write(directory.resolve("payload.jar"), request, jdkDigest, artifacts);
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrapTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrapTest.java
@@ -1,0 +1,379 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.camel.component.stub.StubComponent;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogExpressionInventory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShipCamelMainBootstrapTest {
+
+    @TempDir
+    Path project;
+
+    @Test
+    void startsTheAcceptedRouteAndExercisesItsDirectBehavior() throws Exception {
+        Path route = write("""
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:orders
+                      steps:
+                        - setBody:
+                            simple: accepted-order
+                """);
+
+        ShipCamelMainBootstrap.withStarted(project, List.of(route), Set.of("orders"), context -> {
+            String response = context.createProducerTemplate()
+                    .requestBody("direct:orders", "new-order", String.class);
+            assertEquals("accepted-order", response);
+        });
+    }
+
+    @Test
+    void startsAnExactSafeGenericSimpleExpression() throws Exception {
+        Path route = write(routeWithExpression("""
+                language:
+                  language: simple
+                  expression: "accepted-${body}"
+                """));
+
+        ShipCamelMainBootstrap.withStarted(project, List.of(route), Set.of("orders"), context -> {
+            String response = context.createProducerTemplate()
+                    .requestBody("direct:orders", "new-order", String.class);
+            assertEquals("accepted-new-order", response);
+        });
+    }
+
+    @Test
+    void startsEveryAdmittedDotFreeRuntimeLookupWithoutBeanFallback() throws Exception {
+        List<String> expressions = List.of(
+                "${header.request-id}",
+                "${headers.request-id}",
+                "${exchangeProperty.correlation_id}",
+                "${variable.route-key}",
+                "${variables.route-key}");
+        for (String expression : expressions) {
+            Path route = write(validRoute().replace(
+                    "simple: accepted-order", "simple: \"" + expression + "\""));
+
+            ShipCamelMainBootstrap.withStarted(project, List.of(route), Set.of("orders"), context -> {
+                var exchange = context.createProducerTemplate().request("direct:orders", candidate -> {
+                    candidate.getMessage().setBody("new-order");
+                    candidate.getMessage().setHeader("request-id", "accepted-lookup");
+                    candidate.setProperty("correlation_id", "accepted-lookup");
+                    candidate.setVariable("route-key", "accepted-lookup");
+                });
+                assertEquals("accepted-lookup", exchange.getMessage().getBody(String.class), expression);
+            });
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void replacesEveryNonDirectEndpointWithTheInMemoryStubComponent() throws Exception {
+        Path route = write("""
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:orders
+                      steps:
+                        - to:
+                            uri: https://outside.example/orders
+                """);
+
+        ShipCamelMainBootstrap.withStarted(project, List.of(route), Set.of("orders"), context -> {
+            assertInstanceOf(StubComponent.class, context.getComponent("https"));
+            context.createProducerTemplate().sendBody("direct:orders", "new-order");
+        });
+    }
+
+    @Test
+    void replacesExternalConsumersWithTheControllerTestEntryBeforeStartup() throws Exception {
+        for (String source : List.of("kafka:orders", "file:inbox", "jms:queue:orders")) {
+            Path route = write(validRoute().replace("direct:orders", source));
+
+            ShipCamelMainBootstrap.withTestEntryPoint(
+                    project, List.of(route), Set.of("orders"), "orders", context -> {
+                        String response = context.createProducerTemplate().requestBody(
+                                ShipCamelMainBootstrap.testEntryUri("orders"), "new-order", String.class);
+                        assertEquals("accepted-order", response, source);
+                        assertInstanceOf(
+                                StubComponent.class,
+                                context.getComponent(source.substring(0, source.indexOf(':'))),
+                                source);
+                    });
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void reservesTheInjectedEndpointNamespace() throws Exception {
+        Path route = write(validRoute().replace(
+                "direct:orders", ShipCamelMainBootstrap.testEntryUri("orders")));
+
+        assertThrows(IOException.class,
+                () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")));
+    }
+
+    @Test
+    void rejectsUnapprovedTopicThresholdAndBooleanPlaceholders() throws Exception {
+        Path route = write("""
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:{{orders.input}}
+                      steps:
+                        - setBody:
+                            simple: "${body}"
+                        - delay:
+                            simple: "{{orders.delay}}"
+                        - setBody:
+                            simple: "{{orders.enabled}}"
+                """);
+
+        assertThrows(IOException.class,
+                () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")));
+    }
+
+    @Test
+    void rejectsDottedSimpleLookupKeysThatCamelCouldExecuteAsOgnl() throws Exception {
+        for (String expression : List.of(
+                "${header.control.stop}",
+                "${exchangeProperty.control.stop}",
+                "${exchangeProperties.clear}",
+                "${exchangeProperties.size}",
+                "${exchangeProperties.toString}",
+                "${variable.control.stop}",
+                "${header.foo.trim}")) {
+            Path route = write(validRoute().replace(
+                    "simple: accepted-order", "simple: \"" + expression + "\""));
+
+            assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")), expression);
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void rejectsYamlReferencesMultipleDocumentsAndDynamicJavaAccess() throws Exception {
+        for (String invalid : List.of(
+                validRoute().replace("direct:orders", "&endpoint direct:orders"),
+                validRoute().replace("direct:orders", "*endpoint"),
+                validRoute().replace("direct:orders", "!!java.lang.String direct:orders"),
+                validRoute() + "---\n" + validRoute().replace("orders", "hidden"),
+                validRoute().replace("simple: accepted-order", "simple: \"${body.class}\""),
+                validRoute().replace("simple: accepted-order", "simple: \"${type:java.lang.Runtime}\""),
+                validRoute().replace("simple: accepted-order", "simple: \"${bean:executor}\""),
+                validRoute().replace("simple: accepted-order", "simple:\n              expression: \"${body}\""),
+                validRoute().replace("simple: accepted-order", "bean:\n              ref: executor"),
+                validRoute().replace("simple: accepted-order", "script:\n              groovy: exit(0)"))) {
+            Path route = write(invalid);
+            assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")));
+        }
+    }
+
+    @Test
+    void rejectsUnexpectedOrMissingRouteIdsAndSnapshotEscapes() throws Exception {
+        Path route = write(validRoute());
+        Path outside = Files.writeString(project.getParent().resolve("outside.camel.yaml"), validRoute());
+
+        assertThrows(IOException.class,
+                () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("other")));
+        assertThrows(IOException.class,
+                () -> ShipCamelMainBootstrap.start(project, List.of(outside), Set.of("orders")));
+        assertThrows(IOException.class,
+                () -> ShipCamelMainBootstrap.start(project, List.of(route, route), Set.of("orders")));
+    }
+
+    @Test
+    void rejectsEveryCandidateRuntimeConfigurationSurface() throws Exception {
+        Path route = write(validRoute());
+        for (String relative : List.of(
+                "application.properties",
+                "config/application-dev.yml",
+                "src/main/resources/application.yaml",
+                "config/camel-main.properties")) {
+            Path extra = writeRelative(relative, "hidden=true\n");
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")), relative);
+            assertTrue(failure.getMessage().contains("runtime configuration")
+                    || failure.getMessage().contains("runtime resource"), failure::getMessage);
+            Files.delete(extra);
+        }
+    }
+
+    @Test
+    void rejectsAlternateLaunchInputsAcrossTheAcceptedCandidate() throws Exception {
+        Path route = write(validRoute());
+        for (String relative : List.of(
+                "hidden.camel.yaml",
+                "routes/orders.camel.xml",
+                "routes/orders.pipe.yaml",
+                "routes/orders.kamelet.yml",
+                "src/main/resources/META-INF/services/org.apache.camel.spi.ComponentResolver",
+                "src/main/resources/schema.xsd",
+                "src/main/java/example/Processor.java",
+                "lib/hidden.jar",
+                "target/classes/Hidden.class",
+                ".mvn/extensions.xml",
+                "build.gradle",
+                "bin/start.sh")) {
+            Path extra = writeRelative(relative, "untrusted\n");
+
+            assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")), relative);
+            Files.delete(extra);
+        }
+    }
+
+    @Test
+    void allowsOnlyTheBoundedNonRuntimeProjectSupportSurface() throws Exception {
+        Path route = writeRelative("src/main/resources/routes/orders.camel.yaml", validRoute());
+        writeRelative("pom.xml", "<project/>\n");
+        writeRelative(".camel-kit/config.properties", "project.runtime=main\n");
+        writeRelative("mvnw", "#!/bin/sh\n");
+        writeRelative("mvnw.cmd", "@echo off\r\n");
+        writeRelative("test/orders.camel.it.yaml", "name: orders\n");
+        writeRelative(".pi/extensions/camel-kit-ship.js", "export default {};\n");
+        writeRelative(".github/workflows/ci.yml", "name: ci\n");
+        writeRelative("README.md", "# Orders\n");
+
+        ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders"));
+    }
+
+    @Test
+    void rejectsEveryNonSimpleCatalogExpressionLanguage() throws Exception {
+        for (String language : CatalogExpressionInventory.catalogLanguages().stream()
+                .filter(value -> !CatalogExpressionInventory.SIMPLE.equals(value))
+                .sorted()
+                .toList()) {
+            Path route = write(String.format(Locale.ROOT, """
+                    - route:
+                        id: orders
+                        from:
+                          uri: direct:orders
+                          steps:
+                            - setBody:
+                                %s: accepted-order
+                    """, language));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")), language);
+            assertTrue(failure.getMessage().contains("only the Simple expression language"),
+                    failure::getMessage);
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void rejectsGenericConstantAndBeanMethodExpressions() throws Exception {
+        for (String expression : List.of(
+                """
+                        language:
+                          language: constant
+                          expression: accepted-order
+                        """,
+                "method: ordersBean")) {
+            Path route = write(routeWithExpression(expression));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")), expression);
+            assertTrue(failure.getMessage().contains("Simple expression language")
+                    || failure.getMessage().contains("select exactly Simple"), failure::getMessage);
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void rejectsMalformedAmbiguousAndUnsafeGenericExpressions() throws Exception {
+        for (String expression : List.of(
+                "language: simple",
+                "language:\n  language: simple",
+                "language:\n  expression: accepted-order",
+                "language:\n  language: [simple]\n  expression: accepted-order",
+                "language:\n  language: simple\n  expression: [accepted-order]",
+                "language:\n  language: simple\n  expression: accepted-order\n  trim: true",
+                "language:\n  language: simple\n  expression: accepted-order\nsimple: hidden",
+                "Language:\n  language: simple\n  expression: accepted-order",
+                "language:\n  language: simple\n  expression: \"${body.class}\"",
+                "language:\n  language: simple\n  language: simple\n  expression: accepted-order",
+                "language:\n  language: simple\n  expression: accepted-order\nlanguage:\n  language: simple\n  expression: hidden")) {
+            Path route = write(routeWithExpression(expression));
+
+            assertThrows(IOException.class,
+                    () -> ShipCamelMainBootstrap.start(project, List.of(route), Set.of("orders")), expression);
+            Files.delete(route);
+        }
+    }
+
+    @Test
+    void enforcesTheCanonicalAggregateRouteYamlByteLimitAtItsBoundary() throws Exception {
+        Path accepted = write(padWithComment(validRoute(), ShipArtifactLimits.MAX_ROUTE_YAML_BYTES));
+        assertEquals(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES, Files.size(accepted));
+        ShipCamelMainBootstrap.validatePolicy(accepted);
+
+        Path rejected = write(padWithComment(validRoute(), ShipArtifactLimits.MAX_ROUTE_YAML_BYTES + 1));
+        assertEquals(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES + 1L, Files.size(rejected));
+        assertThrows(IOException.class, () -> ShipCamelMainBootstrap.validatePolicy(rejected));
+    }
+
+    private Path write(String content) throws IOException {
+        return Files.writeString(
+                Files.createTempFile(project, "orders-", ".camel.yaml"), content);
+    }
+
+    private Path writeRelative(String relative, String content) throws IOException {
+        Path target = project.resolve(relative);
+        Files.createDirectories(target.getParent());
+        return Files.writeString(target, content);
+    }
+
+    private static String validRoute() {
+        return """
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:orders
+                      steps:
+                        - setBody:
+                            simple: accepted-order
+                """;
+    }
+
+    private static String routeWithExpression(String expression) {
+        String indented = expression.strip().lines()
+                .map(line -> "            " + line)
+                .reduce((left, right) -> left + '\n' + right)
+                .orElseThrow();
+        return """
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:orders
+                      steps:
+                        - setBody:
+                """ + indented + '\n';
+    }
+
+    private static String padWithComment(String source, int bytes) {
+        int padding = bytes - source.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        if (padding < 2) {
+            throw new IllegalArgumentException("Requested route fixture size is too small");
+        }
+        return source + '#' + "x".repeat(padding - 2) + '\n';
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrapTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelMainBootstrapTest.java
@@ -148,6 +148,62 @@ class ShipCamelMainBootstrapTest {
     }
 
     @Test
+    void acceptsEndpointSelectorPatternsWithoutTreatingThemAsEndpointUris() throws Exception {
+        Path route = write("- interceptFrom:\n    steps: []\n" + validRoute());
+        ShipCamelMainBootstrap.validatePolicy(route);
+
+        for (String operation : List.of("interceptFrom", "interceptSendToEndpoint")) {
+            for (String definition : List.of(
+                    "- " + operation + ": jms*",
+                    "- " + operation + ":\n    uri: jms*\n    steps: []")) {
+                route = write(definition + '\n' + validRoute());
+
+                ShipCamelMainBootstrap.validatePolicy(route);
+            }
+        }
+    }
+
+    @Test
+    void rejectsUnsafeOrMissingEndpointSelectorPatterns() throws Exception {
+        for (String operation : List.of("interceptFrom", "interceptSendToEndpoint")) {
+            for (String definition : List.of(
+                    "- " + operation + ": \"{{selector}}\"",
+                    "- " + operation + ":\n    uri: \"{{selector}}\"",
+                    "- " + operation + ":\n    uri: \"${body}\"",
+                    "- " + operation + ":\n    uri: \"#bean:selector\"")) {
+                Path route = write(definition + '\n' + validRoute());
+
+                assertThrows(IOException.class, () -> ShipCamelMainBootstrap.validatePolicy(route), definition);
+            }
+        }
+
+        Path missingRequiredPattern = write(
+                "- interceptSendToEndpoint:\n    steps: []\n" + validRoute());
+        assertThrows(IOException.class, () -> ShipCamelMainBootstrap.validatePolicy(missingRequiredPattern));
+    }
+
+    @Test
+    void startsEndpointSelectorsAndStubsTheConcreteAfterUri() throws Exception {
+        Path route = write("""
+                - interceptFrom:
+                    steps:
+                      - setBody:
+                          simple: intercepted
+                - interceptSendToEndpoint:
+                    uri: jms*
+                    afterUri: https://outside.example/orders
+                    steps:
+                      - setBody:
+                          simple: intercepted
+                """ + validRoute());
+
+        ShipCamelMainBootstrap.withStarted(project, List.of(route), Set.of("orders"), context -> {
+            assertInstanceOf(StubComponent.class, context.getComponent("https"));
+            assertFalse(context.getComponentNames().contains("jms"));
+        });
+    }
+
+    @Test
     void rejectsDottedSimpleLookupKeysThatCamelCouldExecuteAsOgnl() throws Exception {
         for (String expression : List.of(
                 "${header.control.stop}",

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelYamlValidateMainTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCamelYamlValidateMainTest.java
@@ -1,0 +1,61 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ShipCamelYamlValidateMainTest {
+
+    @TempDir
+    Path project;
+
+    @Test
+    void enforcesTheCanonicalAggregateRouteYamlByteLimitAtItsBoundary() throws Exception {
+        Path accepted = write("accepted.camel.yaml", padWithComment(
+                validRoute(), ShipArtifactLimits.MAX_ROUTE_YAML_BYTES));
+        assertEquals(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES, Files.size(accepted));
+        assertDoesNotThrow(() -> ShipCamelYamlValidateMain.validate(
+                project, List.of(accepted.toString())));
+
+        Path rejected = write("rejected.camel.yaml", padWithComment(
+                validRoute(), ShipArtifactLimits.MAX_ROUTE_YAML_BYTES + 1));
+        assertEquals(ShipArtifactLimits.MAX_ROUTE_YAML_BYTES + 1L, Files.size(rejected));
+        assertThrows(IOException.class, () -> ShipCamelYamlValidateMain.validate(
+                project, List.of(rejected.toString())));
+    }
+
+    private Path write(String name, String content) throws IOException {
+        return Files.writeString(project.resolve(name), content, StandardCharsets.UTF_8);
+    }
+
+    private static String validRoute() {
+        return """
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:orders
+                      steps:
+                        - setBody:
+                            simple: accepted-order
+                """;
+    }
+
+    private static String padWithComment(String value, int bytes) {
+        int padding = bytes - value.getBytes(StandardCharsets.UTF_8).length;
+        if (padding < 2) {
+            throw new IllegalArgumentException("Target byte size is too small");
+        }
+        return value + '#' + "x".repeat(padding - 2) + '\n';
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCitrusYamlMainTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipCitrusYamlMainTest.java
@@ -1,0 +1,306 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShipCitrusYamlMainTest {
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void acceptsOnlyOneLiteralSynchronousCamelBehaviorAssertion() throws Exception {
+        ShipCitrusYamlMain.TestContract contract = ShipCitrusYamlMain.inspect(write(validTest()), "orders");
+
+        assertEquals("orders-behavior", contract.name());
+        assertEquals("camel:sync:direct:camel-kit-ship-test-orders", contract.endpoint());
+        assertEquals(1, contract.cases().size());
+        assertEquals("new-order", contract.cases().get(0).requestBody());
+        assertEquals("accepted-order", contract.cases().get(0).responseBody());
+        assertTrue(contract.cases().get(0).requestHeaders().isEmpty());
+        assertTrue(contract.cases().get(0).responseHeaders().isEmpty());
+    }
+
+    @Test
+    void acceptsBoundedLiteralAcceptanceMatrixWithApplicationHeaders() throws Exception {
+        ShipCitrusYamlMain.TestContract contract = ShipCitrusYamlMain.inspect(write(matrixTest()), "orders");
+
+        assertEquals(2, contract.cases().size());
+        assertEquals(List.of(
+                new ShipCitrusYamlMain.Header("requestId", "req-1"),
+                new ShipCitrusYamlMain.Header("timestamp", "2026-07-17T10:15:30Z"),
+                new ShipCitrusYamlMain.Header("strategy", "priority")),
+                contract.cases().get(0).requestHeaders());
+        assertEquals(List.of(new ShipCitrusYamlMain.Header("requestId", "req-1")),
+                contract.cases().get(0).responseHeaders());
+        assertEquals("standard-order", contract.cases().get(1).requestBody());
+        assertEquals("accepted-standard", contract.cases().get(1).responseBody());
+    }
+
+    @Test
+    void enforcesCompleteAlternatingCasesAndActionBounds() throws Exception {
+        assertEquals(ShipCitrusYamlMain.MAX_CASES,
+                ShipCitrusYamlMain.inspect(write(testWithCases(ShipCitrusYamlMain.MAX_CASES)), "orders")
+                        .cases().size());
+
+        for (String invalid : List.of(
+                validTest().replace("  - receive:", "  - send:"),
+                validTest() + sendAction("extra"),
+                testWithCases(ShipCitrusYamlMain.MAX_CASES + 1))) {
+            assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(write(invalid), "orders"));
+        }
+    }
+
+    @Test
+    void rejectsUnsafeDuplicateNonLiteralAndOversizedHeaders() throws Exception {
+        String maxHeaders = java.util.stream.IntStream
+                .range(0, ShipCitrusYamlMain.MAX_HEADERS_PER_ACTION)
+                .mapToObj(index -> "          - name: header" + index + "\n            value: value\n")
+                .collect(java.util.stream.Collectors.joining());
+        ShipCitrusYamlMain.inspect(write(withRequestHeaders(maxHeaders)), "orders");
+
+        String tooManyHeaders = maxHeaders
+                                + "          - name: overflow\n            value: value\n";
+        for (String headers : List.of(
+                "          - name: requestId\n            value: one\n"
+                                      + "          - name: RequestId\n            value: two\n",
+                "          - name: _requestId\n            value: one\n",
+                "          - name: " + "h".repeat(129) + "\n            value: one\n",
+                "          - name: CamelHttpUri\n            value: hidden\n",
+                "          - name: citrus_camel_exchange_pattern\n            value: InOnly\n",
+                "          - name: requestId\n            value: 42\n",
+                "          - name: requestId\n            value: true\n",
+                "          - name: requestId\n            value: null\n",
+                "          - name: requestId\n            value: [one]\n",
+                "          - name: requestId\n            value: \"line\\nbreak\"\n",
+                "          - name: requestId\n            value: \"" + "x".repeat(
+                        ShipCitrusYamlMain.MAX_HEADER_VALUE_CHARS + 1) + "\"\n",
+                "          - name: requestId\n            value: one\n            type: java.lang.String\n",
+                tooManyHeaders)) {
+            assertThrows(IOException.class,
+                    () -> ShipCitrusYamlMain.inspect(write(withRequestHeaders(headers)), "orders"));
+        }
+        assertThrows(IOException.class,
+                () -> ShipCitrusYamlMain.inspect(write(withRequestHeaders("")), "orders"));
+    }
+
+    @Test
+    void rejectsOversizedLiteralBodies() throws Exception {
+        String invalid = validTest().replace(
+                "data: new-order", "data: " + "x".repeat(ShipCitrusYamlMain.MAX_BODY_CHARS + 1));
+
+        assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(write(invalid), "orders"));
+    }
+
+    @Test
+    void acceptsOrdinaryLiteralContentThatOnlyLooksLikeCodeOrAResource() throws Exception {
+        String literal = "description script for user@example.test at https://example.test/file:payload.class";
+        Path test = write(validTest().replace("accepted-order", '"' + literal + '"'));
+
+        ShipCitrusYamlMain.TestContract contract = ShipCitrusYamlMain.inspect(test, "orders");
+
+        assertEquals(literal, contract.cases().get(0).responseBody());
+    }
+
+    @Test
+    void rejectsOnlyActualDynamicExpressionsAndAssertionBypasses() throws Exception {
+        for (String bypass : List.of(
+                "${variable}", "#{bean}", "{{property}}", "citrus:readFileResource(payload.txt)",
+                "@ignore@", "@matches(.*)@")) {
+            Path test = write(validTest().replace("accepted-order", bypass));
+            assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(test, "orders"), bypass);
+        }
+    }
+
+    @Test
+    void enforcesTheCanonicalAggregateCitrusYamlByteLimitAtItsBoundary() throws Exception {
+        Path accepted = write(padWithComment(validTest(), ShipArtifactLimits.MAX_CITRUS_YAML_BYTES));
+        assertEquals(ShipArtifactLimits.MAX_CITRUS_YAML_BYTES, Files.size(accepted));
+        ShipCitrusYamlMain.inspect(accepted, "orders");
+
+        Path rejected = write(padWithComment(validTest(), ShipArtifactLimits.MAX_CITRUS_YAML_BYTES + 1));
+        assertEquals(ShipArtifactLimits.MAX_CITRUS_YAML_BYTES + 1L, Files.size(rejected));
+        assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(rejected, "orders"));
+    }
+
+    @Test
+    void rejectsEndpointAndActionShapeBypasses() throws Exception {
+        for (String invalid : List.of(
+                validTest().replace("camel:sync:direct:camel-kit-ship-test-orders", "camel:sync:http:example.test"),
+                validTest().replace("camel:sync:direct:camel-kit-ship-test-orders", "camel:direct:orders"),
+                validTest().replace(
+                        "camel:sync:direct:camel-kit-ship-test-orders", "camel:sync:direct:other"),
+                validTest().replaceFirst(
+                        "camel:sync:direct:camel-kit-ship-test-orders", "camel:sync:direct:other"),
+                validTest().replace(
+                        "endpoint: \"camel:sync:direct:camel-kit-ship-test-orders\"",
+                        "endpoint:\n        uri: \"camel:sync:direct:camel-kit-ship-test-orders\""),
+                validTest().replaceFirst("  - send:", "  - receive:"),
+                validTest().replace("  - receive:", "  - send:"),
+                validTest().replace("  - receive:", "  - echo:"),
+                validTest().replace("actions:\n", "actions:\n  - send:\n      endpoint: other\n"))) {
+            assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(write(invalid), "orders"));
+        }
+    }
+
+    @Test
+    void rejectsExtensionsResourcesPlaceholdersAndMultipleDocuments() throws Exception {
+        for (String invalid : List.of(
+                validTest().replace("actions:", "beans: []\nactions:"),
+                validTest().replace("actions:", "endpoints: []\nactions:"),
+                validTest().replace("actions:", "description: hidden\nactions:"),
+                validTest().replace("data: accepted-order", "resource:\n            file: classpath:test.txt"),
+                validTest().replace("data: accepted-order", "data: &response accepted-order"),
+                validTest().replace("data: new-order", "data: *response"),
+                validTest().replace("data: accepted-order", "data: !!java.lang.String accepted-order"),
+                validTest() + "---\nname: hidden\nactions: []\n",
+                validTest().replace("name: orders-behavior", "name: orders behavior"),
+                validTest().replace("name: orders-behavior", "name: ${name}"))) {
+            assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(write(invalid), "orders"));
+        }
+    }
+
+    @Test
+    void rejectsDuplicateFieldsAndNonLiteralBodies() throws Exception {
+        for (String invalid : List.of(
+                validTest().replace("name: orders-behavior", "name: one\nname: two"),
+                validTest().replace("data: accepted-order", "data: accepted-order\n          data: hidden"),
+                validTest().replace("data: accepted-order", "data: 42"),
+                validTest().replace("data: accepted-order", "data: true"),
+                validTest().replace("data: accepted-order", "data: \"\""),
+                validTest().replace("message:\n        body:", "message:\n        headers: []\n        body:"))) {
+            assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(write(invalid), "orders"));
+        }
+    }
+
+    @Test
+    void bindsTheLiteralEndpointToTheDeclaredRoute() throws Exception {
+        Path test = write(validTest());
+
+        assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(test, "other"));
+        assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(test, "orders/escape"));
+        assertThrows(IOException.class, () -> ShipCitrusYamlMain.inspect(
+                write(replaceLast(
+                        matrixTest(),
+                        "camel:sync:direct:camel-kit-ship-test-orders",
+                        "camel:sync:direct:other")),
+                "orders"));
+    }
+
+    private Path write(String content) throws IOException {
+        Path file = Files.createTempFile(directory, "orders-", ".camel.it.yaml");
+        return Files.writeString(file, content);
+    }
+
+    private static String validTest() {
+        return """
+                name: orders-behavior
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: new-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: accepted-order
+                """;
+    }
+
+    private static String matrixTest() {
+        return """
+                name: orders-matrix
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        headers:
+                          - name: requestId
+                            value: req-1
+                          - name: timestamp
+                            value: "2026-07-17T10:15:30Z"
+                          - name: strategy
+                            value: priority
+                        body:
+                          data: priority-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        headers:
+                          - name: requestId
+                            value: req-1
+                        body:
+                          data: accepted-priority
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: standard-order
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: accepted-standard
+                """;
+    }
+
+    private static String testWithCases(int count) {
+        StringBuilder yaml = new StringBuilder("name: orders-matrix\nactions:\n");
+        for (int index = 0; index < count; index++) {
+            yaml.append(sendAction("request-")).append(index).append('\n')
+                    .append(receiveAction("response-")).append(index).append('\n');
+        }
+        return yaml.toString();
+    }
+
+    private static String sendAction(String body) {
+        return String.format(Locale.ROOT, """
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: %s
+                """, body).stripTrailing();
+    }
+
+    private static String receiveAction(String body) {
+        return String.format(Locale.ROOT, """
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: %s
+                """, body).stripTrailing();
+    }
+
+    private static String withRequestHeaders(String entries) {
+        return validTest().replace(
+                "      message:\n        body:\n          data: new-order",
+                "      message:\n        headers:\n" + entries + "        body:\n          data: new-order");
+    }
+
+    private static String replaceLast(String source, String value, String replacement) {
+        int index = source.lastIndexOf(value);
+        return source.substring(0, index) + replacement + source.substring(index + value.length());
+    }
+
+    private static String padWithComment(String source, int bytes) {
+        int padding = bytes - source.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        if (padding < 2) {
+            throw new IllegalArgumentException("Requested Citrus fixture size is too small");
+        }
+        return source + '#' + "x".repeat(padding - 2) + '\n';
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipMainPackageMainTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/launcher/ShipMainPackageMainTest.java
@@ -1,0 +1,180 @@
+package io.github.luigidemasi.camelkit.ship.evidence.launcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShipMainPackageMainTest {
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void repeatedPackagingProducesIdenticalBytesAndExactRouteEntries() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path nested = Files.createDirectories(project.resolve("route bundles"));
+        Path beta = Files.writeString(project.resolve("beta.camel.yaml"), "- route: {id: beta}\n");
+        Path alpha = Files.writeString(nested.resolve("alpha.camel.yaml"), "- route: {id: alpha}\n");
+        List<String> arguments = arguments(
+                new Route("route bundles/alpha.camel.yaml", digest(alpha)),
+                new Route("beta.camel.yaml", digest(beta)));
+        Path first = directory.resolve("first.jar");
+        Path second = directory.resolve("second.jar");
+
+        ShipMainPackageMain.Summary firstSummary
+                = ShipMainPackageMain.packageAndInspect(project, first, arguments);
+        ShipMainPackageMain.Summary secondSummary
+                = ShipMainPackageMain.packageAndInspect(project, second, arguments);
+
+        assertArrayEquals(Files.readAllBytes(first), Files.readAllBytes(second));
+        assertEquals(firstSummary, secondSummary);
+        assertEquals(digest(first), firstSummary.packageDigest());
+        assertEquals(List.of("beta.camel.yaml", "route bundles/alpha.camel.yaml"), entryNames(first));
+        assertEquals(firstSummary, ShipMainPackageMain.Summary.parse(firstSummary.encode()));
+        assertEquals(firstSummary, ShipMainPackageMain.verifySummary(firstSummary.encode(), project, arguments));
+        assertTrue(
+                ShipMainPackageMain.MAX_PACKAGE_BYTES
+                   > (long) ShipMainPackageMain.MAX_ROUTES
+                     * (io.github.luigidemasi.camelkit.ship.ShipArtifactLimits.MAX_ROUTE_YAML_BYTES
+                        + 2L * ShipMainPackageMain.MAX_ROUTE_PATH_CHARACTERS * 4),
+                "the archive cap must cover route bytes and worst-case duplicated ZIP path names");
+        assertTrue(
+                ShipMainPackageMain.MAX_SUMMARY_BYTES
+                   > (long) ShipMainPackageMain.MAX_ROUTES
+                     * ((ShipMainPackageMain.MAX_ROUTE_PATH_CHARACTERS * 4L + 2) / 3 * 4),
+                "the summary cap must cover every worst-case base64-encoded route path");
+    }
+
+    @Test
+    void rejectsMissingDuplicateTraversalSymlinkMutationAndExtraRoutes() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path route = Files.writeString(project.resolve("orders.camel.yaml"), "- route: {id: orders}\n");
+        Route accepted = new Route("orders.camel.yaml", digest(route));
+
+        assertThrows(IOException.class, () -> ShipMainPackageMain.packageAndInspect(
+                project, directory.resolve("zero.jar"), bindings()));
+
+        List<String> duplicate = arguments(accepted, accepted);
+        assertThrows(IOException.class, () -> ShipMainPackageMain.packageAndInspect(
+                project, directory.resolve("duplicate.jar"), duplicate));
+
+        List<String> traversal = new ArrayList<>(bindings());
+        traversal.add("--route=../orders.camel.yaml");
+        traversal.add("--route-digest=" + accepted.digest());
+        assertThrows(IOException.class, () -> ShipMainPackageMain.packageAndInspect(
+                project, directory.resolve("traversal.jar"), traversal));
+
+        List<String> mutated = arguments(new Route(accepted.path(), sha(99)));
+        assertThrows(IOException.class, () -> ShipMainPackageMain.packageAndInspect(
+                project, directory.resolve("mutated.jar"), mutated));
+
+        Path linked = project.resolve("linked.camel.yaml");
+        Files.createSymbolicLink(linked, route.getFileName());
+        assertThrows(IOException.class, () -> ShipMainPackageMain.packageAndInspect(
+                project, directory.resolve("symlink.jar"), arguments(accepted)));
+        Files.delete(linked);
+
+        Files.writeString(project.resolve("extra.camel.yaml"), "- route: {id: extra}\n");
+        assertThrows(IOException.class, () -> ShipMainPackageMain.packageAndInspect(
+                project, directory.resolve("extra.jar"), arguments(accepted)));
+    }
+
+    @Test
+    void rejectsPreexistingAndTamperedPackageOutputsAndSummaries() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path route = Files.writeString(project.resolve("orders.camel.yaml"), "- route: {id: orders}\n");
+        List<String> arguments = arguments(new Route("orders.camel.yaml", digest(route)));
+        Path archive = Files.writeString(directory.resolve("occupied.jar"), "occupied");
+
+        assertThrows(IOException.class,
+                () -> ShipMainPackageMain.packageAndInspect(project, archive, arguments));
+
+        Files.delete(archive);
+        ShipMainPackageMain.Summary summary
+                = ShipMainPackageMain.packageAndInspect(project, archive, arguments);
+        rewrite(archive, "../escaped.camel.yaml", Files.readAllBytes(route));
+        assertThrows(IOException.class,
+                () -> ShipMainPackageMain.inspectPackage(project, archive, arguments));
+
+        byte[] unknownField = (new String(summary.encode(), java.nio.charset.StandardCharsets.UTF_8)
+                               + "unexpected=value\n")
+                .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertThrows(IOException.class, () -> ShipMainPackageMain.verifySummary(
+                unknownField, project, arguments));
+        byte[] wrongBinding = new String(summary.encode(), java.nio.charset.StandardCharsets.UTF_8)
+                .replace(sha(1), sha(90))
+                .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertThrows(IOException.class, () -> ShipMainPackageMain.verifySummary(
+                wrongBinding, project, arguments));
+
+        assertThrows(IOException.class, () -> ShipMainPackageMain.verifySummary(
+                new byte[ShipMainPackageMain.MAX_SUMMARY_BYTES + 1], project, arguments));
+    }
+
+    private static List<String> bindings() {
+        return new ArrayList<>(
+                List.of(
+                        "--candidate-digest=" + sha(1),
+                        "--manifest-digest=" + sha(2),
+                        "--catalog-usage-digest=" + sha(3),
+                        "--pom-digest=" + sha(4),
+                        "--main-payload-digest=" + sha(5)));
+    }
+
+    private static List<String> arguments(Route... routes) {
+        List<String> arguments = bindings();
+        for (Route route : routes) {
+            arguments.add("--route=" + route.path());
+            arguments.add("--route-digest=" + route.digest());
+        }
+        return arguments;
+    }
+
+    private static List<String> entryNames(Path archive) throws IOException {
+        try (ZipFile zip = new ZipFile(archive.toFile())) {
+            List<String> result = new ArrayList<>();
+            Enumeration<? extends ZipEntry> entries = zip.entries();
+            while (entries.hasMoreElements()) {
+                result.add(entries.nextElement().getName());
+            }
+            return result;
+        }
+    }
+
+    private static void rewrite(Path archive, String name, byte[] bytes) throws IOException {
+        Files.delete(archive);
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(archive))) {
+            ZipEntry entry = new ZipEntry(name);
+            entry.setTime(0);
+            zip.putNextEntry(entry);
+            zip.write(bytes);
+            zip.closeEntry();
+        }
+    }
+
+    private static String digest(Path path) throws Exception {
+        return "sha256:" + HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path)));
+    }
+
+    private static String sha(int seed) {
+        return "sha256:" + String.format(Locale.ROOT, "%064x", seed);
+    }
+
+    private record Route(String path, String digest) {
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ledger/LedgerValidatorTest.java
@@ -1,0 +1,586 @@
+package io.github.luigidemasi.camelkit.ship.ledger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Assumption;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Category;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Claim;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Conflict;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Entry;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.GapReviewStatus;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Question;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RouteContract;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.SourceRef;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LedgerValidatorTest {
+
+    private static final String CITRUS_VERSION = "5.0.0-M2";
+    private static final List<String> CITRUS_DEPENDENCIES = List.of(
+            "org.citrusframework:citrus-camel:5.0.0-M2",
+            "org.citrusframework:citrus-junit-jupiter:5.0.0-M2",
+            "org.citrusframework:citrus-yaml:5.0.0-M2");
+
+    @Test
+    void nullLedgerFailsClosedWithValidationError() {
+        LedgerValidationException analysis = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateAnalysis(null));
+        LedgerValidationException ready = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateReady(null));
+
+        assertTrue(analysis.getMessage().contains("Decision ledger is required"));
+        assertTrue(ready.getMessage().contains("Decision ledger is required"));
+    }
+
+    @Test
+    void acceptsCompleteLedgerOnlyAfterGapReview() {
+        assertDoesNotThrow(() -> LedgerValidator.validateReady(readyLedger()));
+    }
+
+    @Test
+    void citrusPolicyMustMatchItsResolvedVersionAndDependencyDecisions() {
+        DecisionLedger ready = readyLedger();
+
+        LedgerValidationException version = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(withDecisionValue(
+                        ready, "citrus-version", "5.0.0-M1")));
+        assertTrue(version.getMessage().contains(
+                "Implementation policy citrus-version does not match the resolved ledger value"));
+
+        LedgerValidationException dependencies = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(withDecisionValue(
+                        ready, "citrus-dependencies", CITRUS_DEPENDENCIES.get(0))));
+        assertTrue(dependencies.getMessage().contains(
+                "Implementation policy citrus-dependencies does not match the resolved ledger values"));
+    }
+
+    @Test
+    void rejectsMissingRequiredCategory() {
+        DecisionLedger ready = readyLedger();
+        DecisionLedger incomplete = copy(ready, ready.completeness().stream()
+                .filter(category -> !"runtime".equals(category.id()))
+                .toList(), ready.decisions(), List.of(), List.of(), GapReviewStatus.PASSED);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateReady(incomplete));
+
+        assertTrue(error.getMessage().contains("Missing completeness category: runtime"));
+    }
+
+    @Test
+    void rejectsSilentRecommendationAsResolvedDecision() {
+        DecisionLedger ready = readyLedger();
+        List<Entry> decisions = new ArrayList<>(
+                ready.decisions().stream()
+                        .filter(entry -> !"runtime".equals(entry.category()))
+                        .toList());
+        decisions.add(new Entry(
+                "decision-runtime", "runtime", null, LedgerStatus.NEEDS_USER_DECISION,
+                List.of(), "Camel Main is recommended"));
+        DecisionLedger incomplete = copy(
+                ready, ready.completeness(), decisions, List.of(), List.of("decision-runtime"), GapReviewStatus.PASSED);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateReady(incomplete));
+
+        assertTrue(error.getMessage().contains("Blocking ledger items remain"));
+        assertTrue(error.getMessage().contains("Open or undecided ledger items remain"));
+    }
+
+    @Test
+    void conflictsAndAssumptionsCannotSelfAttestResolution() {
+        DecisionLedger ready = readyLedger();
+        SourceRef source = source();
+        DecisionLedger invalid = new DecisionLedger(
+                ready.schemaVersion(), ready.revision(), ready.facts(), ready.decisions(),
+                List.of(new Conflict(
+                        "conflict-runtime", "runtime",
+                        List.of(new Claim("main", source), new Claim("spring-boot", source)),
+                        LedgerStatus.RESOLVED, "worker chose one claim")),
+                List.of(new Assumption(
+                        "assumption-runtime", "runtime", "main", LedgerStatus.RESOLVED,
+                        List.of(source), "worker accepted its recommendation")),
+                ready.catalogEvidence(), ready.openQuestions(), ready.completeness(),
+                ready.blockingOpenItemIds(), ready.gapReviewStatus(), ready.requirementsPolicy());
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateAnalysis(invalid));
+
+        assertTrue(error.getMessage().contains(
+                "conflict conflict-runtime must remain open until a controller-recorded answer replaces it"));
+        assertTrue(error.getMessage().contains(
+                "assumption assumption-runtime must remain open until a controller-recorded answer replaces it"));
+    }
+
+    @Test
+    void acceptsExactlyOneQuestionForAnOpenItem() {
+        Entry decision = new Entry(
+                "decision-runtime", "runtime", null, LedgerStatus.NEEDS_USER_DECISION,
+                List.of(), "Camel Main is recommended");
+        Question question = new Question(
+                "question-runtime", decision.id(), "Which runtime should host the integration?",
+                List.of("main", "spring-boot", "quarkus"), "main", LedgerStatus.OPEN);
+        DecisionLedger ledger = new DecisionLedger(
+                1, 1, List.of(), List.of(decision), List.of(), List.of(), List.of(), List.of(question),
+                categories(LedgerStatus.OPEN), List.of(decision.id()), GapReviewStatus.NOT_RUN, null);
+
+        assertDoesNotThrow(() -> LedgerValidator.validateAnalysis(ledger));
+    }
+
+    @Test
+    void rejectsBatchedQuestions() {
+        Entry runtime = new Entry(
+                "decision-runtime", "runtime", null, LedgerStatus.OPEN, List.of(), null);
+        Entry dsl = new Entry("decision-dsl", "dsl", null, LedgerStatus.OPEN, List.of(), null);
+        DecisionLedger ledger = new DecisionLedger(
+                1, 1, List.of(), List.of(runtime, dsl), List.of(), List.of(), List.of(),
+                List.of(
+                        new Question("q-runtime", runtime.id(), "Runtime?", List.of(), null, LedgerStatus.OPEN),
+                        new Question("q-dsl", dsl.id(), "DSL?", List.of(), null, LedgerStatus.OPEN)),
+                categories(LedgerStatus.OPEN), List.of(runtime.id(), dsl.id()), GapReviewStatus.NOT_RUN, null);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateAnalysis(ledger));
+
+        assertTrue(error.getMessage().contains("At most one blocking discovery question"));
+    }
+
+    @Test
+    void rejectsQuestionForAlreadyResolvedItem() {
+        Entry runtime = new Entry(
+                "decision-runtime", "runtime", "main", LedgerStatus.RESOLVED, List.of(), null);
+        Question question = new Question(
+                "q-runtime", runtime.id(), "Runtime?", List.of(), null, LedgerStatus.OPEN);
+        DecisionLedger ledger = new DecisionLedger(
+                1, 1, List.of(), List.of(runtime), List.of(), List.of(), List.of(), List.of(question),
+                categories(LedgerStatus.OPEN), List.of(), GapReviewStatus.NOT_RUN, null);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateAnalysis(ledger));
+
+        assertTrue(error.getMessage().contains("does not reference an open ledger item"));
+    }
+
+    @Test
+    void resolvedSingleValuedChoiceCannotBeReaskedThroughAFreshItemId() {
+        Entry resolved = new Entry(
+                "decision-runtime", "runtime", "main", LedgerStatus.RESOLVED,
+                List.of(source()), null);
+        Assumption fresh = new Assumption(
+                "runtime-choice-again", "runtime", "spring-boot", LedgerStatus.NEEDS_USER_DECISION,
+                List.of(source()), "worker attempted to reopen a settled choice");
+        Question question = new Question(
+                "question-runtime-again", fresh.id(), "Which runtime?",
+                List.of("main", "spring-boot"), "main", LedgerStatus.OPEN);
+        DecisionLedger ledger = new DecisionLedger(
+                1, 2, List.of(), List.of(resolved), List.of(), List.of(fresh), List.of(), List.of(question),
+                List.of(new Category("runtime", LedgerStatus.RESOLVED, null, List.of(source()))),
+                List.of(fresh.id()), GapReviewStatus.NOT_RUN, null);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateAnalysis(ledger));
+
+        assertTrue(error.getMessage().contains(
+                "Resolved single-valued category cannot be reopened with another item: runtime"));
+    }
+
+    @Test
+    void notApplicableCategoryRequiresRationale() {
+        DecisionLedger ready = readyLedger();
+        List<Category> categories = ready.completeness().stream()
+                .map(category -> "deployment".equals(category.id())
+                        ? new Category(category.id(), LedgerStatus.NOT_APPLICABLE, null, List.of())
+                        : category)
+                .toList();
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(copy(
+                        ready, categories, ready.decisions(), List.of(), List.of(), GapReviewStatus.PASSED)));
+
+        assertTrue(error.getMessage().contains("Not-applicable category requires a rationale: deployment"));
+    }
+
+    @Test
+    void requiresRouteAndCitrusBasenamesToMatchTheRouteIdExactly() {
+        DecisionLedger ready = readyLedger();
+        RequirementsPolicy policy = new RequirementsPolicy(
+                "main", "4.21.0", null, null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/order-route.camel.yaml",
+                        "test/order-test.camel.it.yaml")),
+                true, true);
+        DecisionLedger invalid = withPolicy(ready, policy);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class, () -> LedgerValidator.validateReady(invalid));
+
+        assertTrue(error.getMessage().contains("Route contract path must be named exactly orders.camel.yaml"));
+        assertTrue(error.getMessage().contains(
+                "Citrus contract path must be exactly test/orders.camel.it.yaml"));
+    }
+
+    @Test
+    void rejectsRouteIdThatIsNotASafeFileSegment() {
+        DecisionLedger ready = readyLedger();
+        RequirementsPolicy policy = new RequirementsPolicy(
+                "main", "4.21.0", null, null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders/hidden", "src/main/resources/routes/orders/hidden.camel.yaml",
+                        "test/orders/hidden.camel.it.yaml")),
+                true, true);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(withPolicy(ready, policy)));
+
+        assertTrue(error.getMessage().contains("invalid or duplicate route ID"));
+    }
+
+    @Test
+    void rejectsRouteIdThatCannotFormTheReservedTestEndpoint() {
+        DecisionLedger ready = readyLedger();
+        RequirementsPolicy policy = new RequirementsPolicy(
+                "main", "4.21.0", null, null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders route", "src/main/resources/routes/orders route.camel.yaml",
+                        "test/orders route.camel.it.yaml")),
+                true, true);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(withPolicy(ready, policy)));
+
+        assertTrue(error.getMessage().contains("invalid or duplicate route ID"));
+    }
+
+    @Test
+    void springBootPolicyRequiresExplicitFrameworkVersion() {
+        DecisionLedger ready = readyLedger();
+        RequirementsPolicy policy = new RequirementsPolicy(
+                "spring-boot", "4.21.0", "4.21.0", null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(withPolicy(ready, policy)));
+
+        assertTrue(error.getMessage().contains("Spring Boot policies require an explicit Spring Boot version"));
+    }
+
+    @Test
+    void nonSpringPolicyRejectsSpringBootFrameworkVersion() {
+        DecisionLedger ready = readyLedger();
+        RequirementsPolicy policy = new RequirementsPolicy(
+                "main", "4.21.0", null, "4.1.0", "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+
+        LedgerValidationException error = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateReady(withPolicy(ready, policy)));
+
+        assertTrue(error.getMessage().contains("Spring Boot version is valid only for the spring-boot runtime"));
+    }
+
+    @Test
+    void catalogGateAcceptsOnlyResolvedRuntimeSpecificVersionPolicy() {
+        assertDoesNotThrow(() -> LedgerValidator.validateCatalogPrerequisites(
+                catalogLedger("main", "4.21.0", null, null)));
+
+        LedgerValidationException missingSpringVersions = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateCatalogPrerequisites(
+                        catalogLedger("spring-boot", "4.21.0", null, null)));
+        assertTrue(missingSpringVersions.getMessage().contains("explicit platform version"));
+        assertTrue(missingSpringVersions.getMessage().contains("explicit Spring Boot version"));
+
+        LedgerValidationException spring = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateCatalogPrerequisites(
+                        catalogLedger("spring-boot", "4.21.0", "4.21.0", "3.5.0")));
+        assertTrue(spring.getMessage().contains("direct startup evidence only for the Camel Main runtime"));
+
+        LedgerValidationException quarkus = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateCatalogPrerequisites(
+                        catalogLedger("quarkus", "4.21.0", "3.23.0", null)));
+        assertTrue(quarkus.getMessage().contains("direct startup evidence only for the Camel Main runtime"));
+
+        DecisionLedger bound = catalogLedger("spring-boot", "4.21.0", "4.21.0", "3.5.0");
+        RequirementsPolicy mismatched = new RequirementsPolicy(
+                "spring-boot", "4.21.0", "3.23.0", "3.5.0",
+                null, null, null, List.of(), null, List.of(), List.of(), false, false);
+        LedgerValidationException mismatch = assertThrows(
+                LedgerValidationException.class,
+                () -> LedgerValidator.validateCatalogPrerequisites(withPolicy(bound, mismatched)));
+        assertTrue(mismatch.getMessage().contains(
+                "platform-version does not match the resolved ledger value"));
+    }
+
+    @Test
+    void candidateReadyRejectsEveryRuntimeTupleOutsideTheExactEvidenceMatrix() {
+        for (DecisionLedger unsupported : List.of(
+                readyLedger("main", "4.14.7", null, null),
+                readyLedger("spring-boot", "4.21.0", "4.21.0", "4.1.0"),
+                readyLedger("quarkus", "4.18.3", "3.33.1", null))) {
+            LedgerValidationException error = assertThrows(
+                    LedgerValidationException.class,
+                    () -> LedgerValidator.validateCandidateReady(unsupported));
+
+            assertTrue(error.getMessage().contains("direct startup evidence")
+                    || error.getMessage().contains("direct YAML/startup evidence payload"),
+                    error::getMessage);
+        }
+    }
+
+    @Test
+    void candidateReadyRejectsEveryExpressionLanguageOtherThanSimple() {
+        DecisionLedger ready = readyLedger();
+        for (String language : List.of("constant", "csimple", "jsonpath", "xpath")) {
+            RequirementsPolicy baseline = ready.requirementsPolicy();
+            RequirementsPolicy policy = new RequirementsPolicy(
+                    baseline.runtime(), baseline.camelVersion(), baseline.platformVersion(),
+                    baseline.springBootVersion(), baseline.routeDsl(), language,
+                    baseline.citrusVersion(), baseline.citrusDependencies(), baseline.javaPolicy(),
+                    baseline.approvedJavaExceptions(), baseline.routes(), baseline.citrusTestsRequired(),
+                    baseline.oneCitrusTestPerRoute());
+
+            LedgerValidationException error = assertThrows(
+                    LedgerValidationException.class,
+                    () -> LedgerValidator.validateCandidateReady(withPolicy(ready, policy)), language);
+
+            assertTrue(error.getMessage().contains(
+                    "Ship protocol v1 supports only the Simple expression language"), error::getMessage);
+        }
+    }
+
+    @Test
+    void rejectsBlankOrOversizedExactSourceExcerpts() {
+        for (String excerpt : List.of(" ", "x".repeat(LedgerValidator.MAX_SOURCE_EXCERPT_CHARS + 1))) {
+            SourceRef invalidSource = new SourceRef(
+                    "source-test", "test", "sha256:" + "a".repeat(64), excerpt);
+            Entry decision = new Entry(
+                    "decision-runtime", "runtime", "main", LedgerStatus.RESOLVED,
+                    List.of(invalidSource), null);
+            DecisionLedger ledger = new DecisionLedger(
+                    1, 1, List.of(), List.of(decision), List.of(), List.of(), List.of(), List.of(), List.of(),
+                    List.of(), GapReviewStatus.NOT_RUN, null);
+
+            LedgerValidationException error = assertThrows(
+                    LedgerValidationException.class, () -> LedgerValidator.validateAnalysis(ledger));
+
+            assertTrue(error.getMessage().contains("contains an invalid source reference"));
+        }
+    }
+
+    @Test
+    void camelMainRejectsJavaPoliciesWithoutCompilationEvidence() {
+        DecisionLedger ready = readyLedger();
+        for (JavaPolicy javaPolicy : List.of(JavaPolicy.ALLOWED, JavaPolicy.JUSTIFICATION_REQUIRED)) {
+            RequirementsPolicy policy = new RequirementsPolicy(
+                    "main", "4.21.0", null, null, "yaml", "simple",
+                    CITRUS_VERSION, CITRUS_DEPENDENCIES, javaPolicy,
+                    List.of(), List.of(new RouteContract(
+                            "orders", "src/main/resources/routes/orders.camel.yaml",
+                            "test/orders.camel.it.yaml")),
+                    true, true);
+            String decisionValue = javaPolicy.name().toLowerCase(java.util.Locale.ROOT).replace('_', '-');
+            List<Entry> decisions = ready.decisions().stream()
+                    .map(entry -> "java-policy".equals(entry.category())
+                            ? new Entry(
+                                    entry.id(), entry.category(), decisionValue, entry.status(),
+                                    entry.sourceRefs(), entry.rationale())
+                            : entry)
+                    .toList();
+            DecisionLedger invalid = new DecisionLedger(
+                    ready.schemaVersion(), ready.revision(), ready.facts(), decisions, ready.conflicts(),
+                    ready.assumptions(), ready.catalogEvidence(), ready.openQuestions(), ready.completeness(),
+                    ready.blockingOpenItemIds(), ready.gapReviewStatus(), policy);
+
+            LedgerValidationException error = assertThrows(
+                    LedgerValidationException.class, () -> LedgerValidator.validateReady(invalid));
+
+            assertTrue(error.getMessage().contains(
+                    "requires Java policy FORBIDDEN for Camel Main because its mandatory startup evidence does not "
+                                                   + "compile Java sources"),
+                    javaPolicy::name);
+        }
+    }
+
+    private static DecisionLedger readyLedger() {
+        return new DecisionLedger(
+                1, 4, List.of(), resolvedDecisions(), List.of(), List.of(), List.of(), List.of(),
+                categories(LedgerStatus.RESOLVED), List.of(), GapReviewStatus.PASSED, policy());
+    }
+
+    private static DecisionLedger readyLedger(
+            String runtime, String camelVersion, String platformVersion, String springBootVersion) {
+        DecisionLedger baseline = readyLedger();
+        List<Entry> decisions = new ArrayList<>(
+                baseline.decisions().stream()
+                        .map(entry -> switch (entry.category()) {
+                            case "runtime" -> new Entry(
+                                    entry.id(), entry.category(), runtime, entry.status(), entry.sourceRefs(),
+                                    entry.rationale());
+                            case "camel-version" -> new Entry(
+                                    entry.id(), entry.category(), camelVersion, entry.status(), entry.sourceRefs(),
+                                    entry.rationale());
+                            default -> entry;
+                        })
+                        .toList());
+        List<Category> completeness = new ArrayList<>(baseline.completeness());
+        if (platformVersion != null) {
+            addCatalogDecision(decisions, completeness, source(), "platform-version", platformVersion);
+        }
+        if (springBootVersion != null) {
+            addCatalogDecision(decisions, completeness, source(), "spring-boot-version", springBootVersion);
+        }
+        RequirementsPolicy policy = new RequirementsPolicy(
+                runtime, camelVersion, platformVersion, springBootVersion, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+        return new DecisionLedger(
+                baseline.schemaVersion(), baseline.revision(), baseline.facts(), decisions,
+                baseline.conflicts(), baseline.assumptions(), baseline.catalogEvidence(),
+                baseline.openQuestions(), completeness, baseline.blockingOpenItemIds(),
+                GapReviewStatus.NOT_RUN, policy);
+    }
+
+    private static DecisionLedger catalogLedger(
+            String runtime, String camelVersion, String platformVersion, String springBootVersion) {
+        SourceRef source = new SourceRef(
+                "source-catalog", "test", "sha256:" + "b".repeat(64),
+                "main spring-boot quarkus 4.21.0 3.23.0 3.5.0");
+        List<Entry> decisions = new ArrayList<>();
+        List<Category> completeness = new ArrayList<>();
+        addCatalogDecision(decisions, completeness, source, "runtime", runtime);
+        addCatalogDecision(decisions, completeness, source, "camel-version", camelVersion);
+        if (platformVersion != null) {
+            addCatalogDecision(decisions, completeness, source, "platform-version", platformVersion);
+        }
+        if (springBootVersion != null) {
+            addCatalogDecision(decisions, completeness, source, "spring-boot-version", springBootVersion);
+        }
+        RequirementsPolicy policy = new RequirementsPolicy(
+                runtime, camelVersion, platformVersion, springBootVersion,
+                null, null, null, List.of(), null, List.of(), List.of(), false, false);
+        return new DecisionLedger(
+                1, 1, List.of(), decisions, List.of(), List.of(), List.of(), List.of(), completeness,
+                List.of(), GapReviewStatus.NOT_RUN, policy);
+    }
+
+    private static void addCatalogDecision(
+            List<Entry> decisions,
+            List<Category> completeness,
+            SourceRef source,
+            String category,
+            String value) {
+        decisions.add(new Entry(
+                "decision-" + category, category, value, LedgerStatus.RESOLVED,
+                List.of(source), null));
+        completeness.add(new Category(category, LedgerStatus.RESOLVED, null, List.of(source)));
+    }
+
+    private static List<Category> categories(LedgerStatus status) {
+        return LedgerValidator.REQUIRED_CATEGORIES.stream()
+                .sorted()
+                .map(category -> new Category(
+                        category, status, status == LedgerStatus.NOT_APPLICABLE ? "N/A" : null,
+                        List.of()))
+                .toList();
+    }
+
+    private static DecisionLedger copy(
+            DecisionLedger source,
+            List<Category> categories,
+            List<Entry> decisions,
+            List<Question> questions,
+            List<String> blockers,
+            GapReviewStatus gapReviewStatus) {
+        return new DecisionLedger(
+                source.schemaVersion(), source.revision(), source.facts(), decisions, source.conflicts(),
+                source.assumptions(), source.catalogEvidence(), questions, categories, blockers, gapReviewStatus,
+                source.requirementsPolicy());
+    }
+
+    private static DecisionLedger withPolicy(DecisionLedger source, RequirementsPolicy policy) {
+        return new DecisionLedger(
+                source.schemaVersion(), source.revision(), source.facts(), source.decisions(), source.conflicts(),
+                source.assumptions(), source.catalogEvidence(), source.openQuestions(), source.completeness(),
+                source.blockingOpenItemIds(), source.gapReviewStatus(), policy);
+    }
+
+    private static DecisionLedger withDecisionValue(
+            DecisionLedger source, String category, String value) {
+        List<Entry> decisions = source.decisions().stream()
+                .map(entry -> category.equals(entry.category())
+                        ? new Entry(
+                                entry.id(), entry.category(), value, entry.status(), entry.sourceRefs(),
+                                entry.rationale())
+                        : entry)
+                .toList();
+        return new DecisionLedger(
+                source.schemaVersion(), source.revision(), source.facts(), decisions, source.conflicts(),
+                source.assumptions(), source.catalogEvidence(), source.openQuestions(), source.completeness(),
+                source.blockingOpenItemIds(), source.gapReviewStatus(), source.requirementsPolicy());
+    }
+
+    private static List<Entry> resolvedDecisions() {
+        return LedgerValidator.REQUIRED_CATEGORIES.stream().sorted()
+                .map(category -> new Entry(
+                        "decision-" + category, category, value(category), LedgerStatus.RESOLVED,
+                        List.of(source()), null))
+                .toList();
+    }
+
+    private static String value(String category) {
+        return switch (category) {
+            case "runtime" -> "main";
+            case "camel-version" -> "4.21.0";
+            case "dsl" -> "yaml";
+            case "expression-language" -> "simple";
+            case "java-policy" -> "forbidden";
+            case "citrus-version" -> CITRUS_VERSION;
+            case "citrus-dependencies" -> String.join(", ", CITRUS_DEPENDENCIES);
+            default -> "resolved";
+        };
+    }
+
+    private static RequirementsPolicy policy() {
+        return new RequirementsPolicy(
+                "main", "4.21.0", null, null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+    }
+
+    private static SourceRef source() {
+        return new SourceRef(
+                "source-test", "test", "sha256:" + "a".repeat(64),
+                "main 4.21.0 yaml simple forbidden resolved");
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/InteractionTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/InteractionTest.java
@@ -1,0 +1,143 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction.DiscoveryAnswer;
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction.DiscoveryChallenge;
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction.DocumentConsentChallenge;
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction.DocumentConsentResponse;
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction.RemoteProviderConsentChallenge;
+import io.github.luigidemasi.camelkit.ship.protocol.Interaction.RemoteProviderConsentResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InteractionTest {
+
+    private static final String RUN_ID = "ship-00000000000000000000000000000001";
+    private static final String NONCE = "n".repeat(43);
+    private static final String MAC = "hmac-sha256:" + "a".repeat(64);
+    private static final String DIGEST = "sha256:" + "b".repeat(64);
+    private static final String PRINCIPAL = "unix:uid=1000";
+    private static final String UI_PROFILE = "camel-kit-cli:1";
+
+    @Test
+    void discoveryMacBindsOrderedOptionsAndRecommendation() {
+        String[] original = Interaction.discoveryChallengeMacFields(
+                RUN_ID, 1, "question-1", "open-1", "Runtime?",
+                List.of("main", "quarkus"), "main", NONCE);
+        String[] reordered = Interaction.discoveryChallengeMacFields(
+                RUN_ID, 1, "question-1", "open-1", "Runtime?",
+                List.of("quarkus", "main"), "main", NONCE);
+        String[] changedRecommendation = Interaction.discoveryChallengeMacFields(
+                RUN_ID, 1, "question-1", "open-1", "Runtime?",
+                List.of("main", "quarkus"), "quarkus", NONCE);
+
+        assertFalse(Arrays.equals(original, reordered));
+        assertFalse(Arrays.equals(original, changedRecommendation));
+        assertEquals("discovery-challenge-v1", original[0]);
+    }
+
+    @Test
+    void interactionRecordsRejectOversizedOrMalformedUntrustedFields() {
+        assertThrows(IllegalArgumentException.class, () -> new DiscoveryChallenge(
+                1, RUN_ID, 1, "question-1", "open-1", "x".repeat(Interaction.MAX_PROMPT_CHARS + 1),
+                List.of(), null, NONCE, MAC));
+        assertThrows(IllegalArgumentException.class, () -> new DiscoveryChallenge(
+                1, RUN_ID, 1, "question-1", "open-1", "Runtime?",
+                List.of("main", "main"), null, NONCE, MAC));
+        assertThrows(IllegalArgumentException.class, () -> new DiscoveryAnswer(
+                1, RUN_ID, 1, "question-1", "open-1", NONCE,
+                "x".repeat(Interaction.MAX_RESPONSE_CHARS + 1), "external", Instant.EPOCH, MAC));
+        assertThrows(IllegalArgumentException.class, () -> new DiscoveryAnswer(
+                1, RUN_ID, 1, "question-1", "open-1", "short", "main", "external",
+                Instant.EPOCH, MAC));
+        assertThrows(IllegalArgumentException.class, () -> new DiscoveryAnswer(
+                1, RUN_ID, 1, "question-1", "open-1", NONCE, "main", "external",
+                Instant.EPOCH, "not-a-mac"));
+    }
+
+    @Test
+    void localDocumentAndRemoteProviderConsentRemainSeparate() {
+        DocumentConsentChallenge local = new DocumentConsentChallenge(
+                1, RUN_ID, "document-1", 0, "/outside/requirements.md", "initial-context", DIGEST,
+                NONCE, MAC);
+        DocumentConsentResponse localResponse = new DocumentConsentResponse(
+                1, RUN_ID, "document-1", 0, "/outside/requirements.md", "initial-context", DIGEST,
+                NONCE, Interaction.ConsentDecision.AUTHORIZE, PRINCIPAL, UI_PROFILE, "protected-cli",
+                Instant.EPOCH, MAC);
+        RemoteProviderConsentChallenge remote = new RemoteProviderConsentChallenge(
+                1, RUN_ID, "provider-1", ShipStage.DISCOVERY, "semantic-discovery", DIGEST, DIGEST,
+                "provider", "model", "broker:1", "source:document-1", NONCE, MAC);
+        RemoteProviderConsentResponse remoteResponse = new RemoteProviderConsentResponse(
+                1, RUN_ID, "provider-1", ShipStage.DISCOVERY, "semantic-discovery", DIGEST, DIGEST,
+                "provider", "model", "broker:1", "source:document-1", NONCE,
+                Interaction.ConsentDecision.DENY, PRINCIPAL, UI_PROFILE, "protected-cli", Instant.EPOCH, MAC);
+
+        assertEquals("document-consent-challenge-v1", Interaction.documentConsentChallengeMacFields(local)[0]);
+        assertEquals("document-consent-response-v1", Interaction.documentConsentResponseMacFields(localResponse)[0]);
+        assertEquals("remote-provider-consent-challenge-v1",
+                Interaction.remoteProviderConsentChallengeMacFields(remote)[0]);
+        assertEquals("remote-provider-consent-response-v1",
+                Interaction.remoteProviderConsentResponseMacFields(remoteResponse)[0]);
+        assertFalse(Arrays.equals(
+                Interaction.documentConsentChallengeMacFields(local),
+                Interaction.remoteProviderConsentChallengeMacFields(remote)));
+    }
+
+    @Test
+    void designAndPlanHaveIndependentExactApprovalBindings() {
+        Interaction.DesignChallenge design = new Interaction.DesignChallenge(
+                1, RUN_ID, DIGEST, 2, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, "design.md", NONCE, MAC);
+        Interaction.DesignResponse designResponse = new Interaction.DesignResponse(
+                1, RUN_ID, DIGEST, 2, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, NONCE,
+                Interaction.DesignDecision.APPROVE, "", PRINCIPAL, UI_PROFILE, "protected-cli",
+                Instant.EPOCH, MAC);
+        Interaction.PlanChallenge plan = new Interaction.PlanChallenge(
+                1, RUN_ID, DIGEST, 2, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, "plan.md",
+                NONCE, MAC);
+        Interaction.PlanResponse planResponse = new Interaction.PlanResponse(
+                1, RUN_ID, DIGEST, 2, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, NONCE,
+                Interaction.PlanDecision.APPROVE, "", PRINCIPAL, UI_PROFILE, "protected-cli",
+                Instant.EPOCH, MAC);
+
+        assertEquals("design-challenge-v1", Interaction.designChallengeMacFields(design)[0]);
+        assertEquals("design-response-v1", Interaction.designResponseMacFields(designResponse)[0]);
+        assertEquals("plan-challenge-v1", Interaction.planChallengeMacFields(plan)[0]);
+        assertEquals("plan-response-v1", Interaction.planResponseMacFields(planResponse)[0]);
+        assertFalse(Arrays.equals(
+                Interaction.designResponseMacFields(designResponse),
+                Interaction.planResponseMacFields(planResponse)));
+        assertFalse(Arrays.equals(
+                Interaction.designResponseMacFields(designResponse),
+                Interaction.designResponseMacFields(
+                        RUN_ID, DIGEST, 2, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, NONCE,
+                        Interaction.DesignDecision.APPROVE, "", "unix:uid=1001", UI_PROFILE,
+                        "protected-cli", Instant.EPOCH)));
+    }
+
+    @Test
+    void waiverBindsEligibilitySubjectEvidenceAndResponder() {
+        Interaction.WaiverChallenge challenge = new Interaction.WaiverChallenge(
+                1, RUN_ID, "runner-isolation", DIGEST, DIGEST, DIGEST, "waiver.txt",
+                "Runner isolation is incomplete", "Normal PASS remains unavailable", NONCE, MAC);
+        Interaction.WaiverResponse response = new Interaction.WaiverResponse(
+                1, RUN_ID, "runner-isolation", DIGEST, DIGEST, DIGEST, NONCE,
+                Interaction.WaiverDecision.WAIVE, "Accept platform-specific evidence", PRINCIPAL, UI_PROFILE,
+                "protected-cli", Instant.EPOCH, MAC);
+
+        assertEquals("waiver-challenge-v1", Interaction.waiverChallengeMacFields(challenge)[0]);
+        assertEquals("waiver-response-v1", Interaction.waiverResponseMacFields(response)[0]);
+        assertThrows(IllegalArgumentException.class, () -> new Interaction.WaiverResponse(
+                1, RUN_ID, "runner-isolation", DIGEST, DIGEST, DIGEST, NONCE,
+                Interaction.WaiverDecision.WAIVE, "", PRINCIPAL, UI_PROFILE, "protected-cli",
+                Instant.EPOCH, MAC));
+        assertThrows(IllegalArgumentException.class, () -> new Interaction.DesignResponse(
+                1, RUN_ID, DIGEST, 2, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, NONCE,
+                Interaction.DesignDecision.APPROVE, "", "", UI_PROFILE, "protected-cli",
+                Instant.EPOCH, MAC));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/InteractionTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/InteractionTest.java
@@ -2,6 +2,7 @@ package io.github.luigidemasi.camelkit.ship.protocol;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
 
 import io.github.luigidemasi.camelkit.ship.protocol.Interaction.DiscoveryAnswer;
@@ -25,6 +26,28 @@ class InteractionTest {
     private static final String UI_PROFILE = "camel-kit-cli:1";
 
     @Test
+    void canonicalMacEncodingPreservesDomainsFieldBoundariesAndNulls() {
+        byte[] separated = Interaction.canonicalMacBytes(new String[]{"response-v1", "a", "b\nc"});
+        byte[] injected = Interaction.canonicalMacBytes(new String[]{"response-v1", "a\nb", "c"});
+        byte[] otherDomain = Interaction.canonicalMacBytes(new String[]{"challenge-v1", "a", "b\nc"});
+        byte[] nullField = Interaction.canonicalMacBytes(new String[]{"response-v1", null});
+        byte[] emptyField = Interaction.canonicalMacBytes(new String[]{"response-v1", ""});
+
+        assertArrayEquals(separated,
+                Interaction.canonicalMacBytes(new String[]{"response-v1", "a", "b\nc"}));
+        assertFalse(Arrays.equals(separated, injected));
+        assertFalse(Arrays.equals(separated, otherDomain));
+        assertFalse(Arrays.equals(nullField, emptyField));
+        assertThrows(IllegalArgumentException.class,
+                () -> Interaction.canonicalMacBytes(new String[]{"response-v1", "unpaired-\ud800"}));
+        assertArrayEquals(
+                HexFormat.of().parseHex(
+                        "000000040000000b726573706f6e73652d7631"
+                                        + "00000002c3a9ffffffff00000000"),
+                Interaction.canonicalMacBytes(new String[]{"response-v1", "é", null, ""}));
+    }
+
+    @Test
     void discoveryMacBindsOrderedOptionsAndRecommendation() {
         String[] original = Interaction.discoveryChallengeMacFields(
                 RUN_ID, 1, "question-1", "open-1", "Runtime?",
@@ -38,6 +61,8 @@ class InteractionTest {
 
         assertFalse(Arrays.equals(original, reordered));
         assertFalse(Arrays.equals(original, changedRecommendation));
+        assertFalse(Arrays.equals(
+                Interaction.canonicalMacBytes(original), Interaction.canonicalMacBytes(reordered)));
         assertEquals("discovery-challenge-v1", original[0]);
     }
 
@@ -86,6 +111,9 @@ class InteractionTest {
         assertFalse(Arrays.equals(
                 Interaction.documentConsentChallengeMacFields(local),
                 Interaction.remoteProviderConsentChallengeMacFields(remote)));
+        assertFalse(Arrays.equals(
+                Interaction.canonicalMacBytes(Interaction.documentConsentChallengeMacFields(local)),
+                Interaction.canonicalMacBytes(Interaction.remoteProviderConsentChallengeMacFields(remote))));
     }
 
     @Test
@@ -111,6 +139,9 @@ class InteractionTest {
         assertFalse(Arrays.equals(
                 Interaction.designResponseMacFields(designResponse),
                 Interaction.planResponseMacFields(planResponse)));
+        assertFalse(Arrays.equals(
+                Interaction.canonicalMacBytes(Interaction.designResponseMacFields(designResponse)),
+                Interaction.canonicalMacBytes(Interaction.planResponseMacFields(planResponse))));
         assertFalse(Arrays.equals(
                 Interaction.designResponseMacFields(designResponse),
                 Interaction.designResponseMacFields(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageCapabilityTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageCapabilityTest.java
@@ -1,0 +1,27 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.Operation;
+import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.RepositoryAccess;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StageCapabilityTest {
+
+    @Test
+    void excludesChildProcessesAndBuildCommandsFromWorkerAuthority() {
+        assertThrows(IllegalArgumentException.class, () -> new StageCapability(
+                RepositoryAccess.READ_ONLY, List.of(), List.of(), List.of(Operation.READ), true, false));
+        assertEquals(
+                List.of(
+                        Operation.READ,
+                        Operation.SEARCH,
+                        Operation.WRITE_STAGED_ARTIFACT,
+                        Operation.RETURN_STRUCTURED_RESULT),
+                List.of(Operation.values()));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidatorTest.java
@@ -274,6 +274,28 @@ class StageResultValidatorTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
+    void symbolicAttemptOutputAncestorIsRejected() throws Exception {
+        Path realParent = Files.createDirectory(temporaryDirectory.resolve("real"));
+        Path realOutput = Files.createDirectory(realParent.resolve("output"));
+        Path alias = Files.createSymbolicLink(temporaryDirectory.resolve("alias"), realParent);
+        Path aliasedOutput = alias.resolve("output");
+        byte[] content = "candidate".getBytes(StandardCharsets.UTF_8);
+        Files.write(realOutput.resolve("design.md"), content);
+        ProducedArtifact artifact = producedArtifact("design", "design.md", content);
+        StageRequest request = request(
+                ShipStage.DESIGN, aliasedOutput.toString(), stagedCapability(aliasedOutput));
+        StageResult result = result(
+                request, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, result, aliasedOutput));
+
+        assertTrue(error.getMessage().contains("symbolic"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void hardLinkedArtifactCannotAliasContentOutsideTheAttemptOutputDirectory() throws Exception {
         byte[] content = "mutable external content".getBytes(StandardCharsets.UTF_8);
         Path outside = Files.write(temporaryDirectory.resolve("external-design.md"), content);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidatorTest.java
@@ -1,0 +1,364 @@
+package io.github.luigidemasi.camelkit.ship.protocol;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Category;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.GapReviewStatus;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RouteContract;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.SourceRef;
+import io.github.luigidemasi.camelkit.ship.ledger.LedgerStatus;
+import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidator;
+import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.Operation;
+import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.RepositoryAccess;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StageResultValidatorTest {
+
+    private static final String CITRUS_VERSION = "5.0.0-M2";
+    private static final List<String> CITRUS_DEPENDENCIES = List.of(
+            "org.citrusframework:citrus-camel:5.0.0-M2",
+            "org.citrusframework:citrus-junit-jupiter:5.0.0-M2",
+            "org.citrusframework:citrus-yaml:5.0.0-M2");
+    private static final List<CatalogSubject> CATALOG_REQUESTS = List.of(new CatalogSubject(Kind.COMPONENT, "kafka"));
+
+    @TempDir
+    Path output;
+
+    @Test
+    void acceptsCompletedDiscoveryOnlyWithCompleteUnreviewedCandidateLedger() {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, readyLedger(), null, List.of());
+
+        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+    }
+
+    @Test
+    void rejectsCrossRunStaleAndFabricatedResultIdentity() {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        StageResult result = new StageResult(
+                1, "another-run", request.stage(), "old-attempt", "fabricated", request.inputDigest(),
+                StageResult.Outcome.COMPLETED, readyLedger(), null, List.of(), List.of(), null, null, null);
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("run ID"));
+        assertTrue(error.getMessage().contains("attempt ID"));
+        assertTrue(error.getMessage().contains("challenge"));
+    }
+
+    @Test
+    void completedDiscoveryCannotReturnImplementationArtifacts() throws Exception {
+        ProducedArtifact artifact = artifact("route", "early.camel.yaml", "route");
+        StageRequest request = request(ShipStage.DISCOVERY);
+        StageResult result = result(
+                request, StageResult.Outcome.COMPLETED, readyLedger(), null, List.of(artifact));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("may not return implementation artifacts"));
+    }
+
+    @Test
+    void discoveryMayReturnATypedCatalogContinuation() {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null, List.of());
+
+        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+    }
+
+    @Test
+    void catalogRequestsAreImmutableCopies() {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        List<CatalogSubject> mutable = new ArrayList<>(CATALOG_REQUESTS);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null, mutable, List.of());
+
+        mutable.clear();
+
+        assertEquals(CATALOG_REQUESTS, result.catalogRequests());
+        assertThrows(UnsupportedOperationException.class, () -> result.catalogRequests().clear());
+    }
+
+    @Test
+    void discoveryContinuationRequiresCatalogRequests() {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null, List.of(), List.of());
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("requires at least one catalog request"));
+    }
+
+    @Test
+    void nonCatalogDiscoveryReopenCannotCarryCatalogRequests() {
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null,
+                CATALOG_REQUESTS, List.of());
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("Only discovery may return catalog requests"));
+    }
+
+    @Test
+    void designMayRequestNonCatalogRediscoveryWithoutCatalogRequests() {
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null, List.of(), List.of());
+
+        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+    }
+
+    @Test
+    void discoveryContinuationCannotSmuggleArtifacts() throws Exception {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null,
+                List.of(artifact("route", "early.camel.yaml", "route")));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("may not return implementation artifacts"));
+    }
+
+    @Test
+    void designArtifactMustUseAPortableRelativePath() throws Exception {
+        StageRequest request = request(ShipStage.DESIGN);
+        ProducedArtifact escaped = new ProducedArtifact("design", "../design.md", "sha256:" + "0".repeat(64), 1);
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(escaped));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("portable relative path"));
+    }
+
+    @Test
+    void forgedArtifactDigestIsRejected() throws Exception {
+        Files.writeString(output.resolve("design.md"), "candidate");
+        ProducedArtifact forged = new ProducedArtifact(
+                "design", "design.md", "sha256:" + "0".repeat(64), "candidate".length());
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(forged));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("digest mismatch"));
+    }
+
+    @Test
+    void rejectsNonPortableMalformedAndOversizedArtifactDeclarations() {
+        StageRequest request = request(ShipStage.DESIGN);
+        List<ProducedArtifact> artifacts = List.of(
+                new ProducedArtifact("Design", "..\\outside", "not-a-digest", -1),
+                new ProducedArtifact(
+                        "design", "design.md", "sha256:" + "0".repeat(64),
+                        ShipTreePolicy.current().maxFileBytes() + 1));
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, artifacts);
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("canonical kind"));
+        assertTrue(error.getMessage().contains("per-file limit"));
+    }
+
+    @Test
+    void validDesignArtifactIsAccepted() throws Exception {
+        ProducedArtifact artifact = artifact("design", "design.md", "candidate");
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
+
+        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+    }
+
+    @Test
+    void completedDesignCannotSmuggleAdditionalArtifactKinds() throws Exception {
+        ProducedArtifact design = artifact("design", "design.md", "candidate");
+        ProducedArtifact route = artifact("route", "orders.camel.yaml", "route");
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(
+                request, StageResult.Outcome.COMPLETED, null, null, List.of(design, route));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("exactly one design artifact"));
+    }
+
+    @Test
+    void failedResultCannotReturnArtifacts() throws Exception {
+        ProducedArtifact artifact = artifact("plan", "plan.md", "candidate");
+        StageRequest request = request(ShipStage.PLAN);
+        StageResult result = new StageResult(
+                1, request.runId(), request.stage(), request.attemptId(), request.challenge(), request.inputDigest(),
+                StageResult.Outcome.FAILED, null, null, List.of(), List.of(artifact), null,
+                "worker-failed", "worker failed");
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("may not return implementation artifacts"));
+    }
+
+    @Test
+    void needsUserInputCannotReturnArtifacts() throws Exception {
+        ProducedArtifact artifact = artifact("design", "design.md", "candidate");
+        StageRequest request = request(ShipStage.DESIGN);
+        DecisionLedger.Question question = new DecisionLedger.Question(
+                "question-runtime", "decision-runtime", "Which runtime?", List.of("main"), "main",
+                LedgerStatus.NEEDS_USER_DECISION);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_USER_INPUT, readyLedger(), question, List.of(artifact));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("may not return implementation artifacts"));
+    }
+
+    @Test
+    void designCannotAskTheUserDirectly() {
+        StageRequest request = request(ShipStage.DESIGN);
+        DecisionLedger.Question question = new DecisionLedger.Question(
+                "question-runtime", "decision-runtime", "Which runtime?", List.of("main"), "main",
+                LedgerStatus.NEEDS_USER_DECISION);
+        StageResult result = result(
+                request, StageResult.Outcome.NEEDS_USER_INPUT, readyLedger(), question, List.of());
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("Only discovery may request user input"));
+    }
+
+    @Test
+    void failedResultRequiresTypedFailure() {
+        StageRequest request = request(ShipStage.PLAN);
+        StageResult result = result(request, StageResult.Outcome.FAILED, null, null, List.of());
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validate(request, result, output));
+
+        assertTrue(error.getMessage().contains("failure code and message"));
+    }
+
+    private StageRequest request(ShipStage stage) {
+        StageCapability capability = new StageCapability(
+                RepositoryAccess.READ_ONLY, List.of(output.toString()), List.of(),
+                List.of(Operation.READ, Operation.RETURN_STRUCTURED_RESULT), false, false);
+        return new StageRequest(
+                1, "ship-run", stage, "attempt-1", 1, "idempotency", "challenge",
+                "sha256:" + "1".repeat(64), "sha256:" + "2".repeat(64),
+                null, null, null,
+                "context.json", "ledger.json", null, null, null, null, null, null, List.of(), null, null,
+                "contract.md", output.toString(), capability);
+    }
+
+    private StageResult result(
+            StageRequest request,
+            StageResult.Outcome outcome,
+            DecisionLedger ledger,
+            DecisionLedger.Question question,
+            List<ProducedArtifact> artifacts) {
+        List<CatalogSubject> catalogRequests = outcome == StageResult.Outcome.NEEDS_DISCOVERY
+                ? CATALOG_REQUESTS
+                : List.of();
+        return result(request, outcome, ledger, question, catalogRequests, artifacts);
+    }
+
+    private StageResult result(
+            StageRequest request,
+            StageResult.Outcome outcome,
+            DecisionLedger ledger,
+            DecisionLedger.Question question,
+            List<CatalogSubject> catalogRequests,
+            List<ProducedArtifact> artifacts) {
+        return new StageResult(
+                1, request.runId(), request.stage(), request.attemptId(), request.challenge(), request.inputDigest(),
+                outcome, ledger, question, catalogRequests, artifacts, null, null, null);
+    }
+
+    private ProducedArtifact artifact(String kind, String name, String content) throws Exception {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        Files.write(output.resolve(name), bytes);
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return new ProducedArtifact(
+                kind, name, "sha256:" + java.util.HexFormat.of().formatHex(digest.digest(bytes)), bytes.length);
+    }
+
+    private DecisionLedger readyLedger() {
+        SourceRef source = new SourceRef(
+                "source-test", "test", "sha256:" + "a".repeat(64),
+                "main 4.21.0 yaml simple forbidden resolved");
+        List<Category> categories = LedgerValidator.REQUIRED_CATEGORIES.stream()
+                .sorted()
+                .map(category -> new Category(category, LedgerStatus.RESOLVED, null, List.of()))
+                .toList();
+        List<DecisionLedger.Entry> decisions = LedgerValidator.REQUIRED_CATEGORIES.stream().sorted()
+                .map(category -> new DecisionLedger.Entry(
+                        "decision-" + category, category, value(category), LedgerStatus.RESOLVED,
+                        List.of(source), null))
+                .toList();
+        RequirementsPolicy policy = new RequirementsPolicy(
+                "main", "4.21.0", null, null, "yaml", "simple",
+                CITRUS_VERSION, CITRUS_DEPENDENCIES, JavaPolicy.FORBIDDEN,
+                List.of(), List.of(new RouteContract(
+                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true, true);
+        return new DecisionLedger(
+                1, 1, List.of(), decisions, List.of(), List.of(), List.of(), List.of(),
+                categories, List.of(), GapReviewStatus.NOT_RUN, policy);
+    }
+
+    private static String value(String category) {
+        return switch (category) {
+            case "runtime" -> "main";
+            case "camel-version" -> "4.21.0";
+            case "dsl" -> "yaml";
+            case "expression-language" -> "simple";
+            case "java-policy" -> "forbidden";
+            case "citrus-version" -> CITRUS_VERSION;
+            case "citrus-dependencies" -> String.join(", ", CITRUS_DEPENDENCIES);
+            default -> "resolved";
+        };
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/protocol/StageResultValidatorTest.java
@@ -22,7 +22,10 @@ import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.Operation;
 import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.RepositoryAccess;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,14 +40,21 @@ class StageResultValidatorTest {
     private static final List<CatalogSubject> CATALOG_REQUESTS = List.of(new CatalogSubject(Kind.COMPONENT, "kafka"));
 
     @TempDir
+    Path temporaryDirectory;
+
     Path output;
+
+    @BeforeEach
+    void createAttemptOutput() throws Exception {
+        output = Files.createDirectory(temporaryDirectory.resolve("output"));
+    }
 
     @Test
     void acceptsCompletedDiscoveryOnlyWithCompleteUnreviewedCandidateLedger() {
         StageRequest request = request(ShipStage.DISCOVERY);
         StageResult result = result(request, StageResult.Outcome.COMPLETED, readyLedger(), null, List.of());
 
-        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+        assertDoesNotThrow(() -> StageResultValidator.validatePreflight(request, result, output));
     }
 
     @Test
@@ -56,11 +66,42 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("run ID"));
         assertTrue(error.getMessage().contains("attempt ID"));
         assertTrue(error.getMessage().contains("challenge"));
+    }
+
+    @Test
+    void rejectsUnsupportedRequestSchemaBeforeApplyingVersionedCapabilityRules() {
+        StageRequest request = request(
+                2, ShipStage.DISCOVERY, output.toString(), capability(ShipStage.DISCOVERY, output));
+        StageResult result = result(
+                request, StageResult.Outcome.COMPLETED, readyLedger(), null, List.of());
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, result, output));
+
+        assertTrue(error.getMessage().contains("request schema version"));
+        assertTrue(error.getMessage().contains("schema version"));
+    }
+
+    @Test
+    void everyResultRequiresStructuredResultAuthority() {
+        StageCapability noReturn = new StageCapability(
+                RepositoryAccess.READ_ONLY, List.of(output.toString()), List.of(),
+                List.of(Operation.READ), false, false);
+        StageRequest request = request(ShipStage.DISCOVERY, output.toString(), noReturn);
+        StageResult result = result(
+                request, StageResult.Outcome.COMPLETED, readyLedger(), null, List.of());
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, result, output));
+
+        assertTrue(error.getMessage().contains("structured result"));
     }
 
     @Test
@@ -72,7 +113,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("may not return implementation artifacts"));
     }
@@ -83,7 +124,7 @@ class StageResultValidatorTest {
         StageResult result = result(
                 request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null, List.of());
 
-        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+        assertDoesNotThrow(() -> StageResultValidator.validatePreflight(request, result, output));
     }
 
     @Test
@@ -107,7 +148,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("requires at least one catalog request"));
     }
@@ -121,7 +162,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("Only discovery may return catalog requests"));
     }
@@ -132,7 +173,7 @@ class StageResultValidatorTest {
         StageResult result = result(
                 request, StageResult.Outcome.NEEDS_DISCOVERY, readyLedger(), null, List.of(), List.of());
 
-        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+        assertDoesNotThrow(() -> StageResultValidator.validatePreflight(request, result, output));
     }
 
     @Test
@@ -144,25 +185,61 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("may not return implementation artifacts"));
     }
 
     @Test
-    void designArtifactMustUseAPortableRelativePath() throws Exception {
+    void designArtifactMustUseTheSharedPortablePathAndDepthPolicy() {
         StageRequest request = request(ShipStage.DESIGN);
-        ProducedArtifact escaped = new ProducedArtifact("design", "../design.md", "sha256:" + "0".repeat(64), 1);
-        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(escaped));
+        String tooDeep = "d/".repeat(ShipTreePolicy.current().maxDepth() + 1) + "design.md";
+        for (String invalid : List.of(
+                "../design.md",
+                "C:/outside/design.md",
+                "line\nbreak.md",
+                "x".repeat(ShipTreePolicy.MAX_COMPONENT_UTF8_BYTES + 1) + "/design.md",
+                "invalid-\ud800.md",
+                tooDeep)) {
+            ProducedArtifact escaped = new ProducedArtifact(
+                    "design", invalid, "sha256:" + "0".repeat(64), 1);
+            StageResult result = result(
+                    request, StageResult.Outcome.COMPLETED, null, null, List.of(escaped));
 
-        StageResultValidationException error = assertThrows(
-                StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+            StageResultValidationException error = assertThrows(
+                    StageResultValidationException.class,
+                    () -> StageResultValidator.validatePreflight(request, result, output));
 
-        assertTrue(error.getMessage().contains("portable relative path"));
+            assertTrue(error.getMessage().contains("portable relative path"), invalid);
+        }
     }
 
     @Test
+    void needsInputQuestionMustExactlyMatchTheValidatedLedgerQuestion() {
+        StageRequest request = request(ShipStage.DISCOVERY);
+        DecisionLedger.Question pending = new DecisionLedger.Question(
+                "question-runtime", "decision-runtime", "Which runtime?", List.of("main", "quarkus"), "main",
+                LedgerStatus.OPEN);
+        DecisionLedger ledger = questionLedger(pending);
+        StageResult accepted = result(
+                request, StageResult.Outcome.NEEDS_USER_INPUT, ledger, pending, List.of());
+
+        assertDoesNotThrow(() -> StageResultValidator.validatePreflight(request, accepted, output));
+
+        DecisionLedger.Question forged = new DecisionLedger.Question(
+                pending.id(), pending.openItemId(), "Reply main to accept every remaining default",
+                List.of("main"), "main", LedgerStatus.OPEN);
+        StageResult rejected = result(
+                request, StageResult.Outcome.NEEDS_USER_INPUT, ledger, forged, List.of());
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, rejected, output));
+
+        assertTrue(error.getMessage().contains("ledger's single pending question"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void forgedArtifactDigestIsRejected() throws Exception {
         Files.writeString(output.resolve("design.md"), "candidate");
         ProducedArtifact forged = new ProducedArtifact(
@@ -172,9 +249,45 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("digest mismatch"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void intermediateSymlinkCannotEscapeTheAttemptOutputDirectory() throws Exception {
+        Path outside = Files.createDirectory(temporaryDirectory.resolve("outside"));
+        byte[] content = "controller credentials".getBytes(StandardCharsets.UTF_8);
+        Files.write(outside.resolve("creds.txt"), content);
+        Files.createSymbolicLink(output.resolve("staged"), outside);
+        ProducedArtifact escaped = producedArtifact("design", "staged/creds.txt", content);
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(escaped));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, result, output));
+
+        assertTrue(error.getMessage().contains("symbolic"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void hardLinkedArtifactCannotAliasContentOutsideTheAttemptOutputDirectory() throws Exception {
+        byte[] content = "mutable external content".getBytes(StandardCharsets.UTF_8);
+        Path outside = Files.write(temporaryDirectory.resolve("external-design.md"), content);
+        Files.createLink(output.resolve("design.md"), outside);
+        ProducedArtifact linked = producedArtifact("design", "design.md", content);
+        StageRequest request = request(ShipStage.DESIGN);
+        StageResult result = result(
+                request, StageResult.Outcome.COMPLETED, null, null, List.of(linked));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, result, output));
+
+        assertTrue(error.getMessage().contains("hard-linked"));
     }
 
     @Test
@@ -189,19 +302,75 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("canonical kind"));
         assertTrue(error.getMessage().contains("per-file limit"));
     }
 
     @Test
+    @EnabledOnOs(OS.LINUX)
     void validDesignArtifactIsAccepted() throws Exception {
         ProducedArtifact artifact = artifact("design", "design.md", "candidate");
         StageRequest request = request(ShipStage.DESIGN);
         StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
 
-        assertDoesNotThrow(() -> StageResultValidator.validate(request, result, output));
+        assertDoesNotThrow(() -> StageResultValidator.validatePreflight(request, result, output));
+    }
+
+    @Test
+    void stagedArtifactRequiresControllerIssuedWriteAuthority() throws Exception {
+        ProducedArtifact artifact = artifact("design", "design.md", "candidate");
+        StageCapability readOnly = new StageCapability(
+                RepositoryAccess.READ_ONLY, List.of(output.toString()), List.of(),
+                List.of(Operation.READ, Operation.RETURN_STRUCTURED_RESULT), false, false);
+        StageRequest request = request(ShipStage.DESIGN, output.toString(), readOnly);
+        StageResult result = result(request, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
+
+        StageResultValidationException error = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(request, result, output));
+
+        assertTrue(error.getMessage().contains("staged-artifact write authority"));
+
+        StageCapability executionOnly = new StageCapability(
+                RepositoryAccess.DECLARED_EXECUTION_PATHS, List.of(output.toString()), List.of(output.toString()),
+                List.of(Operation.READ, Operation.WRITE_STAGED_ARTIFACT, Operation.RETURN_STRUCTURED_RESULT),
+                false, false);
+        StageRequest wrongStage = request(ShipStage.DESIGN, output.toString(), executionOnly);
+        StageResult wrongStageResult = result(
+                wrongStage, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
+        StageResultValidationException wrongStageError = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(wrongStage, wrongStageResult, output));
+        assertTrue(wrongStageError.getMessage().contains("stage-compatible"));
+    }
+
+    @Test
+    void stagedArtifactMustStayInsideTheCapabilityOutputEnvelope() throws Exception {
+        ProducedArtifact artifact = artifact("design", "design.md", "candidate");
+        Path other = Files.createDirectory(temporaryDirectory.resolve("other"));
+        StageCapability wrongRoot = new StageCapability(
+                RepositoryAccess.READ_WITH_STAGED_OUTPUT, List.of(output.toString()), List.of(other.toString()),
+                List.of(Operation.READ, Operation.WRITE_STAGED_ARTIFACT, Operation.RETURN_STRUCTURED_RESULT),
+                false, false);
+        StageRequest uncovered = request(ShipStage.DESIGN, output.toString(), wrongRoot);
+        StageResult uncoveredResult = result(
+                uncovered, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
+
+        StageResultValidationException uncoveredError = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(uncovered, uncoveredResult, output));
+        assertTrue(uncoveredError.getMessage().contains("covered by a canonical capability write root"));
+
+        StageCapability authority = stagedCapability(output);
+        StageRequest mismatched = request(ShipStage.DESIGN, other.toString(), authority);
+        StageResult mismatchedResult = result(
+                mismatched, StageResult.Outcome.COMPLETED, null, null, List.of(artifact));
+        StageResultValidationException mismatchedError = assertThrows(
+                StageResultValidationException.class,
+                () -> StageResultValidator.validatePreflight(mismatched, mismatchedResult, output));
+        assertTrue(mismatchedError.getMessage().contains("does not match the request capability envelope"));
     }
 
     @Test
@@ -214,7 +383,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("exactly one design artifact"));
     }
@@ -230,7 +399,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("may not return implementation artifacts"));
     }
@@ -247,7 +416,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("may not return implementation artifacts"));
     }
@@ -263,7 +432,7 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("Only discovery may request user input"));
     }
@@ -275,21 +444,52 @@ class StageResultValidatorTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> StageResultValidator.validate(request, result, output));
+                () -> StageResultValidator.validatePreflight(request, result, output));
 
         assertTrue(error.getMessage().contains("failure code and message"));
     }
 
     private StageRequest request(ShipStage stage) {
-        StageCapability capability = new StageCapability(
-                RepositoryAccess.READ_ONLY, List.of(output.toString()), List.of(),
-                List.of(Operation.READ, Operation.RETURN_STRUCTURED_RESULT), false, false);
+        return request(stage, output.toString(), capability(stage, output));
+    }
+
+    private StageRequest request(ShipStage stage, String outputDirectory, StageCapability capability) {
+        return request(StageRequest.SCHEMA_VERSION, stage, outputDirectory, capability);
+    }
+
+    private StageRequest request(
+            int schemaVersion,
+            ShipStage stage,
+            String outputDirectory,
+            StageCapability capability) {
         return new StageRequest(
-                1, "ship-run", stage, "attempt-1", 1, "idempotency", "challenge",
+                schemaVersion, "ship-run", stage, "attempt-1", 1, "idempotency", "challenge",
                 "sha256:" + "1".repeat(64), "sha256:" + "2".repeat(64),
                 null, null, null,
                 "context.json", "ledger.json", null, null, null, null, null, null, List.of(), null, null,
-                "contract.md", output.toString(), capability);
+                "contract.md", outputDirectory, capability);
+    }
+
+    private static StageCapability stagedCapability(Path output) {
+        return new StageCapability(
+                RepositoryAccess.READ_WITH_STAGED_OUTPUT, List.of(output.toString()), List.of(output.toString()),
+                List.of(Operation.READ, Operation.WRITE_STAGED_ARTIFACT, Operation.RETURN_STRUCTURED_RESULT),
+                false, false);
+    }
+
+    private static StageCapability capability(ShipStage stage, Path output) {
+        if (stage == ShipStage.EXECUTE) {
+            return new StageCapability(
+                    RepositoryAccess.DECLARED_EXECUTION_PATHS, List.of(output.toString()), List.of(output.toString()),
+                    List.of(Operation.READ, Operation.WRITE_STAGED_ARTIFACT, Operation.RETURN_STRUCTURED_RESULT),
+                    false, false);
+        }
+        if (stage == ShipStage.DESIGN || stage == ShipStage.PLAN || stage == ShipStage.VALIDATE) {
+            return stagedCapability(output);
+        }
+        return new StageCapability(
+                RepositoryAccess.READ_ONLY, List.of(output.toString()), List.of(),
+                List.of(Operation.READ, Operation.RETURN_STRUCTURED_RESULT), false, false);
     }
 
     private StageResult result(
@@ -319,9 +519,26 @@ class StageResultValidatorTest {
     private ProducedArtifact artifact(String kind, String name, String content) throws Exception {
         byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         Files.write(output.resolve(name), bytes);
+        return producedArtifact(kind, name, bytes);
+    }
+
+    private static ProducedArtifact producedArtifact(String kind, String name, byte[] bytes) throws Exception {
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
         return new ProducedArtifact(
                 kind, name, "sha256:" + java.util.HexFormat.of().formatHex(digest.digest(bytes)), bytes.length);
+    }
+
+    private DecisionLedger questionLedger(DecisionLedger.Question question) {
+        DecisionLedger.Entry decision = new DecisionLedger.Entry(
+                question.openItemId(), "runtime", null, LedgerStatus.NEEDS_USER_DECISION,
+                List.of(), "Camel Main is recommended");
+        List<Category> categories = LedgerValidator.REQUIRED_CATEGORIES.stream()
+                .sorted()
+                .map(category -> new Category(category, LedgerStatus.OPEN, null, List.of()))
+                .toList();
+        return new DecisionLedger(
+                1, 1, List.of(), List.of(decision), List.of(), List.of(), List.of(), List.of(question),
+                categories, List.of(decision.id()), GapReviewStatus.NOT_RUN, null);
     }
 
     private DecisionLedger readyLedger() {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -651,6 +651,16 @@ class ProjectSnapshotServiceTest {
         assertFalse(Modifier.isPublic(ShipSecureFilesystem.class.getModifiers()));
         assertFalse(Modifier.isPublic(ShipSecureFilesystem.SecureRoot.class.getModifiers()));
         assertFalse(Modifier.isPublic(ProjectSnapshotService.class.getModifiers()));
+        assertTrue(Modifier.isPublic(ProjectEvidenceFiles.class.getModifiers()));
+        assertTrue(Modifier.isFinal(ProjectEvidenceFiles.class.getModifiers()));
+        assertEquals(0, ProjectEvidenceFiles.class.getConstructors().length);
+        assertEquals(
+                Set.of("capture", "captureSealed", "unchanged", "unchangedMaterialTree",
+                        "materializeMaterial", "readMaterial"),
+                Arrays.stream(ProjectEvidenceFiles.class.getDeclaredMethods())
+                        .filter(method -> Modifier.isPublic(method.getModifiers()))
+                        .map(method -> method.getName())
+                        .collect(Collectors.toSet()));
         assertTrue(Arrays.stream(ShipFilesystemException.class.getDeclaredConstructors())
                 .noneMatch(constructor -> Modifier.isPublic(constructor.getModifiers())));
     }

--- a/camel-kit-core/src/test/resources/ship/expression-policy/catalog-yaml-inventory.json
+++ b/camel-kit-core/src/test/resources/ship/expression-policy/catalog-yaml-inventory.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "versions": {
+    "4.18.3": {
+      "yamlSchemaSha256": "sha256:5d86a18895db53b84e56924e1f39391afa796e11c033de9c3c7a730f702ec627",
+      "catalogLanguagesSha256": "sha256:b5a2a2ad2234cd73abe350766130fd9f00154f59f7b9adf5062d34eba83a173d",
+      "yamlAliases": {
+        "constant": "org.apache.camel.model.language.ConstantExpression",
+        "csimple": "org.apache.camel.model.language.CSimpleExpression",
+        "datasonnet": "org.apache.camel.model.language.DatasonnetExpression",
+        "exchangeProperty": "org.apache.camel.model.language.ExchangePropertyExpression",
+        "groovy": "org.apache.camel.model.language.GroovyExpression",
+        "header": "org.apache.camel.model.language.HeaderExpression",
+        "hl7terser": "org.apache.camel.model.language.Hl7TerserExpression",
+        "java": "org.apache.camel.model.language.JavaExpression",
+        "joor": "org.apache.camel.model.language.JoorExpression",
+        "jq": "org.apache.camel.model.language.JqExpression",
+        "js": "org.apache.camel.model.language.JavaScriptExpression",
+        "jsonpath": "org.apache.camel.model.language.JsonPathExpression",
+        "language": "org.apache.camel.model.language.LanguageExpression",
+        "method": "org.apache.camel.model.language.MethodCallExpression",
+        "mvel": "org.apache.camel.model.language.MvelExpression",
+        "ognl": "org.apache.camel.model.language.OgnlExpression",
+        "python": "org.apache.camel.model.language.PythonExpression",
+        "ref": "org.apache.camel.model.language.RefExpression",
+        "simple": "org.apache.camel.model.language.SimpleExpression",
+        "spel": "org.apache.camel.model.language.SpELExpression",
+        "tokenize": "org.apache.camel.model.language.TokenizerExpression",
+        "variable": "org.apache.camel.model.language.VariableExpression",
+        "wasm": "org.apache.camel.model.language.WasmExpression",
+        "xpath": "org.apache.camel.model.language.XPathExpression",
+        "xquery": "org.apache.camel.model.language.XQueryExpression",
+        "xtokenize": "org.apache.camel.model.language.XMLTokenizerExpression"
+      },
+      "catalogLanguages": [
+        "bean", "constant", "csimple", "datasonnet", "exchangeProperty", "file", "groovy",
+        "header", "hl7terser", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
+        "python", "ref", "simple", "spel", "tokenize", "variable", "wasm", "xpath",
+        "xquery", "xtokenize"
+      ],
+      "generic": {
+        "properties": ["expression", "id", "language", "trim"],
+        "required": ["expression", "language"]
+      },
+      "simple": {
+        "properties": ["expression", "id", "nested", "pretty", "resultType", "trim", "trimResult"],
+        "required": ["expression"]
+      },
+      "method": {
+        "properties": ["beanType", "id", "method", "ref", "resultType", "scope", "trim", "validate"]
+      }
+    },
+    "4.21.0": {
+      "yamlSchemaSha256": "sha256:76bd2fdd99098009b0c6c23b287c8e89095b79fccebb8b10570cc65db4ebafd0",
+      "catalogLanguagesSha256": "sha256:b5a2a2ad2234cd73abe350766130fd9f00154f59f7b9adf5062d34eba83a173d",
+      "yamlAliases": {
+        "constant": "org.apache.camel.model.language.ConstantExpression",
+        "csimple": "org.apache.camel.model.language.CSimpleExpression",
+        "datasonnet": "org.apache.camel.model.language.DatasonnetExpression",
+        "exchangeProperty": "org.apache.camel.model.language.ExchangePropertyExpression",
+        "groovy": "org.apache.camel.model.language.GroovyExpression",
+        "header": "org.apache.camel.model.language.HeaderExpression",
+        "hl7terser": "org.apache.camel.model.language.Hl7TerserExpression",
+        "java": "org.apache.camel.model.language.JavaExpression",
+        "joor": "org.apache.camel.model.language.JoorExpression",
+        "jq": "org.apache.camel.model.language.JqExpression",
+        "js": "org.apache.camel.model.language.JavaScriptExpression",
+        "jsonpath": "org.apache.camel.model.language.JsonPathExpression",
+        "language": "org.apache.camel.model.language.LanguageExpression",
+        "method": "org.apache.camel.model.language.MethodCallExpression",
+        "mvel": "org.apache.camel.model.language.MvelExpression",
+        "ognl": "org.apache.camel.model.language.OgnlExpression",
+        "python": "org.apache.camel.model.language.PythonExpression",
+        "ref": "org.apache.camel.model.language.RefExpression",
+        "simple": "org.apache.camel.model.language.SimpleExpression",
+        "spel": "org.apache.camel.model.language.SpELExpression",
+        "tokenize": "org.apache.camel.model.language.TokenizerExpression",
+        "variable": "org.apache.camel.model.language.VariableExpression",
+        "wasm": "org.apache.camel.model.language.WasmExpression",
+        "xpath": "org.apache.camel.model.language.XPathExpression",
+        "xquery": "org.apache.camel.model.language.XQueryExpression",
+        "xtokenize": "org.apache.camel.model.language.XMLTokenizerExpression"
+      },
+      "catalogLanguages": [
+        "bean", "constant", "csimple", "datasonnet", "exchangeProperty", "file", "groovy",
+        "header", "hl7terser", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
+        "python", "ref", "simple", "spel", "tokenize", "variable", "wasm", "xpath",
+        "xquery", "xtokenize"
+      ],
+      "generic": {
+        "properties": ["expression", "id", "language", "trim"],
+        "required": ["expression", "language"]
+      },
+      "simple": {
+        "properties": ["expression", "id", "nested", "pretty", "resultType", "trim", "trimResult"],
+        "required": ["expression"]
+      },
+      "method": {
+        "properties": ["beanType", "id", "method", "ref", "resultType", "scope", "trim", "validate"]
+      }
+    }
+  }
+}

--- a/camel-kit-core/src/test/resources/ship/expression-policy/catalog-yaml-inventory.json
+++ b/camel-kit-core/src/test/resources/ship/expression-policy/catalog-yaml-inventory.json
@@ -2,7 +2,9 @@
   "schemaVersion": 1,
   "versions": {
     "4.18.3": {
+      "yamlSchemaArtifact": "org.apache.camel:camel-yaml-dsl:4.18.3!/schema/camelYamlDsl.json",
       "yamlSchemaSha256": "sha256:5d86a18895db53b84e56924e1f39391afa796e11c033de9c3c7a730f702ec627",
+      "catalogLanguagesArtifact": "org.apache.camel:camel-catalog:4.18.3!/org/apache/camel/catalog/languages.properties",
       "catalogLanguagesSha256": "sha256:b5a2a2ad2234cd73abe350766130fd9f00154f59f7b9adf5062d34eba83a173d",
       "yamlAliases": {
         "constant": "org.apache.camel.model.language.ConstantExpression",
@@ -51,7 +53,9 @@
       }
     },
     "4.21.0": {
+      "yamlSchemaArtifact": "org.apache.camel:camel-yaml-dsl:4.21.0!/schema/camelYamlDsl.json",
       "yamlSchemaSha256": "sha256:76bd2fdd99098009b0c6c23b287c8e89095b79fccebb8b10570cc65db4ebafd0",
+      "catalogLanguagesArtifact": "org.apache.camel:camel-catalog:4.21.0!/org/apache/camel/catalog/languages.properties",
       "catalogLanguagesSha256": "sha256:b5a2a2ad2234cd73abe350766130fd9f00154f59f7b9adf5062d34eba83a173d",
       "yamlAliases": {
         "constant": "org.apache.camel.model.language.ConstantExpression",

--- a/distribution.properties
+++ b/distribution.properties
@@ -58,7 +58,19 @@ maven.provider.version=3.9.12
 maven.jar.plugin.version=3.5.0
 maven.shade.plugin.version=3.6.1
 maven.surefire.plugin.version=3.5.4
+maven.failsafe.plugin.version=3.5.4
 slf4j.version=1.7.36
+
+# Content-locked JVM payload compatibility. Rows are exact and fail closed;
+# 4.14.x remains excluded until its Simple/runtime edge cases are resolved.
+ship.evidence.camel-yaml-validator.supported=4.21.0,4.18.3
+ship.evidence.camel-yaml-validator.4.21.0.json-schema-validator.version=2.0.1
+ship.evidence.camel-yaml-validator.4.18.3.json-schema-validator.version=1.5.9
+ship.evidence.camel-yaml-validator.networknt-itu.version=1.14.0
+ship.evidence.camel-yaml-validator.networknt-slf4j.version=2.0.17
+ship.evidence.citrus.5.0.0-M2.camel.supported=4.21.0,4.18.3
+ship.evidence.jackson-yaml.version=2.19.2
+ship.evidence.snakeyaml.version=2.4
 
 # ─── Forage (KaotoIO) ────────────────────────────────────────────────────────
 #

--- a/pom.xml
+++ b/pom.xml
@@ -31,24 +31,27 @@
         <minimalJavaBuildVersion>${jdk.version}</minimalJavaBuildVersion>
         <picocli.version>4.7.7</picocli.version>
         <ascii-table.version>1.9.0</ascii-table.version>
-        <jackson.version>2.19.2</jackson.version>
+        <jackson.version>${ship.evidence.jackson-yaml.version}</jackson.version>
         <jline.version>3.30.6</jline.version>
         <tamboui.version>0.1.0</tamboui.version>
         <tomlj.version>1.1.1</tomlj.version>
         <quarkus.version>3.20.2.2</quarkus.version>
         <quarkus-mcp.version>1.6.1</quarkus-mcp.version>
-        <camel.version>4.21.0</camel.version>
+        <camel.version>${camel.main.version}</camel.version>
         <!-- BEGIN distribution property mirrors
              distribution.properties is the packaged runtime source of truth.
              These literals must also exist here because Maven builds its model
              and resolves dependency/plugin versions before a lifecycle plugin
              can read that file. DistributionVersionMirrorTest prevents drift. -->
+        <camel.main.version>4.21.0</camel.main.version>
         <camel.mcp.version>4.21.0</camel.mcp.version>
+        <ship.evidence.jackson-yaml.version>2.19.2</ship.evidence.jackson-yaml.version>
         <maven.resolver.version>1.9.27</maven.resolver.version>
         <maven.provider.version>3.9.12</maven.provider.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
         <maven.shade.plugin.version>3.6.1</maven.shade.plugin.version>
         <maven.surefire.plugin.version>3.5.4</maven.surefire.plugin.version>
+        <maven.failsafe.plugin.version>3.5.4</maven.failsafe.plugin.version>
         <slf4j.version>1.7.36</slf4j.version>
         <!-- END distribution property mirrors -->
 


### PR DESCRIPTION
## Summary

- add deterministic Ship artifact, ledger, protocol, and catalog-usage validation contracts
- execute controller-selected JVM payloads through content-locked, bounded Bubblewrap evidence runners
- add collision-free canonical MAC encoding for the five authenticated interaction families
- verify exact Camel Main, YAML validation, packaging, and Citrus payload compatibility outside the development classpath

This slice introduces no controller state machine or public Ship command. `StageResultValidator.validatePreflight` validates one live, stopped-worker view; it does not certify a later path reopen. The controller slice must hash while importing that same opened stream into controller-owned quarantine/CAS and commit only the imported copy.

## Review follow-up

- bound Maven XML element depth; reject test-failure-ignore controls; cover stale and malformed artifact digests
- keep endpoint metadata out of URI extraction, validate every supported static endpoint field, reject non-exact aliases and unprovable endpoint EIPs
- treat `interceptFrom.uri` and `interceptSendToEndpoint.uri` as static selector patterns rather than endpoint dependencies; keep `interceptSendToEndpoint.afterUri` catalog-validated and runtime-stubbed
- remove `componentParameters` / `endpointParameters`: they are not accepted by either certified Camel YAML schema, so there is no sidecar stripping contract
- bind staged results to exact ledger questions, schema versions, capabilities, output roots, and descriptor-relative regular-file identity
- avoid shared-ancestor timestamp binding while retaining `NOFOLLOW_LINKS`, stable file-key checks, and full attempt-root/artifact identity checks
- require successful stdout-backed executable version queries, block commands without a version query, and keep evidence directories exclusive per run
- make packaged-payload certification an explicit Linux/Bubblewrap profile used by build, release, and snapshot workflows; document when contributors should reproduce it while ordinary `clean install` remains portable

## Verification

- `./mvnw -B -Psourcecheck validate`
- focused follow-up suite: 82 tests, no failures or skips
- complete Core suite: 695 tests, no failures or skips
- `./mvnw -B -Plinux-ship-certification -Dformat.skip=true -pl camel-kit-core -am verify`
- `./mvnw -B clean install`

The certified build includes all resolver, graph, and Core tests plus 3 packaged compatibility integration tests and forbidden-API checks.

Part of #149

Website impact: not required — this PR implements internal validation and interaction contracts; public behavior remains unavailable.
