### PR TITLE
Add protected Ship broker, evidence, and publication

### DIFF
--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipArtifactImportWiringIT.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipArtifactImportWiringIT.java
@@ -22,6 +22,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
 import io.github.luigidemasi.camelkit.ship.protocol.StageRequest;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResultValidator;
@@ -34,27 +35,36 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Full-reactor accidental-wiring tripwire while staged import has no production broker.
+ * Full-reactor trusted-chain tripwire for protected artifact import.
  *
  * <p>
- * This is not a security boundary. Production import still requires proof that the full worker process tree is dead
- * with protected exclusive ancestry, or a killable native nonblocking no-follow open.
+ * This is not the OS security boundary. It prevents bypassing the broker lease which must retain stopped-containment
+ * and protected exclusive ancestry through transactional import.
  */
 class ShipArtifactImportWiringIT {
 
     private static final String WORKSPACE_SERVICE
             = "io.github.luigidemasi.camelkit.ship.controller.ShipWorkspaceService";
     private static final String WORKSPACE_ACCEPT = WORKSPACE_SERVICE.replace('.', '/') + ".accept:";
+    private static final String CONTROLLER
+            = "io.github.luigidemasi.camelkit.ship.controller.ShipController";
+    private static final String BROKER
+            = "io.github.luigidemasi.camelkit.ship.controller.ShipProtectedWorkerBroker";
+    private static final String COMPLETED_ATTEMPT = BROKER + "$CompletedAttempt";
+    private static final String TRANSACTION
+            = "io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore$Transaction";
+    private static final String BROKER_SUBMIT = CONTROLLER.replace('.', '/') + ".submitProtectedStageResult:";
     private static final String RESULT_PREFLIGHT
             = "io/github/luigidemasi/camelkit/ship/protocol/StageResultValidator.validatePreflight:";
-    private static final String BLOB_IMPORT
-            = "io/github/luigidemasi/camelkit/ship/controller/ShipBlobStore.importArtifacts:";
-    private static final Set<String> GUARDED_METHODS = Set.of(WORKSPACE_ACCEPT, RESULT_PREFLIGHT, BLOB_IMPORT);
+    private static final String TRANSACTION_IMPORT
+            = TRANSACTION.replace('.', '/') + ".importArtifacts:";
+    private static final Set<String> GUARDED_METHODS = Set.of(
+            WORKSPACE_ACCEPT, BROKER_SUBMIT, RESULT_PREFLIGHT, TRANSACTION_IMPORT);
     private static final Pattern METHOD_REFERENCE = Pattern.compile(
             "^\\s+#[0-9]+ = (?:Interface)?Methodref\\s+#[^\\r\\n]*//\\s+(\\S+)$", Pattern.MULTILINE);
 
     @Test
-    void stagedArtifactImportRemainsUnwiredAcrossTheCompiledReactor() throws Exception {
+    void stagedArtifactImportUsesOnlyTheTrustedBrokerChainAcrossTheCompiledReactor() throws Exception {
         Path testClasses = Path.of(ShipArtifactImportWiringIT.class.getProtectionDomain()
                 .getCodeSource().getLocation().toURI());
         Path reactor = testClasses.getParent().getParent().getParent();
@@ -69,17 +79,21 @@ class ShipArtifactImportWiringIT {
         }
 
         assertEquals(
-                Set.of(),
+                Set.of(CONTROLLER),
                 callers.getOrDefault(WORKSPACE_ACCEPT, Set.of()),
-                "Accidental-wiring tripwire: ShipWorkspaceService.accept must remain production-dead");
+                "ShipWorkspaceService.accept must be called only by ShipController");
+        assertEquals(
+                Set.of(BROKER),
+                callers.getOrDefault(BROKER_SUBMIT, Set.of()),
+                "Protected broker must be the only artifact-bearing controller entry point");
         assertEquals(
                 Set.of(),
                 callers.getOrDefault(RESULT_PREFLIGHT, Set.of()),
                 "Accidental-wiring tripwire: StageResultValidator.validatePreflight must remain production-dead");
         assertEquals(
-                Set.of(WORKSPACE_SERVICE),
-                callers.getOrDefault(BLOB_IMPORT, Set.of()),
-                "Accidental-wiring tripwire: ShipBlobStore.importArtifacts is reserved for ShipWorkspaceService");
+                Set.of(COMPLETED_ATTEMPT),
+                callers.getOrDefault(TRANSACTION_IMPORT, Set.of()),
+                "Transactional artifact import must be called only by the custody-held completed attempt");
     }
 
     @Test
@@ -205,11 +219,20 @@ class ShipArtifactImportWiringIT {
         }
 
         private static void guardedCalls(
-                StageRequest request, StageResult result, Path output, ShipBlobStore blobs)
+                StageRequest request,
+                StageResult result,
+                Path output,
+                ShipBlobStore blobs,
+                ShipBlobStore.Transaction transaction,
+                ShipProtectedWorkerBroker.CompletedAttempt completed,
+                ShipController controller,
+                ShipCatalogService.Snapshot snapshot)
                 throws IOException {
-            ShipWorkspaceService.accept(request, result, output, blobs);
+            controller.submitProtectedStageResult(
+                    request.runId(), request.inputDigest(), completed, snapshot);
+            ShipWorkspaceService.accept(request, result, completed, blobs, transaction);
             StageResultValidator.validatePreflight(request, result, output);
-            blobs.importArtifacts(output, result.artifacts());
+            transaction.importArtifacts(null, result.artifacts());
         }
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/CatalogEvidenceValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/CatalogEvidenceValidator.java
@@ -1,6 +1,7 @@
 package io.github.luigidemasi.camelkit.ship.controller;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -16,6 +17,10 @@ import java.util.regex.Pattern;
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactValidator;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactValidator.CatalogDependencyBinding;
+import io.github.luigidemasi.camelkit.ship.catalog.CamelYamlCatalogUsageExtractor;
+import io.github.luigidemasi.camelkit.ship.catalog.CamelYamlCatalogUsageExtractor.Extraction;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogComponentModel;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet.SubjectEvidence;
@@ -26,6 +31,7 @@ import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.EndpointUs
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RouteUsage;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
 import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService.Snapshot;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
 
 /** Deterministically binds catalog evidence and accepted usage to one frozen catalog snapshot. */
 final class CatalogEvidenceValidator {
@@ -47,6 +53,92 @@ final class CatalogEvidenceValidator {
             .thenComparing(value -> String.join("\u0000", value.endpointOptions()));
 
     private CatalogEvidenceValidator() {
+    }
+
+    /** Derives the exact route/catalog/dependency closure from one sealed candidate. */
+    static CatalogUsageRecord deriveUsage(
+            Snapshot snapshot,
+            DecisionLedger ledger,
+            CatalogEvidenceSet approvedEvidence,
+            ArtifactManifest manifest,
+            Path candidate,
+            String runId,
+            String catalogEvidenceDigest,
+            String artifactManifestDigest,
+            String candidateSnapshotDigest,
+            String candidateContentDigest)
+            throws IOException {
+        Objects.requireNonNull(snapshot, "snapshot must not be null");
+        Objects.requireNonNull(ledger, "ledger must not be null");
+        Objects.requireNonNull(candidate, "candidate must not be null");
+        CatalogTarget target = snapshot.target();
+        validateManifestIdentity(manifest, target);
+        List<CatalogSubject> inventory = canonicalInventory(snapshot.availableSubjects());
+        String inventoryDigest = ShipDigest.sha256(
+                ShipJson.mapper().writeValueAsBytes(inventory));
+        CamelYamlCatalogUsageExtractor extractor = new CamelYamlCatalogUsageExtractor();
+        List<RouteArtifact> manifestRoutes = manifest.routes().stream()
+                .sorted(Comparator.comparing(RouteArtifact::path)
+                        .thenComparing(RouteArtifact::routeId))
+                .toList();
+        TreeSet<CatalogSubject> used = new TreeSet<>();
+        for (RouteArtifact route : manifestRoutes) {
+            Extraction extraction = extractor.extractBound(candidate.resolve(route.path()), inventory);
+            if (!route.digest().equals(extraction.digest())) {
+                reject("catalog-route-digest-mismatch",
+                        "Catalog extraction did not read the accepted route bytes: " + route.path());
+            }
+            used.addAll(extraction.subjects());
+        }
+        CatalogEvidenceSet exactUsage = resolveEvidence(snapshot, target, used);
+        List<CatalogSubject> components = used.stream()
+                .filter(subject -> subject.kind() == CatalogSubject.Kind.COMPONENT)
+                .toList();
+        List<CatalogComponentModel> models = snapshot.componentModelsFor(components).stream()
+                .sorted(Comparator.comparing(model -> model.evidence().subject()))
+                .toList();
+        List<RouteUsage> routes = new ArrayList<>();
+        for (RouteArtifact route : manifestRoutes) {
+            Extraction extraction = extractor.extractBound(
+                    candidate.resolve(route.path()), inventory, models);
+            if (!route.digest().equals(extraction.digest())) {
+                reject("catalog-route-digest-mismatch",
+                        "Catalog endpoint validation did not read the accepted route bytes: "
+                                                        + route.path());
+            }
+            routes.add(new RouteUsage(
+                    route.routeId(), route.path(), route.digest(),
+                    extraction.subjects(), extraction.endpoints()));
+        }
+        CatalogDependencyBinding dependencies = ArtifactValidator.bindCatalogDependencies(
+                candidate, ledger.requirementsPolicy(), exactUsage);
+        if (!dependencies.validation().passed() || dependencies.pomDigest() == null) {
+            reject("catalog-runtime-dependencies-invalid",
+                    "Candidate runtime dependencies do not match frozen catalog usage");
+        }
+        CatalogUsageRecord usage = new CatalogUsageRecord(
+                CatalogUsageRecord.SCHEMA_VERSION,
+                runId,
+                catalogEvidenceDigest,
+                artifactManifestDigest,
+                candidateSnapshotDigest,
+                candidateContentDigest,
+                dependencies.pomDigest(),
+                inventoryDigest,
+                routes,
+                models,
+                dependencies.runtimeDependencies(),
+                exactUsage);
+        validateUsage(
+                snapshot,
+                new UsageBinding(
+                        runId, catalogEvidenceDigest, artifactManifestDigest,
+                        candidateSnapshotDigest, candidateContentDigest,
+                        dependencies.pomDigest()),
+                approvedEvidence,
+                manifest,
+                usage);
+        return usage;
     }
 
     /** Resolves exact evidence from the already-frozen snapshot for one canonical controller request. */

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipBlobStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipBlobStore.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
@@ -77,6 +78,11 @@ public final class ShipBlobStore {
     }
 
     public BlobReference writeBytes(String kind, byte[] value) throws IOException {
+        return writeBytes(kind, value, null);
+    }
+
+    private BlobReference writeBytes(String kind, byte[] value, Set<Path> transactionBlobs)
+            throws IOException {
         requireKind(kind);
         if (value == null || value.length > ShipTreePolicy.current().maxFileBytes()) {
             throw new IllegalArgumentException("Ship blob bytes exceed the per-file limit");
@@ -100,6 +106,9 @@ public final class ShipBlobStore {
                 }
                 verifyTemporary(temporary, value.length);
                 promoted = promote(temporary, target, reference);
+                if (promoted && transactionBlobs != null) {
+                    transactionBlobs.add(target);
+                }
                 return reference;
             } finally {
                 Files.deleteIfExists(temporary);
@@ -142,6 +151,38 @@ public final class ShipBlobStore {
 
     Path expectedSourceDirectory() {
         return runRoot.resolve("source");
+    }
+
+    Path runRoot() {
+        return runRoot;
+    }
+
+    Path privateWorkDirectory(String name) throws IOException {
+        if (name == null || !name.matches("[a-z][a-z0-9-]{0,63}")) {
+            throw new IllegalArgumentException("Invalid Ship work directory name");
+        }
+        Path directory = runRoot.resolve(name);
+        try (ShipOperationLock.Lease ignored = ShipOperationLock.acquireRun(stateRoot, runId)) {
+            verifyStore();
+            createPrivateDirectory(directory, name + " Ship work directory");
+            return directory;
+        }
+    }
+
+    Transaction beginTransaction() throws IOException {
+        ShipOperationLock.Lease lease = ShipOperationLock.acquireRun(stateRoot, runId);
+        boolean opened = false;
+        try {
+            verifyStore();
+            cleanQuarantine();
+            Transaction transaction = new Transaction(lease);
+            opened = true;
+            return transaction;
+        } finally {
+            if (!opened) {
+                lease.close();
+            }
+        }
     }
 
     Path verifiedPath(BlobReference reference) throws IOException {
@@ -194,6 +235,25 @@ public final class ShipBlobStore {
         if (candidate == null || !candidate.isAbsolute() || !candidate.normalize().equals(candidate)) {
             throw new IOException("Ship candidate directory must be absolute and normalized");
         }
+        Path publication = runRoot.resolve("publication");
+        if (candidate.startsWith(publication)) {
+            Path relative = publication.relativize(candidate);
+            if (relative.getNameCount() != 2
+                    || !relative.getName(0).toString().matches(
+                            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+                    || !"candidate".equals(relative.getName(1).toString())) {
+                throw new IOException("Ship candidate is not an exact protected publication transaction");
+            }
+            BasicFileAttributes attributes = Files.readAttributes(
+                    candidate, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!attributes.isDirectory() || attributes.isSymbolicLink()
+                    || !candidate.toRealPath(LinkOption.NOFOLLOW_LINKS).equals(candidate)) {
+                throw new IOException("Ship publication candidate is not a real sealed directory");
+            }
+            requireSameOwner(candidate, candidate.getParent(), "Ship publication candidate");
+            requireSameDevice(candidate, candidate.getParent(), "Ship publication candidate");
+            return candidate;
+        }
         Path attempts = runRoot.resolve("attempts");
         Path relative;
         try {
@@ -225,8 +285,13 @@ public final class ShipBlobStore {
         return runRoot.resolve("attempts").resolve(attemptId).resolve(leaf);
     }
 
-    /** Imports a whole accepted result before any artifact becomes addressable. */
-    List<ImportedBlob> importArtifacts(Path attemptOutput, List<ProducedArtifact> artifacts) throws IOException {
+    /** Imports a whole accepted result while its protected-custody session remains open. */
+    private List<ImportedBlob> importArtifacts(
+            StagedArtifactSource.Session source,
+            List<ProducedArtifact> artifacts,
+            Set<Path> transactionBlobs)
+            throws IOException {
+        Objects.requireNonNull(source, "protected artifact source");
         if (artifacts == null) {
             throw new IllegalArgumentException("Produced artifacts are required");
         }
@@ -239,27 +304,27 @@ public final class ShipBlobStore {
             List<PendingBlob> pending = new ArrayList<>();
             Set<Path> promoted = new HashSet<>();
             try {
-                try (StagedArtifactSource.Session source = StagedArtifactSource.open(attemptOutput)) {
-                    for (ProducedArtifact artifact : artifacts) {
-                        Path temporary = newTemporary();
+                for (ProducedArtifact artifact : artifacts) {
+                    Path temporary = newTemporary();
+                    try {
+                        pending.add(copyToQuarantine(source, artifact, temporary));
+                    } catch (IOException | RuntimeException e) {
                         try {
-                            pending.add(copyToQuarantine(source, artifact, temporary));
-                        } catch (IOException | RuntimeException e) {
-                            try {
-                                Files.deleteIfExists(temporary);
-                            } catch (IOException cleanup) {
-                                e.addSuppressed(cleanup);
-                            }
-                            throw e;
+                            Files.deleteIfExists(temporary);
+                        } catch (IOException cleanup) {
+                            e.addSuppressed(cleanup);
                         }
+                        throw e;
                     }
                 }
                 validateBatch(pending);
                 List<ImportedBlob> result = promoteBatch(pending, promoted);
+                transactionBlobs.addAll(promoted);
                 cleanPending(pending);
                 return result;
             } catch (IOException | RuntimeException e) {
                 rollbackPromoted(promoted, e);
+                transactionBlobs.removeAll(promoted);
                 try {
                     cleanPending(pending);
                 } catch (IOException cleanup) {
@@ -369,6 +434,33 @@ public final class ShipBlobStore {
             forceDirectory(blobs);
         } catch (IOException cleanup) {
             failure.addSuppressed(cleanup);
+        }
+    }
+
+    private void rollbackTransaction(Set<Path> installed) throws IOException {
+        IOException failure = null;
+        for (Path target : installed) {
+            try {
+                Files.deleteIfExists(target);
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        try {
+            forceDirectory(blobs);
+        } catch (IOException e) {
+            if (failure == null) {
+                failure = e;
+            } else {
+                failure.addSuppressed(e);
+            }
+        }
+        if (failure != null) {
+            throw failure;
         }
     }
 
@@ -689,6 +781,99 @@ public final class ShipBlobStore {
             requireReference(reference);
             if (unixMode != (REGULAR_FILE_TYPE | 0644)) {
                 throw new IllegalArgumentException("Invalid imported Ship artifact mode");
+            }
+        }
+    }
+
+    /** One event-sized CAS transaction. Closing before commit removes only addresses installed by this transaction. */
+    final class Transaction implements AutoCloseable {
+
+        private final ShipOperationLock.Lease lease;
+        private final Set<Path> installed = new HashSet<>();
+        private boolean committed;
+        private boolean closed;
+
+        private Transaction(ShipOperationLock.Lease lease) {
+            this.lease = lease;
+        }
+
+        BlobReference writeBytes(String kind, byte[] value) throws IOException {
+            requireOpen();
+            return ShipBlobStore.this.writeBytes(kind, value, installed);
+        }
+
+        List<ImportedBlob> importArtifacts(
+                StagedArtifactSource.Session source, List<ProducedArtifact> artifacts)
+                throws IOException {
+            requireOpen();
+            return ShipBlobStore.this.importArtifacts(source, artifacts, installed);
+        }
+
+        BlobReference importControllerFile(String kind, Path source, String expectedDigest)
+                throws IOException {
+            requireOpen();
+            Path file = Objects.requireNonNull(source, "controller evidence file")
+                    .toAbsolutePath().normalize();
+            BasicFileAttributes before = Files.readAttributes(
+                    file, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!before.isRegularFile() || before.isSymbolicLink() || before.fileKey() == null
+                    || before.size() > ShipTreePolicy.current().maxFileBytes()
+                    || before.size() > Integer.MAX_VALUE
+                    || linkCount(file, "Controller evidence file") != 1) {
+                throw new IOException("Controller evidence file has unsafe metadata");
+            }
+            byte[] bytes = Files.readAllBytes(file);
+            BasicFileAttributes after = Files.readAttributes(
+                    file, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!before.fileKey().equals(after.fileKey())
+                    || before.size() != after.size()
+                    || !before.lastModifiedTime().equals(after.lastModifiedTime())
+                    || bytes.length != before.size()) {
+                throw new IOException("Controller evidence file changed while it was retained");
+            }
+            String digest = ShipDigest.sha256(bytes);
+            if (expectedDigest != null && !expectedDigest.equals(digest)) {
+                throw new IOException("Controller evidence file differs from its recorded digest");
+            }
+            return writeBytes(kind, bytes);
+        }
+
+        void commit() {
+            requireOpen();
+            committed = true;
+        }
+
+        private void requireOpen() {
+            if (closed) {
+                throw new IllegalStateException("Ship blob transaction is closed");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            IOException failure = null;
+            if (!committed) {
+                try {
+                    rollbackTransaction(installed);
+                } catch (IOException e) {
+                    failure = e;
+                }
+            }
+            try {
+                lease.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
             }
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -49,14 +49,33 @@ final class ShipController {
 
     private final Path stateRoot;
     private final Clock clock;
+    private final ShipValidationService validationService;
+    private final EventStoreAccess eventStoreAccess;
 
     ShipController(Path stateRoot) {
         this(stateRoot, Clock.systemUTC());
     }
 
     ShipController(Path stateRoot, Clock clock) {
+        this(stateRoot, clock, new ShipValidationService(), EventStoreAccess.DIRECT);
+    }
+
+    ShipController(
+                   Path stateRoot,
+                   Clock clock,
+                   ShipValidationService validationService) {
+        this(stateRoot, clock, validationService, EventStoreAccess.DIRECT);
+    }
+
+    ShipController(
+                   Path stateRoot,
+                   Clock clock,
+                   ShipValidationService validationService,
+                   EventStoreAccess eventStoreAccess) {
         this.stateRoot = Objects.requireNonNull(stateRoot, "stateRoot").toAbsolutePath().normalize();
         this.clock = Objects.requireNonNull(clock, "clock");
+        this.validationService = Objects.requireNonNull(validationService, "validation service");
+        this.eventStoreAccess = Objects.requireNonNull(eventStoreAccess, "event store access");
     }
 
     ShipRunView start(PreparedRun prepared) throws IOException {
@@ -130,14 +149,16 @@ final class ShipController {
 
     ShipRunView status(String runId) throws IOException {
         OpenRun run = open(runId);
-        ShipRunView before = projector(run.events(), run.blobs(), run.signer()).replay();
+        ShipRunProjector projector = projector(run.events(), run.blobs(), run.signer());
+        ShipRunView before = projector.replay();
         try (ShipOperationLock.Lease runLease = ShipOperationLock.acquireRun(stateRoot, runId);
              ShipOperationLock.Lease projectLease
                      = ShipOperationLock.acquireProject(stateRoot, before.projectRoot())) {
-            ShipRunView current = projector(run.events(), run.blobs(), run.signer()).replay();
-            List<ShipEvent> history = run.events().replay();
-            ShipPublicationService.recover(current, run.blobs(), history);
-            return projector(run.events(), run.blobs(), run.signer()).replay();
+            ShipRunProjector.ReplayResult replay = projector.replayResult();
+            ShipRunView current = replay.view();
+            ShipPublicationService.recover(current, run.blobs(), replay.history());
+            ShipProjectPublisher.reconcileCandidates(run.blobs(), replay.history());
+            return current;
         }
     }
 
@@ -454,10 +475,9 @@ final class ShipController {
         BlobReference design = onlyArtifact(workspace, "design");
         return new Mutation(
                 ShipAuthorityCommand.value(ShipEventType.DESIGN_READY, design.digest()),
-                new ShipEventPayloads.StageAccepted(
+                ShipEventPayloads.StageAccepted.design(
                         result.stage(), current.view().activeRequestReference(), resultReference,
-                        workspace.artifacts(), null, null, null, null, null,
-                        design.digest(), null, null, List.of(), null, null));
+                        workspace.artifacts(), design.digest()));
     }
 
     private static Mutation acceptedPlan(
@@ -468,10 +488,9 @@ final class ShipController {
         BlobReference plan = onlyArtifact(workspace, "plan");
         return new Mutation(
                 ShipAuthorityCommand.value(ShipEventType.PLAN_VALIDATED, plan.digest()),
-                new ShipEventPayloads.StageAccepted(
+                ShipEventPayloads.StageAccepted.plan(
                         result.stage(), current.view().activeRequestReference(), resultReference,
-                        workspace.artifacts(), null, null, null, null, null,
-                        null, null, null, List.of(), null, null));
+                        workspace.artifacts()));
     }
 
     private Mutation acceptedExecution(
@@ -497,7 +516,7 @@ final class ShipController {
         }
         BlobReference manifestReference = write(
                 current.transaction(), "artifact-manifest", result.artifactManifest());
-        ShipProjectPublisher.PublicationTransaction publication
+        ShipProjectPublisher.StagedCandidate staged
                 = ShipProjectPublisher.stageSealedCandidate(
                         stateRoot,
                         current.view().runId(),
@@ -506,43 +525,49 @@ final class ShipController {
                         current.view().authority().revision(),
                         current.blobs(),
                         workspace);
-        Path candidateDirectory = current.blobs().runRoot()
-                .resolve("publication")
-                .resolve(publication.transactionId())
-                .resolve("candidate");
-        ProjectSnapshot candidate = ProjectEvidenceFiles.captureSealed(candidateDirectory);
-        if (!publication.postimageDigest().equals(candidate.digest())) {
-            throw new IOException("Publication transaction differs from its sealed candidate");
+        try {
+            Path candidateDirectory = staged.candidateDirectory();
+            ProjectSnapshot candidate = ProjectEvidenceFiles.captureSealed(candidateDirectory);
+            if (!staged.postimageDigest().equals(candidate.digest())) {
+                throw new IOException("Publication transaction differs from its sealed candidate");
+            }
+            BlobReference candidateReference = write(
+                    current.transaction(), "project-snapshot", candidate);
+            DecisionLedger ledger = read(
+                    current.blobs(), current.view().ledger(),
+                    "decision-ledger", DecisionLedger.class);
+            CatalogEvidenceSet approved = read(
+                    current.blobs(), current.view().catalogEvidence(),
+                    "catalog-evidence", CatalogEvidenceSet.class);
+            CatalogUsageRecord usage = CatalogEvidenceValidator.deriveUsage(
+                    catalogSnapshot,
+                    ledger,
+                    approved,
+                    result.artifactManifest(),
+                    candidateDirectory,
+                    current.view().runId(),
+                    current.view().catalogEvidence().digest(),
+                    manifestReference.digest(),
+                    candidateReference.digest(),
+                    candidate.digest());
+            BlobReference usageReference = write(
+                    current.transaction(), "catalog-usage", usage);
+            return Mutation.withCandidate(
+                    ShipAuthorityCommand.value(
+                            ShipEventType.EXECUTION_VALIDATED, resultReference.digest()),
+                    ShipEventPayloads.StageAccepted.execution(
+                            result.stage(), current.view().activeRequestReference(), resultReference,
+                            workspace.artifacts(), manifestReference, usageReference,
+                            candidateReference, candidateDirectory.toString()),
+                    staged);
+        } catch (IOException | RuntimeException | Error failure) {
+            try {
+                staged.close();
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+            throw failure;
         }
-        BlobReference candidateReference = write(
-                current.transaction(), "project-snapshot", candidate);
-        DecisionLedger ledger = read(
-                current.blobs(), current.view().ledger(),
-                "decision-ledger", DecisionLedger.class);
-        CatalogEvidenceSet approved = read(
-                current.blobs(), current.view().catalogEvidence(),
-                "catalog-evidence", CatalogEvidenceSet.class);
-        CatalogUsageRecord usage = CatalogEvidenceValidator.deriveUsage(
-                catalogSnapshot,
-                ledger,
-                approved,
-                result.artifactManifest(),
-                candidateDirectory,
-                current.view().runId(),
-                current.view().catalogEvidence().digest(),
-                manifestReference.digest(),
-                candidateReference.digest(),
-                candidate.digest());
-        BlobReference usageReference = write(
-                current.transaction(), "catalog-usage", usage);
-        return new Mutation(
-                ShipAuthorityCommand.value(
-                        ShipEventType.EXECUTION_VALIDATED, resultReference.digest()),
-                new ShipEventPayloads.StageAccepted(
-                        result.stage(), current.view().activeRequestReference(), resultReference,
-                        workspace.artifacts(), null, manifestReference, null, usageReference,
-                        null, null, candidateReference, candidateDirectory.toString(),
-                        List.of(), null, null));
     }
 
     private Mutation acceptedValidation(
@@ -577,32 +602,33 @@ final class ShipController {
         ProjectSnapshot candidate = read(
                 current.blobs(), current.view().candidateSnapshot(),
                 "project-snapshot", ProjectSnapshot.class);
-        ShipValidationService.Result assessment = new ShipValidationService().validate(
+        ShipValidationService.Result assessment = validationService.validate(
                 current.blobs(),
                 current.transaction(),
-                current.view().runId(),
-                current.view().candidateDirectory(),
-                candidate,
-                current.view().candidateSnapshot(),
-                manifest,
-                current.view().artifactManifest(),
-                ledger.requirementsPolicy(),
-                usage,
-                current.view().catalogUsage(),
-                catalogSnapshot,
-                approved,
-                current.view().catalogEvidence(),
-                workerValidation);
+                new ShipValidationService.Inputs(
+                        current.view().runId(),
+                        new ShipValidationService.CandidateInput(
+                                current.view().candidateDirectory(), candidate,
+                                current.view().candidateSnapshot()),
+                        new ShipValidationService.ManifestInput(
+                                manifest, current.view().artifactManifest()),
+                        ledger.requirementsPolicy(),
+                        new ShipValidationService.CatalogInput(
+                                new ShipValidationService.UsageInput(
+                                        usage, current.view().catalogUsage()),
+                                catalogSnapshot,
+                                new ShipValidationService.ApprovalInput(
+                                        approved, current.view().catalogEvidence())),
+                        workerValidation));
         if (assessment.verdict() == ShipValidationService.Verdict.PASS) {
             return new Mutation(
                     ShipAuthorityCommand.value(
                             ShipEventType.VALIDATION_PASSED,
                             assessment.reportReference().digest()),
-                    new ShipEventPayloads.StageAccepted(
+                    ShipEventPayloads.StageAccepted.validation(
                             result.stage(), current.view().activeRequestReference(), resultReference,
-                            workspace.artifacts(), null, null, null, null, null, null,
-                            null, null, assessment.evidence(),
-                            assessment.reportReference(), null));
+                            workspace.artifacts(), assessment.evidence(),
+                            assessment.reportReference()));
         }
         if (assessment.verdict() == ShipValidationService.Verdict.WAIVABLE) {
             ShipStamp.Check failed = assessment.failedCheck();
@@ -610,14 +636,12 @@ final class ShipController {
                     ShipAuthorityCommand.waiver(
                             failed.id(), failed.evidenceDigest(),
                             current.view().authority().authority().basis().policy().value()),
-                    new ShipEventPayloads.Failure(
-                            ShipStage.VALIDATE,
+                    ShipEventPayloads.Failure.waivable(
                             "validation-check-waivable",
                             "Controller validation check requires an explicit waiver: " + failed.id(),
                             current.view().activeRequestReference(),
                             resultReference,
                             assessment.reportReference(),
-                            null,
                             current.view().interactionBundle(),
                             assessment.evidence()));
         }
@@ -628,7 +652,7 @@ final class ShipController {
                 current.transaction(), "ship-stamp", stamp);
         return new Mutation(
                 ShipAuthorityCommand.empty(ShipEventType.RUN_FAILED_TERMINAL),
-                new ShipEventPayloads.Failure(
+                ShipEventPayloads.Failure.terminal(
                         ShipStage.VALIDATE,
                         stamp.failureCode(),
                         stamp.failureMessage(),
@@ -949,14 +973,12 @@ final class ShipController {
             MutationContext current, StageResult result, BlobReference resultReference) {
         return new Mutation(
                 ShipAuthorityCommand.empty(ShipEventType.ATTEMPT_FAILED_RETRYABLE),
-                new ShipEventPayloads.Failure(
+                ShipEventPayloads.Failure.retryable(
                         result.stage(),
                         result.failureCode(),
                         result.failureMessage(),
                         current.view().activeRequestReference(),
                         resultReference,
-                        null,
-                        null,
                         null));
     }
 
@@ -968,20 +990,9 @@ final class ShipController {
             BlobReference catalogEvidence,
             String requirementsDigest,
             ShipEventPayloads.StageStarted continuation) {
-        return new ShipEventPayloads.StageAccepted(
-                result.stage(),
-                current.view().activeRequestReference(),
-                resultReference,
-                List.of(),
-                ledger,
-                null,
-                catalogEvidence,
-                null,
-                requirementsDigest,
-                null,
-                null,
-                null,
-                continuation);
+        return ShipEventPayloads.StageAccepted.analysis(
+                result.stage(), current.view().activeRequestReference(), resultReference,
+                ledger, catalogEvidence, requirementsDigest, continuation);
     }
 
     private static CatalogTarget catalogTarget(DecisionLedger ledger) {
@@ -1083,14 +1094,15 @@ final class ShipController {
             String runId, String expectedEventDigest, MutationFactory factory)
             throws IOException {
         OpenRun run = open(runId);
-        ShipRunView before = projector(run.events(), run.blobs(), run.signer()).replay();
+        ShipRunProjector projector = projector(run.events(), run.blobs(), run.signer());
+        ShipRunView before = projector.replay();
         try (ShipOperationLock.Lease runLease = ShipOperationLock.acquireRun(stateRoot, runId);
              ShipOperationLock.Lease projectLease
                      = ShipOperationLock.acquireProject(stateRoot, before.projectRoot())) {
-            ShipRunView current = projector(run.events(), run.blobs(), run.signer()).replay();
-            List<ShipEvent> history = run.events().replay();
-            ShipPublicationService.recover(current, run.blobs(), history);
-            current = projector(run.events(), run.blobs(), run.signer()).replay();
+            ShipRunProjector.ReplayResult replay = projector.replayResult();
+            ShipRunView current = replay.view();
+            ShipPublicationService.recover(current, run.blobs(), replay.history());
+            ShipProjectPublisher.reconcileCandidates(run.blobs(), replay.history());
             if (!Objects.equals(expectedEventDigest, current.eventDigest())) {
                 throw new ShipControllerException(
                         "stale-run-head", "Ship run changed before the requested operation could commit");
@@ -1109,7 +1121,7 @@ final class ShipController {
                         new ShipInteractionBundleService(run.signer()),
                         transaction));
                 ShipRun successor = mutation.authority().apply(current.authority());
-                projector(run.events(), run.blobs(), run.signer()).preflight(
+                projector.preflight(
                         mutation.authority(), mutation.data(), successor);
                 ShipEventDraft draft = new ShipEventDraft(
                         mutation.authority().type(),
@@ -1119,35 +1131,29 @@ final class ShipController {
                         now(),
                         ShipStoredEventCodec.encode(mutation.authority(), mutation.data()));
                 try {
-                    run.events().appendIfLatest(expectedHead, draft);
+                    eventStoreAccess.appendIfLatest(run.events(), expectedHead, draft);
                     eventCommitted = true;
-                } catch (IOException | RuntimeException failure) {
+                } catch (IOException | RuntimeException | Error failure) {
                     ShipEventHead observed;
                     try {
-                        observed = run.events().currentHead();
-                    } catch (IOException | RuntimeException resolutionFailure) {
+                        observed = eventStoreAccess.currentHead(run.events());
+                    } catch (IOException | RuntimeException | Error resolutionFailure) {
                         eventCommitted = true;
                         transaction.commit();
-                        if (mutation.publication() != null) {
-                            mutation.publication().retainForRecovery();
-                        }
+                        retainForRecovery(mutation);
                         failure.addSuppressed(resolutionFailure);
                         throw failure;
                     }
                     if (observed.authorityHead().equals(successor.head())) {
                         eventCommitted = true;
                         transaction.commit();
-                        if (mutation.publication() != null) {
-                            mutation.publication().finish();
-                        }
-                        return projector(run.events(), run.blobs(), run.signer()).replay();
+                        finish(mutation);
+                        return projector.replay();
                     }
                     if (!observed.equals(expectedHead)) {
                         eventCommitted = true;
                         transaction.commit();
-                        if (mutation.publication() != null) {
-                            mutation.publication().retainForRecovery();
-                        }
+                        retainForRecovery(mutation);
                         throw new ShipControllerException(
                                 "event-append-outcome-unknown",
                                 "Ship event head changed to an unexpected authenticated value",
@@ -1156,19 +1162,48 @@ final class ShipController {
                     throw failure;
                 }
                 transaction.commit();
-                if (mutation.publication() != null) {
-                    mutation.publication().finish();
-                }
-                return projector(run.events(), run.blobs(), run.signer()).replay();
-            } catch (IOException | RuntimeException failure) {
-                if (!eventCommitted && mutation != null && mutation.publication() != null) {
-                    try {
-                        mutation.publication().close();
-                    } catch (IOException cleanup) {
-                        failure.addSuppressed(cleanup);
-                    }
+                finish(mutation);
+                return projector.replay();
+            } catch (IOException | RuntimeException | Error failure) {
+                if (!eventCommitted && mutation != null) {
+                    close(mutation, failure);
                 }
                 throw failure;
+            }
+        }
+    }
+
+    private static void finish(Mutation mutation) throws IOException {
+        if (mutation.publication() != null) {
+            mutation.publication().finish();
+        }
+        if (mutation.candidate() != null) {
+            mutation.candidate().transferToHistory();
+        }
+    }
+
+    private static void retainForRecovery(Mutation mutation) {
+        if (mutation.publication() != null) {
+            mutation.publication().retainForRecovery();
+        }
+        if (mutation.candidate() != null) {
+            mutation.candidate().retainForRecovery();
+        }
+    }
+
+    private static void close(Mutation mutation, Throwable failure) {
+        if (mutation.publication() != null) {
+            try {
+                mutation.publication().close();
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+        }
+        if (mutation.candidate() != null) {
+            try {
+                mutation.candidate().close();
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
             }
         }
     }
@@ -1366,6 +1401,33 @@ final class ShipController {
         Mutation create(MutationContext current) throws IOException;
     }
 
+    interface EventStoreAccess {
+
+        EventStoreAccess DIRECT = new EventStoreAccess() {
+            @Override
+            public ShipEvent appendIfLatest(
+                    FileShipEventStore events,
+                    ShipEventHead expectedHead,
+                    ShipEventDraft draft)
+                    throws IOException {
+                return events.appendIfLatest(expectedHead, draft);
+            }
+
+            @Override
+            public ShipEventHead currentHead(FileShipEventStore events) throws IOException {
+                return events.currentHead();
+            }
+        };
+
+        ShipEvent appendIfLatest(
+                FileShipEventStore events,
+                ShipEventHead expectedHead,
+                ShipEventDraft draft)
+                throws IOException;
+
+        ShipEventHead currentHead(FileShipEventStore events) throws IOException;
+    }
+
     private record MutationContext(
             ShipRunView view,
             ShipBlobStore blobs,
@@ -1376,10 +1438,25 @@ final class ShipController {
     private record Mutation(
             ShipAuthorityCommand authority,
             ShipEventPayloads.Payload data,
-            LivePublication publication) {
+            LivePublication publication,
+            ShipProjectPublisher.StagedCandidate candidate) {
 
         private Mutation(ShipAuthorityCommand authority, ShipEventPayloads.Payload data) {
-            this(authority, data, null);
+            this(authority, data, null, null);
+        }
+
+        private Mutation(
+                         ShipAuthorityCommand authority,
+                         ShipEventPayloads.Payload data,
+                         LivePublication publication) {
+            this(authority, data, publication, null);
+        }
+
+        private static Mutation withCandidate(
+                ShipAuthorityCommand authority,
+                ShipEventPayloads.Payload data,
+                ShipProjectPublisher.StagedCandidate candidate) {
+            return new Mutation(authority, data, null, candidate);
         }
 
         private Mutation {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -13,8 +13,10 @@ import java.util.List;
 import java.util.Objects;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord;
 import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
 import io.github.luigidemasi.camelkit.ship.context.ContextFilesystemPolicy;
 import io.github.luigidemasi.camelkit.ship.context.ContextResolution;
@@ -26,6 +28,8 @@ import io.github.luigidemasi.camelkit.ship.context.InitialContextRequest.UserTex
 import io.github.luigidemasi.camelkit.ship.context.InitialContextResolver;
 import io.github.luigidemasi.camelkit.ship.controller.ShipAttemptFactory.AttemptInputs;
 import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+import io.github.luigidemasi.camelkit.ship.controller.ShipProtectedWorkerBroker.CompletedAttempt;
+import io.github.luigidemasi.camelkit.ship.controller.ShipPublicationService.LivePublication;
 import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
 import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidationException;
 import io.github.luigidemasi.camelkit.ship.ledger.LedgerValidator;
@@ -126,7 +130,15 @@ final class ShipController {
 
     ShipRunView status(String runId) throws IOException {
         OpenRun run = open(runId);
-        return projector(run.events(), run.blobs(), run.signer()).replay();
+        ShipRunView before = projector(run.events(), run.blobs(), run.signer()).replay();
+        try (ShipOperationLock.Lease runLease = ShipOperationLock.acquireRun(stateRoot, runId);
+             ShipOperationLock.Lease projectLease
+                     = ShipOperationLock.acquireProject(stateRoot, before.projectRoot())) {
+            ShipRunView current = projector(run.events(), run.blobs(), run.signer()).replay();
+            List<ShipEvent> history = run.events().replay();
+            ShipPublicationService.recover(current, run.blobs(), history);
+            return projector(run.events(), run.blobs(), run.signer()).replay();
+        }
     }
 
     ShipRunView beginContextResolution(
@@ -203,6 +215,30 @@ final class ShipController {
         });
     }
 
+    ShipRunView startPlan(String runId, String expectedEventDigest) throws IOException {
+        return mutate(runId, expectedEventDigest, current -> startStage(
+                current,
+                ShipAuthorityCommand.empty(ShipEventType.PLAN_STARTED),
+                ShipStage.PLAN,
+                AttemptInputs.from(current.view())));
+    }
+
+    ShipRunView startExecution(String runId, String expectedEventDigest) throws IOException {
+        return mutate(runId, expectedEventDigest, current -> startStage(
+                current,
+                ShipAuthorityCommand.empty(ShipEventType.EXECUTION_STARTED),
+                ShipStage.EXECUTE,
+                AttemptInputs.from(current.view())));
+    }
+
+    ShipRunView startValidation(String runId, String expectedEventDigest) throws IOException {
+        return mutate(runId, expectedEventDigest, current -> startStage(
+                current,
+                ShipAuthorityCommand.empty(ShipEventType.VALIDATION_STARTED),
+                ShipStage.VALIDATE,
+                AttemptInputs.from(current.view())));
+    }
+
     ShipRunView retryStage(String runId, String expectedEventDigest) throws IOException {
         return mutate(runId, expectedEventDigest, current -> {
             ShipAuthorityCommand command = ShipAuthorityCommand.empty(ShipEventType.RETRY_STARTED);
@@ -236,6 +272,36 @@ final class ShipController {
         byte[] supplied = ShipStageResultReader.boundedCopy(encodedResult);
         return mutate(runId, expectedEventDigest, current -> acceptResult(
                 current, supplied, catalogSnapshot));
+    }
+
+    ShipRunView submitProtectedStageResult(
+            String runId,
+            String expectedEventDigest,
+            CompletedAttempt completed,
+            ShipCatalogService.Snapshot catalogSnapshot)
+            throws IOException {
+        Objects.requireNonNull(completed, "protected completed attempt");
+        return mutate(runId, expectedEventDigest, current -> acceptProtectedResult(
+                current, completed, catalogSnapshot));
+    }
+
+    ShipRunView complete(String runId, String expectedEventDigest) throws IOException {
+        ShipRunView current = status(runId);
+        if (!Objects.equals(expectedEventDigest, current.eventDigest())) {
+            throw new ShipControllerException(
+                    "stale-run-head", "Ship run changed before Stamp completion began");
+        }
+        if (current.state() == ShipState.VALIDATE_PASSED) {
+            current = mutate(runId, current.eventDigest(), context -> new Mutation(
+                    ShipAuthorityCommand.empty(ShipEventType.STAMP_STARTED),
+                    new ShipEventPayloads.NoData()));
+        } else if (current.state() == ShipState.WAIVER_RECORDED) {
+            current = mutate(runId, current.eventDigest(), context -> new Mutation(
+                    ShipAuthorityCommand.empty(ShipEventType.WAIVER_STAMP_STARTED),
+                    new ShipEventPayloads.NoData()));
+        }
+        String completionHead = current.eventDigest();
+        return mutate(runId, completionHead, context -> completeStamp(context));
     }
 
     ShipRunView answerDiscovery(
@@ -341,6 +407,281 @@ final class ShipController {
                                                     + " results require the protected artifact broker");
             };
         };
+    }
+
+    private Mutation acceptProtectedResult(
+            MutationContext current,
+            CompletedAttempt completed,
+            ShipCatalogService.Snapshot catalogSnapshot)
+            throws IOException {
+        StageRequest request = current.view().activeRequest();
+        if (request == null || current.view().activeRequestReference() == null) {
+            throw new ShipControllerException(
+                    "worker-result-unexpected", "Ship run has no active worker request");
+        }
+        StageResult result = completed.readResult(request);
+        if (result.outcome() != StageResult.Outcome.COMPLETED
+                || result.stage() == ShipStage.DISCOVERY
+                || result.stage() == ShipStage.REVIEW) {
+            throw new ShipControllerException(
+                    "worker-result-outcome-invalid",
+                    "Protected broker accepts only completed artifact-bearing stages");
+        }
+        if (result.ledger() != null) {
+            validateLedger(current, request, result);
+        }
+        ShipWorkspaceService.AcceptedWorkspace workspace = ShipWorkspaceService.accept(
+                request, result, completed, current.blobs(), current.transaction());
+        BlobReference resultReference = write(
+                current.transaction(), "stage-result", result);
+        return switch (result.stage()) {
+            case DESIGN -> acceptedDesign(current, result, resultReference, workspace);
+            case PLAN -> acceptedPlan(current, result, resultReference, workspace);
+            case EXECUTE -> acceptedExecution(
+                    current, result, resultReference, workspace, catalogSnapshot);
+            case VALIDATE -> acceptedValidation(
+                    current, result, resultReference, workspace, catalogSnapshot);
+            case DISCOVERY, REVIEW -> throw new ShipControllerException(
+                    "artifact-broker-stage-invalid", "Analysis stages cannot use artifact custody");
+        };
+    }
+
+    private static Mutation acceptedDesign(
+            MutationContext current,
+            StageResult result,
+            BlobReference resultReference,
+            ShipWorkspaceService.AcceptedWorkspace workspace) {
+        BlobReference design = onlyArtifact(workspace, "design");
+        return new Mutation(
+                ShipAuthorityCommand.value(ShipEventType.DESIGN_READY, design.digest()),
+                new ShipEventPayloads.StageAccepted(
+                        result.stage(), current.view().activeRequestReference(), resultReference,
+                        workspace.artifacts(), null, null, null, null, null,
+                        design.digest(), null, null, List.of(), null, null));
+    }
+
+    private static Mutation acceptedPlan(
+            MutationContext current,
+            StageResult result,
+            BlobReference resultReference,
+            ShipWorkspaceService.AcceptedWorkspace workspace) {
+        BlobReference plan = onlyArtifact(workspace, "plan");
+        return new Mutation(
+                ShipAuthorityCommand.value(ShipEventType.PLAN_VALIDATED, plan.digest()),
+                new ShipEventPayloads.StageAccepted(
+                        result.stage(), current.view().activeRequestReference(), resultReference,
+                        workspace.artifacts(), null, null, null, null, null,
+                        null, null, null, List.of(), null, null));
+    }
+
+    private Mutation acceptedExecution(
+            MutationContext current,
+            StageResult result,
+            BlobReference resultReference,
+            ShipWorkspaceService.AcceptedWorkspace workspace,
+            ShipCatalogService.Snapshot catalogSnapshot)
+            throws IOException {
+        if (catalogSnapshot == null || result.artifactManifest() == null
+                || current.view().ledger() == null
+                || current.view().catalogEvidence() == null
+                || current.view().baselineSnapshot() == null) {
+            throw new IOException("Execution acceptance lacks frozen controller inputs");
+        }
+        ProjectSnapshot baseline = read(
+                current.blobs(), current.view().baselineSnapshot(),
+                "project-snapshot", ProjectSnapshot.class);
+        ProjectSnapshot live = ProjectEvidenceFiles.capture(current.view().projectRoot());
+        if (!ProjectEvidenceFiles.unchangedMaterialTree(baseline, live)) {
+            throw new ShipControllerException(
+                    "project-changed", "Live project changed after the Ship run started");
+        }
+        BlobReference manifestReference = write(
+                current.transaction(), "artifact-manifest", result.artifactManifest());
+        ShipProjectPublisher.PublicationTransaction publication
+                = ShipProjectPublisher.stageSealedCandidate(
+                        stateRoot,
+                        current.view().runId(),
+                        current.view().projectRoot(),
+                        current.view().eventDigest(),
+                        current.view().authority().revision(),
+                        current.blobs(),
+                        workspace);
+        Path candidateDirectory = current.blobs().runRoot()
+                .resolve("publication")
+                .resolve(publication.transactionId())
+                .resolve("candidate");
+        ProjectSnapshot candidate = ProjectEvidenceFiles.captureSealed(candidateDirectory);
+        if (!publication.postimageDigest().equals(candidate.digest())) {
+            throw new IOException("Publication transaction differs from its sealed candidate");
+        }
+        BlobReference candidateReference = write(
+                current.transaction(), "project-snapshot", candidate);
+        DecisionLedger ledger = read(
+                current.blobs(), current.view().ledger(),
+                "decision-ledger", DecisionLedger.class);
+        CatalogEvidenceSet approved = read(
+                current.blobs(), current.view().catalogEvidence(),
+                "catalog-evidence", CatalogEvidenceSet.class);
+        CatalogUsageRecord usage = CatalogEvidenceValidator.deriveUsage(
+                catalogSnapshot,
+                ledger,
+                approved,
+                result.artifactManifest(),
+                candidateDirectory,
+                current.view().runId(),
+                current.view().catalogEvidence().digest(),
+                manifestReference.digest(),
+                candidateReference.digest(),
+                candidate.digest());
+        BlobReference usageReference = write(
+                current.transaction(), "catalog-usage", usage);
+        return new Mutation(
+                ShipAuthorityCommand.value(
+                        ShipEventType.EXECUTION_VALIDATED, resultReference.digest()),
+                new ShipEventPayloads.StageAccepted(
+                        result.stage(), current.view().activeRequestReference(), resultReference,
+                        workspace.artifacts(), null, manifestReference, null, usageReference,
+                        null, null, candidateReference, candidateDirectory.toString(),
+                        List.of(), null, null));
+    }
+
+    private Mutation acceptedValidation(
+            MutationContext current,
+            StageResult result,
+            BlobReference resultReference,
+            ShipWorkspaceService.AcceptedWorkspace workspace,
+            ShipCatalogService.Snapshot catalogSnapshot)
+            throws IOException {
+        if (catalogSnapshot == null
+                || current.view().artifactManifest() == null
+                || current.view().catalogUsage() == null
+                || current.view().catalogEvidence() == null
+                || current.view().candidateSnapshot() == null
+                || current.view().candidateDirectory() == null
+                || current.view().ledger() == null) {
+            throw new IOException("Validation acceptance lacks exact execution inputs");
+        }
+        BlobReference workerValidation = onlyArtifact(workspace, "validation");
+        ArtifactManifest manifest = read(
+                current.blobs(), current.view().artifactManifest(),
+                "artifact-manifest", ArtifactManifest.class);
+        CatalogUsageRecord usage = read(
+                current.blobs(), current.view().catalogUsage(),
+                "catalog-usage", CatalogUsageRecord.class);
+        CatalogEvidenceSet approved = read(
+                current.blobs(), current.view().catalogEvidence(),
+                "catalog-evidence", CatalogEvidenceSet.class);
+        DecisionLedger ledger = read(
+                current.blobs(), current.view().ledger(),
+                "decision-ledger", DecisionLedger.class);
+        ProjectSnapshot candidate = read(
+                current.blobs(), current.view().candidateSnapshot(),
+                "project-snapshot", ProjectSnapshot.class);
+        ShipValidationService.Result assessment = new ShipValidationService().validate(
+                current.blobs(),
+                current.transaction(),
+                current.view().runId(),
+                current.view().candidateDirectory(),
+                candidate,
+                current.view().candidateSnapshot(),
+                manifest,
+                current.view().artifactManifest(),
+                ledger.requirementsPolicy(),
+                usage,
+                current.view().catalogUsage(),
+                catalogSnapshot,
+                approved,
+                current.view().catalogEvidence(),
+                workerValidation);
+        if (assessment.verdict() == ShipValidationService.Verdict.PASS) {
+            return new Mutation(
+                    ShipAuthorityCommand.value(
+                            ShipEventType.VALIDATION_PASSED,
+                            assessment.reportReference().digest()),
+                    new ShipEventPayloads.StageAccepted(
+                            result.stage(), current.view().activeRequestReference(), resultReference,
+                            workspace.artifacts(), null, null, null, null, null, null,
+                            null, null, assessment.evidence(),
+                            assessment.reportReference(), null));
+        }
+        if (assessment.verdict() == ShipValidationService.Verdict.WAIVABLE) {
+            ShipStamp.Check failed = assessment.failedCheck();
+            return new Mutation(
+                    ShipAuthorityCommand.waiver(
+                            failed.id(), failed.evidenceDigest(),
+                            current.view().authority().authority().basis().policy().value()),
+                    new ShipEventPayloads.Failure(
+                            ShipStage.VALIDATE,
+                            "validation-check-waivable",
+                            "Controller validation check requires an explicit waiver: " + failed.id(),
+                            current.view().activeRequestReference(),
+                            resultReference,
+                            assessment.reportReference(),
+                            null,
+                            current.view().interactionBundle(),
+                            assessment.evidence()));
+        }
+        ShipStamp stamp = ShipStampService.issue(
+                current.view(), assessment.report(), ShipStamp.Status.FAIL, null, now(),
+                "validation-check-failed", "One or more mandatory controller checks failed");
+        BlobReference stampReference = write(
+                current.transaction(), "ship-stamp", stamp);
+        return new Mutation(
+                ShipAuthorityCommand.empty(ShipEventType.RUN_FAILED_TERMINAL),
+                new ShipEventPayloads.Failure(
+                        ShipStage.VALIDATE,
+                        stamp.failureCode(),
+                        stamp.failureMessage(),
+                        current.view().activeRequestReference(),
+                        resultReference,
+                        assessment.reportReference(),
+                        stampReference,
+                        current.view().interactionBundle(),
+                        assessment.evidence()));
+    }
+
+    private Mutation completeStamp(MutationContext current) throws IOException {
+        boolean waiver = current.view().state() == ShipState.WAIVER_STAMP_RUNNING;
+        if (!waiver && current.view().state() != ShipState.STAMP_RUNNING) {
+            throw new ShipControllerException(
+                    "lifecycle-boundary", "Ship run is not ready for Stamp completion");
+        }
+        ShipValidationReport report = read(
+                current.blobs(), current.view().validationReport(),
+                "validation-report", ShipValidationReport.class);
+        ShipStamp.Status status = waiver
+                ? ShipStamp.Status.COMPLETED_WITH_WAIVER : ShipStamp.Status.PASS;
+        BlobReference waiverResponse = waiver ? current.view().latestInteraction() : null;
+        ShipStamp stamp = ShipStampService.issue(
+                current.view(), report, status, waiverResponse, now(), null, null);
+        BlobReference stampReference = write(
+                current.transaction(), "ship-stamp", stamp);
+        ShipEventType event = waiver
+                ? ShipEventType.RUN_COMPLETED_WITH_WAIVER : ShipEventType.RUN_COMPLETED;
+        LivePublication publication = ShipPublicationService.apply(
+                current.view(), current.blobs(), stampReference, event);
+        BlobReference publishedSnapshot = write(
+                current.transaction(), "project-snapshot",
+                publication.publishedSnapshot());
+        return new Mutation(
+                ShipAuthorityCommand.value(event, stampReference.digest()),
+                new ShipEventPayloads.StampRecorded(
+                        stampReference, publishedSnapshot,
+                        current.view().validationReport()),
+                publication);
+    }
+
+    private static BlobReference onlyArtifact(
+            ShipWorkspaceService.AcceptedWorkspace workspace, String kind) {
+        List<BlobReference> matches = workspace.artifacts().stream()
+                .filter(artifact -> kind.equals(artifact.claim().kind()))
+                .map(ShipWorkspaceService.AcceptedArtifact::blob)
+                .toList();
+        if (matches.size() != 1 || workspace.artifacts().size() != 1) {
+            throw new ShipControllerException(
+                    "artifact-set-invalid", "Stage must produce exactly one " + kind + " artifact");
+        }
+        return matches.get(0);
     }
 
     private static void validateLedger(
@@ -722,6 +1063,12 @@ final class ShipController {
         return blobs.writeBytes(kind, ShipJson.mapper().writeValueAsBytes(value));
     }
 
+    private static <T> BlobReference write(
+            ShipBlobStore.Transaction transaction, String kind, T value)
+            throws IOException {
+        return transaction.writeBytes(kind, ShipJson.mapper().writeValueAsBytes(value));
+    }
+
     private static <T> T read(
             ShipBlobStore blobs, BlobReference reference, String kind, Class<T> type)
             throws IOException {
@@ -741,6 +1088,9 @@ final class ShipController {
              ShipOperationLock.Lease projectLease
                      = ShipOperationLock.acquireProject(stateRoot, before.projectRoot())) {
             ShipRunView current = projector(run.events(), run.blobs(), run.signer()).replay();
+            List<ShipEvent> history = run.events().replay();
+            ShipPublicationService.recover(current, run.blobs(), history);
+            current = projector(run.events(), run.blobs(), run.signer()).replay();
             if (!Objects.equals(expectedEventDigest, current.eventDigest())) {
                 throw new ShipControllerException(
                         "stale-run-head", "Ship run changed before the requested operation could commit");
@@ -750,23 +1100,76 @@ final class ShipController {
                     || !expectedHead.authorityHead().equals(current.authority().head())) {
                 throw new IOException("Durable event head differs from the reconstructed lifecycle authority");
             }
-            Mutation mutation = factory.create(new MutationContext(
-                    current,
-                    run.blobs(),
-                    new ShipInteractionBundleService(run.signer())));
-            ShipRun successor = mutation.authority().apply(current.authority());
-            projector(run.events(), run.blobs(), run.signer()).preflight(
-                    mutation.authority(), mutation.data(), successor);
-            run.events().appendIfLatest(
-                    expectedHead,
-                    new ShipEventDraft(
-                            mutation.authority().type(),
-                            successor.state(),
-                            current.authority().head(),
-                            successor.head(),
-                            now(),
-                            ShipStoredEventCodec.encode(mutation.authority(), mutation.data())));
-            return projector(run.events(), run.blobs(), run.signer()).replay();
+            Mutation mutation = null;
+            boolean eventCommitted = false;
+            try (ShipBlobStore.Transaction transaction = run.blobs().beginTransaction()) {
+                mutation = factory.create(new MutationContext(
+                        current,
+                        run.blobs(),
+                        new ShipInteractionBundleService(run.signer()),
+                        transaction));
+                ShipRun successor = mutation.authority().apply(current.authority());
+                projector(run.events(), run.blobs(), run.signer()).preflight(
+                        mutation.authority(), mutation.data(), successor);
+                ShipEventDraft draft = new ShipEventDraft(
+                        mutation.authority().type(),
+                        successor.state(),
+                        current.authority().head(),
+                        successor.head(),
+                        now(),
+                        ShipStoredEventCodec.encode(mutation.authority(), mutation.data()));
+                try {
+                    run.events().appendIfLatest(expectedHead, draft);
+                    eventCommitted = true;
+                } catch (IOException | RuntimeException failure) {
+                    ShipEventHead observed;
+                    try {
+                        observed = run.events().currentHead();
+                    } catch (IOException | RuntimeException resolutionFailure) {
+                        eventCommitted = true;
+                        transaction.commit();
+                        if (mutation.publication() != null) {
+                            mutation.publication().retainForRecovery();
+                        }
+                        failure.addSuppressed(resolutionFailure);
+                        throw failure;
+                    }
+                    if (observed.authorityHead().equals(successor.head())) {
+                        eventCommitted = true;
+                        transaction.commit();
+                        if (mutation.publication() != null) {
+                            mutation.publication().finish();
+                        }
+                        return projector(run.events(), run.blobs(), run.signer()).replay();
+                    }
+                    if (!observed.equals(expectedHead)) {
+                        eventCommitted = true;
+                        transaction.commit();
+                        if (mutation.publication() != null) {
+                            mutation.publication().retainForRecovery();
+                        }
+                        throw new ShipControllerException(
+                                "event-append-outcome-unknown",
+                                "Ship event head changed to an unexpected authenticated value",
+                                failure);
+                    }
+                    throw failure;
+                }
+                transaction.commit();
+                if (mutation.publication() != null) {
+                    mutation.publication().finish();
+                }
+                return projector(run.events(), run.blobs(), run.signer()).replay();
+            } catch (IOException | RuntimeException failure) {
+                if (!eventCommitted && mutation != null && mutation.publication() != null) {
+                    try {
+                        mutation.publication().close();
+                    } catch (IOException cleanup) {
+                        failure.addSuppressed(cleanup);
+                    }
+                }
+                throw failure;
+            }
         }
     }
 
@@ -966,10 +1369,18 @@ final class ShipController {
     private record MutationContext(
             ShipRunView view,
             ShipBlobStore blobs,
-            ShipInteractionBundleService interactions) {
+            ShipInteractionBundleService interactions,
+            ShipBlobStore.Transaction transaction) {
     }
 
-    private record Mutation(ShipAuthorityCommand authority, ShipEventPayloads.Payload data) {
+    private record Mutation(
+            ShipAuthorityCommand authority,
+            ShipEventPayloads.Payload data,
+            LivePublication publication) {
+
+        private Mutation(ShipAuthorityCommand authority, ShipEventPayloads.Payload data) {
+            this(authority, data, null);
+        }
 
         private Mutation {
             Objects.requireNonNull(authority, "authority");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipEventPayloads.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipEventPayloads.java
@@ -83,12 +83,34 @@ final class ShipEventPayloads {
             String designDigest,
             BlobReference candidateSnapshot,
             String candidateDirectory,
+            List<BlobReference> evidence,
+            BlobReference validationReport,
             StageStarted continuation)
             implements
                 Payload {
 
         StageAccepted {
             artifacts = artifacts == null ? List.of() : List.copyOf(artifacts);
+            evidence = evidence == null ? List.of() : List.copyOf(evidence);
+        }
+
+        StageAccepted(
+                      ShipStage stage,
+                      BlobReference request,
+                      BlobReference result,
+                      List<ShipWorkspaceService.AcceptedArtifact> artifacts,
+                      BlobReference ledger,
+                      BlobReference artifactManifest,
+                      BlobReference catalogEvidence,
+                      BlobReference catalogUsage,
+                      String requirementsDigest,
+                      String designDigest,
+                      BlobReference candidateSnapshot,
+                      String candidateDirectory,
+                      StageStarted continuation) {
+            this(stage, request, result, artifacts, ledger, artifactManifest, catalogEvidence,
+                 catalogUsage, requirementsDigest, designDigest, candidateSnapshot,
+                 candidateDirectory, List.of(), null, continuation);
         }
     }
 
@@ -172,19 +194,25 @@ final class ShipEventPayloads {
                 Payload {
     }
 
-    /** Storage shape only; policy eligibility and authority issuance remain PR 6 work. */
     record WaiverRequested(WaiverChallenge challenge, BlobReference interactionBundle)
             implements
                 Payload {
     }
 
-    /** Storage shape only; recording this value cannot complete a lifecycle waiver. */
     record WaiverRecorded(
             WaiverResponse response,
             BlobReference responseReference,
-            BlobReference interactionBundle)
+            BlobReference interactionBundle,
+            BlobReference stamp)
             implements
                 Payload {
+
+        WaiverRecorded(
+                       WaiverResponse response,
+                       BlobReference responseReference,
+                       BlobReference interactionBundle) {
+            this(response, responseReference, interactionBundle, null);
+        }
     }
 
     record Failure(
@@ -195,9 +223,27 @@ final class ShipEventPayloads {
             BlobReference result,
             BlobReference validationReport,
             BlobReference stamp,
-            BlobReference interactionBundle)
+            BlobReference interactionBundle,
+            List<BlobReference> evidence)
             implements
                 Payload {
+
+        Failure(
+                ShipStage failedStage,
+                String code,
+                String message,
+                BlobReference request,
+                BlobReference result,
+                BlobReference validationReport,
+                BlobReference stamp,
+                BlobReference interactionBundle) {
+            this(failedStage, code, message, request, result, validationReport, stamp,
+                 interactionBundle, List.of());
+        }
+
+        Failure {
+            evidence = evidence == null ? List.of() : List.copyOf(evidence);
+        }
     }
 
     record StampRecorded(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipEventPayloads.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipEventPayloads.java
@@ -94,6 +94,66 @@ final class ShipEventPayloads {
             evidence = evidence == null ? List.of() : List.copyOf(evidence);
         }
 
+        static StageAccepted analysis(
+                ShipStage stage,
+                BlobReference request,
+                BlobReference result,
+                BlobReference ledger,
+                BlobReference catalogEvidence,
+                String requirementsDigest,
+                StageStarted continuation) {
+            return new StageAccepted(
+                    stage, request, result, List.of(), ledger, null, catalogEvidence, null,
+                    requirementsDigest, null, null, null, List.of(), null, continuation);
+        }
+
+        static StageAccepted design(
+                ShipStage stage,
+                BlobReference request,
+                BlobReference result,
+                List<ShipWorkspaceService.AcceptedArtifact> artifacts,
+                String designDigest) {
+            return new StageAccepted(
+                    stage, request, result, artifacts, null, null, null, null,
+                    null, designDigest, null, null, List.of(), null, null);
+        }
+
+        static StageAccepted plan(
+                ShipStage stage,
+                BlobReference request,
+                BlobReference result,
+                List<ShipWorkspaceService.AcceptedArtifact> artifacts) {
+            return new StageAccepted(
+                    stage, request, result, artifacts, null, null, null, null,
+                    null, null, null, null, List.of(), null, null);
+        }
+
+        static StageAccepted execution(
+                ShipStage stage,
+                BlobReference request,
+                BlobReference result,
+                List<ShipWorkspaceService.AcceptedArtifact> artifacts,
+                BlobReference artifactManifest,
+                BlobReference catalogUsage,
+                BlobReference candidateSnapshot,
+                String candidateDirectory) {
+            return new StageAccepted(
+                    stage, request, result, artifacts, null, artifactManifest, null, catalogUsage,
+                    null, null, candidateSnapshot, candidateDirectory, List.of(), null, null);
+        }
+
+        static StageAccepted validation(
+                ShipStage stage,
+                BlobReference request,
+                BlobReference result,
+                List<ShipWorkspaceService.AcceptedArtifact> artifacts,
+                List<BlobReference> evidence,
+                BlobReference validationReport) {
+            return new StageAccepted(
+                    stage, request, result, artifacts, null, null, null, null,
+                    null, null, null, null, evidence, validationReport, null);
+        }
+
         StageAccepted(
                       ShipStage stage,
                       BlobReference request,
@@ -243,6 +303,46 @@ final class ShipEventPayloads {
 
         Failure {
             evidence = evidence == null ? List.of() : List.copyOf(evidence);
+        }
+
+        static Failure retryable(
+                ShipStage stage,
+                String code,
+                String message,
+                BlobReference request,
+                BlobReference result,
+                BlobReference interactionBundle) {
+            return new Failure(
+                    stage, code, message, request, result, null, null,
+                    interactionBundle, List.of());
+        }
+
+        static Failure waivable(
+                String code,
+                String message,
+                BlobReference request,
+                BlobReference result,
+                BlobReference validationReport,
+                BlobReference interactionBundle,
+                List<BlobReference> evidence) {
+            return new Failure(
+                    ShipStage.VALIDATE, code, message, request, result, validationReport,
+                    null, interactionBundle, evidence);
+        }
+
+        static Failure terminal(
+                ShipStage stage,
+                String code,
+                String message,
+                BlobReference request,
+                BlobReference result,
+                BlobReference validationReport,
+                BlobReference stamp,
+                BlobReference interactionBundle,
+                List<BlobReference> evidence) {
+            return new Failure(
+                    stage, code, message, request, result, validationReport,
+                    stamp, interactionBundle, evidence);
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipJson.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipJson.java
@@ -1,6 +1,7 @@
 package io.github.luigidemasi.camelkit.ship.controller;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -73,6 +74,33 @@ public final class ShipJson {
                 } catch (RuntimeException e) {
                     throw context.weirdStringException("invalid-timestamp", Instant.class,
                             "Ship timestamp is invalid or noncanonical");
+                }
+            }
+        });
+        values.addSerializer(Duration.class, new JsonSerializer<>() {
+            @Override
+            public void serialize(Duration value, JsonGenerator generator, SerializerProvider serializers)
+                    throws IOException {
+                generator.writeString(value.toString());
+            }
+        });
+        values.addDeserializer(Duration.class, new JsonDeserializer<>() {
+            @Override
+            public Duration deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+                String value = parser.getValueAsString(null);
+                if (value == null) {
+                    throw context.weirdStringException("non-string", Duration.class,
+                            "Ship durations must be canonical strings");
+                }
+                try {
+                    Duration parsed = Duration.parse(value);
+                    if (!parsed.toString().equals(value)) {
+                        throw new IllegalArgumentException("duration is not canonical");
+                    }
+                    return parsed;
+                } catch (RuntimeException e) {
+                    throw context.weirdStringException("invalid-duration", Duration.class,
+                            "Ship duration is invalid or noncanonical");
                 }
             }
         });

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipProjectPublisher.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipProjectPublisher.java
@@ -9,6 +9,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
@@ -55,7 +56,7 @@ final class ShipProjectPublisher {
     }
 
     /** Stages and seals a candidate while leaving the live project byte-for-byte untouched. */
-    static PublicationTransaction stageSealedCandidate(
+    static StagedCandidate stageSealedCandidate(
             Path stateRoot,
             String runId,
             Path projectRoot,
@@ -76,7 +77,7 @@ final class ShipProjectPublisher {
                 });
     }
 
-    static PublicationTransaction stageSealedCandidate(
+    static StagedCandidate stageSealedCandidate(
             Path stateRoot,
             String runId,
             Path projectRoot,
@@ -155,7 +156,7 @@ final class ShipProjectPublisher {
                 writeBinding(transactionRoot.resolve("binding.bin"), binding);
                 forceDirectory(transactionRoot);
                 forceDirectory(publicationRoot);
-                PublicationTransaction result = new PublicationTransaction(
+                PublicationTransaction transaction = new PublicationTransaction(
                         transactionId,
                         runId,
                         expectedEventHeadDigest,
@@ -164,6 +165,8 @@ final class ShipProjectPublisher {
                         postimage.digest(),
                         bindingDigest,
                         artifacts);
+                StagedCandidate result = new StagedCandidate(
+                        publicationRoot, transactionRoot, transaction);
                 complete = true;
                 return result;
             } catch (IOException | RuntimeException | Error failure) {
@@ -183,6 +186,109 @@ final class ShipProjectPublisher {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Removes candidates that are not owned by any authenticated execution-acceptance event. The caller must hold the
+     * run and project operation locks and must pass the exact immutable history returned by the projector replay that
+     * produced the current view.
+     */
+    static void reconcileCandidates(
+            ShipBlobStore blobs, List<ShipEvent> authenticatedHistory)
+            throws IOException {
+        java.util.Objects.requireNonNull(blobs, "Ship blob store");
+        java.util.Objects.requireNonNull(authenticatedHistory, "authenticated Ship history");
+        Path publicationRoot = blobs.runRoot().resolve("publication");
+        Set<Path> retained = new HashSet<>();
+        for (ShipEvent event : authenticatedHistory) {
+            if (event.type() != ShipEventType.EXECUTION_VALIDATED) {
+                continue;
+            }
+            ShipStoredEventCodec.StoredEvent stored = ShipStoredEventCodec.decode(event);
+            if (!(stored.data() instanceof ShipEventPayloads.StageAccepted accepted)) {
+                throw new IOException("Execution acceptance has an invalid publication payload");
+            }
+            retained.add(requireCandidateTransaction(
+                    publicationRoot, accepted.candidateDirectory()));
+        }
+
+        if (!Files.exists(publicationRoot, LinkOption.NOFOLLOW_LINKS)) {
+            if (!retained.isEmpty()) {
+                throw new IOException("Authenticated publication candidate directory is missing");
+            }
+            return;
+        }
+        BasicFileAttributes publicationAttributes = Files.readAttributes(
+                publicationRoot, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!publicationAttributes.isDirectory() || publicationAttributes.isSymbolicLink()) {
+            throw new IOException("Ship publication directory is not a real directory");
+        }
+
+        List<Path> transactions = new ArrayList<>();
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(publicationRoot)) {
+            for (Path entry : entries) {
+                requireTransactionDirectory(publicationRoot, entry);
+                transactions.add(entry);
+            }
+        }
+        if (!transactions.containsAll(retained)) {
+            throw new IOException("Authenticated publication candidate directory is missing");
+        }
+        boolean removed = false;
+        for (Path transaction : transactions) {
+            if (!retained.contains(transaction)) {
+                deleteOwnedTree(transaction);
+                removed = true;
+            }
+        }
+        if (removed) {
+            forceDirectory(publicationRoot);
+        }
+    }
+
+    private static Path requireCandidateTransaction(
+            Path publicationRoot, String candidateDirectory)
+            throws IOException {
+        if (candidateDirectory == null) {
+            throw new IOException("Execution acceptance has no publication candidate directory");
+        }
+        Path candidate;
+        try {
+            Path supplied = Path.of(candidateDirectory);
+            candidate = supplied.toAbsolutePath().normalize();
+            if (!supplied.equals(candidate)) {
+                throw new IOException("Execution acceptance has a non-canonical candidate directory");
+            }
+        } catch (InvalidPathException e) {
+            throw new IOException("Execution acceptance has an invalid candidate directory", e);
+        }
+        Path transaction = candidate.getParent();
+        if (transaction == null
+                || candidate.getFileName() == null
+                || !candidate.getFileName().toString().equals("candidate")
+                || transaction.getParent() == null
+                || !transaction.getParent().equals(publicationRoot)) {
+            throw new IOException("Execution acceptance candidate is outside its Ship run");
+        }
+        requireTransactionDirectory(publicationRoot, transaction);
+        BasicFileAttributes candidateAttributes = Files.readAttributes(
+                candidate, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!candidateAttributes.isDirectory() || candidateAttributes.isSymbolicLink()) {
+            throw new IOException("Authenticated publication candidate is not a real directory");
+        }
+        return transaction;
+    }
+
+    private static void requireTransactionDirectory(Path publicationRoot, Path transaction)
+            throws IOException {
+        BasicFileAttributes basic = Files.readAttributes(
+                transaction, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        String name = transaction.getFileName().toString();
+        if (!transaction.getParent().equals(publicationRoot)
+                || !name.matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+                || !basic.isDirectory() || basic.isSymbolicLink()) {
+            throw new IOException("Ship publication directory contains an unsafe transaction entry");
         }
     }
 
@@ -482,6 +588,79 @@ final class ShipProjectPublisher {
                 throw new IllegalArgumentException("Invalid Ship publication transaction");
             }
             artifacts = List.copyOf(artifacts);
+        }
+    }
+
+    /** Owns an uncommitted candidate until its accepting event is confirmed or recovery takes custody. */
+    static final class StagedCandidate implements AutoCloseable {
+
+        private final Path publicationRoot;
+        private final Path transactionRoot;
+        private final PublicationTransaction transaction;
+        private boolean retained;
+        private boolean closed;
+
+        private StagedCandidate(
+                                Path publicationRoot, Path transactionRoot, PublicationTransaction transaction) {
+            this.publicationRoot = java.util.Objects.requireNonNull(publicationRoot, "publication root");
+            this.transactionRoot = java.util.Objects.requireNonNull(transactionRoot, "transaction root");
+            this.transaction = java.util.Objects.requireNonNull(transaction, "publication transaction");
+        }
+
+        String transactionId() {
+            return transaction.transactionId();
+        }
+
+        String runId() {
+            return transaction.runId();
+        }
+
+        String expectedEventHeadDigest() {
+            return transaction.expectedEventHeadDigest();
+        }
+
+        long expectedEventHeadRevision() {
+            return transaction.expectedEventHeadRevision();
+        }
+
+        String baselineDigest() {
+            return transaction.baselineDigest();
+        }
+
+        String postimageDigest() {
+            return transaction.postimageDigest();
+        }
+
+        String bindingDigest() {
+            return transaction.bindingDigest();
+        }
+
+        List<PublicationArtifact> artifacts() {
+            return transaction.artifacts();
+        }
+
+        Path candidateDirectory() {
+            return transactionRoot.resolve("candidate");
+        }
+
+        void transferToHistory() {
+            retained = true;
+        }
+
+        void retainForRecovery() {
+            retained = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            if (!retained) {
+                deleteOwnedTree(transactionRoot);
+                forceDirectory(publicationRoot);
+            }
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipProjectPublisher.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipProjectPublisher.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.protocol.ShipStage;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.FileEntry;
@@ -561,7 +562,7 @@ final class ShipProjectPublisher {
         if (stateRoot == null || projectRoot == null || runId == null
                 || eventRevision < 0 || !ShipDigest.isSha256(eventDigest)
                 || blobs == null || workspace == null || !runId.equals(workspace.runId())
-                || workspace.stage() != io.github.luigidemasi.camelkit.ship.protocol.ShipStage.EXECUTE
+                || workspace.stage() != ShipStage.EXECUTE
                 || workspace.artifacts().isEmpty()) {
             throw new IllegalArgumentException("Invalid sealed Ship publication inputs");
         }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipProtectedWorkerBroker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipProtectedWorkerBroker.java
@@ -1,0 +1,132 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
+import io.github.luigidemasi.camelkit.ship.protocol.ProducedArtifact;
+import io.github.luigidemasi.camelkit.ship.protocol.StageRequest;
+import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
+import io.github.luigidemasi.camelkit.ship.security.StagedArtifactSource;
+
+/**
+ * The only artifact-bearing worker-result entry point. A backend must stop the complete containment, revoke every
+ * worker write handle, and retain exclusive custody until the returned lease closes.
+ */
+final class ShipProtectedWorkerBroker {
+
+    private final ShipController controller;
+    private final Backend backend;
+
+    ShipProtectedWorkerBroker(ShipController controller, Backend backend) {
+        this.controller = Objects.requireNonNull(controller, "Ship controller");
+        this.backend = Objects.requireNonNull(backend, "protected worker backend");
+    }
+
+    ShipRunView submit(
+            String runId,
+            String expectedEventDigest,
+            ShipCatalogService.Snapshot catalogSnapshot)
+            throws IOException {
+        ShipRunView current = controller.status(runId);
+        if (!Objects.equals(expectedEventDigest, current.eventDigest())
+                || current.activeRequest() == null) {
+            throw new ShipControllerException(
+                    "stale-run-head", "Ship run changed before protected worker custody was acquired");
+        }
+        try (CompletedAttempt completed = acquire(current.activeRequest())) {
+            return controller.submitProtectedStageResult(
+                    runId, expectedEventDigest, completed, catalogSnapshot);
+        }
+    }
+
+    CompletedAttempt acquire(StageRequest request) throws IOException {
+        Custody custody = backend.stopAndAcquireExclusiveCustody(request);
+        boolean accepted = false;
+        try {
+            custody.requireExactAttempt(request);
+            byte[] result = ShipStageResultReader.boundedCopy(custody.readResultBytes());
+            CompletedAttempt completed = new CompletedAttempt(request, result, custody);
+            accepted = true;
+            return completed;
+        } finally {
+            if (!accepted) {
+                custody.close();
+            }
+        }
+    }
+
+    interface Backend {
+
+        Custody stopAndAcquireExclusiveCustody(StageRequest request) throws IOException;
+    }
+
+    interface Custody extends AutoCloseable {
+
+        /** Fails unless this lease owns the exact stopped containment and its output ancestry. */
+        void requireExactAttempt(StageRequest request) throws IOException;
+
+        byte[] readResultBytes() throws IOException;
+
+        StagedArtifactSource.Session openArtifactSource() throws IOException;
+
+        @Override
+        void close() throws IOException;
+    }
+
+    static final class CompletedAttempt implements AutoCloseable {
+
+        private final StageRequest request;
+        private final byte[] resultBytes;
+        private final Custody custody;
+        private boolean imported;
+        private boolean closed;
+
+        private CompletedAttempt(StageRequest request, byte[] resultBytes, Custody custody) {
+            this.request = request;
+            this.resultBytes = resultBytes;
+            this.custody = custody;
+        }
+
+        StageResult readResult(StageRequest expected) throws IOException {
+            requireBound(expected);
+            return ShipStageResultReader.readBrokered(expected, resultBytes);
+        }
+
+        List<ShipBlobStore.ImportedBlob> importArtifacts(
+                StageRequest expected,
+                List<ProducedArtifact> artifacts,
+                ShipBlobStore.Transaction transaction)
+                throws IOException {
+            requireBound(expected);
+            if (imported) {
+                throw new IOException("Protected worker artifacts were already consumed");
+            }
+            imported = true;
+            try (StagedArtifactSource.Session source = custody.openArtifactSource()) {
+                return transaction.importArtifacts(source, artifacts);
+            }
+        }
+
+        private void requireBound(StageRequest expected) throws IOException {
+            if (closed || expected == null
+                    || !request.runId().equals(expected.runId())
+                    || request.stage() != expected.stage()
+                    || !request.attemptId().equals(expected.attemptId())
+                    || !request.challenge().equals(expected.challenge())
+                    || !request.inputDigest().equals(expected.inputDigest())
+                    || !request.outputDirectory().equals(expected.outputDirectory())) {
+                throw new IOException("Protected worker custody is not bound to the active attempt");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!closed) {
+                closed = true;
+                custody.close();
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -1,0 +1,598 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+import io.github.luigidemasi.camelkit.ship.protocol.ProducedArtifact;
+import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.FileEntry;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+
+/** Write-ahead, replay-recoverable material publication for one validated candidate. */
+final class ShipPublicationService {
+
+    private static final int SCHEMA_VERSION = 1;
+    private static final String JOURNAL = "live-publication.json";
+
+    private ShipPublicationService() {
+    }
+
+    static LivePublication apply(
+            ShipRunView run,
+            ShipBlobStore blobs,
+            BlobReference stamp,
+            ShipEventType completionType)
+            throws IOException {
+        if (run.baselineSnapshot() == null
+                || run.candidateSnapshot() == null
+                || run.executionResult() == null
+                || run.candidateDirectory() == null
+                || run.sourceDirectory() == null
+                || stamp == null
+                || !"ship-stamp".equals(stamp.kind())
+                || completionType != ShipEventType.RUN_COMPLETED
+                        && completionType != ShipEventType.RUN_COMPLETED_WITH_WAIVER) {
+            throw new IOException("Ship publication lacks its exact durable inputs");
+        }
+        blobs.verify(stamp);
+        Path publicationRoot = blobs.privateWorkDirectory("publication");
+        Path journal = publicationRoot.resolve(JOURNAL);
+        if (Files.exists(journal, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("A Ship live publication already requires recovery");
+        }
+        ProjectSnapshot baseline = read(
+                blobs, run.baselineSnapshot(), ProjectSnapshot.class);
+        ProjectSnapshot candidate = read(
+                blobs, run.candidateSnapshot(), ProjectSnapshot.class);
+        Path candidateDirectory = blobs.verifyCandidateDirectory(run.candidateDirectory());
+        ProjectSnapshot sealed = ProjectEvidenceFiles.captureSealed(candidateDirectory);
+        if (!candidate.equals(sealed)) {
+            throw new IOException("Sealed publication candidate changed before live apply");
+        }
+        ProjectSnapshot live = ProjectEvidenceFiles.capture(run.projectRoot());
+        if (!ProjectEvidenceFiles.unchangedMaterialTree(baseline, live)) {
+            throw new IOException("Live project differs from the run-start publication baseline");
+        }
+        StageResult execution = read(blobs, run.executionResult(), StageResult.class);
+        List<Artifact> artifacts = execution.artifacts().stream()
+                .map(artifact -> new Artifact(
+                        artifact,
+                        new BlobReference(artifact.kind(), artifact.digest(), artifact.size())))
+                .toList();
+        Intent intent = new Intent(
+                SCHEMA_VERSION,
+                run.runId(),
+                run.eventDigest(),
+                run.authority().revision(),
+                run.projectRoot().toString(),
+                run.sourceDirectory().toString(),
+                candidateDirectory.toString(),
+                run.baselineSnapshot(),
+                run.candidateSnapshot(),
+                run.executionResult(),
+                stamp,
+                completionType,
+                artifacts);
+        writeJournal(journal, intent);
+        try {
+            applyArtifacts(run.projectRoot(), candidate, blobs, artifacts);
+            ProjectSnapshot published = ProjectEvidenceFiles.capture(run.projectRoot());
+            if (!ProjectEvidenceFiles.unchangedMaterialTree(candidate, published)) {
+                throw new IOException("Published project differs from the validated candidate");
+            }
+            return new LivePublication(journal, intent, baseline, candidate, published, blobs);
+        } catch (IOException | RuntimeException failure) {
+            try {
+                rollback(intent, baseline, candidate, blobs);
+                Files.deleteIfExists(journal);
+                forceDirectory(publicationRoot);
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+            throw failure;
+        }
+    }
+
+    static void recover(
+            ShipRunView run, ShipBlobStore blobs, List<ShipEvent> history)
+            throws IOException {
+        Path journal = blobs.runRoot().resolve("publication").resolve(JOURNAL);
+        if (!Files.exists(journal, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        if (history == null || history.isEmpty()) {
+            throw new IOException("Ship publication recovery lacks authenticated event history");
+        }
+        ShipEvent authenticatedHead = history.get(history.size() - 1);
+        if (!authenticatedHead.eventDigest().equals(run.eventDigest())
+                || !authenticatedHead.authorityHead().equals(run.authority().head())) {
+            throw new IOException("Ship publication recovery history differs from its projection");
+        }
+        Intent intent = readJournal(journal);
+        requireIntent(run, blobs, intent);
+        ProjectSnapshot baseline = read(blobs, intent.baselineSnapshot(), ProjectSnapshot.class);
+        ProjectSnapshot candidate = read(blobs, intent.candidateSnapshot(), ProjectSnapshot.class);
+        Path candidateDirectory = blobs.verifyCandidateDirectory(Path.of(intent.candidateDirectory()));
+        ProjectSnapshot sealed = ProjectEvidenceFiles.captureSealed(candidateDirectory);
+        if (!candidate.equals(sealed)) {
+            throw new IOException("Recovery candidate differs from its protected snapshot");
+        }
+        boolean completed = run.state() == ShipState.COMPLETED
+                || run.state() == ShipState.COMPLETED_WITH_WAIVER;
+        if (completed) {
+            ShipState expectedState = intent.completionType() == ShipEventType.RUN_COMPLETED
+                    ? ShipState.COMPLETED : ShipState.COMPLETED_WITH_WAIVER;
+            if (run.state() != expectedState
+                    || run.authority().revision() != intent.expectedRevision() + 1
+                    || authenticatedHead.type() != intent.completionType()
+                    || !authenticatedHead.previousEventDigest()
+                            .equals(intent.expectedEventDigest())
+                    || !intent.stamp().equals(run.stamp())) {
+                throw new IOException("Committed Ship publication differs from its recovery intent");
+            }
+            if (run.candidateSnapshot() == null) {
+                throw new IOException("Completed Ship run lacks its published snapshot");
+            }
+            ProjectSnapshot recordedPublished = read(blobs, run.candidateSnapshot(), ProjectSnapshot.class);
+            ProjectSnapshot live = ProjectEvidenceFiles.capture(run.projectRoot());
+            if (!ProjectEvidenceFiles.unchangedMaterialTree(candidate, recordedPublished)
+                    || !ProjectEvidenceFiles.unchangedMaterialTree(recordedPublished, live)) {
+                throw new IOException("Committed Ship publication differs from its recorded snapshot");
+            }
+        } else {
+            if (!intent.expectedEventDigest().equals(run.eventDigest())
+                    || run.authority().revision() != intent.expectedRevision()) {
+                throw new IOException("Ship publication head is neither its predecessor nor completion");
+            }
+            rollback(intent, baseline, candidate, blobs);
+        }
+        Files.delete(journal);
+        forceDirectory(journal.getParent());
+    }
+
+    private static void requireIntent(ShipRunView run, ShipBlobStore blobs, Intent intent)
+            throws IOException {
+        if (intent == null
+                || intent.schemaVersion() != SCHEMA_VERSION
+                || !run.runId().equals(intent.runId())
+                || intent.expectedEventDigest() == null
+                || !intent.expectedEventDigest().matches("sha256:[0-9a-f]{64}")
+                || intent.expectedRevision() < 0
+                || !run.projectRoot().toString().equals(intent.projectRoot())
+                || !run.sourceDirectory().toString().equals(intent.sourceDirectory())
+                || !Objects.equals(run.baselineSnapshot(), intent.baselineSnapshot())
+                || !Objects.equals(run.executionResult(), intent.executionResult())
+                || !Objects.equals(run.candidateDirectory() == null
+                        ? null : run.candidateDirectory().toString(), intent.candidateDirectory())
+                || run.candidateSnapshot() != null
+                        && run.state() != ShipState.COMPLETED
+                        && run.state() != ShipState.COMPLETED_WITH_WAIVER
+                        && !run.candidateSnapshot().equals(intent.candidateSnapshot())
+                || intent.completionType() != ShipEventType.RUN_COMPLETED
+                        && intent.completionType() != ShipEventType.RUN_COMPLETED_WITH_WAIVER
+                || !blobs.belongsToRun(intent.runId())) {
+            throw new IOException("Ship publication recovery intent has an invalid identity");
+        }
+        blobs.verify(intent.baselineSnapshot());
+        blobs.verify(intent.candidateSnapshot());
+        blobs.verify(intent.executionResult());
+        blobs.verify(intent.stamp());
+    }
+
+    private static void applyArtifacts(
+            Path projectRoot,
+            ProjectSnapshot candidate,
+            ShipBlobStore blobs,
+            List<Artifact> artifacts)
+            throws IOException {
+        for (Artifact artifact : artifacts) {
+            String relative = artifact.claim().relativePath();
+            FileEntry expected = candidate.files().get(relative);
+            if (expected == null
+                    || expected.classification() != Classification.MATERIAL
+                    || !expected.digest().equals(artifact.blob().digest())
+                    || expected.size() != artifact.blob().byteSize()) {
+                throw new IOException("Publication artifact differs from the sealed candidate: " + relative);
+            }
+            Path target = safeTarget(projectRoot, relative);
+            createParents(projectRoot, target.getParent(), candidate);
+            writeAtomically(
+                    target,
+                    blobs.readBytes(artifact.blob(), Math.toIntExact(artifact.blob().byteSize())),
+                    expected.unixMode());
+        }
+    }
+
+    private static void rollback(
+            Intent intent,
+            ProjectSnapshot baseline,
+            ProjectSnapshot candidate,
+            ShipBlobStore blobs)
+            throws IOException {
+        Path projectRoot = Path.of(intent.projectRoot());
+        ProjectSnapshot current = ProjectEvidenceFiles.capture(projectRoot);
+        requireKnownMixture(current, baseline, candidate);
+        Path source = Path.of(intent.sourceDirectory());
+        List<String> paths = intent.artifacts().stream()
+                .map(artifact -> artifact.claim().relativePath())
+                .distinct()
+                .sorted()
+                .toList();
+        for (String relative : paths) {
+            Path target = safeTarget(projectRoot, relative);
+            FileEntry original = baseline.files().get(relative);
+            if (original == null) {
+                Files.deleteIfExists(target);
+                if (target.getParent() != null) {
+                    forceDirectory(target.getParent());
+                }
+            } else {
+                Path originalFile = safeTarget(source, relative);
+                byte[] content = ProjectEvidenceFiles.readMaterial(
+                        source, relative, Math.toIntExact(original.size()));
+                if (content.length != original.size()
+                        || !io.github.luigidemasi.camelkit.ship.ShipDigest.sha256(content)
+                                .equals(original.digest())) {
+                    throw new IOException("Immutable Ship source differs from publication baseline");
+                }
+                createParents(projectRoot, target.getParent(), baseline);
+                writeAtomically(target, content, original.unixMode());
+            }
+        }
+        removeCandidateOnlyDirectories(projectRoot, baseline, candidate);
+        ProjectSnapshot restored = ProjectEvidenceFiles.capture(projectRoot);
+        if (!ProjectEvidenceFiles.unchangedMaterialTree(baseline, restored)) {
+            throw new IOException("Ship publication rollback did not restore the exact baseline");
+        }
+    }
+
+    private static void requireKnownMixture(
+            ProjectSnapshot current, ProjectSnapshot baseline, ProjectSnapshot candidate)
+            throws IOException {
+        Set<String> paths = new HashSet<>();
+        baseline.files().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                paths.add(path);
+            }
+        });
+        candidate.files().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                paths.add(path);
+            }
+        });
+        current.files().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                paths.add(path);
+            }
+        });
+        for (MapEntry item : paths.stream().map(path -> new MapEntry(
+                path, current.files().get(path), baseline.files().get(path), candidate.files().get(path))).toList()) {
+            if (!Objects.equals(item.current(), item.baseline())
+                    && !Objects.equals(item.current(), item.candidate())) {
+                throw new IOException(
+                        "Live project changed outside the recoverable publication mixture: "
+                                      + item.path());
+            }
+        }
+        Set<String> directories = new HashSet<>();
+        baseline.directories().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                directories.add(path);
+            }
+        });
+        candidate.directories().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                directories.add(path);
+            }
+        });
+        current.directories().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                directories.add(path);
+            }
+        });
+        for (String path : directories) {
+            var actual = current.directories().get(path);
+            var before = baseline.directories().get(path);
+            var after = candidate.directories().get(path);
+            if (!Objects.equals(actual, before) && !Objects.equals(actual, after)) {
+                throw new IOException(
+                        "Live project directory changed outside the recoverable publication mixture: "
+                                      + path);
+            }
+        }
+    }
+
+    private static void removeCandidateOnlyDirectories(
+            Path projectRoot, ProjectSnapshot baseline, ProjectSnapshot candidate)
+            throws IOException {
+        List<String> directories = candidate.directories().keySet().stream()
+                .filter(path -> !baseline.directories().containsKey(path))
+                .sorted(Comparator.comparingInt(String::length).reversed())
+                .toList();
+        for (String relative : directories) {
+            try {
+                Files.deleteIfExists(safeTarget(projectRoot, relative));
+            } catch (DirectoryNotEmptyException ignored) {
+                // A protected or baseline entry still owns the directory.
+            }
+        }
+    }
+
+    private static void createParents(
+            Path root, Path parent, ProjectSnapshot desired)
+            throws IOException {
+        if (parent == null || parent.equals(root)) {
+            return;
+        }
+        Path relative = root.relativize(parent);
+        Path current = root;
+        for (Path component : relative) {
+            current = current.resolve(component);
+            if (Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+                if (Files.isSymbolicLink(current)
+                        || !Files.isDirectory(current, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException("Publication parent is not a real directory");
+                }
+                continue;
+            }
+            Files.createDirectory(current, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rwx------")));
+            var entry = desired.directories().get(
+                    root.relativize(current).toString().replace(root.getFileSystem().getSeparator(), "/"));
+            if (entry != null) {
+                setMode(current, entry.unixMode());
+            }
+            forceDirectory(current.getParent());
+        }
+    }
+
+    private static Path safeTarget(Path root, String relative) throws IOException {
+        String canonical = io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy
+                .requireCanonicalRelativePath(relative);
+        Path target = root.resolve(canonical.replace('/', root.getFileSystem().getSeparator().charAt(0)))
+                .normalize();
+        if (!target.startsWith(root) || target.equals(root)) {
+            throw new IOException("Publication path escapes its protected root");
+        }
+        return target;
+    }
+
+    private static void writeAtomically(Path target, byte[] content, int unixMode)
+            throws IOException {
+        if (Files.isSymbolicLink(target)) {
+            throw new IOException("Refusing to publish through a symbolic link");
+        }
+        Path temporary = target.resolveSibling(
+                ".camel-kit-publish-" + UUID.randomUUID() + ".tmp");
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.CREATE_NEW,
+                    StandardOpenOption.WRITE,
+                    LinkOption.NOFOLLOW_LINKS)) {
+                ByteBuffer bytes = ByteBuffer.wrap(content);
+                while (bytes.hasRemaining()) {
+                    channel.write(bytes);
+                }
+                channel.force(true);
+            }
+            setMode(temporary, unixMode);
+            try {
+                Files.move(
+                        temporary, target,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw new IOException("Ship publication requires atomic same-directory replacement", e);
+            }
+            forceDirectory(target.getParent());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static void writeJournal(Path journal, Intent intent) throws IOException {
+        byte[] encoded = ShipJson.mapper().writeValueAsBytes(intent);
+        Path temporary = journal.resolveSibling("." + JOURNAL + '-' + UUID.randomUUID());
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.CREATE_NEW,
+                    StandardOpenOption.WRITE,
+                    LinkOption.NOFOLLOW_LINKS)) {
+                ByteBuffer bytes = ByteBuffer.wrap(encoded);
+                while (bytes.hasRemaining()) {
+                    channel.write(bytes);
+                }
+                channel.force(true);
+            }
+            Files.setPosixFilePermissions(temporary, PosixFilePermissions.fromString("r--------"));
+            Files.move(temporary, journal, StandardCopyOption.ATOMIC_MOVE);
+            forceDirectory(journal.getParent());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static Intent readJournal(Path journal) throws IOException {
+        var attributes = Files.readAttributes(
+                journal,
+                java.nio.file.attribute.BasicFileAttributes.class,
+                LinkOption.NOFOLLOW_LINKS);
+        Set<PosixFilePermission> expectedPermissions = Set.of(PosixFilePermission.OWNER_READ);
+        Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(journal, LinkOption.NOFOLLOW_LINKS);
+        var owner = Files.getOwner(journal, LinkOption.NOFOLLOW_LINKS);
+        var parentOwner = Files.getOwner(journal.getParent(), LinkOption.NOFOLLOW_LINKS);
+        Object links = Files.getAttribute(journal, "unix:nlink", LinkOption.NOFOLLOW_LINKS);
+        if (!attributes.isRegularFile()
+                || attributes.isSymbolicLink()
+                || attributes.fileKey() == null
+                || attributes.size() <= 0
+                || attributes.size() > ShipJson.MAX_DOCUMENT_BYTES
+                || !permissions.equals(expectedPermissions)
+                || !owner.equals(parentOwner)
+                || !(links instanceof Number count)
+                || count.longValue() != 1) {
+            throw new IOException("Ship publication recovery journal has unsafe metadata");
+        }
+        byte[] encoded;
+        try (FileChannel channel = FileChannel.open(
+                journal, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+            encoded = new byte[Math.toIntExact(attributes.size())];
+            ByteBuffer target = ByteBuffer.wrap(encoded);
+            while (target.hasRemaining()) {
+                if (channel.read(target) < 0) {
+                    throw new IOException("Ship publication recovery journal is truncated");
+                }
+            }
+            if (channel.read(ByteBuffer.allocate(1)) != -1) {
+                throw new IOException("Ship publication recovery journal has trailing bytes");
+            }
+        }
+        var after = Files.readAttributes(
+                journal,
+                java.nio.file.attribute.BasicFileAttributes.class,
+                LinkOption.NOFOLLOW_LINKS);
+        if (!attributes.fileKey().equals(after.fileKey())
+                || attributes.size() != after.size()
+                || !attributes.lastModifiedTime().equals(after.lastModifiedTime())
+                || !permissions.equals(Files.getPosixFilePermissions(
+                        journal, LinkOption.NOFOLLOW_LINKS))
+                || !owner.equals(Files.getOwner(journal, LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException("Ship publication recovery journal changed while read");
+        }
+        return ShipJson.mapper().readValue(encoded, Intent.class);
+    }
+
+    private static void setMode(Path path, int unixMode) throws IOException {
+        Set<PosixFilePermission> permissions = new HashSet<>();
+        PosixFilePermission[] values = {
+                PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_READ,
+                PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_EXECUTE,
+                PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_WRITE,
+                PosixFilePermission.OTHERS_EXECUTE
+        };
+        int[] bits = {0400, 0200, 0100, 0040, 0020, 0010, 0004, 0002, 0001};
+        for (int index = 0; index < bits.length; index++) {
+            if ((unixMode & bits[index]) != 0) {
+                permissions.add(values[index]);
+            }
+        }
+        Files.setPosixFilePermissions(path, permissions);
+    }
+
+    private static void forceDirectory(Path path) throws IOException {
+        try (FileChannel directory = FileChannel.open(path, StandardOpenOption.READ)) {
+            directory.force(true);
+        } catch (UnsupportedOperationException ignored) {
+            // Some POSIX providers do not expose directory fsync.
+        }
+    }
+
+    private static <T> T read(
+            ShipBlobStore blobs, BlobReference reference, Class<T> type)
+            throws IOException {
+        return ShipJson.mapper().readValue(
+                blobs.readBytes(reference, ShipJson.MAX_DOCUMENT_BYTES), type);
+    }
+
+    static final class LivePublication implements AutoCloseable {
+
+        private final Path journal;
+        private final Intent intent;
+        private final ProjectSnapshot baseline;
+        private final ProjectSnapshot candidate;
+        private final ProjectSnapshot published;
+        private final ShipBlobStore blobs;
+        private boolean finished;
+
+        private LivePublication(
+                                Path journal,
+                                Intent intent,
+                                ProjectSnapshot baseline,
+                                ProjectSnapshot candidate,
+                                ProjectSnapshot published,
+                                ShipBlobStore blobs) {
+            this.journal = journal;
+            this.intent = intent;
+            this.baseline = baseline;
+            this.candidate = candidate;
+            this.published = published;
+            this.blobs = blobs;
+        }
+
+        ProjectSnapshot publishedSnapshot() {
+            return published;
+        }
+
+        void finish() throws IOException {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            Files.deleteIfExists(journal);
+            forceDirectory(journal.getParent());
+        }
+
+        void retainForRecovery() {
+            finished = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!finished) {
+                rollback(intent, baseline, candidate, blobs);
+                Files.deleteIfExists(journal);
+                forceDirectory(journal.getParent());
+                finished = true;
+            }
+        }
+    }
+
+    private record Artifact(ProducedArtifact claim, BlobReference blob) {
+    }
+
+    private record MapEntry(
+            String path, FileEntry current, FileEntry baseline, FileEntry candidate) {
+    }
+
+    private record Intent(
+            int schemaVersion,
+            String runId,
+            String expectedEventDigest,
+            long expectedRevision,
+            String projectRoot,
+            String sourceDirectory,
+            String candidateDirectory,
+            BlobReference baselineSnapshot,
+            BlobReference candidateSnapshot,
+            BlobReference executionResult,
+            BlobReference stamp,
+            ShipEventType completionType,
+            List<Artifact> artifacts) {
+
+        private Intent {
+            artifacts = artifacts == null ? List.of() : List.copyOf(artifacts);
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -13,12 +14,14 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
@@ -33,8 +36,16 @@ import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classificatio
 /** Write-ahead, replay-recoverable material publication for one validated candidate. */
 final class ShipPublicationService {
 
-    private static final int SCHEMA_VERSION = 1;
+    private static final int SCHEMA_VERSION = 2;
     private static final String JOURNAL = "live-publication.json";
+    private static final Pattern JOURNAL_TEMP = Pattern.compile(
+            "\\.live-publication\\.json-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    private static final Pattern REPLACEMENT_TEMP = Pattern.compile(
+            "\\.camel-kit-publish-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.tmp");
+    private static final Set<PosixFilePermission> PRIVATE_TEMP
+            = PosixFilePermissions.fromString("rw-------");
+    private static final Set<PosixFilePermission> SEALED_JOURNAL
+            = PosixFilePermissions.fromString("r--------");
 
     private ShipPublicationService() {
     }
@@ -76,11 +87,15 @@ final class ShipPublicationService {
             throw new IOException("Live project differs from the run-start publication baseline");
         }
         StageResult execution = read(blobs, run.executionResult(), StageResult.class);
-        List<Artifact> artifacts = execution.artifacts().stream()
-                .map(artifact -> new Artifact(
-                        artifact,
-                        new BlobReference(artifact.kind(), artifact.digest(), artifact.size())))
-                .toList();
+        List<Artifact> artifacts = new ArrayList<>();
+        for (ProducedArtifact artifact : execution.artifacts()) {
+            artifacts.add(new Artifact(
+                    artifact,
+                    new BlobReference(artifact.kind(), artifact.digest(), artifact.size()),
+                    replacementTemporaryPath(artifact.relativePath())));
+        }
+        requireTemporaryBindings(
+                run.projectRoot(), baseline, candidate, artifacts, true);
         Intent intent = new Intent(
                 SCHEMA_VERSION,
                 run.runId(),
@@ -118,7 +133,9 @@ final class ShipPublicationService {
     static void recover(
             ShipRunView run, ShipBlobStore blobs, List<ShipEvent> history)
             throws IOException {
-        Path journal = blobs.runRoot().resolve("publication").resolve(JOURNAL);
+        Path publicationRoot = blobs.privateWorkDirectory("publication");
+        cleanupJournalTemporaries(publicationRoot);
+        Path journal = publicationRoot.resolve(JOURNAL);
         if (!Files.exists(journal, LinkOption.NOFOLLOW_LINKS)) {
             return;
         }
@@ -134,6 +151,8 @@ final class ShipPublicationService {
         requireIntent(run, blobs, intent);
         ProjectSnapshot baseline = read(blobs, intent.baselineSnapshot(), ProjectSnapshot.class);
         ProjectSnapshot candidate = read(blobs, intent.candidateSnapshot(), ProjectSnapshot.class);
+        requireTemporaryBindings(
+                run.projectRoot(), baseline, candidate, intent.artifacts(), false);
         Path candidateDirectory = blobs.verifyCandidateDirectory(Path.of(intent.candidateDirectory()));
         ProjectSnapshot sealed = ProjectEvidenceFiles.captureSealed(candidateDirectory);
         if (!candidate.equals(sealed)) {
@@ -142,6 +161,8 @@ final class ShipPublicationService {
         boolean completed = run.state() == ShipState.COMPLETED
                 || run.state() == ShipState.COMPLETED_WITH_WAIVER;
         if (completed) {
+            cleanupReplacementTemporaries(
+                    run.projectRoot(), baseline, candidate, intent.artifacts());
             ShipState expectedState = intent.completionType() == ShipEventType.RUN_COMPLETED
                     ? ShipState.COMPLETED : ShipState.COMPLETED_WITH_WAIVER;
             if (run.state() != expectedState
@@ -204,6 +225,18 @@ final class ShipPublicationService {
         blobs.verify(intent.candidateSnapshot());
         blobs.verify(intent.executionResult());
         blobs.verify(intent.stamp());
+        StageResult execution = read(blobs, intent.executionResult(), StageResult.class);
+        List<ProducedArtifact> recorded = intent.artifacts().stream()
+                .map(Artifact::claim)
+                .toList();
+        if (!execution.artifacts().equals(recorded)
+                || intent.artifacts().stream().anyMatch(artifact -> !artifact.blob().equals(
+                        new BlobReference(
+                                artifact.claim().kind(),
+                                artifact.claim().digest(),
+                                artifact.claim().size())))) {
+            throw new IOException("Ship publication recovery artifacts differ from execution");
+        }
     }
 
     private static void applyArtifacts(
@@ -222,9 +255,11 @@ final class ShipPublicationService {
                 throw new IOException("Publication artifact differs from the sealed candidate: " + relative);
             }
             Path target = safeTarget(projectRoot, relative);
+            Path temporary = requireBoundTemporary(projectRoot, artifact);
             createParents(projectRoot, target.getParent(), candidate);
             writeAtomically(
                     target,
+                    temporary,
                     blobs.readBytes(artifact.blob(), Math.toIntExact(artifact.blob().byteSize())),
                     expected.unixMode());
         }
@@ -236,15 +271,18 @@ final class ShipPublicationService {
             ProjectSnapshot candidate)
             throws IOException {
         Path projectRoot = Path.of(intent.projectRoot());
+        requireTemporaryBindings(
+                projectRoot, baseline, candidate, intent.artifacts(), false);
+        cleanupReplacementTemporaries(
+                projectRoot, baseline, candidate, intent.artifacts());
         ProjectSnapshot current = ProjectEvidenceFiles.capture(projectRoot);
         requireKnownMixture(current, baseline, candidate);
         Path source = Path.of(intent.sourceDirectory());
-        List<String> paths = intent.artifacts().stream()
-                .map(artifact -> artifact.claim().relativePath())
-                .distinct()
-                .sorted()
+        List<Artifact> artifacts = intent.artifacts().stream()
+                .sorted(Comparator.comparing(artifact -> artifact.claim().relativePath()))
                 .toList();
-        for (String relative : paths) {
+        for (Artifact artifact : artifacts) {
+            String relative = artifact.claim().relativePath();
             Path target = safeTarget(projectRoot, relative);
             FileEntry original = baseline.files().get(relative);
             if (original == null) {
@@ -262,7 +300,11 @@ final class ShipPublicationService {
                     throw new IOException("Immutable Ship source differs from publication baseline");
                 }
                 createParents(projectRoot, target.getParent(), baseline);
-                writeAtomically(target, content, original.unixMode());
+                writeAtomically(
+                        target,
+                        requireBoundTemporary(projectRoot, artifact),
+                        content,
+                        original.unixMode());
             }
         }
         removeCandidateOnlyDirectories(projectRoot, baseline, candidate);
@@ -382,17 +424,20 @@ final class ShipPublicationService {
         return target;
     }
 
-    private static void writeAtomically(Path target, byte[] content, int unixMode)
+    private static void writeAtomically(
+            Path target, Path temporary, byte[] content, int unixMode)
             throws IOException {
         if (Files.isSymbolicLink(target)) {
             throw new IOException("Refusing to publish through a symbolic link");
         }
-        Path temporary = target.resolveSibling(
-                ".camel-kit-publish-" + UUID.randomUUID() + ".tmp");
+        boolean created = false;
         try {
+            Files.createFile(
+                    temporary,
+                    PosixFilePermissions.asFileAttribute(PRIVATE_TEMP));
+            created = true;
             try (FileChannel channel = FileChannel.open(
                     temporary,
-                    StandardOpenOption.CREATE_NEW,
                     StandardOpenOption.WRITE,
                     LinkOption.NOFOLLOW_LINKS)) {
                 ByteBuffer bytes = ByteBuffer.wrap(content);
@@ -412,17 +457,23 @@ final class ShipPublicationService {
             }
             forceDirectory(target.getParent());
         } finally {
-            Files.deleteIfExists(temporary);
+            if (created && Files.deleteIfExists(temporary)) {
+                forceDirectory(temporary.getParent());
+            }
         }
     }
 
     private static void writeJournal(Path journal, Intent intent) throws IOException {
         byte[] encoded = ShipJson.mapper().writeValueAsBytes(intent);
         Path temporary = journal.resolveSibling("." + JOURNAL + '-' + UUID.randomUUID());
+        boolean created = false;
         try {
+            Files.createFile(
+                    temporary,
+                    PosixFilePermissions.asFileAttribute(PRIVATE_TEMP));
+            created = true;
             try (FileChannel channel = FileChannel.open(
                     temporary,
-                    StandardOpenOption.CREATE_NEW,
                     StandardOpenOption.WRITE,
                     LinkOption.NOFOLLOW_LINKS)) {
                 ByteBuffer bytes = ByteBuffer.wrap(encoded);
@@ -431,12 +482,153 @@ final class ShipPublicationService {
                 }
                 channel.force(true);
             }
-            Files.setPosixFilePermissions(temporary, PosixFilePermissions.fromString("r--------"));
+            Files.setPosixFilePermissions(temporary, SEALED_JOURNAL);
             Files.move(temporary, journal, StandardCopyOption.ATOMIC_MOVE);
             forceDirectory(journal.getParent());
         } finally {
-            Files.deleteIfExists(temporary);
+            if (created && Files.deleteIfExists(temporary)) {
+                forceDirectory(temporary.getParent());
+            }
         }
+    }
+
+    private static String replacementTemporaryPath(String relativePath) {
+        String canonical = ShipTreePolicy.requireCanonicalRelativePath(relativePath);
+        int separator = canonical.lastIndexOf('/');
+        String name = ".camel-kit-publish-" + UUID.randomUUID() + ".tmp";
+        return separator < 0 ? name : canonical.substring(0, separator + 1) + name;
+    }
+
+    private static void requireTemporaryBindings(
+            Path projectRoot,
+            ProjectSnapshot baseline,
+            ProjectSnapshot candidate,
+            List<Artifact> artifacts,
+            boolean requireAbsent)
+            throws IOException {
+        Set<String> targets = new HashSet<>();
+        Set<String> temporaries = new HashSet<>();
+        for (Artifact artifact : artifacts) {
+            String relative = artifact.claim().relativePath();
+            Path temporary = requireBoundTemporary(projectRoot, artifact);
+            String temporaryRelative = artifact.temporaryPath();
+            FileEntry expected = candidate.files().get(relative);
+            if (!targets.add(relative)
+                    || !temporaries.add(temporaryRelative)
+                    || expected == null
+                    || expected.classification() != Classification.MATERIAL
+                    || !expected.digest().equals(artifact.blob().digest())
+                    || expected.size() != artifact.blob().byteSize()
+                    || baseline.files().containsKey(temporaryRelative)
+                    || baseline.directories().containsKey(temporaryRelative)
+                    || candidate.files().containsKey(temporaryRelative)
+                    || candidate.directories().containsKey(temporaryRelative)
+                    || requireAbsent && Files.exists(temporary, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Ship publication has an invalid bound replacement temporary");
+            }
+        }
+    }
+
+    private static Path requireBoundTemporary(Path projectRoot, Artifact artifact)
+            throws IOException {
+        try {
+            Path target = safeTarget(projectRoot, artifact.claim().relativePath());
+            Path temporary = safeTarget(projectRoot, artifact.temporaryPath());
+            if (!Objects.equals(target.getParent(), temporary.getParent())
+                    || temporary.getFileName() == null
+                    || !REPLACEMENT_TEMP.matcher(temporary.getFileName().toString()).matches()) {
+                throw new IOException("Ship publication replacement temporary is not bound to its target");
+            }
+            return temporary;
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Ship publication replacement temporary is invalid", e);
+        }
+    }
+
+    private static void cleanupJournalTemporaries(Path publicationRoot) throws IOException {
+        boolean removed = false;
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(publicationRoot)) {
+            for (Path entry : entries) {
+                if (JOURNAL_TEMP.matcher(entry.getFileName().toString()).matches()) {
+                    deleteOwnedTemporary(
+                            entry,
+                            publicationRoot,
+                            Set.of(PRIVATE_TEMP, SEALED_JOURNAL),
+                            ShipJson.MAX_DOCUMENT_BYTES,
+                            "Ship publication journal temporary");
+                    removed = true;
+                }
+            }
+        }
+        if (removed) {
+            forceDirectory(publicationRoot);
+        }
+    }
+
+    private static void cleanupReplacementTemporaries(
+            Path projectRoot,
+            ProjectSnapshot baseline,
+            ProjectSnapshot candidate,
+            List<Artifact> artifacts)
+            throws IOException {
+        Set<Path> changedParents = new HashSet<>();
+        for (Artifact artifact : artifacts) {
+            Path temporary = requireBoundTemporary(projectRoot, artifact);
+            if (!Files.exists(temporary, LinkOption.NOFOLLOW_LINKS)) {
+                continue;
+            }
+            FileEntry expected = candidate.files().get(artifact.claim().relativePath());
+            Set<Set<PosixFilePermission>> permissions = new HashSet<>();
+            permissions.add(PRIVATE_TEMP);
+            permissions.add(permissions(expected.unixMode()));
+            FileEntry original = baseline.files().get(artifact.claim().relativePath());
+            if (original != null) {
+                permissions.add(permissions(original.unixMode()));
+            }
+            deleteOwnedTemporary(
+                    temporary,
+                    temporary.getParent(),
+                    permissions,
+                    Math.max(
+                            artifact.blob().byteSize(),
+                            original == null ? 0 : original.size()),
+                    "Ship publication replacement temporary");
+            changedParents.add(temporary.getParent());
+        }
+        for (Path parent : changedParents) {
+            forceDirectory(parent);
+        }
+    }
+
+    private static void deleteOwnedTemporary(
+            Path temporary,
+            Path parent,
+            Set<Set<PosixFilePermission>> allowedPermissions,
+            long maximumSize,
+            String description)
+            throws IOException {
+        BasicFileAttributes attributes = Files.readAttributes(
+                temporary, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!Objects.equals(temporary.getParent(), parent)
+                || !attributes.isRegularFile()
+                || attributes.isSymbolicLink()
+                || attributes.fileKey() == null
+                || attributes.size() < 0
+                || attributes.size() > maximumSize) {
+            throw new IOException(description + " has unsafe metadata");
+        }
+        Set<PosixFilePermission> actualPermissions = Files.getPosixFilePermissions(
+                temporary, LinkOption.NOFOLLOW_LINKS);
+        Object links = Files.getAttribute(
+                temporary, "unix:nlink", LinkOption.NOFOLLOW_LINKS);
+        if (!allowedPermissions.contains(actualPermissions)
+                || !Files.getOwner(temporary, LinkOption.NOFOLLOW_LINKS)
+                        .equals(Files.getOwner(parent, LinkOption.NOFOLLOW_LINKS))
+                || !(links instanceof Number count)
+                || count.longValue() != 1) {
+            throw new IOException(description + " has unsafe metadata");
+        }
+        Files.delete(temporary);
     }
 
     private static Intent readJournal(Path journal) throws IOException {
@@ -444,7 +636,6 @@ final class ShipPublicationService {
                 journal,
                 BasicFileAttributes.class,
                 LinkOption.NOFOLLOW_LINKS);
-        Set<PosixFilePermission> expectedPermissions = Set.of(PosixFilePermission.OWNER_READ);
         Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(journal, LinkOption.NOFOLLOW_LINKS);
         var owner = Files.getOwner(journal, LinkOption.NOFOLLOW_LINKS);
         var parentOwner = Files.getOwner(journal.getParent(), LinkOption.NOFOLLOW_LINKS);
@@ -454,7 +645,7 @@ final class ShipPublicationService {
                 || attributes.fileKey() == null
                 || attributes.size() <= 0
                 || attributes.size() > ShipJson.MAX_DOCUMENT_BYTES
-                || !permissions.equals(expectedPermissions)
+                || !permissions.equals(SEALED_JOURNAL)
                 || !owner.equals(parentOwner)
                 || !(links instanceof Number count)
                 || count.longValue() != 1) {
@@ -490,6 +681,10 @@ final class ShipPublicationService {
     }
 
     private static void setMode(Path path, int unixMode) throws IOException {
+        Files.setPosixFilePermissions(path, permissions(unixMode));
+    }
+
+    private static Set<PosixFilePermission> permissions(int unixMode) {
         Set<PosixFilePermission> permissions = new HashSet<>();
         PosixFilePermission[] values = {
                 PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE,
@@ -504,7 +699,7 @@ final class ShipPublicationService {
                 permissions.add(values[index]);
             }
         }
-        Files.setPosixFilePermissions(path, permissions);
+        return Set.copyOf(permissions);
     }
 
     private static void forceDirectory(Path path) throws IOException {
@@ -572,7 +767,14 @@ final class ShipPublicationService {
         }
     }
 
-    private record Artifact(ProducedArtifact claim, BlobReference blob) {
+    private record Artifact(
+            ProducedArtifact claim, BlobReference blob, String temporaryPath) {
+
+        private Artifact {
+            Objects.requireNonNull(claim, "publication artifact claim");
+            Objects.requireNonNull(blob, "publication artifact blob");
+            temporaryPath = ShipTreePolicy.requireCanonicalRelativePath(temporaryPath);
+        }
     }
 
     private record MapEntry(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -10,6 +10,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Comparator;
@@ -19,12 +20,14 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
 import io.github.luigidemasi.camelkit.ship.protocol.ProducedArtifact;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.FileEntry;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
 
 /** Write-ahead, replay-recoverable material publication for one validated candidate. */
@@ -99,10 +102,10 @@ final class ShipPublicationService {
             if (!ProjectEvidenceFiles.unchangedMaterialTree(candidate, published)) {
                 throw new IOException("Published project differs from the validated candidate");
             }
-            return new LivePublication(journal, intent, baseline, candidate, published, blobs);
+            return new LivePublication(journal, intent, baseline, candidate, published);
         } catch (IOException | RuntimeException failure) {
             try {
-                rollback(intent, baseline, candidate, blobs);
+                rollback(intent, baseline, candidate);
                 Files.deleteIfExists(journal);
                 forceDirectory(publicationRoot);
             } catch (IOException cleanup) {
@@ -163,7 +166,7 @@ final class ShipPublicationService {
                     || run.authority().revision() != intent.expectedRevision()) {
                 throw new IOException("Ship publication head is neither its predecessor nor completion");
             }
-            rollback(intent, baseline, candidate, blobs);
+            rollback(intent, baseline, candidate);
         }
         Files.delete(journal);
         forceDirectory(journal.getParent());
@@ -181,8 +184,13 @@ final class ShipPublicationService {
                 || !run.sourceDirectory().toString().equals(intent.sourceDirectory())
                 || !Objects.equals(run.baselineSnapshot(), intent.baselineSnapshot())
                 || !Objects.equals(run.executionResult(), intent.executionResult())
-                || !Objects.equals(run.candidateDirectory() == null
-                        ? null : run.candidateDirectory().toString(), intent.candidateDirectory())
+                || (run.state() == ShipState.COMPLETED
+                        || run.state() == ShipState.COMPLETED_WITH_WAIVER
+                                ? intent.candidateDirectory() == null || run.candidateDirectory() != null
+                                : !Objects.equals(
+                                        run.candidateDirectory() == null
+                                                ? null : run.candidateDirectory().toString(),
+                                        intent.candidateDirectory()))
                 || run.candidateSnapshot() != null
                         && run.state() != ShipState.COMPLETED
                         && run.state() != ShipState.COMPLETED_WITH_WAIVER
@@ -225,8 +233,7 @@ final class ShipPublicationService {
     private static void rollback(
             Intent intent,
             ProjectSnapshot baseline,
-            ProjectSnapshot candidate,
-            ShipBlobStore blobs)
+            ProjectSnapshot candidate)
             throws IOException {
         Path projectRoot = Path.of(intent.projectRoot());
         ProjectSnapshot current = ProjectEvidenceFiles.capture(projectRoot);
@@ -246,12 +253,12 @@ final class ShipPublicationService {
                     forceDirectory(target.getParent());
                 }
             } else {
-                Path originalFile = safeTarget(source, relative);
+                // Validate the immutable-source target before the bounded no-follow read.
+                safeTarget(source, relative);
                 byte[] content = ProjectEvidenceFiles.readMaterial(
                         source, relative, Math.toIntExact(original.size()));
                 if (content.length != original.size()
-                        || !io.github.luigidemasi.camelkit.ship.ShipDigest.sha256(content)
-                                .equals(original.digest())) {
+                        || !ShipDigest.sha256(content).equals(original.digest())) {
                     throw new IOException("Immutable Ship source differs from publication baseline");
                 }
                 createParents(projectRoot, target.getParent(), baseline);
@@ -366,8 +373,7 @@ final class ShipPublicationService {
     }
 
     private static Path safeTarget(Path root, String relative) throws IOException {
-        String canonical = io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy
-                .requireCanonicalRelativePath(relative);
+        String canonical = ShipTreePolicy.requireCanonicalRelativePath(relative);
         Path target = root.resolve(canonical.replace('/', root.getFileSystem().getSeparator().charAt(0)))
                 .normalize();
         if (!target.startsWith(root) || target.equals(root)) {
@@ -436,7 +442,7 @@ final class ShipPublicationService {
     private static Intent readJournal(Path journal) throws IOException {
         var attributes = Files.readAttributes(
                 journal,
-                java.nio.file.attribute.BasicFileAttributes.class,
+                BasicFileAttributes.class,
                 LinkOption.NOFOLLOW_LINKS);
         Set<PosixFilePermission> expectedPermissions = Set.of(PosixFilePermission.OWNER_READ);
         Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(journal, LinkOption.NOFOLLOW_LINKS);
@@ -470,7 +476,7 @@ final class ShipPublicationService {
         }
         var after = Files.readAttributes(
                 journal,
-                java.nio.file.attribute.BasicFileAttributes.class,
+                BasicFileAttributes.class,
                 LinkOption.NOFOLLOW_LINKS);
         if (!attributes.fileKey().equals(after.fileKey())
                 || attributes.size() != after.size()
@@ -523,7 +529,6 @@ final class ShipPublicationService {
         private final ProjectSnapshot baseline;
         private final ProjectSnapshot candidate;
         private final ProjectSnapshot published;
-        private final ShipBlobStore blobs;
         private boolean finished;
 
         private LivePublication(
@@ -531,14 +536,12 @@ final class ShipPublicationService {
                                 Intent intent,
                                 ProjectSnapshot baseline,
                                 ProjectSnapshot candidate,
-                                ProjectSnapshot published,
-                                ShipBlobStore blobs) {
+                                ProjectSnapshot published) {
             this.journal = journal;
             this.intent = intent;
             this.baseline = baseline;
             this.candidate = candidate;
             this.published = published;
-            this.blobs = blobs;
         }
 
         ProjectSnapshot publishedSnapshot() {
@@ -561,7 +564,7 @@ final class ShipPublicationService {
         @Override
         public void close() throws IOException {
             if (!finished) {
-                rollback(intent, baseline, candidate, blobs);
+                rollback(intent, baseline, candidate);
                 Files.deleteIfExists(journal);
                 forceDirectory(journal.getParent());
                 finished = true;

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjector.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjector.java
@@ -14,6 +14,7 @@ import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord;
 import io.github.luigidemasi.camelkit.ship.context.InitialContext;
 import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
 import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
@@ -854,16 +855,26 @@ final class ShipRunProjector {
                     throw new IOException(
                             "Accepted validation has no resolved requirements policy");
                 }
+                ProjectSnapshot candidate = read(
+                        projection.candidateSnapshot, ProjectSnapshot.class);
+                CatalogUsageRecord usage = read(
+                        projection.catalogUsage, CatalogUsageRecord.class);
+                ShipValidationService.VerificationInputs verificationInputs
+                        = new ShipValidationService.VerificationInputs(
+                                projection.authority.id().toString(),
+                                new ShipValidationService.CandidateInput(
+                                        projection.candidateDirectory,
+                                        candidate,
+                                        projection.candidateSnapshot),
+                                new ShipValidationService.ManifestInput(
+                                        manifest, projection.artifactManifest),
+                                policy,
+                                new ShipValidationService.UsageInput(
+                                        usage, projection.catalogUsage),
+                                workerValidation);
                 Map<String, BlobReference> evidenceById = ShipValidationService.verifyReport(
                         blobs,
-                        projection.authority.id().toString(),
-                        projection.candidateDirectory,
-                        manifest,
-                        policy,
-                        projection.artifactManifest,
-                        projection.candidateSnapshot,
-                        projection.catalogUsage,
-                        workerValidation,
+                        verificationInputs,
                         report,
                         value.evidence());
                 requireContent(authority, value.validationReport().digest(), "accepted validation");
@@ -1118,16 +1129,26 @@ final class ShipRunProjector {
                 throw new IOException(
                         "Validation failure has no resolved requirements policy");
             }
+            ProjectSnapshot candidate = read(
+                    projection.candidateSnapshot, ProjectSnapshot.class);
+            CatalogUsageRecord usage = read(
+                    projection.catalogUsage, CatalogUsageRecord.class);
+            ShipValidationService.VerificationInputs verificationInputs
+                    = new ShipValidationService.VerificationInputs(
+                            projection.authority.id().toString(),
+                            new ShipValidationService.CandidateInput(
+                                    projection.candidateDirectory,
+                                    candidate,
+                                    projection.candidateSnapshot),
+                            new ShipValidationService.ManifestInput(
+                                    manifest, projection.artifactManifest),
+                            policy,
+                            new ShipValidationService.UsageInput(
+                                    usage, projection.catalogUsage),
+                            report.workerValidation());
             Map<String, BlobReference> evidenceById = ShipValidationService.verifyReport(
                     blobs,
-                    projection.authority.id().toString(),
-                    projection.candidateDirectory,
-                    manifest,
-                    policy,
-                    projection.artifactManifest,
-                    projection.candidateSnapshot,
-                    projection.catalogUsage,
-                    report.workerValidation(),
+                    verificationInputs,
                     report,
                     value.evidence());
             projection.evidence.clear();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjector.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjector.java
@@ -573,11 +573,49 @@ final class ShipRunProjector {
                 ShipEventPayloads.StampRecorded value = cast(
                         data, ShipEventPayloads.StampRecorded.class);
                 verify(value.stamp(), "ship-stamp");
-                verifyOptional(value.publishedSnapshot(), "project-snapshot");
-                verifyOptional(value.validationReport(), "validation-report");
+                verify(value.publishedSnapshot(), "project-snapshot");
+                verify(value.validationReport(), "validation-report");
                 requireContent(stored.authority(), value.stamp().digest(), "stamp completion");
+                if (!value.validationReport().equals(projection.validationReport)
+                        || projection.artifactManifest == null
+                        || projection.candidateSnapshot == null
+                        || projection.catalogUsage == null
+                        || projection.candidateDirectory == null) {
+                    throw new IOException("Stamp completion differs from validated durable inputs");
+                }
+                ShipValidationReport report = read(
+                        value.validationReport(), ShipValidationReport.class);
+                ShipStamp stamp = read(value.stamp(), ShipStamp.class);
+                ShipStamp.Status expectedStatus = stored.authority().type() == ShipEventType.RUN_COMPLETED
+                        ? ShipStamp.Status.PASS : ShipStamp.Status.COMPLETED_WITH_WAIVER;
+                if (stamp.status() != expectedStatus
+                        || !successor.id().toString().equals(stamp.runId())
+                        || !projection.adapterId.equals(stamp.adapterId())
+                        || !projection.requirementsDigest.equals(stamp.requirementsDigest())
+                        || !projection.designDigest.equals(stamp.designDigest())
+                        || !projection.artifactManifest.digest().equals(stamp.artifactManifestDigest())
+                        || !projection.candidateSnapshot.digest().equals(stamp.candidateSnapshotDigest())
+                        || !projection.catalogUsage.digest().equals(stamp.catalogUsageDigest())
+                        || !report.checks().equals(stamp.checks())) {
+                    throw new IOException("Ship Stamp differs from exact controller evidence");
+                }
+                if (expectedStatus == ShipStamp.Status.COMPLETED_WITH_WAIVER
+                        && (projection.latestInteraction == null
+                                || stamp.waivers().size() != 1
+                                || !projection.latestInteraction.digest().equals(
+                                        stamp.waivers().get(0).responseDigest()))) {
+                    throw new IOException("Waiver Stamp differs from the signed waiver response");
+                }
+                ProjectSnapshot candidate = read(
+                        projection.candidateSnapshot, ProjectSnapshot.class);
+                ProjectSnapshot published = read(
+                        value.publishedSnapshot(), ProjectSnapshot.class);
+                if (!ProjectEvidenceFiles.unchangedMaterialTree(candidate, published)) {
+                    throw new IOException("Published snapshot differs from the validated candidate");
+                }
                 projection.stamp = value.stamp();
                 projection.candidateSnapshot = value.publishedSnapshot();
+                projection.candidateDirectory = null;
                 projection.validationReport = value.validationReport();
                 projection.activeRequest = null;
                 projection.activeRequestReference = null;
@@ -644,6 +682,10 @@ final class ShipRunProjector {
         verifyOptional(value.catalogEvidence(), "catalog-evidence");
         verifyOptional(value.catalogUsage(), "catalog-usage");
         verifyOptional(value.candidateSnapshot(), "project-snapshot");
+        for (BlobReference evidence : value.evidence()) {
+            verify(evidence, "ship-check-evidence");
+        }
+        verifyOptional(value.validationReport(), "validation-report");
         if ((result.ledger() == null) != (value.ledger() == null)
                 || result.ledger() != null && !result.ledger().equals(read(value.ledger(), DecisionLedger.class))) {
             throw new IOException("Accepted ledger differs from the exact worker result");
@@ -738,6 +780,7 @@ final class ShipRunProjector {
             }
             case DESIGN_READY -> {
                 requireStageOutcome(value, result, ShipStage.DESIGN, StageResult.Outcome.COMPLETED);
+                requireNoValidationEvidence(value);
                 projection.design = artifact(value, "design");
                 requireContent(authority, projection.design.digest(), "accepted design");
                 requireDigest(value.designDigest(), projection.design, "accepted design");
@@ -745,23 +788,81 @@ final class ShipRunProjector {
             }
             case PLAN_VALIDATED -> {
                 requireStageOutcome(value, result, ShipStage.PLAN, StageResult.Outcome.COMPLETED);
+                requireNoValidationEvidence(value);
                 projection.plan = artifact(value, "plan");
                 requireContent(authority, projection.plan.digest(), "accepted plan");
             }
             case EXECUTION_VALIDATED -> {
                 requireStageOutcome(value, result, ShipStage.EXECUTE, StageResult.Outcome.COMPLETED);
+                requireNoValidationEvidence(value);
+                if (value.artifactManifest() == null
+                        || value.catalogUsage() == null
+                        || value.candidateSnapshot() == null
+                        || value.candidateDirectory() == null) {
+                    throw new IOException("Accepted execution lacks its sealed controller bindings");
+                }
+                Path candidateDirectory = absolutePath(
+                        value.candidateDirectory(), "candidate directory");
+                blobs.verifyCandidateDirectory(candidateDirectory);
+                ProjectSnapshot expectedCandidate = read(
+                        value.candidateSnapshot(), ProjectSnapshot.class);
+                ProjectSnapshot observedCandidate = ProjectEvidenceFiles.captureSealed(
+                        candidateDirectory);
+                if (!expectedCandidate.equals(observedCandidate)) {
+                    throw new IOException("Accepted execution candidate changed before projection");
+                }
                 requireContent(authority, value.result().digest(), "accepted execution");
                 projection.executionResult = value.result();
                 projection.candidateSnapshot = value.candidateSnapshot();
-                projection.candidateDirectory = value.candidateDirectory() == null
-                        ? null : absolutePath(value.candidateDirectory(), "candidate directory");
+                projection.candidateDirectory = candidateDirectory;
                 projection.artifactManifest = value.artifactManifest();
                 projection.catalogUsage = value.catalogUsage();
             }
             case VALIDATION_PASSED -> {
                 requireStageOutcome(value, result, ShipStage.VALIDATE, StageResult.Outcome.COMPLETED);
-                requireContent(authority, value.result().digest(), "accepted validation");
-                projection.validationReport = value.result();
+                BlobReference workerValidation = artifact(value, "validation");
+                if (value.validationReport() == null
+                        || value.evidence().isEmpty()
+                        || projection.artifactManifest == null
+                        || projection.catalogUsage == null
+                        || projection.candidateSnapshot == null
+                        || projection.candidateDirectory == null) {
+                    throw new IOException("Accepted validation lacks controller evidence bindings");
+                }
+                ShipValidationReport report = read(
+                        value.validationReport(), ShipValidationReport.class);
+                io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest manifest = read(
+                        projection.artifactManifest,
+                        io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.class);
+                if (projection.ledger == null) {
+                    throw new IOException(
+                            "Accepted validation has no approved requirements ledger");
+                }
+                DecisionLedger ledger = read(
+                        projection.ledger, DecisionLedger.class);
+                DecisionLedger.RequirementsPolicy policy = ledger.requirementsPolicy();
+                if (policy == null) {
+                    throw new IOException(
+                            "Accepted validation has no resolved requirements policy");
+                }
+                Map<String, BlobReference> evidenceById = ShipValidationService.verifyReport(
+                        blobs,
+                        projection.authority.id().toString(),
+                        projection.candidateDirectory,
+                        manifest,
+                        policy,
+                        projection.artifactManifest,
+                        projection.candidateSnapshot,
+                        projection.catalogUsage,
+                        workerValidation,
+                        report,
+                        value.evidence());
+                requireContent(authority, value.validationReport().digest(), "accepted validation");
+                projection.evidence.clear();
+                projection.evidence.addAll(value.evidence());
+                projection.evidenceById.clear();
+                projection.evidenceById.putAll(evidenceById);
+                projection.validationReport = value.validationReport();
             }
             default -> throw new IOException("Event is not a stage acceptance: " + event.stableId());
         }
@@ -982,6 +1083,51 @@ final class ShipRunProjector {
         verifyOptional(value.validationReport(), "validation-report");
         verifyOptional(value.stamp(), "ship-stamp");
         verifyOptional(value.interactionBundle(), "interaction-bundle");
+        for (BlobReference evidence : value.evidence()) {
+            verify(evidence, "ship-check-evidence");
+        }
+        if (value.validationReport() != null) {
+            if (projection.artifactManifest == null
+                    || projection.catalogUsage == null
+                    || projection.candidateSnapshot == null
+                    || projection.candidateDirectory == null) {
+                throw new IOException("Validation failure lacks its durable execution bindings");
+            }
+            ShipValidationReport report = read(
+                    value.validationReport(), ShipValidationReport.class);
+            io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest manifest = read(
+                    projection.artifactManifest,
+                    io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.class);
+            if (projection.ledger == null) {
+                throw new IOException(
+                        "Validation failure has no approved requirements ledger");
+            }
+            DecisionLedger ledger = read(
+                    projection.ledger, DecisionLedger.class);
+            DecisionLedger.RequirementsPolicy policy = ledger.requirementsPolicy();
+            if (policy == null) {
+                throw new IOException(
+                        "Validation failure has no resolved requirements policy");
+            }
+            Map<String, BlobReference> evidenceById = ShipValidationService.verifyReport(
+                    blobs,
+                    projection.authority.id().toString(),
+                    projection.candidateDirectory,
+                    manifest,
+                    policy,
+                    projection.artifactManifest,
+                    projection.candidateSnapshot,
+                    projection.catalogUsage,
+                    report.workerValidation(),
+                    report,
+                    value.evidence());
+            projection.evidence.clear();
+            projection.evidence.addAll(value.evidence());
+            projection.evidenceById.clear();
+            projection.evidenceById.putAll(evidenceById);
+        } else if (!value.evidence().isEmpty()) {
+            throw new IOException("Failure evidence has no controller validation report");
+        }
         projection.failedStage = value.failedStage();
         projection.failureCode = requiredText(value.code(), "failure code");
         projection.failureMessage = requiredText(value.message(), "failure message");
@@ -992,6 +1138,13 @@ final class ShipRunProjector {
         projection.activeRequest = null;
         projection.activeRequestReference = null;
         projection.pendingInteraction = null;
+    }
+
+    private static void requireNoValidationEvidence(ShipEventPayloads.StageAccepted value)
+            throws IOException {
+        if (!value.evidence().isEmpty() || value.validationReport() != null) {
+            throw new IOException("Pre-validation stage cannot carry controller validation evidence");
+        }
     }
 
     private void applyAttemptFailure(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjector.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjector.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
 import io.github.luigidemasi.camelkit.ship.context.InitialContext;
@@ -45,7 +46,12 @@ final class ShipRunProjector {
     }
 
     ShipRunView replay() throws IOException {
-        return replayProjection().view();
+        return replayResult().view();
+    }
+
+    ReplayResult replayResult() throws IOException {
+        List<ShipEvent> history = List.copyOf(events.replay());
+        return new ReplayResult(replayProjection(history).view(), history);
     }
 
     void preflightCreated(
@@ -98,8 +104,11 @@ final class ShipRunProjector {
     }
 
     private Projection replayProjection() throws IOException {
+        return replayProjection(List.copyOf(events.replay()));
+    }
+
+    private Projection replayProjection(List<ShipEvent> history) throws IOException {
         attemptFactory.beginVerificationScope();
-        List<ShipEvent> history = events.replay();
         if (history.isEmpty()) {
             throw new IOException("Ship run has no authoritative events");
         }
@@ -694,7 +703,7 @@ final class ShipRunProjector {
                 || result.artifactManifest() != null
                         && !result.artifactManifest().equals(read(
                                 value.artifactManifest(),
-                                io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.class))) {
+                                ArtifactManifest.class))) {
             throw new IOException("Accepted artifact manifest differs from the exact worker result");
         }
         if (value.stage() == ShipStage.DISCOVERY
@@ -831,9 +840,9 @@ final class ShipRunProjector {
                 }
                 ShipValidationReport report = read(
                         value.validationReport(), ShipValidationReport.class);
-                io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest manifest = read(
+                ArtifactManifest manifest = read(
                         projection.artifactManifest,
-                        io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.class);
+                        ArtifactManifest.class);
                 if (projection.ledger == null) {
                     throw new IOException(
                             "Accepted validation has no approved requirements ledger");
@@ -1095,9 +1104,9 @@ final class ShipRunProjector {
             }
             ShipValidationReport report = read(
                     value.validationReport(), ShipValidationReport.class);
-            io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest manifest = read(
+            ArtifactManifest manifest = read(
                     projection.artifactManifest,
-                    io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.class);
+                    ArtifactManifest.class);
             if (projection.ledger == null) {
                 throw new IOException(
                         "Validation failure has no approved requirements ledger");
@@ -1458,6 +1467,14 @@ final class ShipRunProjector {
             throw new IOException("Ship event has the wrong typed controller payload");
         }
         return type.cast(value);
+    }
+
+    record ReplayResult(ShipRunView view, List<ShipEvent> history) {
+
+        ReplayResult {
+            Objects.requireNonNull(view, "replayed view");
+            history = List.copyOf(history);
+        }
     }
 
     private static final class Projection {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResultReader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResultReader.java
@@ -26,8 +26,22 @@ final class ShipStageResultReader {
     static StageResult read(
             StageRequest request, Path attemptOutputDirectory, byte[] encoded)
             throws IOException {
-        requireBounded(encoded);
+        StageResult result = decode(request, attemptOutputDirectory, encoded);
+        if (!result.artifacts().isEmpty() || result.artifactManifest() != null) {
+            throw new IOException(
+                    "Artifact-bearing Ship results require the production broker/import boundary");
+        }
+        return result;
+    }
 
+    static StageResult readBrokered(StageRequest request, byte[] encoded) throws IOException {
+        return decode(request, Path.of(request.outputDirectory()), encoded);
+    }
+
+    private static StageResult decode(
+            StageRequest request, Path attemptOutputDirectory, byte[] encoded)
+            throws IOException {
+        requireBounded(encoded);
         ObjectMapper mapper = ShipJson.mapper();
         JsonNode document = mapper.readTree(encoded);
         if (document == null) {
@@ -36,10 +50,6 @@ final class ShipStageResultReader {
         StageResultWireSchema.validate(document);
         StageResult result = mapper.treeToValue(document, StageResult.class);
         StageResultValidator.validateEnvelope(request, result, attemptOutputDirectory);
-        if (!result.artifacts().isEmpty() || result.artifactManifest() != null) {
-            throw new IOException(
-                    "Artifact-bearing Ship results require the production broker/import boundary");
-        }
         return result;
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStamp.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStamp.java
@@ -26,7 +26,7 @@ public record ShipStamp(
         String failureCode,
         String failureMessage) {
 
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
 
     public ShipStamp {
         checks = checks == null ? List.of() : List.copyOf(checks);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStamp.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStamp.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 
-/** Controller-derived final assessment value; production issuance is deferred to orchestration. */
+/** Controller-derived final assessment value bound to retained check evidence. */
 public record ShipStamp(
         int schemaVersion,
         String runId,
@@ -52,7 +52,7 @@ public record ShipStamp(
 
         Set<String> checkIds = new HashSet<>();
         for (Check check : checks) {
-            if (check == null || !checkIds.add(check.id())) {
+            if (check == null || !checkIds.add(check.id()) || check.evidenceDigest() == null) {
                 throw new IllegalArgumentException("Ship Stamp checks require unique IDs");
             }
         }
@@ -98,8 +98,35 @@ public record ShipStamp(
                             "PASS Stamp cannot contain failed checks, waivers, or failure details");
                 }
             }
-            case COMPLETED_WITH_WAIVER -> throw new IllegalArgumentException(
-                    "Evidence-bound waiver Stamp issuance is not available in this controller slice");
+            case COMPLETED_WITH_WAIVER -> {
+                if (failureCode != null || failureMessage != null || waivers.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "Waiver Stamp requires exact waiver receipts and no failure details");
+                }
+                Set<String> failed = checks.stream()
+                        .filter(Check::mandatory)
+                        .filter(check -> !check.passed())
+                        .map(Check::id)
+                        .collect(java.util.stream.Collectors.toSet());
+                Set<String> waived = new HashSet<>();
+                for (Waiver waiver : waivers) {
+                    Check check = checks.stream()
+                            .filter(candidate -> candidate.id().equals(waiver.checkId()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "Waiver references an unknown check"));
+                    if (check.passed()
+                            || !check.evidenceDigest().equals(waiver.evidenceDigest())
+                            || !waived.add(waiver.checkId())) {
+                        throw new IllegalArgumentException(
+                                "Waiver does not exactly bind one failed check evidence record");
+                    }
+                }
+                if (!failed.equals(waived)) {
+                    throw new IllegalArgumentException(
+                            "Waiver Stamp must cover every and only failed mandatory checks");
+                }
+            }
             case FAIL -> {
                 if (!mandatoryFailed
                         || !waivers.isEmpty()
@@ -112,10 +139,6 @@ public record ShipStamp(
                 requireText(failureMessage, "failure message");
             }
         }
-        if (!waivers.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Waiver references require the later evidence-bound waiver policy");
-        }
     }
 
     public enum Status {
@@ -127,13 +150,11 @@ public record ShipStamp(
     public record Check(String id, boolean mandatory, boolean passed, String evidenceDigest) {
         public Check {
             requireText(id, "check ID");
-            if (evidenceDigest != null) {
-                requireDigest(evidenceDigest, "check evidence digest");
-            }
+            requireDigest(evidenceDigest, "check evidence digest");
         }
     }
 
-    /** Storage scaffold only; PR 6 owns policy eligibility and receipt verification. */
+    /** Exact evidence and signed response which authorize one failed mandatory check. */
     public record Waiver(String checkId, String evidenceDigest, String responseDigest) {
         public Waiver {
             requireText(checkId, "waiver check ID");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStamp.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStamp.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 
@@ -107,7 +108,7 @@ public record ShipStamp(
                         .filter(Check::mandatory)
                         .filter(check -> !check.passed())
                         .map(Check::id)
-                        .collect(java.util.stream.Collectors.toSet());
+                        .collect(Collectors.toSet());
                 Set<String> waived = new HashSet<>();
                 for (Waiver waiver : waivers) {
                     Check check = checks.stream()

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStampService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStampService.java
@@ -1,0 +1,87 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.time.Instant;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+
+/** Issues and replays a Stamp only from one persisted controller validation report. */
+final class ShipStampService {
+
+    private ShipStampService() {
+    }
+
+    static ShipStamp issue(
+            ShipRunView run,
+            ShipValidationReport report,
+            ShipStamp.Status status,
+            BlobReference waiverResponse,
+            Instant generatedAt,
+            String failureCode,
+            String failureMessage) {
+        requireBindings(run, report);
+        List<ShipStamp.Waiver> waivers = List.of();
+        if (status == ShipStamp.Status.COMPLETED_WITH_WAIVER) {
+            List<ShipStamp.Check> failed = report.checks().stream()
+                    .filter(ShipStamp.Check::mandatory)
+                    .filter(check -> !check.passed())
+                    .toList();
+            if (failed.size() != 1
+                    || !failed.get(0).id().matches("citrus-integration-test-[0-9]{3}")
+                    || waiverResponse == null) {
+                throw new ShipControllerException(
+                        "waiver-policy-ineligible",
+                        "Only one exact failed Citrus integration check can be waived");
+            }
+            ShipStamp.Check check = failed.get(0);
+            waivers = List.of(new ShipStamp.Waiver(
+                    check.id(), check.evidenceDigest(), waiverResponse.digest()));
+        }
+        return new ShipStamp(
+                ShipStamp.SCHEMA_VERSION,
+                run.runId(),
+                status,
+                run.adapterId(),
+                run.requirementsDigest(),
+                run.designDigest(),
+                run.artifactManifest().digest(),
+                run.candidateSnapshot().digest(),
+                run.catalogUsage().digest(),
+                report.checks(),
+                waivers,
+                generatedAt,
+                failureCode,
+                failureMessage);
+    }
+
+    static void verify(ShipRunView run, ShipValidationReport report, ShipStamp stamp) {
+        requireBindings(run, report);
+        if (stamp == null
+                || !run.runId().equals(stamp.runId())
+                || !run.adapterId().equals(stamp.adapterId())
+                || !run.requirementsDigest().equals(stamp.requirementsDigest())
+                || !run.designDigest().equals(stamp.designDigest())
+                || !run.artifactManifest().digest().equals(stamp.artifactManifestDigest())
+                || !run.candidateSnapshot().digest().equals(stamp.candidateSnapshotDigest())
+                || !run.catalogUsage().digest().equals(stamp.catalogUsageDigest())
+                || !report.checks().equals(stamp.checks())) {
+            throw new ShipControllerException(
+                    "stamp-binding-invalid", "Ship Stamp differs from durable run evidence");
+        }
+    }
+
+    private static void requireBindings(ShipRunView run, ShipValidationReport report) {
+        if (run == null || report == null
+                || run.artifactManifest() == null
+                || run.candidateSnapshot() == null
+                || run.catalogUsage() == null
+                || !run.runId().equals(report.runId())
+                || !run.artifactManifest().digest().equals(report.artifactManifestDigest())
+                || !run.candidateSnapshot().digest().equals(report.candidateSnapshotDigest())
+                || !run.catalogUsage().digest().equals(report.catalogUsageDigest())) {
+            throw new ShipControllerException(
+                    "validation-report-binding-invalid",
+                    "Controller validation report differs from the durable run inputs");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationReport.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationReport.java
@@ -1,0 +1,97 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+import io.github.luigidemasi.camelkit.ship.controller.ShipEvidenceVerifier.RetainedEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceCommand;
+
+/** Controller-authored replay bundle for the exact checks summarized by a Ship Stamp. */
+record ShipValidationReport(
+        int schemaVersion,
+        String runId,
+        String artifactManifestDigest,
+        String candidateSnapshotDigest,
+        String catalogUsageDigest,
+        BlobReference workerValidation,
+        List<ShipStamp.Check> checks,
+        List<BlobReference> evidence,
+        Instant generatedAt) {
+
+    static final int SCHEMA_VERSION = 1;
+
+    ShipValidationReport {
+        checks = checks == null ? List.of() : new ArrayList<>(checks);
+        evidence = evidence == null ? List.of() : new ArrayList<>(evidence);
+        if (schemaVersion != SCHEMA_VERSION
+                || runId == null || !runId.matches("ship-[0-9a-f]{32}")
+                || !ShipDigest.isSha256(artifactManifestDigest)
+                || !ShipDigest.isSha256(candidateSnapshotDigest)
+                || !ShipDigest.isSha256(catalogUsageDigest)
+                || workerValidation == null
+                || generatedAt == null
+                || checks.isEmpty()
+                || checks.size() > 64
+                || checks.size() != evidence.size()) {
+            throw new IllegalArgumentException("Invalid controller validation report");
+        }
+
+        HashSet<String> checkIds = new HashSet<>();
+        HashSet<String> evidenceDigests = new HashSet<>();
+        for (int index = 0; index < checks.size(); index++) {
+            ShipStamp.Check check = checks.get(index);
+            BlobReference reference = evidence.get(index);
+            if (check == null
+                    || reference == null
+                    || !"ship-check-evidence".equals(reference.kind())
+                    || !checkIds.add(check.id())
+                    || !evidenceDigests.add(reference.digest())
+                    || !check.evidenceDigest().equals(reference.digest())) {
+                throw new IllegalArgumentException("Validation check differs from its retained evidence");
+            }
+        }
+        checks = List.copyOf(checks);
+        evidence = List.copyOf(evidence);
+    }
+}
+
+record ShipCheckEvidence(
+        int schemaVersion,
+        String runId,
+        String checkId,
+        boolean mandatory,
+        boolean passed,
+        List<BlobReference> subjects,
+        EvidenceCommand command,
+        CommandEvidence commandEvidence,
+        RetainedEvidence retainedEvidence) {
+
+    static final int SCHEMA_VERSION = 1;
+
+    ShipCheckEvidence {
+        subjects = subjects == null ? List.of() : new ArrayList<>(subjects);
+        if (schemaVersion != SCHEMA_VERSION
+                || runId == null || !runId.matches("ship-[0-9a-f]{32}")
+                || checkId == null || !checkId.matches("[a-z0-9][a-z0-9-]{0,127}")
+                || subjects.isEmpty()
+                || subjects.size() > 64
+                || (command == null) != (commandEvidence == null)
+                || (command == null) != (retainedEvidence == null)) {
+            throw new IllegalArgumentException("Invalid Ship check evidence");
+        }
+
+        HashSet<String> subjectDigests = new HashSet<>();
+        for (BlobReference subject : subjects) {
+            if (subject == null || !subjectDigests.add(subject.digest())) {
+                throw new IllegalArgumentException(
+                        "Ship check evidence subjects must be nonnull and unique");
+            }
+        }
+        subjects = List.copyOf(subjects);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationService.java
@@ -1,0 +1,796 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.TestArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactValidationResult;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactValidator;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
+import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+import io.github.luigidemasi.camelkit.ship.controller.ShipEvidenceVerifier.RetainedEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceCommand;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceRunner;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadArchive;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipJvmPayloadBootstrap;
+import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.RequirementsPolicy;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+
+/** Runs and replays the closed controller-owned validation check set. */
+final class ShipValidationService {
+
+    private final EvidenceExecutor executor;
+    private final Clock clock;
+
+    ShipValidationService() {
+        this(new EvidenceRunner()::run, Clock.systemUTC());
+    }
+
+    ShipValidationService(EvidenceExecutor executor, Clock clock) {
+        this.executor = Objects.requireNonNull(executor, "evidence executor");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    Result validate(
+            ShipBlobStore blobs,
+            ShipBlobStore.Transaction transaction,
+            String runId,
+            Path candidate,
+            ProjectSnapshot candidateValue,
+            BlobReference candidateReference,
+            ArtifactManifest manifest,
+            BlobReference manifestReference,
+            RequirementsPolicy policy,
+            CatalogUsageRecord usage,
+            BlobReference usageReference,
+            ShipCatalogService.Snapshot catalogSnapshot,
+            CatalogEvidenceSet approvedCatalogEvidence,
+            BlobReference approvedCatalogEvidenceReference,
+            BlobReference workerValidation)
+            throws IOException {
+        Objects.requireNonNull(transaction, "blob transaction");
+        Path exactCandidate = blobs.verifyCandidateDirectory(candidate);
+        CatalogEvidenceValidator.validateUsage(
+                catalogSnapshot,
+                new CatalogEvidenceValidator.UsageBinding(
+                        runId,
+                        approvedCatalogEvidenceReference.digest(),
+                        manifestReference.digest(),
+                        candidateReference.digest(),
+                        candidateValue.digest(),
+                        usage.pomDigest()),
+                approvedCatalogEvidence,
+                manifest,
+                usage);
+
+        List<BlobReference> evidence = new ArrayList<>();
+        List<ShipStamp.Check> checks = new ArrayList<>();
+        ArtifactValidationResult artifactValidation = ArtifactValidator.validate(
+                exactCandidate, manifest, policy);
+        BlobReference artifactValidationReference = write(
+                transaction, "artifact-validation", artifactValidation);
+        addSimple(
+                transaction, runId, "artifact-policy", true,
+                artifactValidation.passed(), List.of(artifactValidationReference),
+                evidence, checks);
+        addSimple(
+                transaction, runId, "catalog-usage", true, true,
+                List.of(approvedCatalogEvidenceReference, usageReference),
+                evidence, checks);
+
+        Map<String, EvidenceCommand> expectedCommands = expectedCommands(
+                manifest,
+                candidateValue,
+                candidateReference,
+                manifestReference,
+                usage,
+                usageReference);
+        for (String id : controllerCommandIds(manifest)) {
+            EvidenceCommand expected = expectedCommands.remove(id);
+            if (expected == null) {
+                if (!id.matches("citrus-integration-test-[0-9]{3}")) {
+                    throw new IOException(
+                            "Controller failed to construct required evidence command " + id);
+                }
+                addSimple(
+                        transaction, runId, id, true, false,
+                        List.of(manifestReference), evidence, checks);
+            } else {
+                addCommand(
+                        blobs,
+                        transaction,
+                        runId,
+                        exactCandidate,
+                        manifest,
+                        expected,
+                        List.of(
+                                candidateReference,
+                                manifestReference,
+                                usageReference),
+                        evidence,
+                        checks);
+            }
+        }
+        if (!expectedCommands.isEmpty()) {
+            throw new IOException(
+                    "Controller constructed unexpected evidence commands");
+        }
+
+        ProjectSnapshot observed = ProjectEvidenceFiles.captureSealed(exactCandidate);
+        BlobReference observedReference = write(transaction, "project-snapshot", observed);
+        addSimple(
+                transaction, runId, "candidate-integrity", true,
+                observed.equals(candidateValue),
+                List.of(observedReference), evidence, checks);
+        addSimple(
+                transaction, runId, "bounded-validation-report", false, true,
+                List.of(workerValidation), evidence, checks);
+
+        Instant generatedAt = Instant.now(clock);
+        ShipValidationReport report = new ShipValidationReport(
+                ShipValidationReport.SCHEMA_VERSION,
+                runId,
+                manifestReference.digest(),
+                candidateReference.digest(),
+                usageReference.digest(),
+                workerValidation,
+                checks,
+                evidence,
+                generatedAt);
+        BlobReference reportReference = write(transaction, "validation-report", report);
+        List<ShipStamp.Check> failed = checks.stream()
+                .filter(ShipStamp.Check::mandatory)
+                .filter(check -> !check.passed())
+                .toList();
+        Verdict verdict = failed.isEmpty() ? Verdict.PASS
+                : failed.size() == 1
+                        && failed.get(0).id().matches("citrus-integration-test-[0-9]{3}")
+                        ? Verdict.WAIVABLE
+                : Verdict.FAIL;
+        return new Result(
+                verdict, report, reportReference, List.copyOf(evidence),
+                verdict == Verdict.WAIVABLE ? failed.get(0) : null);
+    }
+
+    static Map<String, BlobReference> verifyReport(
+            ShipBlobStore blobs,
+            String expectedRunId,
+            Path candidate,
+            ArtifactManifest manifest,
+            RequirementsPolicy policy,
+            BlobReference manifestReference,
+            BlobReference candidateReference,
+            BlobReference usageReference,
+            BlobReference workerValidation,
+            ShipValidationReport report,
+            List<BlobReference> evidence)
+            throws IOException {
+        Path exactCandidate = blobs.verifyCandidateDirectory(candidate);
+        ProjectSnapshot candidateValue = ShipJson.mapper().readValue(
+                blobs.readBytes(
+                        candidateReference, ShipJson.MAX_DOCUMENT_BYTES),
+                ProjectSnapshot.class);
+        CatalogUsageRecord usage = ShipJson.mapper().readValue(
+                blobs.readBytes(
+                        usageReference, ShipJson.MAX_DOCUMENT_BYTES),
+                CatalogUsageRecord.class);
+
+        if (report == null
+                || !expectedRunId.equals(report.runId())
+                || !manifestReference.digest()
+                        .equals(report.artifactManifestDigest())
+                || !candidateReference.digest()
+                        .equals(report.candidateSnapshotDigest())
+                || !usageReference.digest()
+                        .equals(report.catalogUsageDigest())
+                || !workerValidation.equals(report.workerValidation())
+                || !evidence.equals(report.evidence())
+                || !manifestReference.digest()
+                        .equals(usage.artifactManifestDigest())
+                || !candidateReference.digest()
+                        .equals(usage.candidateSnapshotDigest())
+                || !candidateValue.digest()
+                        .equals(usage.candidateContentDigest())) {
+            throw new IOException("Validation report differs from exact durable run inputs");
+        }
+
+        ArtifactValidationResult expectedArtifactValidation
+                = ArtifactValidator.validate(exactCandidate, manifest, policy);
+        ProjectSnapshot currentCandidate = ProjectEvidenceFiles.captureSealed(exactCandidate);
+        Map<String, EvidenceCommand> expectedCommands = expectedCommands(
+                manifest,
+                candidateValue,
+                candidateReference,
+                manifestReference,
+                usage,
+                usageReference);
+
+        Map<String, BlobReference> byId = new LinkedHashMap<>();
+        for (int index = 0; index < evidence.size(); index++) {
+            BlobReference reference = evidence.get(index);
+            if (!"ship-check-evidence".equals(reference.kind())) {
+                throw new IOException("Validation evidence has an invalid blob kind");
+            }
+            ShipCheckEvidence value = ShipJson.mapper().readValue(
+                    blobs.readBytes(reference, ShipJson.MAX_DOCUMENT_BYTES),
+                    ShipCheckEvidence.class);
+            ShipStamp.Check check = report.checks().get(index);
+            if (!report.runId().equals(value.runId())
+                    || !check.id().equals(value.checkId())
+                    || check.mandatory() != value.mandatory()
+                    || check.passed() != value.passed()
+                    || !reference.digest().equals(check.evidenceDigest())
+                    || byId.putIfAbsent(check.id(), reference) != null) {
+                throw new IOException("Validation check differs from retained evidence");
+            }
+            for (BlobReference subject : value.subjects()) {
+                blobs.verify(subject);
+            }
+
+            boolean expectedPassed;
+            switch (check.id()) {
+                case "artifact-policy" -> {
+                    requireSimple(value);
+                    if (value.subjects().size() != 1
+                            || !"artifact-validation".equals(
+                                    value.subjects().get(0).kind())) {
+                        throw new IOException(
+                                "Artifact-policy evidence has invalid subjects");
+                    }
+                    ArtifactValidationResult retained = ShipJson.mapper().readValue(
+                            blobs.readBytes(
+                                    value.subjects().get(0),
+                                    ShipJson.MAX_DOCUMENT_BYTES),
+                            ArtifactValidationResult.class);
+                    if (!expectedArtifactValidation.equals(retained)) {
+                        throw new IOException(
+                                "Retained artifact validation differs from deterministic replay");
+                    }
+                    expectedPassed = expectedArtifactValidation.passed();
+                }
+                case "catalog-usage" -> {
+                    requireSimple(value);
+                    if (value.subjects().size() != 2
+                            || !"catalog-evidence".equals(
+                                    value.subjects().get(0).kind())
+                            || !usage.catalogEvidenceDigest().equals(
+                                    value.subjects().get(0).digest())
+                            || !usageReference.equals(
+                                    value.subjects().get(1))) {
+                        throw new IOException(
+                                "Catalog-usage evidence has invalid subjects");
+                    }
+                    expectedPassed = true;
+                }
+                case "candidate-integrity" -> {
+                    requireSimple(value);
+                    if (value.subjects().size() != 1
+                            || !"project-snapshot".equals(
+                                    value.subjects().get(0).kind())) {
+                        throw new IOException(
+                                "Candidate-integrity evidence has invalid subjects");
+                    }
+                    ProjectSnapshot retained = ShipJson.mapper().readValue(
+                            blobs.readBytes(
+                                    value.subjects().get(0),
+                                    ShipJson.MAX_DOCUMENT_BYTES),
+                            ProjectSnapshot.class);
+                    if (!currentCandidate.equals(retained)) {
+                        throw new IOException(
+                                "Retained candidate observation differs from current sealed candidate");
+                    }
+                    expectedPassed = currentCandidate.equals(candidateValue);
+                }
+                case "bounded-validation-report" -> {
+                    requireSimple(value);
+                    if (!value.subjects().equals(List.of(workerValidation))) {
+                        throw new IOException(
+                                "Worker validation evidence has invalid subjects");
+                    }
+                    expectedPassed = true;
+                }
+                default -> {
+                    EvidenceCommand expected = expectedCommands.remove(check.id());
+                    if (expected == null) {
+                        if (!isExpectedStructuralCitrusFailure(
+                                check.id(),
+                                manifest,
+                                usage,
+                                manifestReference,
+                                value)) {
+                            throw new IOException(
+                                    "Validation report contains an unknown check");
+                        }
+                        expectedPassed = false;
+                    } else {
+                        if (!expected.equals(value.command())
+                                || !value.subjects().equals(List.of(
+                                        candidateReference,
+                                        manifestReference,
+                                        usageReference))) {
+                            throw new IOException(
+                                    "Command evidence differs from controller-selected inputs");
+                        }
+                        expectedPassed = ShipEvidenceVerifier.verify(
+                                blobs,
+                                exactCandidate,
+                                manifest,
+                                expected,
+                                value.commandEvidence(),
+                                value.retainedEvidence());
+                    }
+                }
+            }
+
+            if (check.passed() != expectedPassed
+                    || value.passed() != expectedPassed) {
+                throw new IOException(
+                        "Validation check result differs from deterministic replay");
+            }
+        }
+
+        if (!expectedCommands.isEmpty()
+                || !new ArrayList<>(byId.keySet())
+                        .equals(expectedCheckIds(manifest))) {
+            throw new IOException(
+                    "Validation report omits or reorders controller-required checks");
+        }
+        return Map.copyOf(byId);
+    }
+
+    private void addCommand(
+            ShipBlobStore blobs,
+            ShipBlobStore.Transaction transaction,
+            String runId,
+            Path candidate,
+            ArtifactManifest manifest,
+            EvidenceCommand command,
+            List<BlobReference> subjects,
+            List<BlobReference> evidence,
+            List<ShipStamp.Check> checks)
+            throws IOException {
+        Path root = blobs.privateWorkDirectory("evidence");
+        Path directory = root.resolve(command.id() + '-' + UUID.randomUUID());
+        CommandEvidence commandEvidence = null;
+        boolean collected = false;
+        Throwable pending = null;
+        try {
+            try {
+                commandEvidence = Objects.requireNonNull(
+                        executor.run(candidate, directory, command),
+                        "Evidence executor returned no command evidence");
+                collected = true;
+            } catch (IOException | RuntimeException failure) {
+                commandEvidence = failedEvidence(
+                        transaction,
+                        candidate,
+                        command,
+                        failure.getClass().getSimpleName()
+                                 + ": " + safeMessage(failure));
+            }
+
+            RetainedEvidence retained = collected
+                    ? retain(transaction, commandEvidence)
+                    : failedRetained(transaction);
+            boolean passed = ShipEvidenceVerifier.verify(
+                    blobs,
+                    candidate,
+                    manifest,
+                    command,
+                    commandEvidence,
+                    retained);
+            ShipCheckEvidence value = new ShipCheckEvidence(
+                    ShipCheckEvidence.SCHEMA_VERSION,
+                    runId,
+                    command.id(),
+                    true,
+                    passed,
+                    subjects,
+                    command,
+                    commandEvidence,
+                    retained);
+            BlobReference reference = write(transaction, "ship-check-evidence", value);
+            evidence.add(reference);
+            checks.add(new ShipStamp.Check(
+                    command.id(),
+                    true,
+                    passed,
+                    reference.digest()));
+        } catch (IOException | RuntimeException | Error failure) {
+            pending = failure;
+            throw failure;
+        } finally {
+            if (collected) {
+                try {
+                    EvidenceRunner.cleanupEphemeral(
+                            directory, command, commandEvidence);
+                } catch (IOException cleanupFailure) {
+                    if (pending != null) {
+                        pending.addSuppressed(cleanupFailure);
+                    } else {
+                        throw cleanupFailure;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void addSimple(
+            ShipBlobStore.Transaction transaction,
+            String runId,
+            String id,
+            boolean mandatory,
+            boolean passed,
+            List<BlobReference> subjects,
+            List<BlobReference> evidence,
+            List<ShipStamp.Check> checks)
+            throws IOException {
+        ShipCheckEvidence value = new ShipCheckEvidence(
+                ShipCheckEvidence.SCHEMA_VERSION,
+                runId, id, mandatory, passed, subjects, null, null, null);
+        BlobReference reference = write(transaction, "ship-check-evidence", value);
+        evidence.add(reference);
+        checks.add(new ShipStamp.Check(id, mandatory, passed, reference.digest()));
+    }
+
+    private static RetainedEvidence retain(
+            ShipBlobStore.Transaction transaction, CommandEvidence evidence)
+            throws IOException {
+        BlobReference stdout = transaction.importControllerFile(
+                "evidence-stdout", Path.of(evidence.stdoutLog()), evidence.stdoutDigest());
+        BlobReference stderr = transaction.importControllerFile(
+                "evidence-stderr", Path.of(evidence.stderrLog()), evidence.stderrDigest());
+        BlobReference sandbox = evidence.sandbox() == null
+                ? null
+                : transaction.importControllerFile(
+                        "sandbox-executable", Path.of(evidence.sandbox().executable()),
+                        evidence.sandbox().executableDigest());
+        BlobReference toolchain = evidence.toolchainSnapshot() == null
+                ? null
+                : transaction.importControllerFile(
+                        "toolchain-archive", Path.of(evidence.toolchainSnapshot()),
+                        evidence.toolchainSnapshotDigest());
+        BlobReference executable = evidence.executable() == null
+                ? null
+                : transaction.importControllerFile(
+                        "command-executable", Path.of(evidence.executable()),
+                        evidence.executableDigest());
+        return new RetainedEvidence(stdout, stderr, sandbox, toolchain, executable);
+    }
+
+    private static CommandEvidence failedEvidence(
+            ShipBlobStore.Transaction transaction,
+            Path candidate,
+            EvidenceCommand command,
+            String message)
+            throws IOException {
+        BlobReference empty = transaction.writeBytes("evidence-log", new byte[0]);
+        Instant now = Instant.EPOCH;
+        return new CommandEvidence(
+                CommandEvidence.SCHEMA_VERSION,
+                command.id(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                command.arguments(),
+                candidate.toString(),
+                Map.of(),
+                now,
+                now,
+                false,
+                false,
+                null,
+                message == null || message.isBlank() ? "evidence setup failed" : message,
+                "cas:" + empty.digest(),
+                empty.digest(),
+                "cas:" + empty.digest(),
+                empty.digest(),
+                command.inputDigests());
+    }
+
+    private static RetainedEvidence failedRetained(ShipBlobStore.Transaction transaction)
+            throws IOException {
+        BlobReference empty = transaction.writeBytes("evidence-log", new byte[0]);
+        return new RetainedEvidence(empty, empty, null, null, null);
+    }
+
+    private static Map<String, EvidenceCommand> expectedCommands(
+            ArtifactManifest manifest,
+            ProjectSnapshot candidateValue,
+            BlobReference candidateReference,
+            BlobReference manifestReference,
+            CatalogUsageRecord usage,
+            BlobReference usageReference) {
+        List<RouteArtifact> routes = canonicalRoutes(manifest);
+        List<TestArtifact> tests = canonicalTests(manifest);
+        List<String> commonInputs = List.of(
+                candidateReference.digest(),
+                manifestReference.digest(),
+                usageReference.digest());
+
+        Map<String, EvidenceCommand> result = new LinkedHashMap<>();
+
+        JvmPayloadRequest yaml = JvmPayloadRequest.yamlValidator(manifest.camelVersion());
+        result.put(
+                "route-schema",
+                command(
+                        "route-schema",
+                        Duration.ofMinutes(5),
+                        yaml,
+                        routes.stream()
+                                .map(route -> "/workspace/" + route.path())
+                                .toList(),
+                        commonInputs));
+
+        JvmPayloadRequest main = JvmPayloadRequest.camelMain(
+                manifest.camelVersion(), usage.runtimeDependencies());
+        List<String> packageArguments = new ArrayList<>(
+                List.of(
+                        "--candidate-digest=" + candidateValue.digest(),
+                        "--manifest-digest=" + manifestReference.digest(),
+                        "--catalog-usage-digest=" + usageReference.digest(),
+                        "--pom-digest=" + usage.pomDigest(),
+                        "--main-payload-digest=" + main.digest()));
+        for (RouteArtifact route : routes) {
+            packageArguments.add("--route=" + route.path());
+            packageArguments.add("--route-digest=" + route.digest());
+        }
+        result.put(
+                "main-package-and-inspect",
+                command(
+                        "main-package-and-inspect",
+                        Duration.ofMinutes(5),
+                        JvmPayloadRequest.mainPackage(manifest.camelVersion()),
+                        packageArguments,
+                        commonInputs));
+
+        List<String> runtimeArguments = new ArrayList<>();
+        for (RouteArtifact route : routes) {
+            runtimeArguments.add("--route=/workspace/" + route.path());
+            runtimeArguments.add("--expected-route=" + route.routeId());
+        }
+        result.put(
+                "main-runtime-resolve-and-start",
+                command(
+                        "main-runtime-resolve-and-start",
+                        Duration.ofMinutes(10),
+                        main,
+                        runtimeArguments,
+                        commonInputs));
+
+        if (tests.isEmpty()) {
+            return result;
+        }
+
+        JvmPayloadRequest citrus;
+        try {
+            citrus = JvmPayloadRequest.citrus(
+                    manifest.camelVersion(),
+                    manifest.citrusVersion(),
+                    manifest.citrusDependencies(),
+                    usage.runtimeDependencies());
+        } catch (IllegalArgumentException invalidPayload) {
+            return result;
+        }
+
+        for (int index = 0; index < tests.size(); index++) {
+            TestArtifact test = tests.get(index);
+            List<RouteArtifact> matchingRoutes = routes.stream()
+                    .filter(route -> test.routeId().equals(route.routeId()))
+                    .limit(2)
+                    .toList();
+            if (matchingRoutes.size() != 1) {
+                continue;
+            }
+            RouteArtifact route = matchingRoutes.get(0);
+            String id = String.format(
+                    Locale.ROOT,
+                    "citrus-integration-test-%03d",
+                    index + 1);
+            result.put(
+                    id,
+                    command(
+                            id,
+                            Duration.ofMinutes(10),
+                            citrus,
+                            List.of(
+                                    "--route=/workspace/" + route.path(),
+                                    "--expected-route=" + route.routeId(),
+                                    "--test=/workspace/" + test.path()),
+                            commonInputs));
+        }
+        return result;
+    }
+
+    private static List<RouteArtifact> canonicalRoutes(
+            ArtifactManifest manifest) {
+        return manifest.routes().stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(RouteArtifact::path)
+                        .thenComparing(RouteArtifact::routeId))
+                .toList();
+    }
+
+    private static List<TestArtifact> canonicalTests(
+            ArtifactManifest manifest) {
+        return manifest.citrusTests().stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(TestArtifact::path)
+                        .thenComparing(TestArtifact::routeId))
+                .toList();
+    }
+
+    private static List<String> controllerCommandIds(
+            ArtifactManifest manifest) {
+        List<String> result = new ArrayList<>(
+                List.of(
+                        "route-schema",
+                        "main-package-and-inspect",
+                        "main-runtime-resolve-and-start"));
+        List<TestArtifact> tests = canonicalTests(manifest);
+        int citrusChecks = Math.max(1, tests.size());
+        for (int index = 0; index < citrusChecks; index++) {
+            result.add(String.format(
+                    Locale.ROOT,
+                    "citrus-integration-test-%03d",
+                    index + 1));
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<String> expectedCheckIds(
+            ArtifactManifest manifest) {
+        List<String> result = new ArrayList<>(
+                List.of(
+                        "artifact-policy",
+                        "catalog-usage"));
+        result.addAll(controllerCommandIds(manifest));
+        result.add("candidate-integrity");
+        result.add("bounded-validation-report");
+        return List.copyOf(result);
+    }
+
+    private static boolean isExpectedStructuralCitrusFailure(
+            String id,
+            ArtifactManifest manifest,
+            CatalogUsageRecord usage,
+            BlobReference manifestReference,
+            ShipCheckEvidence value) {
+        if (!id.matches("citrus-integration-test-[0-9]{3}")
+                || value.command() != null
+                || value.commandEvidence() != null
+                || value.retainedEvidence() != null
+                || !value.mandatory()
+                || value.passed()
+                || !value.subjects().equals(List.of(manifestReference))) {
+            return false;
+        }
+
+        List<TestArtifact> tests = canonicalTests(manifest);
+        if (tests.isEmpty()) {
+            return "citrus-integration-test-001".equals(id);
+        }
+
+        int selected = -1;
+        for (int index = 0; index < tests.size(); index++) {
+            String expected = String.format(
+                    Locale.ROOT,
+                    "citrus-integration-test-%03d",
+                    index + 1);
+            if (expected.equals(id)) {
+                selected = index;
+                break;
+            }
+        }
+        if (selected < 0) {
+            return false;
+        }
+
+        TestArtifact test = tests.get(selected);
+        long matchingRoutes = canonicalRoutes(manifest).stream()
+                .filter(route -> test.routeId().equals(route.routeId()))
+                .limit(2)
+                .count();
+        if (matchingRoutes != 1) {
+            return true;
+        }
+
+        try {
+            JvmPayloadRequest.citrus(
+                    manifest.camelVersion(),
+                    manifest.citrusVersion(),
+                    manifest.citrusDependencies(),
+                    usage.runtimeDependencies());
+            return false;
+        } catch (IllegalArgumentException invalidPayload) {
+            return true;
+        }
+    }
+
+    private static void requireSimple(ShipCheckEvidence value)
+            throws IOException {
+        if (value.command() != null
+                || value.commandEvidence() != null
+                || value.retainedEvidence() != null) {
+            throw new IOException(
+                    "Non-command validation evidence contains command authority");
+        }
+    }
+
+    private static EvidenceCommand command(
+            String id,
+            Duration timeout,
+            JvmPayloadRequest payload,
+            List<String> launcherArguments,
+            List<String> inputDigests) {
+        List<String> base = List.of(
+                EvidenceRunner.JAVA_EXECUTABLE,
+                "-cp",
+                JvmPayloadArchive.SANDBOX_ARCHIVE,
+                ShipJvmPayloadBootstrap.class.getName());
+        List<String> arguments = new ArrayList<>(base);
+        arguments.addAll(launcherArguments);
+        List<String> version = new ArrayList<>(base);
+        version.add("--payload-version");
+        return new EvidenceCommand(
+                id, arguments, version, null, timeout, inputDigests,
+                Map.of("LANG", "C", "LC_ALL", "C"),
+                List.of(), null, payload);
+    }
+
+    private static <T> BlobReference write(
+            ShipBlobStore.Transaction transaction, String kind, T value)
+            throws IOException {
+        return transaction.writeBytes(kind, ShipJson.mapper().writeValueAsBytes(value));
+    }
+
+    private static String safeMessage(Throwable failure) {
+        String message = failure.getMessage();
+        return message == null || message.isBlank() ? "unreported" : message;
+    }
+
+    @FunctionalInterface
+    interface EvidenceExecutor {
+        CommandEvidence run(Path candidate, Path evidenceDirectory, EvidenceCommand command)
+                throws IOException;
+    }
+
+    enum Verdict {
+        PASS,
+        WAIVABLE,
+        FAIL
+    }
+
+    record Result(
+            Verdict verdict,
+            ShipValidationReport report,
+            BlobReference reportReference,
+            List<BlobReference> evidence,
+            ShipStamp.Check failedCheck) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationService.java
@@ -174,26 +174,22 @@ final class ShipValidationService {
 
     static Map<String, BlobReference> verifyReport(
             ShipBlobStore blobs,
-            String expectedRunId,
-            Path candidate,
-            ArtifactManifest manifest,
-            RequirementsPolicy policy,
-            BlobReference manifestReference,
-            BlobReference candidateReference,
-            BlobReference usageReference,
-            BlobReference workerValidation,
+            VerificationInputs inputs,
             ShipValidationReport report,
             List<BlobReference> evidence)
             throws IOException {
+        Objects.requireNonNull(inputs, "verification inputs");
+        String expectedRunId = inputs.runId();
+        Path candidate = inputs.candidate().directory();
+        ProjectSnapshot candidateValue = inputs.candidate().snapshot();
+        BlobReference candidateReference = inputs.candidate().reference();
+        ArtifactManifest manifest = inputs.manifest().manifest();
+        BlobReference manifestReference = inputs.manifest().reference();
+        RequirementsPolicy policy = inputs.policy();
+        CatalogUsageRecord usage = inputs.usage().usage();
+        BlobReference usageReference = inputs.usage().reference();
+        BlobReference workerValidation = inputs.workerValidation();
         Path exactCandidate = blobs.verifyCandidateDirectory(candidate);
-        ProjectSnapshot candidateValue = ShipJson.mapper().readValue(
-                blobs.readBytes(
-                        candidateReference, ShipJson.MAX_DOCUMENT_BYTES),
-                ProjectSnapshot.class);
-        CatalogUsageRecord usage = ShipJson.mapper().readValue(
-                blobs.readBytes(
-                        usageReference, ShipJson.MAX_DOCUMENT_BYTES),
-                CatalogUsageRecord.class);
 
         if (report == null
                 || !expectedRunId.equals(report.runId())
@@ -794,6 +790,27 @@ final class ShipValidationService {
             Objects.requireNonNull(manifest, "manifest input");
             Objects.requireNonNull(policy, "requirements policy");
             Objects.requireNonNull(catalog, "catalog input");
+            requireInputReference(workerValidation, "validation", "worker validation");
+        }
+    }
+
+    record VerificationInputs(
+            String runId,
+            CandidateInput candidate,
+            ManifestInput manifest,
+            RequirementsPolicy policy,
+            UsageInput usage,
+            BlobReference workerValidation) {
+
+        VerificationInputs {
+            if (runId == null || !runId.matches("ship-[0-9a-f]{32}")) {
+                throw new IllegalArgumentException(
+                        "Report verification inputs require a canonical run ID");
+            }
+            Objects.requireNonNull(candidate, "candidate input");
+            Objects.requireNonNull(manifest, "manifest input");
+            Objects.requireNonNull(policy, "requirements policy");
+            Objects.requireNonNull(usage, "catalog usage input");
             requireInputReference(workerValidation, "validation", "worker validation");
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipValidationService.java
@@ -52,21 +52,23 @@ final class ShipValidationService {
     Result validate(
             ShipBlobStore blobs,
             ShipBlobStore.Transaction transaction,
-            String runId,
-            Path candidate,
-            ProjectSnapshot candidateValue,
-            BlobReference candidateReference,
-            ArtifactManifest manifest,
-            BlobReference manifestReference,
-            RequirementsPolicy policy,
-            CatalogUsageRecord usage,
-            BlobReference usageReference,
-            ShipCatalogService.Snapshot catalogSnapshot,
-            CatalogEvidenceSet approvedCatalogEvidence,
-            BlobReference approvedCatalogEvidenceReference,
-            BlobReference workerValidation)
+            Inputs inputs)
             throws IOException {
         Objects.requireNonNull(transaction, "blob transaction");
+        Objects.requireNonNull(inputs, "validation inputs");
+        String runId = inputs.runId();
+        Path candidate = inputs.candidate().directory();
+        ProjectSnapshot candidateValue = inputs.candidate().snapshot();
+        BlobReference candidateReference = inputs.candidate().reference();
+        ArtifactManifest manifest = inputs.manifest().manifest();
+        BlobReference manifestReference = inputs.manifest().reference();
+        RequirementsPolicy policy = inputs.policy();
+        CatalogUsageRecord usage = inputs.catalog().usage().usage();
+        BlobReference usageReference = inputs.catalog().usage().reference();
+        ShipCatalogService.Snapshot catalogSnapshot = inputs.catalog().snapshot();
+        CatalogEvidenceSet approvedCatalogEvidence = inputs.catalog().approval().evidence();
+        BlobReference approvedCatalogEvidenceReference = inputs.catalog().approval().reference();
+        BlobReference workerValidation = inputs.workerValidation();
         Path exactCandidate = blobs.verifyCandidateDirectory(candidate);
         CatalogEvidenceValidator.validateUsage(
                 catalogSnapshot,
@@ -418,16 +420,18 @@ final class ShipValidationService {
             pending = failure;
             throw failure;
         } finally {
-            if (collected) {
-                try {
+            try {
+                if (collected) {
                     EvidenceRunner.cleanupEphemeral(
                             directory, command, commandEvidence);
-                } catch (IOException cleanupFailure) {
-                    if (pending != null) {
-                        pending.addSuppressed(cleanupFailure);
-                    } else {
-                        throw cleanupFailure;
-                    }
+                } else {
+                    EvidenceRunner.cleanupAbandoned(directory, command);
+                }
+            } catch (IOException cleanupFailure) {
+                if (pending != null) {
+                    pending.addSuppressed(cleanupFailure);
+                } else {
+                    throw cleanupFailure;
                 }
             }
         }
@@ -772,6 +776,80 @@ final class ShipValidationService {
     private static String safeMessage(Throwable failure) {
         String message = failure.getMessage();
         return message == null || message.isBlank() ? "unreported" : message;
+    }
+
+    record Inputs(
+            String runId,
+            CandidateInput candidate,
+            ManifestInput manifest,
+            RequirementsPolicy policy,
+            CatalogInput catalog,
+            BlobReference workerValidation) {
+
+        Inputs {
+            if (runId == null || !runId.matches("ship-[0-9a-f]{32}")) {
+                throw new IllegalArgumentException("Validation inputs require a canonical run ID");
+            }
+            Objects.requireNonNull(candidate, "candidate input");
+            Objects.requireNonNull(manifest, "manifest input");
+            Objects.requireNonNull(policy, "requirements policy");
+            Objects.requireNonNull(catalog, "catalog input");
+            requireInputReference(workerValidation, "validation", "worker validation");
+        }
+    }
+
+    record CandidateInput(
+            Path directory, ProjectSnapshot snapshot, BlobReference reference) {
+
+        CandidateInput {
+            Objects.requireNonNull(directory, "candidate directory");
+            Objects.requireNonNull(snapshot, "candidate snapshot");
+            requireInputReference(reference, "project-snapshot", "candidate snapshot");
+        }
+    }
+
+    record ManifestInput(ArtifactManifest manifest, BlobReference reference) {
+
+        ManifestInput {
+            Objects.requireNonNull(manifest, "artifact manifest");
+            requireInputReference(reference, "artifact-manifest", "artifact manifest");
+        }
+    }
+
+    record UsageInput(CatalogUsageRecord usage, BlobReference reference) {
+
+        UsageInput {
+            Objects.requireNonNull(usage, "catalog usage");
+            requireInputReference(reference, "catalog-usage", "catalog usage");
+        }
+    }
+
+    record ApprovalInput(CatalogEvidenceSet evidence, BlobReference reference) {
+
+        ApprovalInput {
+            Objects.requireNonNull(evidence, "approved catalog evidence");
+            requireInputReference(reference, "catalog-evidence", "approved catalog evidence");
+        }
+    }
+
+    record CatalogInput(
+            UsageInput usage,
+            ShipCatalogService.Snapshot snapshot,
+            ApprovalInput approval) {
+
+        CatalogInput {
+            Objects.requireNonNull(usage, "catalog usage input");
+            Objects.requireNonNull(snapshot, "catalog snapshot");
+            Objects.requireNonNull(approval, "catalog approval input");
+        }
+    }
+
+    private static void requireInputReference(
+            BlobReference reference, String kind, String label) {
+        if (reference == null || !kind.equals(reference.kind())) {
+            throw new IllegalArgumentException(
+                    "Validation " + label + " reference must have kind " + kind);
+        }
     }
 
     @FunctionalInterface

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipWorkspaceService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipWorkspaceService.java
@@ -1,7 +1,6 @@
 package io.github.luigidemasi.camelkit.ship.controller;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,21 +19,24 @@ final class ShipWorkspaceService {
     static AcceptedWorkspace accept(
             StageRequest request,
             StageResult result,
-            Path attemptOutput,
-            ShipBlobStore blobs)
+            ShipProtectedWorkerBroker.CompletedAttempt completed,
+            ShipBlobStore blobs,
+            ShipBlobStore.Transaction transaction)
             throws IOException {
-        if (blobs == null) {
+        if (blobs == null || transaction == null || completed == null) {
             throw new IllegalArgumentException("Ship blob store is required");
         }
 
         // This deliberately performs no worker-controlled file I/O. A malformed envelope
         // is rejected before StagedArtifactSource opens even one artifact.
-        StageResultValidator.validateEnvelope(request, result, attemptOutput);
+        StageResultValidator.validateEnvelope(
+                request, result, java.nio.file.Path.of(request.outputDirectory()));
         if (!blobs.belongsToRun(request.runId())) {
             throw new ShipControllerException(
                     "blob-run-mismatch", "Ship attempt output belongs to a different controller blob store");
         }
-        List<ShipBlobStore.ImportedBlob> imported = blobs.importArtifacts(attemptOutput, result.artifacts());
+        List<ShipBlobStore.ImportedBlob> imported = completed.importArtifacts(
+                request, result.artifacts(), transaction);
         if (imported.size() != result.artifacts().size()) {
             throw new IOException("Ship artifact import returned an incomplete receipt");
         }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
@@ -172,10 +172,10 @@ public final class EvidenceRunner {
     public CommandEvidence run(Path projectRoot, Path evidenceDirectory, EvidenceCommand command) throws IOException {
         Path candidate = realDirectory(projectRoot, "project root");
         Path logs = createEvidenceDirectory(evidenceDirectory);
-        Path workingDirectory = resolveWorkingDirectory(candidate, command.relativeWorkingDirectory());
-        Path sandboxRoot = privateTempDirectory(logs, "." + command.id() + "-sandbox-");
         boolean handedToCollector = false;
         try {
+            Path workingDirectory = resolveWorkingDirectory(candidate, command.relativeWorkingDirectory());
+            Path sandboxRoot = privateTempDirectory(logs, "." + command.id() + "-sandbox-");
             Path privateHome = privateDirectory(sandboxRoot.resolve("home"));
             Path privateTemporaryDirectory = privateDirectory(sandboxRoot.resolve("tmp"));
             Path acceptedSnapshot = acceptedSnapshot(candidate, sandboxRoot, command);
@@ -353,7 +353,7 @@ public final class EvidenceRunner {
             return evidence;
         } finally {
             if (!handedToCollector) {
-                deleteSandbox(logs, sandboxRoot, command.id());
+                cleanupAbandoned(logs, command);
             }
         }
     }
@@ -383,20 +383,34 @@ public final class EvidenceRunner {
         for (String sandbox : sandboxes) {
             deleteRelativeTree(root, sandbox);
         }
+        Files.delete(root);
     }
 
-    private static void deleteSandbox(Path root, Path sandbox, String commandId) throws IOException {
-        Path normalizedRoot = root.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        Path normalizedSandbox = sandbox.toAbsolutePath().normalize();
-        String expectedPrefix = "." + commandId + "-sandbox-";
-        if (!normalizedSandbox.getParent().equals(normalizedRoot)
-                || !normalizedSandbox.getFileName().toString().startsWith(expectedPrefix)) {
-            throw new IOException("Refusing to delete an unrecognized evidence sandbox");
-        }
-        if (hasProcessRetentionMarker(normalizedSandbox)) {
+    /** Removes an exclusive evidence root after a failed executor, unless process state is quarantined. */
+    public static void cleanupAbandoned(
+            Path evidenceDirectory, EvidenceCommand command)
+            throws IOException {
+        if (evidenceDirectory == null
+                || !Files.exists(evidenceDirectory, LinkOption.NOFOLLOW_LINKS)) {
             return;
         }
-        deleteRelativeTree(normalizedRoot, normalizedSandbox.getFileName().toString());
+        Path root = realDirectory(evidenceDirectory, "evidence directory");
+        String sandboxPrefix = "." + command.id() + "-sandbox-";
+        try (var entries = Files.newDirectoryStream(root)) {
+            for (Path entry : entries) {
+                if (entry.getFileName().toString().startsWith(sandboxPrefix)
+                        && hasProcessRetentionMarker(entry)) {
+                    return;
+                }
+            }
+        }
+        Path parent = root.getParent();
+        if (parent == null) {
+            throw new IOException("Evidence directory has no protected parent");
+        }
+        deleteRelativeTree(
+                realDirectory(parent, "evidence parent"),
+                root.getFileName().toString());
     }
 
     private static void createProcessRetentionMarker(Path sandbox, String commandId) throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTestVerifier.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTestVerifier.java
@@ -53,7 +53,7 @@ public final class CatalogTestVerifier {
         Map<String, String> entries = new LinkedHashMap<>();
         entries.put("META-INF/version.properties", "version=" + CAMEL_VERSION + "\n");
         entries.put(root + "components.properties", "direct\n");
-        entries.put(root + "models.properties", "to\n");
+        entries.put(root + "models.properties", "from\nroute\nto\n");
         entries.put(root + "dataformats.properties", "");
         entries.put(root + "languages.properties", "simple\n");
         entries.put(root + "components/direct.json", """
@@ -80,6 +80,12 @@ public final class CatalogTestVerifier {
                     }
                   }
                 }
+                """);
+        entries.put(root + "models/from.json", """
+                {"model":{"kind":"model","name":"from","deprecated":false}}
+                """);
+        entries.put(root + "models/route.json", """
+                {"model":{"kind":"model","name":"route","deprecated":false}}
                 """);
         entries.put(root + "models/to.json", """
                 {"model":{"kind":"model","name":"to","deprecated":false}}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipBlobStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipBlobStoreTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.protocol.ProducedArtifact;
+import io.github.luigidemasi.camelkit.ship.security.StagedArtifactSource;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +76,7 @@ class ShipBlobStoreTest {
 
         assertThrows(
                 ShipControllerException.class,
-                () -> store.importArtifacts(output, artifacts));
+                () -> importArtifacts(output, artifacts));
 
         assertEquals(0, entryCount(runRoot.resolve("blobs")));
         assertEquals(0, entryCount(runRoot.resolve("quarantine")));
@@ -91,7 +92,7 @@ class ShipBlobStoreTest {
 
         assertThrows(
                 java.io.IOException.class,
-                () -> store.importArtifacts(
+                () -> importArtifacts(
                         output, List.of(artifact("route", "nested/secret.txt", secret))));
         assertArrayEquals(secret, Files.readAllBytes(outside.resolve("secret.txt")));
 
@@ -100,7 +101,7 @@ class ShipBlobStoreTest {
         Files.createLink(output.resolve("linked.txt"), external);
         assertThrows(
                 java.io.IOException.class,
-                () -> store.importArtifacts(
+                () -> importArtifacts(
                         output, List.of(artifact("route", "linked.txt", secret))));
         assertEquals(0, entryCount(runRoot.resolve("blobs")));
         assertEquals(0, entryCount(runRoot.resolve("quarantine")));
@@ -136,7 +137,7 @@ class ShipBlobStoreTest {
 
         assertThrows(
                 java.io.IOException.class,
-                () -> store.importArtifacts(output, List.of(
+                () -> importArtifacts(output, List.of(
                         artifact("route", "fresh.txt", fresh),
                         artifact("route", "existing.txt", existing))));
 
@@ -145,8 +146,53 @@ class ShipBlobStoreTest {
         assertEquals(0, entryCount(runRoot.resolve("quarantine")));
     }
 
+    @Test
+    void uncommittedTransactionRemovesOnlyTheBlobsItInstalled() throws Exception {
+        byte[] existing = "existing".getBytes(StandardCharsets.UTF_8);
+        byte[] written = "transaction-write".getBytes(StandardCharsets.UTF_8);
+        byte[] imported = "transaction-import".getBytes(StandardCharsets.UTF_8);
+        ShipBlobStore.BlobReference existingReference = store.writeBytes("context", existing);
+        Path output = Files.createDirectory(temporaryDirectory.resolve("output"));
+        Files.write(output.resolve("imported.txt"), imported);
+
+        ShipBlobStore.BlobReference writtenReference;
+        ShipBlobStore.BlobReference importedReference;
+        try (ShipBlobStore.Transaction transaction = store.beginTransaction();
+             StagedArtifactSource.Session source = StagedArtifactSource.open(output)) {
+            assertEquals(existingReference, transaction.writeBytes("context", existing));
+            writtenReference = transaction.writeBytes("context", written);
+            importedReference = transaction.importArtifacts(
+                    source, List.of(artifact("route", "imported.txt", imported)))
+                    .get(0)
+                    .reference();
+
+            assertTrue(Files.exists(blobPath(existingReference)));
+            assertTrue(Files.exists(blobPath(writtenReference)));
+            assertTrue(Files.exists(blobPath(importedReference)));
+        }
+
+        store.verify(existingReference);
+        assertArrayEquals(existing, store.readBytes(existingReference, existing.length));
+        assertTrue(Files.exists(blobPath(existingReference)));
+        assertFalse(Files.exists(blobPath(writtenReference)));
+        assertFalse(Files.exists(blobPath(importedReference)));
+        assertEquals(1, entryCount(runRoot.resolve("blobs")));
+        assertEquals(0, entryCount(runRoot.resolve("quarantine")));
+    }
+
     private Path blobPath(ShipBlobStore.BlobReference reference) {
         return runRoot.resolve("blobs").resolve(reference.digest().substring(7) + ".blob");
+    }
+
+    private List<ShipBlobStore.ImportedBlob> importArtifacts(
+            Path output, List<ProducedArtifact> artifacts)
+            throws Exception {
+        try (ShipBlobStore.Transaction transaction = store.beginTransaction();
+             StagedArtifactSource.Session source = StagedArtifactSource.open(output)) {
+            List<ShipBlobStore.ImportedBlob> imported = transaction.importArtifacts(source, artifacts);
+            transaction.commit();
+            return imported;
+        }
     }
 
     private static ProducedArtifact artifact(String kind, String path, byte[] content) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipProjectPublisherTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipProjectPublisherTest.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
@@ -55,32 +56,36 @@ class ShipProjectPublisherTest {
         ShipWorkspaceService.AcceptedWorkspace workspace = workspace("routes/orders.camel.yaml", route);
         byte[] liveReadme = Files.readAllBytes(project.resolve("README.md"));
 
-        ShipProjectPublisher.PublicationTransaction transaction = ShipProjectPublisher.stageSealedCandidate(
-                stateRoot, RUN_ID, project, EVENT_DIGEST, 7, blobs, workspace);
+        Path transactionRoot;
+        try (ShipProjectPublisher.StagedCandidate transaction
+                = ShipProjectPublisher.stageSealedCandidate(
+                        stateRoot, RUN_ID, project, EVENT_DIGEST, 7, blobs, workspace)) {
 
-        assertEquals(RUN_ID, transaction.runId());
-        assertEquals(EVENT_DIGEST, transaction.expectedEventHeadDigest());
-        assertEquals(7, transaction.expectedEventHeadRevision());
-        assertEquals(workspace.artifacts().get(0).blob(), transaction.artifacts().get(0).blob());
-        assertTrue(ShipDigest.isSha256(transaction.baselineDigest()));
-        assertTrue(ShipDigest.isSha256(transaction.postimageDigest()));
-        assertTrue(ShipDigest.isSha256(transaction.bindingDigest()));
+            assertEquals(RUN_ID, transaction.runId());
+            assertEquals(EVENT_DIGEST, transaction.expectedEventHeadDigest());
+            assertEquals(7, transaction.expectedEventHeadRevision());
+            assertEquals(workspace.artifacts().get(0).blob(), transaction.artifacts().get(0).blob());
+            assertTrue(ShipDigest.isSha256(transaction.baselineDigest()));
+            assertTrue(ShipDigest.isSha256(transaction.postimageDigest()));
+            assertTrue(ShipDigest.isSha256(transaction.bindingDigest()));
 
-        assertArrayEquals(liveReadme, Files.readAllBytes(project.resolve("README.md")));
-        assertFalse(Files.exists(project.resolve("routes")));
+            assertArrayEquals(liveReadme, Files.readAllBytes(project.resolve("README.md")));
+            assertFalse(Files.exists(project.resolve("routes")));
 
-        Path transactionRoot = runRoot.resolve("publication").resolve(transaction.transactionId());
-        assertArrayEquals(route, Files.readAllBytes(
-                transactionRoot.resolve("candidate/routes/orders.camel.yaml")));
-        assertEquals(
-                PosixFilePermissions.fromString("rw-r--r--"),
-                Files.getPosixFilePermissions(
-                        transactionRoot.resolve("candidate/routes/orders.camel.yaml")));
-        byte[] binding = Files.readAllBytes(transactionRoot.resolve("binding.bin"));
-        assertEquals(transaction.bindingDigest(), ShipDigest.sha256(binding));
-        assertEquals(
-                PosixFilePermissions.fromString("r--------"),
-                Files.getPosixFilePermissions(transactionRoot.resolve("binding.bin")));
+            transactionRoot = runRoot.resolve("publication").resolve(transaction.transactionId());
+            assertArrayEquals(route, Files.readAllBytes(
+                    transactionRoot.resolve("candidate/routes/orders.camel.yaml")));
+            assertEquals(
+                    PosixFilePermissions.fromString("rw-r--r--"),
+                    Files.getPosixFilePermissions(
+                            transactionRoot.resolve("candidate/routes/orders.camel.yaml")));
+            byte[] binding = Files.readAllBytes(transactionRoot.resolve("binding.bin"));
+            assertEquals(transaction.bindingDigest(), ShipDigest.sha256(binding));
+            assertEquals(
+                    PosixFilePermissions.fromString("r--------"),
+                    Files.getPosixFilePermissions(transactionRoot.resolve("binding.bin")));
+        }
+        assertFalse(Files.exists(transactionRoot));
     }
 
     @Test
@@ -135,9 +140,12 @@ class ShipProjectPublisherTest {
     void retainedPublicationCandidatesAreExplicitlyBoundedPerRun() throws Exception {
         ShipWorkspaceService.AcceptedWorkspace workspace
                 = workspace("route.yaml", "route".getBytes(StandardCharsets.UTF_8));
+        List<ShipProjectPublisher.StagedCandidate> retained = new ArrayList<>();
         for (int revision = 0; revision < ShipProjectPublisher.MAX_RETAINED_CANDIDATES; revision++) {
-            ShipProjectPublisher.stageSealedCandidate(
+            ShipProjectPublisher.StagedCandidate candidate = ShipProjectPublisher.stageSealedCandidate(
                     stateRoot, RUN_ID, project, EVENT_DIGEST, revision, blobs, workspace);
+            candidate.retainForRecovery();
+            retained.add(candidate);
         }
 
         java.io.IOException error = assertThrows(
@@ -155,6 +163,78 @@ class ShipProjectPublisherTest {
         try (var entries = Files.list(runRoot.resolve("publication"))) {
             assertEquals(ShipProjectPublisher.MAX_RETAINED_CANDIDATES, entries.count());
         }
+        for (ShipProjectPublisher.StagedCandidate candidate : retained) {
+            candidate.close();
+        }
+    }
+
+    @Test
+    void reconciliationRemovesAmbiguousOrphansAndRecoversCandidateCapacity() throws Exception {
+        ShipWorkspaceService.AcceptedWorkspace workspace
+                = workspace("route.yaml", "route".getBytes(StandardCharsets.UTF_8));
+        for (int revision = 0; revision < ShipProjectPublisher.MAX_RETAINED_CANDIDATES; revision++) {
+            ShipProjectPublisher.StagedCandidate candidate = ShipProjectPublisher.stageSealedCandidate(
+                    stateRoot, RUN_ID, project, EVENT_DIGEST, revision, blobs, workspace);
+            candidate.retainForRecovery();
+            candidate.close();
+        }
+
+        ShipProjectPublisher.reconcileCandidates(blobs, List.of());
+
+        try (ShipProjectPublisher.StagedCandidate recovered
+                = ShipProjectPublisher.stageSealedCandidate(
+                        stateRoot, RUN_ID, project, EVENT_DIGEST, 12, blobs, workspace)) {
+            assertTrue(Files.isDirectory(recovered.candidateDirectory()));
+        }
+    }
+
+    @Test
+    void reconciliationPreservesEveryCandidateInAuthenticatedExecutionHistory() throws Exception {
+        Path historicalProject = Files.createDirectory(
+                temporaryDirectory.resolve("historical-project")).toAbsolutePath().normalize();
+        Path historicalState = temporaryDirectory.resolve("historical-state")
+                .toAbsolutePath().normalize();
+        ShipRunView created = new ShipController(historicalState).start(
+                new ShipController.PreparedRun(historicalProject, "test-adapter"));
+        ShipBlobStore historicalBlobs = ShipBlobStore.open(
+                historicalState, created.runId());
+        FileShipEventStore events = FileShipEventStore.open(
+                historicalState, created.runId());
+        byte[] route = "historical route\n".getBytes(StandardCharsets.UTF_8);
+        ShipBlobStore.BlobReference blob = historicalBlobs.writeBytes("route", route);
+        ProducedArtifact claim = new ProducedArtifact(
+                "route", "route.yaml", blob.digest(), blob.byteSize());
+        ShipWorkspaceService.AcceptedArtifact accepted
+                = new ShipWorkspaceService.AcceptedArtifact(claim, blob, 0100644);
+        ShipWorkspaceService.AcceptedWorkspace workspace
+                = new ShipWorkspaceService.AcceptedWorkspace(
+                        created.runId(), ShipStage.EXECUTE, "attempt-1",
+                        "sha256:" + "b".repeat(64), List.of(accepted));
+
+        ShipProjectPublisher.StagedCandidate first = ShipProjectPublisher.stageSealedCandidate(
+                historicalState, created.runId(), historicalProject,
+                created.eventDigest(), created.revision(), historicalBlobs, workspace);
+        ShipProjectPublisher.StagedCandidate second = ShipProjectPublisher.stageSealedCandidate(
+                historicalState, created.runId(), historicalProject,
+                created.eventDigest(), created.revision(), historicalBlobs, workspace);
+        ShipProjectPublisher.StagedCandidate orphan = ShipProjectPublisher.stageSealedCandidate(
+                historicalState, created.runId(), historicalProject,
+                created.eventDigest(), created.revision(), historicalBlobs, workspace);
+        first.retainForRecovery();
+        second.retainForRecovery();
+        orphan.retainForRecovery();
+        first.close();
+        second.close();
+        orphan.close();
+
+        appendAuthenticatedExecution(events, first, accepted, blob);
+        appendAuthenticatedExecution(events, second, accepted, blob);
+
+        ShipProjectPublisher.reconcileCandidates(historicalBlobs, events.replay());
+
+        assertTrue(Files.isDirectory(first.candidateDirectory()));
+        assertTrue(Files.isDirectory(second.candidateDirectory()));
+        assertFalse(Files.exists(orphan.candidateDirectory().getParent()));
     }
 
     @Test
@@ -237,5 +317,35 @@ class ShipProjectPublisherTest {
                 "attempt-1",
                 "sha256:" + "b".repeat(64),
                 List.of(artifact));
+    }
+
+    private static void appendAuthenticatedExecution(
+            FileShipEventStore events,
+            ShipProjectPublisher.StagedCandidate candidate,
+            ShipWorkspaceService.AcceptedArtifact artifact,
+            ShipBlobStore.BlobReference reference)
+            throws Exception {
+        ShipEventHead predecessor = events.currentHead();
+        ShipAuthorityCommand command = ShipAuthorityCommand.value(
+                ShipEventType.EXECUTION_VALIDATED, reference.digest());
+        ShipEventPayloads.StageAccepted data = ShipEventPayloads.StageAccepted.execution(
+                ShipStage.EXECUTE,
+                reference,
+                reference,
+                List.of(artifact),
+                reference,
+                reference,
+                reference,
+                candidate.candidateDirectory().toString());
+        events.appendIfLatest(
+                predecessor,
+                new ShipEventDraft(
+                        command.type(),
+                        ShipState.EXECUTE_VALIDATED,
+                        predecessor.authorityHead(),
+                        AuthorityHeadId.create(),
+                        java.time.Instant.parse("2026-07-22T00:00:00Z")
+                                .plusSeconds(predecessor.sequence() + 1),
+                        ShipStoredEventCodec.encode(command, data)));
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipProtectedWorkerBrokerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipProtectedWorkerBrokerTest.java
@@ -1,0 +1,95 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.luigidemasi.camelkit.ship.context.InitialContextRequest;
+import io.github.luigidemasi.camelkit.ship.protocol.StageRequest;
+import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
+import io.github.luigidemasi.camelkit.ship.security.StagedArtifactSource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@EnabledOnOs(OS.LINUX)
+class ShipProtectedWorkerBrokerTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void submitAlwaysClosesExclusiveCustodyWhenControllerRejectsTheResult() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"))
+                .toAbsolutePath().normalize();
+        Path state = temporaryDirectory.resolve("state").toAbsolutePath().normalize();
+        ShipController controller = new ShipController(state);
+        ShipRunView created = controller.start(new ShipController.PreparedRun(project, "test-adapter"));
+        ShipRunView resolving = controller.beginContextResolution(
+                created.runId(), created.eventDigest(), new InitialContextRequest.Text("requirements"));
+        ShipRunView recorded = controller.continueContextResolution(
+                created.runId(), resolving.eventDigest(), List.of());
+        ShipRunView discovery = controller.startDiscovery(
+                recorded.runId(), recorded.eventDigest());
+        AtomicInteger closes = new AtomicInteger();
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(
+                controller,
+                request -> rejectedDiscoveryCustody(request, closes));
+
+        assertThrows(
+                IOException.class,
+                () -> broker.submit(discovery.runId(), discovery.eventDigest(), null));
+
+        assertEquals(1, closes.get());
+        assertEquals(discovery, controller.status(discovery.runId()));
+    }
+
+    private static ShipProtectedWorkerBroker.Custody rejectedDiscoveryCustody(
+            StageRequest request, AtomicInteger closes) {
+        return new ShipProtectedWorkerBroker.Custody() {
+            @Override
+            public void requireExactAttempt(StageRequest expected) throws IOException {
+                if (!request.equals(expected)) {
+                    throw new IOException("unexpected attempt");
+                }
+            }
+
+            @Override
+            public byte[] readResultBytes() throws IOException {
+                StageResult result = new StageResult(
+                        StageResult.SCHEMA_VERSION,
+                        request.runId(),
+                        request.stage(),
+                        request.attemptId(),
+                        request.challenge(),
+                        request.inputDigest(),
+                        StageResult.Outcome.COMPLETED,
+                        null,
+                        null,
+                        List.of(),
+                        List.of(),
+                        null,
+                        null,
+                        null);
+                return ShipJson.mapper().writeValueAsBytes(result);
+            }
+
+            @Override
+            public StagedArtifactSource.Session openArtifactSource() throws IOException {
+                throw new IOException("Rejected analysis result must not open artifact custody");
+            }
+
+            @Override
+            public void close() {
+                closes.incrementAndGet();
+            }
+        };
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
@@ -12,6 +12,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
@@ -181,7 +182,188 @@ class ShipPublicationServiceTest {
         assertJournalPresent(fixture);
     }
 
+    @Test
+    void recoverSweepsOwnedJournalTemporariesBeforeNoJournalReturn() throws Exception {
+        Fixture fixture = fixture("journal-temporary");
+        Path writable = fixture.publicationRoot().resolve(
+                ".live-publication.json-" + UUID.randomUUID());
+        Path sealed = fixture.publicationRoot().resolve(
+                ".live-publication.json-" + UUID.randomUUID());
+        Files.createFile(
+                writable,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        Files.writeString(writable, "partial", StandardOpenOption.WRITE);
+        Files.createFile(
+                sealed,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("r--------")));
+
+        ShipPublicationService.recover(
+                fixture.predecessorView(),
+                ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                List.of());
+
+        assertFalse(Files.exists(writable, LinkOption.NOFOLLOW_LINKS));
+        assertFalse(Files.exists(sealed, LinkOption.NOFOLLOW_LINKS));
+        assertBaseline(fixture);
+    }
+
+    @Test
+    void recoverRejectsUnsafeJournalTemporaryMetadata() throws Exception {
+        Fixture fixture = fixture("unsafe-journal-temporary");
+        Path temporary = fixture.publicationRoot().resolve(
+                ".live-publication.json-" + UUID.randomUUID());
+        Files.createFile(
+                temporary,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-r--r--")));
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.predecessorView(),
+                        ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                        List.of()));
+
+        assertTrue(failure.getMessage().contains("temporary has unsafe metadata"));
+        assertTrue(Files.exists(temporary, LinkOption.NOFOLLOW_LINKS));
+        assertBaseline(fixture);
+    }
+
+    @Test
+    void predecessorRecoveryRemovesSealedBoundTemporaryBeforeRollback() throws Exception {
+        Fixture fixture = fixture("bound-predecessor-temporary");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        Path temporary = boundTemporary(fixture);
+        Files.createFile(
+                temporary,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        Files.write(temporary, ROUTE_BYTES, StandardOpenOption.WRITE);
+        Files.setPosixFilePermissions(
+                temporary, PosixFilePermissions.fromString("rw-r--r--"));
+
+        ShipPublicationService.recover(
+                fixture.predecessorView(),
+                ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                List.of(fixture.predecessorEvent()));
+
+        assertFalse(Files.exists(temporary, LinkOption.NOFOLLOW_LINKS));
+        assertBaseline(fixture);
+        assertJournalRemoved(fixture);
+    }
+
+    @Test
+    void completedRecoveryRemovesPartialBoundTemporaryAndPreservesPublication() throws Exception {
+        Fixture fixture = fixture("bound-completed-temporary");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        ProjectSnapshot published = publication.publishedSnapshot();
+        BlobReference publishedReference = json(
+                fixture.blobs(), "project-snapshot", published);
+        publication.retainForRecovery();
+        publication.close();
+        Path temporary = boundTemporary(fixture);
+        Files.createFile(
+                temporary,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        Files.writeString(temporary, "partial", StandardOpenOption.WRITE);
+        ShipEvent predecessor = fixture.predecessorEvent();
+
+        ShipPublicationService.recover(
+                fixture.completedView(publishedReference),
+                ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                List.of(predecessor, fixture.completionEvent(predecessor)));
+
+        assertFalse(Files.exists(temporary, LinkOption.NOFOLLOW_LINKS));
+        assertPublished(fixture);
+        assertJournalRemoved(fixture);
+    }
+
+    @Test
+    void recoveryReusesBoundTemporaryAfterInterruptedBaselineRestoration() throws Exception {
+        byte[] replacement = "new\n".getBytes(StandardCharsets.UTF_8);
+        Fixture fixture = fixture(
+                "bound-rollback-temporary", "README.md", replacement);
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        assertArrayEquals(replacement, Files.readAllBytes(fixture.readme()));
+        Path temporary = boundTemporary(fixture);
+        Files.createFile(
+                temporary,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        Files.write(temporary, BASELINE_BYTES, StandardOpenOption.WRITE);
+        Files.setPosixFilePermissions(
+                temporary, PosixFilePermissions.fromString("rw-r--r--"));
+
+        ShipPublicationService.recover(
+                fixture.predecessorView(),
+                ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                List.of(fixture.predecessorEvent()));
+
+        assertFalse(Files.exists(temporary, LinkOption.NOFOLLOW_LINKS));
+        assertArrayEquals(BASELINE_BYTES, Files.readAllBytes(fixture.readme()));
+        assertTrue(ProjectEvidenceFiles.unchangedMaterialTree(
+                fixture.baseline(), ProjectEvidenceFiles.capture(fixture.project())));
+        assertJournalRemoved(fixture);
+    }
+
+    @Test
+    void recoverRejectsUnsafeBoundTemporaryWithoutDeletingIt() throws Exception {
+        Fixture fixture = fixture("unsafe-bound-temporary");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        Path temporary = boundTemporary(fixture);
+        Files.createSymbolicLink(temporary, fixture.readme());
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.predecessorView(),
+                        ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                        List.of(fixture.predecessorEvent())));
+
+        assertTrue(failure.getMessage().contains("temporary has unsafe metadata"));
+        assertTrue(Files.isSymbolicLink(temporary));
+        assertArrayEquals(BASELINE_BYTES, Files.readAllBytes(fixture.readme()));
+        assertArrayEquals(ROUTE_BYTES, Files.readAllBytes(fixture.route()));
+        assertJournalPresent(fixture);
+    }
+
+    @Test
+    void recoverNeverWildcardDeletesUnboundPublishNamedUserMaterial() throws Exception {
+        Fixture fixture = fixture("unbound-user-material");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        Path unbound = fixture.project().resolve(
+                ".camel-kit-publish-" + UUID.randomUUID() + ".tmp");
+        byte[] userBytes = "user material\n".getBytes(StandardCharsets.UTF_8);
+        Files.write(unbound, userBytes);
+
+        assertThrows(
+                IOException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.predecessorView(),
+                        ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                        List.of(fixture.predecessorEvent())));
+
+        assertArrayEquals(userBytes, Files.readAllBytes(unbound));
+        assertJournalPresent(fixture);
+    }
+
     private Fixture fixture(String name) throws Exception {
+        return fixture(name, ROUTE, ROUTE_BYTES);
+    }
+
+    private Fixture fixture(String name, String artifactPath, byte[] artifactBytes)
+            throws Exception {
         AuthorityPair authority = authorityPair(name);
         String runId = authority.predecessor().id().toString();
         Path stateRoot = Files.createDirectory(
@@ -207,9 +389,9 @@ class ShipPublicationServiceTest {
                         PosixFilePermissions.fromString("rwx------")));
         ProjectEvidenceFiles.materializeMaterial(project, source);
 
-        BlobReference artifactBlob = blobs.writeBytes("route", ROUTE_BYTES);
+        BlobReference artifactBlob = blobs.writeBytes("route", artifactBytes);
         ProducedArtifact claim = new ProducedArtifact(
-                "route", ROUTE, artifactBlob.digest(), artifactBlob.byteSize());
+                "route", artifactPath, artifactBlob.digest(), artifactBlob.byteSize());
         String inputDigest = digest(name + "-execution-input");
         ShipWorkspaceService.AcceptedArtifact accepted
                 = new ShipWorkspaceService.AcceptedArtifact(claim, artifactBlob, 0100644);
@@ -446,6 +628,13 @@ class ShipPublicationServiceTest {
         return ShipDigest.sha256(value.getBytes(StandardCharsets.UTF_8));
     }
 
+    private static Path boundTemporary(Fixture fixture) throws IOException {
+        ObjectNode intent = (ObjectNode) ShipJson.mapper().readTree(
+                Files.readAllBytes(fixture.journal()));
+        String relative = intent.path("artifacts").path(0).path("temporaryPath").textValue();
+        return fixture.project().resolve(relative);
+    }
+
     private static void assertBaseline(Fixture fixture) throws IOException {
         assertTrue(ProjectEvidenceFiles.unchangedMaterialTree(
                 fixture.baseline(), ProjectEvidenceFiles.capture(fixture.project())));
@@ -499,6 +688,10 @@ class ShipPublicationServiceTest {
 
         Path journal() {
             return runRoot.resolve("publication").resolve("live-publication.json");
+        }
+
+        Path publicationRoot() {
+            return journal().getParent();
         }
 
         ShipRunView completedView(BlobReference publishedSnapshot) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
@@ -1,0 +1,551 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+import io.github.luigidemasi.camelkit.ship.protocol.ProducedArtifact;
+import io.github.luigidemasi.camelkit.ship.protocol.ShipStage;
+import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class ShipPublicationServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-22T00:00:00Z");
+    private static final String SYNTACTIC_MAC = "hmac-sha256:" + "0".repeat(64);
+    private static final String ROUTE = "src/main/resources/routes/orders.camel.yaml";
+    private static final byte[] BASELINE_BYTES
+            = "untouched baseline\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] ROUTE_BYTES
+            = "- from:\n    uri: timer:orders\n".getBytes(StandardCharsets.UTF_8);
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void closeRollsBackTheLiveProjectAndRemovesTheJournal() throws Exception {
+        Fixture fixture = fixture("close");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+
+        assertPublished(fixture);
+        assertJournalPresent(fixture);
+
+        publication.close();
+
+        assertBaseline(fixture);
+        assertJournalRemoved(fixture);
+    }
+
+    @Test
+    void recoverRollsBackAProtectedPredecessorHeadAndRemovesTheJournal() throws Exception {
+        Fixture fixture = fixture("predecessor");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+
+        assertPublished(fixture);
+        assertJournalPresent(fixture);
+
+        ShipPublicationService.recover(
+                fixture.predecessorView(),
+                ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                List.of(fixture.predecessorEvent()));
+
+        assertBaseline(fixture);
+        assertJournalRemoved(fixture);
+    }
+
+    @Test
+    void recoverPreservesAnAuthenticatedCompletionAndRemovesTheJournal() throws Exception {
+        Fixture fixture = fixture("completed");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        ProjectSnapshot published = publication.publishedSnapshot();
+        BlobReference publishedReference = json(
+                fixture.blobs(), "project-snapshot", published);
+        publication.retainForRecovery();
+        publication.close();
+
+        ShipEvent predecessor = fixture.predecessorEvent();
+        ShipEvent completion = fixture.completionEvent(predecessor);
+        ShipRunView completedView = fixture.completedView(publishedReference);
+
+        assertPublished(fixture);
+        assertJournalPresent(fixture);
+
+        ShipPublicationService.recover(
+                completedView,
+                ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                List.of(predecessor, completion));
+
+        assertTrue(ProjectEvidenceFiles.unchangedMaterialTree(
+                published, ProjectEvidenceFiles.capture(fixture.project())));
+        assertPublished(fixture);
+        assertJournalRemoved(fixture);
+    }
+
+    @Test
+    void recoverRefusesAnUnknownMixtureBeforeOverwritingProjectBytes() throws Exception {
+        Fixture fixture = fixture("unknown-mixture");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        byte[] externalBytes = "external concurrent edit\n".getBytes(StandardCharsets.UTF_8);
+        Files.write(fixture.route(), externalBytes);
+
+        assertThrows(
+                IOException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.predecessorView(),
+                        ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                        List.of(fixture.predecessorEvent())));
+
+        assertArrayEquals(externalBytes, Files.readAllBytes(fixture.route()));
+        assertArrayEquals(BASELINE_BYTES, Files.readAllBytes(fixture.readme()));
+        assertJournalPresent(fixture);
+    }
+
+    @Test
+    void recoverRejectsUnsafeJournalMetadataWithoutChangingTheProject() throws Exception {
+        Fixture fixture = fixture("journal-metadata");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        Files.setPosixFilePermissions(
+                fixture.journal(), PosixFilePermissions.fromString("rw-------"));
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.predecessorView(),
+                        ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                        List.of(fixture.predecessorEvent())));
+
+        assertTrue(failure.getMessage().contains("unsafe metadata"));
+        assertPublished(fixture);
+        assertJournalPresent(fixture);
+    }
+
+    @Test
+    void recoverRejectsMismatchedJournalIdentityWithoutChangingTheProject() throws Exception {
+        Fixture fixture = fixture("journal-identity");
+        ShipPublicationService.LivePublication publication = publish(fixture);
+        publication.retainForRecovery();
+        publication.close();
+        Path journal = fixture.journal();
+        Files.setPosixFilePermissions(
+                journal, PosixFilePermissions.fromString("rw-------"));
+        ObjectNode intent = (ObjectNode) ShipJson.mapper().readTree(Files.readAllBytes(journal));
+        intent.put("runId", "ship-" + "f".repeat(32));
+        Files.write(
+                journal,
+                ShipJson.mapper().writeValueAsBytes(intent),
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE);
+        Files.setPosixFilePermissions(
+                journal, PosixFilePermissions.fromString("r--------"));
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.predecessorView(),
+                        ShipBlobStore.open(fixture.stateRoot(), fixture.runId()),
+                        List.of(fixture.predecessorEvent())));
+
+        assertTrue(failure.getMessage().contains("invalid identity"));
+        assertPublished(fixture);
+        assertJournalPresent(fixture);
+    }
+
+    private Fixture fixture(String name) throws Exception {
+        AuthorityPair authority = authorityPair(name);
+        String runId = authority.predecessor().id().toString();
+        Path stateRoot = Files.createDirectory(
+                temporaryDirectory.resolve(name + "-state"),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rwx------")))
+                .toAbsolutePath()
+                .normalize();
+        Path runRoot = Files.createDirectory(
+                stateRoot.resolve(runId),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rwx------")));
+        ShipBlobStore blobs = ShipBlobStore.create(stateRoot, runId);
+        Path project = Files.createDirectory(temporaryDirectory.resolve(name + "-project"))
+                .toAbsolutePath()
+                .normalize();
+        Files.write(project.resolve("README.md"), BASELINE_BYTES);
+        ProjectSnapshot baseline = ProjectEvidenceFiles.capture(project);
+        BlobReference baselineReference = json(blobs, "project-snapshot", baseline);
+        Path source = Files.createDirectory(
+                runRoot.resolve("source"),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rwx------")));
+        ProjectEvidenceFiles.materializeMaterial(project, source);
+
+        BlobReference artifactBlob = blobs.writeBytes("route", ROUTE_BYTES);
+        ProducedArtifact claim = new ProducedArtifact(
+                "route", ROUTE, artifactBlob.digest(), artifactBlob.byteSize());
+        String inputDigest = digest(name + "-execution-input");
+        ShipWorkspaceService.AcceptedArtifact accepted
+                = new ShipWorkspaceService.AcceptedArtifact(claim, artifactBlob, 0100644);
+        ShipWorkspaceService.AcceptedWorkspace workspace
+                = new ShipWorkspaceService.AcceptedWorkspace(
+                        runId,
+                        ShipStage.EXECUTE,
+                        "attempt-1",
+                        inputDigest,
+                        List.of(accepted));
+        String predecessorDigest = digest(name + "-predecessor-event");
+        try (ShipProjectPublisher.StagedCandidate stagedCandidate
+                = ShipProjectPublisher.stageSealedCandidate(
+                        stateRoot,
+                        runId,
+                        project,
+                        predecessorDigest,
+                        authority.predecessor().revision(),
+                        blobs,
+                        workspace)) {
+            Path candidateDirectory = stagedCandidate.candidateDirectory();
+            ProjectSnapshot candidate = ProjectEvidenceFiles.captureSealed(candidateDirectory);
+            BlobReference candidateReference = json(blobs, "project-snapshot", candidate);
+            StageResult execution = new StageResult(
+                    StageResult.SCHEMA_VERSION,
+                    runId,
+                    ShipStage.EXECUTE,
+                    "attempt-1",
+                    "challenge",
+                    inputDigest,
+                    StageResult.Outcome.COMPLETED,
+                    null,
+                    null,
+                    List.of(),
+                    List.of(claim),
+                    null,
+                    null,
+                    null);
+            BlobReference executionReference = json(blobs, "stage-result", execution);
+            BlobReference stamp = blobs.writeBytes(
+                    "ship-stamp", ("stamp " + name).getBytes(StandardCharsets.UTF_8));
+            String completionDigest = digest(name + "-completion-event");
+            ShipRunView predecessorView = view(
+                    authority.predecessor(),
+                    predecessorDigest,
+                    project,
+                    baselineReference,
+                    source,
+                    executionReference,
+                    candidateReference,
+                    candidateDirectory,
+                    null);
+            Fixture fixture = new Fixture(
+                    stateRoot,
+                    runRoot,
+                    project,
+                    blobs,
+                    authority.predecessor(),
+                    authority.completed(),
+                    predecessorView,
+                    baseline,
+                    candidate,
+                    stamp,
+                    predecessorDigest,
+                    completionDigest);
+            stagedCandidate.transferToHistory();
+            return fixture;
+        }
+    }
+
+    private static ShipPublicationService.LivePublication publish(Fixture fixture)
+            throws IOException {
+        return ShipPublicationService.apply(
+                fixture.predecessorView(),
+                fixture.blobs(),
+                fixture.stamp(),
+                ShipEventType.RUN_COMPLETED);
+    }
+
+    private static ShipRunView view(
+            ShipRun authority,
+            String eventDigest,
+            Path project,
+            BlobReference baseline,
+            Path source,
+            BlobReference execution,
+            BlobReference candidate,
+            Path candidateDirectory,
+            BlobReference stamp) {
+        return new ShipRunView(
+                authority,
+                eventDigest,
+                project,
+                "test-adapter",
+                null,
+                baseline,
+                baseline,
+                null,
+                source,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                execution,
+                candidate,
+                candidateDirectory,
+                List.of(),
+                Map.of(),
+                null,
+                stamp,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private static AuthorityPair authorityPair(String suffix) {
+        ShipRun context = ShipLifecycleReducer.startContextResolution(
+                ShipLifecycleReducer.start(), id("context-input-" + suffix));
+        ShipRun recorded = ShipLifecycleReducer.recordContext(
+                context,
+                AcceptedStageResultFactory.context(
+                        ShipLifecycleReducer.attempt(context), id("context-" + suffix)));
+        ShipRun discovery = ShipLifecycleReducer.startDiscovery(recorded);
+        ShipRun review = ShipLifecycleReducer.startGapReview(
+                discovery,
+                AcceptedStageResultFactory.discoveryCandidate(
+                        ShipLifecycleReducer.attempt(discovery), id("candidate-" + suffix)));
+        AuthorityBasis basis = new AuthorityBasis(
+                id("context-" + suffix),
+                id("ledger-" + suffix),
+                1,
+                id("requirements-" + suffix),
+                id("policy"),
+                id("baseline"));
+        ShipRun requirements = ShipLifecycleReducer.requirementsReady(
+                review,
+                AcceptedStageResultFactory.requirements(
+                        ShipLifecycleReducer.attempt(review), basis));
+        ShipRun design = ShipLifecycleReducer.startDesign(requirements);
+        ShipRun designReady = ShipLifecycleReducer.designReady(
+                design,
+                AcceptedStageResultFactory.design(
+                        ShipLifecycleReducer.attempt(design), id("design-" + suffix)));
+        ShipRun waitingDesign = ShipLifecycleReducer.requestDesignApproval(designReady);
+        ShipRun designApproved = ShipLifecycleReducer.approveDesign(
+                waitingDesign, approvedDesign(waitingDesign));
+        ShipRun plan = ShipLifecycleReducer.startPlan(designApproved);
+        ShipRun planValidated = ShipLifecycleReducer.planValidated(
+                plan,
+                AcceptedStageResultFactory.plan(
+                        ShipLifecycleReducer.attempt(plan), id("plan-" + suffix)));
+        ShipRun waitingPlan = ShipLifecycleReducer.requestPlanApproval(planValidated);
+        ShipRun planApproved = ShipLifecycleReducer.approvePlan(
+                waitingPlan, approvedPlan(waitingPlan));
+        ShipRun execution = ShipLifecycleReducer.startExecution(planApproved);
+        ShipRun executionValidated = ShipLifecycleReducer.executionValidated(
+                execution,
+                AcceptedStageResultFactory.execution(
+                        ShipLifecycleReducer.attempt(execution), id("execution-" + suffix)));
+        ShipRun validation = ShipLifecycleReducer.startValidation(executionValidated);
+        ShipRun validationPassed = ShipLifecycleReducer.validationPassed(
+                validation,
+                AcceptedStageResultFactory.validation(
+                        ShipLifecycleReducer.attempt(validation), id("validation-" + suffix)));
+        ShipRun predecessor = ShipLifecycleReducer.startStamp(validationPassed);
+        ShipRun completed = ShipLifecycleReducer.completeStamp(
+                predecessor,
+                AcceptedStageResultFactory.stamp(
+                        ShipLifecycleReducer.attempt(predecessor), id("stamp-" + suffix)));
+        return new AuthorityPair(predecessor, completed);
+    }
+
+    private static DesignApprovalDecision approvedDesign(ShipRun run) {
+        return construct(
+                DesignApprovalDecision.class,
+                new Class<?>[]{
+                        PendingInteraction.class,
+                        DesignApprovalDecisionValue.class,
+                        ContentId.class
+                },
+                ShipLifecycleReducer.pending(run),
+                DesignApprovalDecisionValue.APPROVE,
+                null);
+    }
+
+    private static PlanApprovalDecision approvedPlan(ShipRun run) {
+        return construct(
+                PlanApprovalDecision.class,
+                new Class<?>[]{
+                        PendingInteraction.class,
+                        PlanApprovalDecisionValue.class,
+                        ContentId.class
+                },
+                ShipLifecycleReducer.pending(run),
+                PlanApprovalDecisionValue.APPROVE,
+                null);
+    }
+
+    private static <T> T construct(
+            Class<T> type, Class<?>[] parameterTypes, Object... arguments) {
+        try {
+            Object value = MethodHandles.privateLookupIn(type, MethodHandles.lookup())
+                    .findConstructor(type, MethodType.methodType(void.class, parameterTypes))
+                    .invokeWithArguments(arguments);
+            return type.cast(value);
+        } catch (Throwable failure) {
+            throw new AssertionError("Cannot issue test-only " + type.getSimpleName(), failure);
+        }
+    }
+
+    private static BlobReference json(
+            ShipBlobStore blobs, String kind, Object value)
+            throws IOException {
+        return blobs.writeBytes(kind, ShipJson.mapper().writeValueAsBytes(value));
+    }
+
+    private static ContentId id(String value) {
+        return new ContentId(value);
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void assertBaseline(Fixture fixture) throws IOException {
+        assertTrue(ProjectEvidenceFiles.unchangedMaterialTree(
+                fixture.baseline(), ProjectEvidenceFiles.capture(fixture.project())));
+        assertArrayEquals(BASELINE_BYTES, Files.readAllBytes(fixture.readme()));
+        assertFalse(Files.exists(fixture.route(), LinkOption.NOFOLLOW_LINKS));
+    }
+
+    private static void assertPublished(Fixture fixture) throws IOException {
+        assertTrue(ProjectEvidenceFiles.unchangedMaterialTree(
+                fixture.candidate(), ProjectEvidenceFiles.capture(fixture.project())));
+        assertArrayEquals(BASELINE_BYTES, Files.readAllBytes(fixture.readme()));
+        assertArrayEquals(ROUTE_BYTES, Files.readAllBytes(fixture.route()));
+    }
+
+    private static void assertJournalPresent(Fixture fixture) {
+        assertTrue(Files.isRegularFile(fixture.journal(), LinkOption.NOFOLLOW_LINKS));
+    }
+
+    private static void assertJournalRemoved(Fixture fixture) {
+        assertFalse(Files.exists(fixture.journal(), LinkOption.NOFOLLOW_LINKS));
+    }
+
+    private record AuthorityPair(ShipRun predecessor, ShipRun completed) {
+    }
+
+    private record Fixture(
+            Path stateRoot,
+            Path runRoot,
+            Path project,
+            ShipBlobStore blobs,
+            ShipRun predecessor,
+            ShipRun completed,
+            ShipRunView predecessorView,
+            ProjectSnapshot baseline,
+            ProjectSnapshot candidate,
+            BlobReference stamp,
+            String predecessorDigest,
+            String completionDigest) {
+
+        String runId() {
+            return predecessor.id().toString();
+        }
+
+        Path readme() {
+            return project.resolve("README.md");
+        }
+
+        Path route() {
+            return project.resolve(ROUTE);
+        }
+
+        Path journal() {
+            return runRoot.resolve("publication").resolve("live-publication.json");
+        }
+
+        ShipRunView completedView(BlobReference publishedSnapshot) {
+            return view(
+                    completed,
+                    completionDigest,
+                    project,
+                    predecessorView.baselineSnapshot(),
+                    predecessorView.sourceDirectory(),
+                    predecessorView.executionResult(),
+                    publishedSnapshot,
+                    null,
+                    stamp);
+        }
+
+        ShipEvent predecessorEvent() {
+            return new ShipEvent(
+                    ShipEvent.SCHEMA_VERSION,
+                    predecessor.id(),
+                    predecessor.revision() + 1,
+                    digest(runId() + "-before-stamp"),
+                    ShipEventType.STAMP_STARTED,
+                    ShipState.VALIDATE_PASSED,
+                    ShipState.STAMP_RUNNING,
+                    AuthorityHeadId.create(),
+                    predecessor.head(),
+                    NOW,
+                    NullNode.getInstance(),
+                    predecessorDigest,
+                    SYNTACTIC_MAC);
+        }
+
+        ShipEvent completionEvent(ShipEvent predecessorEvent) {
+            return new ShipEvent(
+                    ShipEvent.SCHEMA_VERSION,
+                    completed.id(),
+                    predecessorEvent.sequence() + 1,
+                    predecessorEvent.eventDigest(),
+                    ShipEventType.RUN_COMPLETED,
+                    ShipState.STAMP_RUNNING,
+                    ShipState.COMPLETED,
+                    predecessor.head(),
+                    completed.head(),
+                    NOW.plusSeconds(1),
+                    NullNode.getInstance(),
+                    completionDigest,
+                    SYNTACTIC_MAC);
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjectorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjectorTest.java
@@ -1,5 +1,6 @@
 package io.github.luigidemasi.camelkit.ship.controller;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,12 +11,24 @@ import java.util.List;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.DeclaredArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.TestArtifact;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogTestVerifier;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService.Snapshot;
 import io.github.luigidemasi.camelkit.ship.context.InitialContext;
 import io.github.luigidemasi.camelkit.ship.context.InitialContextRequest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipAttemptFactory.AttemptInputs;
 import io.github.luigidemasi.camelkit.ship.controller.ShipBlobStore.BlobReference;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence.SandboxIdentity;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceCommand;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceRunner;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain;
 import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger;
 import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Category;
 import io.github.luigidemasi.camelkit.ship.ledger.DecisionLedger.Entry;
@@ -43,6 +56,7 @@ import io.github.luigidemasi.camelkit.ship.protocol.ShipStage;
 import io.github.luigidemasi.camelkit.ship.protocol.StageRequest;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -549,7 +563,7 @@ class ShipRunProjectorTest {
                 ShipEventType.VALIDATION_STARTED,
                 ShipStage.VALIDATE,
                 AttemptInputs.from(flow.view));
-        acceptValidation(flow);
+        recordValidation(flow, true);
         assertNotNull(flow.view.validationReport());
 
         BlobReference requirements = flow.view.ledger();
@@ -784,20 +798,23 @@ class ShipRunProjectorTest {
     @Test
     void stampStartAndCompletionAreReconstructedFromDurableEvents() throws Exception {
         DurableFlow flow = validationRunningFlow("stamp-replay");
-        acceptValidation(flow);
+        ValidationFixture validation = recordValidation(flow, true);
         flow.commit(
                 ShipAuthorityCommand.empty(ShipEventType.STAMP_STARTED),
                 new ShipEventPayloads.NoData());
         assertEquals(ShipState.STAMP_RUNNING, flow.view.state());
 
-        BlobReference stamp = flow.blobs.writeBytes(
-                "ship-stamp", "controller stamp".getBytes(StandardCharsets.UTF_8));
-        flow.commit(
-                ShipAuthorityCommand.value(ShipEventType.RUN_COMPLETED, stamp.digest()),
-                new ShipEventPayloads.StampRecorded(stamp, null, null));
+        BlobReference stamp = completeRun(
+                flow,
+                validation,
+                ShipStamp.Status.PASS,
+                List.of(),
+                ShipEventType.RUN_COMPLETED);
 
         assertEquals(ShipState.COMPLETED, flow.view.state());
         assertEquals(stamp, flow.view.stamp());
+        assertTrue(Files.isRegularFile(
+                flow.view.projectRoot().resolve("src/main/resources/routes/orders.camel.yaml")));
         assertEquals(flow.view, flow.projector().replay());
     }
 
@@ -814,12 +831,16 @@ class ShipRunProjectorTest {
         flow.commit(
                 ShipAuthorityCommand.empty(ShipEventType.WAIVER_STAMP_STARTED),
                 new ShipEventPayloads.NoData());
-        BlobReference stamp = flow.blobs.writeBytes(
-                "ship-stamp", "controller waiver stamp".getBytes(StandardCharsets.UTF_8));
-        flow.commit(
-                ShipAuthorityCommand.value(
-                        ShipEventType.RUN_COMPLETED_WITH_WAIVER, stamp.digest()),
-                new ShipEventPayloads.StampRecorded(stamp, null, pending.evidence()));
+        ShipStamp.Check failed = pending.validation().result().failedCheck();
+        BlobReference stamp = completeRun(
+                flow,
+                pending.validation(),
+                ShipStamp.Status.COMPLETED_WITH_WAIVER,
+                List.of(new ShipStamp.Waiver(
+                        failed.id(),
+                        failed.evidenceDigest(),
+                        approval.responseReference().digest())),
+                ShipEventType.RUN_COMPLETED_WITH_WAIVER);
 
         assertEquals(ShipState.COMPLETED_WITH_WAIVER, flow.view.state());
         assertEquals(stamp, flow.view.stamp());
@@ -861,25 +882,27 @@ class ShipRunProjectorTest {
     @Test
     void waivableFailureCannotSwapTheSignedInteractionBundle() throws Exception {
         DurableFlow flow = validationRunningFlow("waiver-bundle-swap");
-        BlobReference evidence = flow.blobs.writeBytes(
-                "validation-report", "waivable validation failure".getBytes(StandardCharsets.UTF_8));
-        String checkId = ShipDigest.sha256("waivable-check".getBytes(StandardCharsets.UTF_8));
-        String policy = flow.view.authority().authority().basis().policy().value();
+        ValidationFixture validation = validationFixture(flow, false);
+        ShipStamp.Check failed = validation.result().failedCheck();
+        String checkId = failed.id();
         BlobReference swappedBundle = flow.interactions.amend(
                 flow.blobs,
                 flow.view.interactionBundle(),
                 ShipDigest.sha256("swapped-context".getBytes(StandardCharsets.UTF_8)));
         ShipAuthorityCommand command = ShipAuthorityCommand.waiver(
-                checkId, evidence.digest(), policy);
+                checkId,
+                failed.evidenceDigest(),
+                flow.view.authority().authority().basis().policy().value());
         ShipEventPayloads.Failure payload = new ShipEventPayloads.Failure(
                 ShipStage.VALIDATE,
                 "waivable-check-failed",
                 "The validation check requires explicit waiver",
                 flow.view.activeRequestReference(),
+                validation.resultReference(),
+                validation.result().reportReference(),
                 null,
-                evidence,
-                null,
-                swappedBundle);
+                swappedBundle,
+                validation.result().evidence());
         ShipRun previous = flow.view.authority();
         ShipRun successor = command.apply(previous);
         flow.events.appendIfLatest(
@@ -961,21 +984,11 @@ class ShipRunProjectorTest {
     private PendingWaiver requestWaiver(String name) throws Exception {
         DurableFlow flow = validationRunningFlow(name);
         BlobReference originalBundle = flow.view.interactionBundle();
-        BlobReference evidence = flow.blobs.writeBytes(
-                "validation-report", "waivable validation failure".getBytes(StandardCharsets.UTF_8));
-        String checkId = ShipDigest.sha256("waivable-check".getBytes(StandardCharsets.UTF_8));
+        ValidationFixture validation = recordValidation(flow, false);
+        BlobReference evidence = validation.failedEvidence();
+        ShipStamp.Check failed = validation.result().failedCheck();
+        String checkId = failed.id();
         String policy = flow.view.authority().authority().basis().policy().value();
-        flow.commit(
-                ShipAuthorityCommand.waiver(checkId, evidence.digest(), policy),
-                new ShipEventPayloads.Failure(
-                        ShipStage.VALIDATE,
-                        "waivable-check-failed",
-                        "The validation check requires explicit waiver",
-                        flow.view.activeRequestReference(),
-                        null,
-                        evidence,
-                        null,
-                        null));
 
         assertEquals(ShipState.WAIVER_ELIGIBLE, flow.view.state());
         assertEquals(originalBundle, flow.view.interactionBundle());
@@ -989,7 +1002,7 @@ class ShipRunProjectorTest {
                 evidence.digest(),
                 policy,
                 subjectDigest,
-                "validation-report",
+                failed.id(),
                 "The failed check may affect runtime safety",
                 "The user accepts the documented risk",
                 nonce,
@@ -1011,7 +1024,7 @@ class ShipRunProjectorTest {
         flow.commit(
                 ShipAuthorityCommand.empty(ShipEventType.WAIVER_REQUESTED),
                 new ShipEventPayloads.WaiverRequested(challenge, pendingBundle));
-        return new PendingWaiver(flow, evidence, challenge);
+        return new PendingWaiver(flow, evidence, challenge, validation);
     }
 
     private static ShipEventPayloads.WaiverRecorded waiverResponse(
@@ -1110,6 +1123,7 @@ class ShipRunProjectorTest {
         DecisionLedger first = readyLedger(1, GapReviewStatus.NOT_RUN, source);
         Path catalogRoot = Files.createDirectory(
                 temporaryDirectory.resolve(name + "-catalog"));
+        Snapshot catalogSnapshot = CatalogTestVerifier.mainSnapshot(catalogRoot);
         ShipRunView continued = controller.submitStageResult(
                 discovery.runId(),
                 discovery.eventDigest(),
@@ -1117,9 +1131,14 @@ class ShipRunProjectorTest {
                         discovery.activeRequest(),
                         StageResult.Outcome.NEEDS_DISCOVERY,
                         first,
-                        List.of(new CatalogSubject(
-                                CatalogSubject.Kind.COMPONENT, "direct")))),
-                CatalogTestVerifier.mainSnapshot(catalogRoot));
+                        List.of(
+                                new CatalogSubject(
+                                        CatalogSubject.Kind.COMPONENT, "direct"),
+                                new CatalogSubject(
+                                        CatalogSubject.Kind.EIP, "from"),
+                                new CatalogSubject(
+                                        CatalogSubject.Kind.EIP, "route")))),
+                catalogSnapshot);
         ShipRunView reviewing = controller.submitStageResult(
                 continued.runId(),
                 continued.eventDigest(),
@@ -1145,6 +1164,7 @@ class ShipRunProjectorTest {
                 blobs,
                 new ShipInteractionBundleService(signer),
                 signer,
+                catalogSnapshot,
                 ready);
     }
 
@@ -1229,10 +1249,102 @@ class ShipRunProjectorTest {
 
     private static void acceptExecution(DurableFlow flow) throws Exception {
         StageRequest request = flow.view.activeRequest();
-        byte[] content = "generated route".getBytes(StandardCharsets.UTF_8);
-        BlobReference artifact = flow.blobs.writeBytes("route", content);
-        ProducedArtifact claim = new ProducedArtifact(
-                "route", "routes/generated.camel.yaml", artifact.digest(), artifact.byteSize());
+        Path candidateDirectory = Path.of(request.candidateDirectory());
+        Path route = candidateDirectory.resolve(
+                "src/main/resources/routes/orders.camel.yaml");
+        Path test = candidateDirectory.resolve("test/orders.camel.it.yaml");
+        Path pom = candidateDirectory.resolve("pom.xml");
+        Path config = candidateDirectory.resolve(".camel-kit/config.properties");
+        Files.createDirectories(route.getParent());
+        Files.createDirectories(test.getParent());
+        Files.createDirectories(config.getParent());
+        Files.writeString(route, """
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:start
+                """, StandardCharsets.UTF_8);
+        Files.writeString(test, """
+                name: orders-test
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                """, StandardCharsets.UTF_8);
+        Files.writeString(pom, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-main</artifactId>
+                      <version>4.21.0</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-yaml-dsl</artifactId>
+                      <version>4.21.0</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-direct</artifactId>
+                      <version>4.21.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """, StandardCharsets.UTF_8);
+        Files.writeString(config, """
+                project.runtime=main
+                project.camelVersion=4.21.0
+                project.platformBomVersion=4.21.0
+                citrus.version=5.0.0-M2
+                """, StandardCharsets.UTF_8);
+
+        BlobReference routeBlob = flow.blobs.writeBytes(
+                "route", Files.readAllBytes(route));
+        BlobReference testBlob = flow.blobs.writeBytes(
+                "citrus-test", Files.readAllBytes(test));
+        BlobReference pomBlob = flow.blobs.writeBytes(
+                "pom", Files.readAllBytes(pom));
+        BlobReference configBlob = flow.blobs.writeBytes(
+                "runtime-config", Files.readAllBytes(config));
+        List<ProducedArtifact> claims = List.of(
+                new ProducedArtifact(
+                        "route",
+                        "src/main/resources/routes/orders.camel.yaml",
+                        routeBlob.digest(),
+                        routeBlob.byteSize()),
+                new ProducedArtifact(
+                        "citrus-test",
+                        "test/orders.camel.it.yaml",
+                        testBlob.digest(),
+                        testBlob.byteSize()),
+                new ProducedArtifact(
+                        "pom", "pom.xml", pomBlob.digest(), pomBlob.byteSize()),
+                new ProducedArtifact(
+                        "runtime-config",
+                        ".camel-kit/config.properties",
+                        configBlob.digest(),
+                        configBlob.byteSize()));
+        List<ShipWorkspaceService.AcceptedArtifact> accepted = List.of(
+                new ShipWorkspaceService.AcceptedArtifact(
+                        claims.get(0), routeBlob, 0100644),
+                new ShipWorkspaceService.AcceptedArtifact(
+                        claims.get(1), testBlob, 0100644),
+                new ShipWorkspaceService.AcceptedArtifact(
+                        claims.get(2), pomBlob, 0100644),
+                new ShipWorkspaceService.AcceptedArtifact(
+                        claims.get(3), configBlob, 0100644));
         ArtifactManifest manifest = new ArtifactManifest(
                 ArtifactManifest.SCHEMA_VERSION,
                 "main",
@@ -1245,9 +1357,22 @@ class ShipRunProjectorTest {
                 CITRUS_DEPENDENCIES,
                 ArtifactManifest.JavaPolicy.FORBIDDEN,
                 List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
+                List.of(new RouteArtifact(
+                        "orders",
+                        "src/main/resources/routes/orders.camel.yaml",
+                        routeBlob.digest())),
+                List.of(new TestArtifact(
+                        "orders",
+                        "test/orders.camel.it.yaml",
+                        testBlob.digest())),
+                List.of(
+                        new DeclaredArtifact(
+                                "pom", "pom.xml", pomBlob.digest(), true),
+                        new DeclaredArtifact(
+                                "runtime-config",
+                                ".camel-kit/config.properties",
+                                configBlob.digest(),
+                                true)),
                 true,
                 true);
         StageResult result = new StageResult(
@@ -1261,22 +1386,40 @@ class ShipRunProjectorTest {
                 null,
                 null,
                 List.of(),
-                List.of(claim),
+                claims,
                 manifest,
                 null,
                 null);
         BlobReference resultReference = fixtureBlob(flow.blobs, "stage-result", result);
         BlobReference manifestReference = fixtureBlob(
                 flow.blobs, "artifact-manifest", manifest);
-        BlobReference catalogUsage = fixtureBlob(
-                flow.blobs, "catalog-usage", java.util.Map.of());
-        Path candidateDirectory = Path.of(request.candidateDirectory());
-        BlobReference candidateSnapshot = fixtureBlob(
+        ProjectSnapshot candidateValue = ProjectEvidenceFiles.captureSealed(
+                candidateDirectory);
+        BlobReference candidateReference = fixtureBlob(
                 flow.blobs,
                 "project-snapshot",
-                ProjectEvidenceFiles.captureSealed(candidateDirectory));
-        ShipWorkspaceService.AcceptedArtifact accepted = new ShipWorkspaceService.AcceptedArtifact(
-                claim, artifact, 0100644);
+                candidateValue);
+        DecisionLedger ledger = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.ledger(), ShipJson.MAX_DOCUMENT_BYTES),
+                DecisionLedger.class);
+        CatalogEvidenceSet approvedEvidence = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.catalogEvidence(), ShipJson.MAX_DOCUMENT_BYTES),
+                CatalogEvidenceSet.class);
+        CatalogUsageRecord usage = CatalogEvidenceValidator.deriveUsage(
+                flow.catalogSnapshot,
+                ledger,
+                approvedEvidence,
+                manifest,
+                candidateDirectory,
+                flow.view.runId(),
+                flow.view.catalogEvidence().digest(),
+                manifestReference.digest(),
+                candidateReference.digest(),
+                candidateValue.digest());
+        BlobReference usageReference = fixtureBlob(
+                flow.blobs, "catalog-usage", usage);
         flow.commit(
                 ShipAuthorityCommand.value(
                         ShipEventType.EXECUTION_VALIDATED, resultReference.digest()),
@@ -1284,24 +1427,82 @@ class ShipRunProjectorTest {
                         request.stage(),
                         flow.view.activeRequestReference(),
                         resultReference,
-                        List.of(accepted),
+                        accepted,
                         null,
                         manifestReference,
                         null,
-                        catalogUsage,
+                        usageReference,
                         null,
                         null,
-                        candidateSnapshot,
+                        candidateReference,
                         candidateDirectory.toString(),
                         null));
     }
 
-    private static void acceptValidation(DurableFlow flow) throws Exception {
+    private static ValidationFixture recordValidation(
+            DurableFlow flow, boolean citrusPassed)
+            throws Exception {
+        ValidationFixture validation = validationFixture(flow, citrusPassed);
+        ShipValidationService.Verdict expected = citrusPassed
+                ? ShipValidationService.Verdict.PASS
+                : ShipValidationService.Verdict.WAIVABLE;
+        assertEquals(expected, validation.result().verdict());
+        if (citrusPassed) {
+            flow.commit(
+                    ShipAuthorityCommand.value(
+                            ShipEventType.VALIDATION_PASSED,
+                            validation.result().reportReference().digest()),
+                    new ShipEventPayloads.StageAccepted(
+                            flow.view.activeRequest().stage(),
+                            flow.view.activeRequestReference(),
+                            validation.resultReference(),
+                            List.of(validation.accepted()),
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            validation.result().evidence(),
+                            validation.result().reportReference(),
+                            null));
+        } else {
+            ShipStamp.Check failed = validation.result().failedCheck();
+            String stableCheckId = failed.id();
+            flow.commit(
+                    ShipAuthorityCommand.waiver(
+                            stableCheckId,
+                            failed.evidenceDigest(),
+                            flow.view.authority().authority().basis().policy().value()),
+                    new ShipEventPayloads.Failure(
+                            ShipStage.VALIDATE,
+                            "waivable-check-failed",
+                            "The validation check requires explicit waiver",
+                            flow.view.activeRequestReference(),
+                            validation.resultReference(),
+                            validation.result().reportReference(),
+                            null,
+                            null,
+                            validation.result().evidence()));
+        }
+        return validation;
+    }
+
+    private static ValidationFixture validationFixture(
+            DurableFlow flow, boolean citrusPassed)
+            throws Exception {
         StageRequest request = flow.view.activeRequest();
-        byte[] content = "validation passed".getBytes(StandardCharsets.UTF_8);
-        BlobReference artifact = flow.blobs.writeBytes("validation", content);
+        byte[] content = (citrusPassed
+                ? "validation passed"
+                : "validation requires waiver").getBytes(StandardCharsets.UTF_8);
+        BlobReference workerValidation = flow.blobs.writeBytes("validation", content);
         ProducedArtifact claim = new ProducedArtifact(
-                "validation", "validation.md", artifact.digest(), artifact.byteSize());
+                "validation",
+                "validation.md",
+                workerValidation.digest(),
+                workerValidation.byteSize());
         StageResult result = new StageResult(
                 StageResult.SCHEMA_VERSION,
                 request.runId(),
@@ -1319,24 +1520,189 @@ class ShipRunProjectorTest {
                 null);
         BlobReference resultReference = fixtureBlob(flow.blobs, "stage-result", result);
         ShipWorkspaceService.AcceptedArtifact accepted = new ShipWorkspaceService.AcceptedArtifact(
-                claim, artifact, 0100644);
-        flow.commit(
-                ShipAuthorityCommand.value(
-                        ShipEventType.VALIDATION_PASSED, resultReference.digest()),
-                new ShipEventPayloads.StageAccepted(
-                        request.stage(),
-                        flow.view.activeRequestReference(),
-                        resultReference,
-                        List.of(accepted),
+                claim, workerValidation, 0100644);
+        ArtifactManifest manifest = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.artifactManifest(), ShipJson.MAX_DOCUMENT_BYTES),
+                ArtifactManifest.class);
+        ProjectSnapshot candidateValue = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.candidateSnapshot(), ShipJson.MAX_DOCUMENT_BYTES),
+                ProjectSnapshot.class);
+        DecisionLedger ledger = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.ledger(), ShipJson.MAX_DOCUMENT_BYTES),
+                DecisionLedger.class);
+        CatalogUsageRecord usage = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.catalogUsage(), ShipJson.MAX_DOCUMENT_BYTES),
+                CatalogUsageRecord.class);
+        CatalogEvidenceSet approvedEvidence = ShipJson.mapper().readValue(
+                flow.blobs.readBytes(
+                        flow.view.catalogEvidence(), ShipJson.MAX_DOCUMENT_BYTES),
+                CatalogEvidenceSet.class);
+        ShipValidationService.Result validation;
+        try (ShipBlobStore.Transaction transaction = flow.blobs.beginTransaction()) {
+            validation = new ShipValidationService(
+                    (candidate, evidenceDirectory, command) -> deterministicEvidence(
+                            candidate,
+                            evidenceDirectory,
+                            command,
+                            citrusPassed),
+                    Clock.fixed(NOW, ZoneOffset.UTC))
+                    .validate(
+                            flow.blobs,
+                            transaction,
+                            flow.view.runId(),
+                            flow.view.candidateDirectory(),
+                            candidateValue,
+                            flow.view.candidateSnapshot(),
+                            manifest,
+                            flow.view.artifactManifest(),
+                            ledger.requirementsPolicy(),
+                            usage,
+                            flow.view.catalogUsage(),
+                            flow.catalogSnapshot,
+                            approvedEvidence,
+                            flow.view.catalogEvidence(),
+                            workerValidation);
+            transaction.commit();
+        }
+        BlobReference failedEvidence = validation.failedCheck() == null
+                ? null
+                : validation.evidence().stream()
+                        .filter(reference -> reference.digest().equals(
+                                validation.failedCheck().evidenceDigest()))
+                        .findFirst()
+                        .orElseThrow();
+        return new ValidationFixture(
+                validation,
+                resultReference,
+                accepted,
+                failedEvidence);
+    }
+
+    private static CommandEvidence deterministicEvidence(
+            Path candidate,
+            Path evidenceDirectory,
+            EvidenceCommand command,
+            boolean citrusPassed)
+            throws IOException {
+        Files.createDirectory(evidenceDirectory);
+        Path sandboxDirectory = Files.createDirectory(
+                evidenceDirectory.resolve("." + command.id() + "-sandbox-fixture"));
+        Path sandbox = Files.writeString(
+                sandboxDirectory.resolve("sandbox"), "sandbox\n", StandardCharsets.UTF_8);
+        Path toolchain = Files.writeString(
+                sandboxDirectory.resolve("toolchain"), "toolchain\n", StandardCharsets.UTF_8);
+        Path executable = Files.writeString(
+                sandboxDirectory.resolve("executable"), "executable\n", StandardCharsets.UTF_8);
+        byte[] stdoutBytes = new byte[0];
+        if (command.jvmPayload().kind() == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT) {
+            Path archive = sandboxDirectory.resolve("main-routes.jar");
+            try {
+                stdoutBytes = ShipMainPackageMain.packageAndInspect(
+                        candidate,
+                        archive,
+                        command.arguments().subList(4, command.arguments().size()))
+                        .encode();
+            } finally {
+                Files.deleteIfExists(archive);
+            }
+        }
+        Path stdout = Files.write(
+                evidenceDirectory.resolve("stdout.log"), stdoutBytes);
+        Path stderr = Files.write(
+                evidenceDirectory.resolve("stderr.log"), new byte[0]);
+        String sandboxDigest = ShipDigest.sha256(Files.readAllBytes(sandbox));
+        String toolchainDigest = ShipDigest.sha256(Files.readAllBytes(toolchain));
+        String executableDigest = ShipDigest.sha256(Files.readAllBytes(executable));
+        String stdoutDigest = ShipDigest.sha256(Files.readAllBytes(stdout));
+        String stderrDigest = ShipDigest.sha256(Files.readAllBytes(stderr));
+        String jdkDigest = ShipDigest.sha256(
+                "fixture-jdk".getBytes(StandardCharsets.UTF_8));
+        boolean passed = citrusPassed
+                || command.jvmPayload().kind() != JvmPayloadRequest.Kind.CITRUS_YAML;
+        String version = command.jvmPayload().kind()
+                         == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT
+                                 ? ShipMainPackageMain.PAYLOAD_VERSION
+                                 : command.jvmPayload().camelVersion()
+                                   + (command.jvmPayload().citrusVersion() == null
+                                           ? ""
+                                           : " " + command.jvmPayload().citrusVersion());
+        return new CommandEvidence(
+                CommandEvidence.SCHEMA_VERSION,
+                command.id(),
+                new SandboxIdentity(
+                        EvidenceRunner.SANDBOX_PROVIDER,
+                        sandbox.toString(),
+                        sandboxDigest,
+                        sandboxDigest,
                         null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null));
+                        EvidenceRunner.expectedSandboxProfileDigest(command, jdkDigest)),
+                toolchainDigest,
+                toolchainDigest,
+                toolchain.toString(),
+                toolchainDigest,
+                executable.toString(),
+                executableDigest,
+                executableDigest,
+                null,
+                version,
+                command.arguments(),
+                candidate.toAbsolutePath().normalize().toString(),
+                EvidenceRunner.expectedEnvironment(command, jdkDigest),
+                NOW,
+                NOW,
+                true,
+                false,
+                passed ? 0 : 1,
+                null,
+                stdout.toString(),
+                stdoutDigest,
+                stderr.toString(),
+                stderrDigest,
+                command.inputDigests());
+    }
+
+    private static BlobReference completeRun(
+            DurableFlow flow,
+            ValidationFixture validation,
+            ShipStamp.Status status,
+            List<ShipStamp.Waiver> waivers,
+            ShipEventType completionType)
+            throws Exception {
+        ShipStamp stampValue = new ShipStamp(
+                ShipStamp.SCHEMA_VERSION,
+                flow.view.runId(),
+                status,
+                flow.view.adapterId(),
+                flow.view.requirementsDigest(),
+                flow.view.designDigest(),
+                flow.view.artifactManifest().digest(),
+                flow.view.candidateSnapshot().digest(),
+                flow.view.catalogUsage().digest(),
+                validation.result().report().checks(),
+                waivers,
+                NOW,
+                null,
+                null);
+        BlobReference stamp = fixtureBlob(flow.blobs, "ship-stamp", stampValue);
+        try (ShipPublicationService.LivePublication publication
+                = ShipPublicationService.apply(flow.view, flow.blobs, stamp, completionType)) {
+            BlobReference publishedSnapshot = fixtureBlob(
+                    flow.blobs,
+                    "project-snapshot",
+                    publication.publishedSnapshot());
+            flow.commit(
+                    ShipAuthorityCommand.value(completionType, stamp.digest()),
+                    new ShipEventPayloads.StampRecorded(
+                            stamp,
+                            publishedSnapshot,
+                            validation.result().reportReference()));
+            publication.finish();
+        }
+        return stamp;
     }
 
     private static void failActiveAttempt(DurableFlow flow) throws Exception {
@@ -1835,7 +2201,17 @@ class ShipRunProjectorTest {
     }
 
     private record PendingWaiver(
-            DurableFlow flow, BlobReference evidence, WaiverChallenge challenge) {
+            DurableFlow flow,
+            BlobReference evidence,
+            WaiverChallenge challenge,
+            ValidationFixture validation) {
+    }
+
+    private record ValidationFixture(
+            ShipValidationService.Result result,
+            BlobReference resultReference,
+            ShipWorkspaceService.AcceptedArtifact accepted,
+            BlobReference failedEvidence) {
     }
 
     private static final class DurableFlow {
@@ -1844,6 +2220,7 @@ class ShipRunProjectorTest {
         private final ShipBlobStore blobs;
         private final ShipInteractionBundleService interactions;
         private final ShipInteractionSigner signer;
+        private final Snapshot catalogSnapshot;
         private ShipRunView view;
 
         private DurableFlow(
@@ -1851,11 +2228,13 @@ class ShipRunProjectorTest {
                             ShipBlobStore blobs,
                             ShipInteractionBundleService interactions,
                             ShipInteractionSigner signer,
+                            Snapshot catalogSnapshot,
                             ShipRunView view) {
             this.events = events;
             this.blobs = blobs;
             this.interactions = interactions;
             this.signer = signer;
+            this.catalogSnapshot = catalogSnapshot;
             this.view = view;
         }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjectorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjectorTest.java
@@ -8,6 +8,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
@@ -57,6 +58,7 @@ import io.github.luigidemasi.camelkit.ship.protocol.StageRequest;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.StagedArtifactSource;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -64,6 +66,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -82,6 +85,143 @@ class ShipRunProjectorTest {
 
     @TempDir
     Path temporaryDirectory;
+
+    @Test
+    void protectedControllerPassFlowPublishesEvidenceBoundCandidate() throws Exception {
+        ProtectedControllerFlow flow = executionRunningControllerFlow("protected-controller-pass", true);
+        ShipRunView executed = flow.broker().submit(
+                flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot());
+        ShipRunView validating = flow.controller().startValidation(
+                executed.runId(), executed.eventDigest());
+        ShipRunView passed = flow.broker().submit(
+                validating.runId(), validating.eventDigest(), flow.catalogSnapshot());
+
+        ShipRunView completed = flow.controller().complete(
+                passed.runId(), passed.eventDigest());
+
+        assertEquals(ShipState.COMPLETED, completed.state());
+        assertEquals(4, flow.backend().closedCustodies());
+        assertNotNull(completed.artifactManifest());
+        assertNotNull(completed.catalogUsage());
+        assertNotNull(completed.candidateSnapshot());
+        assertNotNull(completed.validationReport());
+        assertNotNull(completed.stamp());
+        assertEquals(routeYaml(), Files.readString(
+                completed.projectRoot().resolve("src/main/resources/routes/orders.camel.yaml")));
+        assertEquals(testYaml(), Files.readString(
+                completed.projectRoot().resolve("test/orders.camel.it.yaml")));
+
+        FileShipEventStore events = FileShipEventStore.open(
+                stateRoot(flow), completed.runId());
+        ShipEvent terminal = events.replay().get(events.replay().size() - 1);
+        ShipStoredEventCodec.StoredEvent stored = ShipStoredEventCodec.decode(terminal);
+        ShipEventPayloads.StampRecorded recorded
+                = (ShipEventPayloads.StampRecorded) stored.data();
+        assertEquals(ShipEventType.RUN_COMPLETED, terminal.type());
+        assertEquals(completed.stamp(), recorded.stamp());
+        assertNotNull(recorded.publishedSnapshot());
+        ShipBlobStore blobs = ShipBlobStore.open(stateRoot(flow), completed.runId());
+        ShipStamp stamp = ShipJson.mapper().readValue(
+                blobs.readBytes(completed.stamp(), ShipJson.MAX_DOCUMENT_BYTES),
+                ShipStamp.class);
+        assertEquals(ShipStamp.Status.PASS, stamp.status());
+        assertTrue(blobs.readBytes(
+                recorded.publishedSnapshot(), ShipJson.MAX_DOCUMENT_BYTES).length > 0);
+    }
+
+    @Test
+    void protectedControllerWaivableFlowStopsAtProtectedWaiverBoundary() throws Exception {
+        ProtectedControllerFlow flow = executionRunningControllerFlow("protected-controller-waivable", false);
+        ShipRunView executed = flow.broker().submit(
+                flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot());
+        ShipRunView validating = flow.controller().startValidation(
+                executed.runId(), executed.eventDigest());
+
+        ShipRunView eligible = flow.broker().submit(
+                validating.runId(), validating.eventDigest(), flow.catalogSnapshot());
+
+        assertEquals(ShipState.WAIVER_ELIGIBLE, eligible.state());
+        assertNotNull(eligible.validationReport());
+        assertFalse(eligible.evidenceById().get("citrus-integration-test-001") == null);
+        assertEquals(4, flow.backend().closedCustodies());
+        assertFalse(java.util.Arrays.stream(ShipController.class.getDeclaredMethods())
+                .anyMatch(method -> method.getName().equals("requestWaiver")
+                        || method.getName().equals("recordWaiver")));
+    }
+
+    @Test
+    void definiteAppendFailureRollsBackExecutionCandidate() throws Exception {
+        ProtectedControllerFlow flow = executionRunningControllerFlow("append-definite", true);
+        ShipController faulting = faultingController(flow, AppendFault.UNCHANGED_HEAD);
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(faulting, flow.backend());
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> broker.submit(
+                        flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot()));
+
+        assertEquals("injected append failure", failure.getMessage());
+        assertEquals(ShipState.EXECUTE_RUNNING,
+                flow.controller().status(flow.view().runId()).state());
+        assertTrue(publicationTransactions(flow).isEmpty());
+    }
+
+    @Test
+    void committedAppendReportedAsFailureFinishesExecutionCandidate() throws Exception {
+        ProtectedControllerFlow flow = executionRunningControllerFlow("append-successor", true);
+        ShipController faulting = faultingController(flow, AppendFault.SUCCESSOR_HEAD);
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(faulting, flow.backend());
+
+        ShipRunView accepted = broker.submit(
+                flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot());
+
+        assertEquals(ShipState.EXECUTE_VALIDATED, accepted.state());
+        assertEquals(1, publicationTransactions(flow).size());
+        assertEquals(accepted.candidateDirectory().getParent(),
+                publicationTransactions(flow).get(0));
+    }
+
+    @Test
+    void unresolvedAppendRetainsCandidateUntilStatusReconcilesIt() throws Exception {
+        ProtectedControllerFlow flow = executionRunningControllerFlow("append-unresolved", true);
+        ShipController faulting = faultingController(flow, AppendFault.HEAD_READ_FAILURE);
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(faulting, flow.backend());
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> broker.submit(
+                        flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot()));
+
+        assertEquals("injected append failure", failure.getMessage());
+        assertEquals(1, failure.getSuppressed().length);
+        assertEquals(1, publicationTransactions(flow).size());
+        ShipRunView recovered = flow.controller().status(flow.view().runId());
+        assertEquals(ShipState.EXECUTE_RUNNING, recovered.state());
+        assertTrue(publicationTransactions(flow).isEmpty());
+    }
+
+    @Test
+    void unexpectedAuthenticatedHeadRetainsCandidateForExplicitReconciliation() throws Exception {
+        ProtectedControllerFlow flow = executionRunningControllerFlow("append-unexpected", true);
+        ShipController faulting = faultingController(flow, AppendFault.UNEXPECTED_AUTHENTICATED_HEAD);
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(faulting, flow.backend());
+
+        ShipControllerException failure = assertThrows(
+                ShipControllerException.class,
+                () -> broker.submit(
+                        flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot()));
+
+        assertEquals("event-append-outcome-unknown", failure.code());
+        assertEquals(1, publicationTransactions(flow).size());
+        FileShipEventStore events = FileShipEventStore.open(
+                stateRoot(flow), flow.view().runId());
+        List<ShipEvent> authenticated = events.replay();
+        assertEquals(ShipEventType.STAMP_STARTED,
+                authenticated.get(authenticated.size() - 1).type());
+        ShipProjectPublisher.reconcileCandidates(
+                ShipBlobStore.open(stateRoot(flow), flow.view().runId()), authenticated);
+        assertTrue(publicationTransactions(flow).isEmpty());
+    }
 
     @Test
     void replayReconstructsTheExactPersistedAttemptHead() throws Exception {
@@ -1553,19 +1693,25 @@ class ShipRunProjectorTest {
                     .validate(
                             flow.blobs,
                             transaction,
-                            flow.view.runId(),
-                            flow.view.candidateDirectory(),
-                            candidateValue,
-                            flow.view.candidateSnapshot(),
-                            manifest,
-                            flow.view.artifactManifest(),
-                            ledger.requirementsPolicy(),
-                            usage,
-                            flow.view.catalogUsage(),
-                            flow.catalogSnapshot,
-                            approvedEvidence,
-                            flow.view.catalogEvidence(),
-                            workerValidation);
+                            new ShipValidationService.Inputs(
+                                    flow.view.runId(),
+                                    new ShipValidationService.CandidateInput(
+                                            flow.view.candidateDirectory(),
+                                            candidateValue,
+                                            flow.view.candidateSnapshot()),
+                                    new ShipValidationService.ManifestInput(
+                                            manifest,
+                                            flow.view.artifactManifest()),
+                                    ledger.requirementsPolicy(),
+                                    new ShipValidationService.CatalogInput(
+                                            new ShipValidationService.UsageInput(
+                                                    usage,
+                                                    flow.view.catalogUsage()),
+                                            flow.catalogSnapshot,
+                                            new ShipValidationService.ApprovalInput(
+                                                    approvedEvidence,
+                                                    flow.view.catalogEvidence())),
+                                    workerValidation));
             transaction.commit();
         }
         BlobReference failedEvidence = validation.failedCheck() == null
@@ -1663,6 +1809,307 @@ class ShipRunProjectorTest {
                 stderr.toString(),
                 stderrDigest,
                 command.inputDigests());
+    }
+
+    private ProtectedControllerFlow executionRunningControllerFlow(
+            String name, boolean citrusPassed)
+            throws Exception {
+        DurableFlow durable = requirementsReadyFlow(name);
+        ShipValidationService validation = new ShipValidationService(
+                (candidate, evidenceDirectory, command) -> deterministicEvidence(
+                        candidate, evidenceDirectory, command, citrusPassed),
+                Clock.fixed(NOW, ZoneOffset.UTC));
+        ShipController controller = new ShipController(
+                durable.blobs.runRoot().getParent(),
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                validation);
+        ProtectedBackend backend = new ProtectedBackend();
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(controller, backend);
+
+        durable.view = controller.startDesign(
+                durable.view.runId(), durable.view.eventDigest());
+        durable.view = broker.submit(
+                durable.view.runId(), durable.view.eventDigest(), durable.catalogSnapshot);
+        approveDesign(durable);
+        durable.view = controller.startPlan(
+                durable.view.runId(), durable.view.eventDigest());
+        durable.view = broker.submit(
+                durable.view.runId(), durable.view.eventDigest(), durable.catalogSnapshot);
+        approvePlan(durable);
+        durable.view = controller.startExecution(
+                durable.view.runId(), durable.view.eventDigest());
+        return new ProtectedControllerFlow(
+                durable, controller, broker, backend, durable.catalogSnapshot, durable.view);
+    }
+
+    private static ShipController faultingController(
+            ProtectedControllerFlow flow, AppendFault fault) {
+        return new ShipController(
+                stateRoot(flow),
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ShipValidationService(
+                        (candidate, evidenceDirectory, command) -> deterministicEvidence(
+                                candidate, evidenceDirectory, command, true),
+                        Clock.fixed(NOW, ZoneOffset.UTC)),
+                new FaultingEventStoreAccess(fault));
+    }
+
+    private static Path stateRoot(ProtectedControllerFlow flow) {
+        return flow.durable().blobs.runRoot().getParent();
+    }
+
+    private static List<Path> publicationTransactions(ProtectedControllerFlow flow)
+            throws IOException {
+        Path publication = flow.durable().blobs.runRoot().resolve("publication");
+        if (!Files.exists(publication)) {
+            return List.of();
+        }
+        try (var entries = Files.list(publication)) {
+            return entries.sorted().toList();
+        }
+    }
+
+    private static String routeYaml() {
+        return """
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:start
+                """;
+    }
+
+    private static String testYaml() {
+        return """
+                name: orders-test
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                """;
+    }
+
+    private static String pomXml() {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-main</artifactId>
+                      <version>4.21.0</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-yaml-dsl</artifactId>
+                      <version>4.21.0</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-direct</artifactId>
+                      <version>4.21.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+    }
+
+    private static String runtimeConfig() {
+        return """
+                project.runtime=main
+                project.camelVersion=4.21.0
+                project.platformBomVersion=4.21.0
+                citrus.version=5.0.0-M2
+                """;
+    }
+
+    private static WorkerOutput workerOutput(StageRequest request) throws IOException {
+        Path root = Path.of(request.outputDirectory());
+        Files.createDirectories(root);
+        List<ProducedArtifact> artifacts;
+        ArtifactManifest manifest = null;
+        if (request.stage() == ShipStage.DESIGN || request.stage() == ShipStage.PLAN) {
+            String kind = request.stage() == ShipStage.DESIGN ? "design" : "plan";
+            artifacts = List.of(writeWorkerArtifact(
+                    root, kind, kind + ".md",
+                    (kind + " approved\n").getBytes(StandardCharsets.UTF_8)));
+        } else if (request.stage() == ShipStage.EXECUTE) {
+            ProducedArtifact route = writeWorkerArtifact(
+                    root, "route", "src/main/resources/routes/orders.camel.yaml",
+                    routeYaml().getBytes(StandardCharsets.UTF_8));
+            ProducedArtifact test = writeWorkerArtifact(
+                    root, "citrus-test", "test/orders.camel.it.yaml",
+                    testYaml().getBytes(StandardCharsets.UTF_8));
+            ProducedArtifact pom = writeWorkerArtifact(
+                    root, "pom", "pom.xml", pomXml().getBytes(StandardCharsets.UTF_8));
+            ProducedArtifact config = writeWorkerArtifact(
+                    root, "config", ".camel-kit/config.properties",
+                    runtimeConfig().getBytes(StandardCharsets.UTF_8));
+            artifacts = List.of(route, test, pom, config);
+            manifest = new ArtifactManifest(
+                    ArtifactManifest.SCHEMA_VERSION,
+                    "main",
+                    CatalogTestVerifier.CAMEL_VERSION,
+                    null,
+                    null,
+                    "yaml",
+                    "simple",
+                    CITRUS_VERSION,
+                    CITRUS_DEPENDENCIES,
+                    ArtifactManifest.JavaPolicy.FORBIDDEN,
+                    List.of(),
+                    List.of(new RouteArtifact("orders", route.relativePath(), route.digest())),
+                    List.of(new TestArtifact("orders", test.relativePath(), test.digest())),
+                    List.of(
+                            new DeclaredArtifact("pom", pom.relativePath(), pom.digest(), true),
+                            new DeclaredArtifact(
+                                    "config", config.relativePath(), config.digest(), true)),
+                    true,
+                    true);
+        } else if (request.stage() == ShipStage.VALIDATE) {
+            artifacts = List.of(writeWorkerArtifact(
+                    root, "validation", "validation.md",
+                    "validation complete\n".getBytes(StandardCharsets.UTF_8)));
+        } else {
+            throw new IOException("Unexpected protected test stage " + request.stage());
+        }
+        StageResult result = new StageResult(
+                StageResult.SCHEMA_VERSION,
+                request.runId(),
+                request.stage(),
+                request.attemptId(),
+                request.challenge(),
+                request.inputDigest(),
+                StageResult.Outcome.COMPLETED,
+                null,
+                null,
+                List.of(),
+                artifacts,
+                manifest,
+                null,
+                null);
+        return new WorkerOutput(root, ShipJson.mapper().writeValueAsBytes(result));
+    }
+
+    private static ProducedArtifact writeWorkerArtifact(
+            Path root, String kind, String relativePath, byte[] content)
+            throws IOException {
+        Path target = root.resolve(relativePath);
+        Files.createDirectories(target.getParent());
+        Files.write(target, content);
+        return new ProducedArtifact(
+                kind, relativePath, ShipDigest.sha256(content), content.length);
+    }
+
+    private enum AppendFault {
+        UNCHANGED_HEAD,
+        SUCCESSOR_HEAD,
+        HEAD_READ_FAILURE,
+        UNEXPECTED_AUTHENTICATED_HEAD
+    }
+
+    private static final class FaultingEventStoreAccess
+            implements ShipController.EventStoreAccess {
+
+        private final AppendFault fault;
+
+        private FaultingEventStoreAccess(AppendFault fault) {
+            this.fault = fault;
+        }
+
+        @Override
+        public ShipEvent appendIfLatest(
+                FileShipEventStore events,
+                ShipEventHead expectedHead,
+                ShipEventDraft draft)
+                throws IOException {
+            if (fault == AppendFault.SUCCESSOR_HEAD) {
+                events.appendIfLatest(expectedHead, draft);
+            } else if (fault == AppendFault.UNEXPECTED_AUTHENTICATED_HEAD) {
+                ShipAuthorityCommand alternate
+                        = ShipAuthorityCommand.empty(ShipEventType.STAMP_STARTED);
+                events.appendIfLatest(
+                        expectedHead,
+                        new ShipEventDraft(
+                                alternate.type(),
+                                draft.state(),
+                                draft.previousAuthorityHead(),
+                                AuthorityHeadId.create(),
+                                draft.occurredAt(),
+                                ShipStoredEventCodec.encode(
+                                        alternate, new ShipEventPayloads.NoData())));
+            }
+            throw new IOException("injected append failure");
+        }
+
+        @Override
+        public ShipEventHead currentHead(FileShipEventStore events) throws IOException {
+            if (fault == AppendFault.HEAD_READ_FAILURE) {
+                throw new IOException("injected current-head failure");
+            }
+            return events.currentHead();
+        }
+    }
+
+    private static final class ProtectedBackend
+            implements ShipProtectedWorkerBroker.Backend {
+
+        private final AtomicInteger closed = new AtomicInteger();
+
+        @Override
+        public ShipProtectedWorkerBroker.Custody stopAndAcquireExclusiveCustody(
+                StageRequest request)
+                throws IOException {
+            WorkerOutput output = workerOutput(request);
+            return new ShipProtectedWorkerBroker.Custody() {
+                @Override
+                public void requireExactAttempt(StageRequest expected) throws IOException {
+                    if (!request.equals(expected)) {
+                        throw new IOException("Protected test custody attempt mismatch");
+                    }
+                }
+
+                @Override
+                public byte[] readResultBytes() {
+                    return output.result();
+                }
+
+                @Override
+                public StagedArtifactSource.Session openArtifactSource() throws IOException {
+                    return StagedArtifactSource.open(output.root());
+                }
+
+                @Override
+                public void close() {
+                    closed.incrementAndGet();
+                }
+            };
+        }
+
+        private int closedCustodies() {
+            return closed.get();
+        }
+    }
+
+    private record WorkerOutput(Path root, byte[] result) {
+    }
+
+    private record ProtectedControllerFlow(
+            DurableFlow durable,
+            ShipController controller,
+            ShipProtectedWorkerBroker broker,
+            ProtectedBackend backend,
+            Snapshot catalogSnapshot,
+            ShipRunView view) {
     }
 
     private static BlobReference completeRun(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjectorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunProjectorTest.java
@@ -8,7 +8,9 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
@@ -130,7 +132,7 @@ class ShipRunProjectorTest {
     }
 
     @Test
-    void protectedControllerWaivableFlowStopsAtProtectedWaiverBoundary() throws Exception {
+    void protectedControllerWaivableFlowCompletesWithResponseBoundStamp() throws Exception {
         ProtectedControllerFlow flow = executionRunningControllerFlow("protected-controller-waivable", false);
         ShipRunView executed = flow.broker().submit(
                 flow.view().runId(), flow.view().eventDigest(), flow.catalogSnapshot());
@@ -147,6 +149,78 @@ class ShipRunProjectorTest {
         assertFalse(java.util.Arrays.stream(ShipController.class.getDeclaredMethods())
                 .anyMatch(method -> method.getName().equals("requestWaiver")
                         || method.getName().equals("recordWaiver")));
+
+        ShipValidationReport report = ShipJson.mapper().readValue(
+                flow.durable().blobs.readBytes(
+                        eligible.validationReport(), ShipJson.MAX_DOCUMENT_BYTES),
+                ShipValidationReport.class);
+        ShipStamp.Check failed = report.checks().stream()
+                .filter(check -> check.mandatory() && !check.passed())
+                .findFirst()
+                .orElseThrow();
+        BlobReference evidence = eligible.evidenceById().get(failed.id());
+        assertNotNull(evidence);
+        flow.durable().view = eligible;
+        PendingWaiver pending = requestWaiver(
+                flow.durable(), evidence, failed, null, eligible.interactionBundle());
+        ShipEventPayloads.WaiverRecorded approval = waiverResponse(
+                pending, WaiverDecision.WAIVE);
+        flow.durable().commit(
+                ShipAuthorityCommand.decision(ShipEventType.WAIVER_RECORDED, null),
+                approval);
+
+        ShipRunView completed = flow.controller().complete(
+                eligible.runId(), flow.durable().view.eventDigest());
+
+        assertEquals(ShipState.COMPLETED_WITH_WAIVER, completed.state());
+        assertEquals(routeYaml(), Files.readString(
+                completed.projectRoot().resolve("src/main/resources/routes/orders.camel.yaml")));
+        assertEquals(testYaml(), Files.readString(
+                completed.projectRoot().resolve("test/orders.camel.it.yaml")));
+        ShipStamp stamp = ShipJson.mapper().readValue(
+                flow.durable().blobs.readBytes(
+                        completed.stamp(), ShipJson.MAX_DOCUMENT_BYTES),
+                ShipStamp.class);
+        assertEquals(ShipStamp.Status.COMPLETED_WITH_WAIVER, stamp.status());
+        assertEquals(
+                List.of(new ShipStamp.Waiver(
+                        failed.id(),
+                        failed.evidenceDigest(),
+                        approval.responseReference().digest())),
+                stamp.waivers());
+    }
+
+    @Test
+    void oneFailedNonCitrusMandatoryCheckIsTerminalFailure() throws Exception {
+        DurableFlow flow = validationRunningFlow("validation-non-citrus-failure");
+        AtomicBoolean failedNonCitrus = new AtomicBoolean();
+
+        ValidationFixture validation = validationFixture(
+                flow,
+                command -> command.jvmPayload().kind() == JvmPayloadRequest.Kind.CITRUS_YAML
+                        || failedNonCitrus.getAndSet(true));
+
+        List<ShipStamp.Check> failures = validation.result().report().checks().stream()
+                .filter(check -> check.mandatory() && !check.passed())
+                .toList();
+        assertEquals(ShipValidationService.Verdict.FAIL, validation.result().verdict());
+        assertEquals(1, failures.size());
+        assertFalse(failures.get(0).id().startsWith("citrus-integration-test-"));
+        assertNull(validation.result().failedCheck());
+    }
+
+    @Test
+    void multipleFailedMandatoryChecksAreTerminalFailure() throws Exception {
+        DurableFlow flow = validationRunningFlow("validation-multiple-failures");
+
+        ValidationFixture validation = validationFixture(flow, command -> false);
+
+        long failures = validation.result().report().checks().stream()
+                .filter(check -> check.mandatory() && !check.passed())
+                .count();
+        assertEquals(ShipValidationService.Verdict.FAIL, validation.result().verdict());
+        assertTrue(failures > 1);
+        assertNull(validation.result().failedCheck());
     }
 
     @Test
@@ -1127,6 +1201,16 @@ class ShipRunProjectorTest {
         ValidationFixture validation = recordValidation(flow, false);
         BlobReference evidence = validation.failedEvidence();
         ShipStamp.Check failed = validation.result().failedCheck();
+        return requestWaiver(flow, evidence, failed, validation, originalBundle);
+    }
+
+    private static PendingWaiver requestWaiver(
+            DurableFlow flow,
+            BlobReference evidence,
+            ShipStamp.Check failed,
+            ValidationFixture validation,
+            BlobReference originalBundle)
+            throws Exception {
         String checkId = failed.id();
         String policy = flow.view.authority().authority().basis().policy().value();
 
@@ -1633,10 +1717,17 @@ class ShipRunProjectorTest {
     private static ValidationFixture validationFixture(
             DurableFlow flow, boolean citrusPassed)
             throws Exception {
+        return validationFixture(
+                flow,
+                command -> citrusPassed
+                        || command.jvmPayload().kind() != JvmPayloadRequest.Kind.CITRUS_YAML);
+    }
+
+    private static ValidationFixture validationFixture(
+            DurableFlow flow, Predicate<EvidenceCommand> passes)
+            throws Exception {
         StageRequest request = flow.view.activeRequest();
-        byte[] content = (citrusPassed
-                ? "validation passed"
-                : "validation requires waiver").getBytes(StandardCharsets.UTF_8);
+        byte[] content = "validation result".getBytes(StandardCharsets.UTF_8);
         BlobReference workerValidation = flow.blobs.writeBytes("validation", content);
         ProducedArtifact claim = new ProducedArtifact(
                 "validation",
@@ -1688,7 +1779,7 @@ class ShipRunProjectorTest {
                             candidate,
                             evidenceDirectory,
                             command,
-                            citrusPassed),
+                            passes),
                     Clock.fixed(NOW, ZoneOffset.UTC))
                     .validate(
                             flow.blobs,
@@ -1734,6 +1825,20 @@ class ShipRunProjectorTest {
             EvidenceCommand command,
             boolean citrusPassed)
             throws IOException {
+        return deterministicEvidence(
+                candidate,
+                evidenceDirectory,
+                command,
+                ignored -> citrusPassed
+                        || command.jvmPayload().kind() != JvmPayloadRequest.Kind.CITRUS_YAML);
+    }
+
+    private static CommandEvidence deterministicEvidence(
+            Path candidate,
+            Path evidenceDirectory,
+            EvidenceCommand command,
+            Predicate<EvidenceCommand> passes)
+            throws IOException {
         Files.createDirectory(evidenceDirectory);
         Path sandboxDirectory = Files.createDirectory(
                 evidenceDirectory.resolve("." + command.id() + "-sandbox-fixture"));
@@ -1767,8 +1872,7 @@ class ShipRunProjectorTest {
         String stderrDigest = ShipDigest.sha256(Files.readAllBytes(stderr));
         String jdkDigest = ShipDigest.sha256(
                 "fixture-jdk".getBytes(StandardCharsets.UTF_8));
-        boolean passed = citrusPassed
-                || command.jvmPayload().kind() != JvmPayloadRequest.Kind.CITRUS_YAML;
+        boolean passed = passes.test(command);
         String version = command.jvmPayload().kind()
                          == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT
                                  ? ShipMainPackageMain.PAYLOAD_VERSION

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResultReaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResultReaderTest.java
@@ -94,6 +94,10 @@ class ShipStageResultReaderTest {
                         ShipJson.mapper().writeValueAsBytes(result)));
 
         assertTrue(failure.getMessage().contains("production broker/import boundary"));
+        assertEquals(
+                result,
+                ShipStageResultReader.readBrokered(
+                        request, ShipJson.mapper().writeValueAsBytes(result)));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStampPackageEvidenceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStampPackageEvidenceTest.java
@@ -27,17 +27,32 @@ class ShipStampPackageEvidenceTest {
     }
 
     @Test
-    void waiverStatusRemainsUnavailableUntilEvidenceBoundPolicyLands() {
+    void waiverStatusRequiresExactFailedMandatoryCheckEvidence() {
         List<ShipStamp.Check> checks = passingChecks();
-        checks.add(check("experimental-runner", false, false));
-        ShipStamp.Waiver scaffold = new ShipStamp.Waiver(
-                "experimental-runner", digest(70), digest(71));
+        ShipStamp.Check failed = check("citrus-integration-test-001", true, false);
+        checks.set(
+                checks.indexOf(checks.stream()
+                        .filter(check -> failed.id().equals(check.id()))
+                        .findFirst()
+                        .orElseThrow()),
+                failed);
 
-        IllegalArgumentException failure = assertThrows(
+        ShipStamp.Waiver waiver = new ShipStamp.Waiver(
+                failed.id(), failed.evidenceDigest(), digest(71));
+        assertDoesNotThrow(
+                () -> stamp(
+                        ShipStamp.Status.COMPLETED_WITH_WAIVER,
+                        checks,
+                        List.of(waiver)));
+
+        ShipStamp.Waiver mismatched = new ShipStamp.Waiver(
+                failed.id(), digest(70), digest(71));
+        assertThrows(
                 IllegalArgumentException.class,
-                () -> stamp(ShipStamp.Status.COMPLETED_WITH_WAIVER, checks, List.of(scaffold)));
-
-        assertTrue(failure.getMessage().contains("waiver"));
+                () -> stamp(
+                        ShipStamp.Status.COMPLETED_WITH_WAIVER,
+                        checks,
+                        List.of(mismatched)));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStampPackageEvidenceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStampPackageEvidenceTest.java
@@ -12,6 +12,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class ShipStampPackageEvidenceTest {
 
     @Test
+    void evidenceBoundStampUsesSchemaVersionTwo() {
+        assertEquals(2, ShipStamp.SCHEMA_VERSION);
+        assertEquals(
+                ShipStamp.SCHEMA_VERSION,
+                stamp(ShipStamp.Status.PASS, passingChecks(), List.of()).schemaVersion());
+    }
+
+    @Test
     void stampRequiresExactlyOneMandatoryPackageInspectionCheck() {
         List<ShipStamp.Check> checks = passingChecks();
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipWorkspaceServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipWorkspaceServiceTest.java
@@ -15,6 +15,7 @@ import io.github.luigidemasi.camelkit.ship.protocol.StageCapability.RepositoryAc
 import io.github.luigidemasi.camelkit.ship.protocol.StageRequest;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResult;
 import io.github.luigidemasi.camelkit.ship.protocol.StageResultValidationException;
+import io.github.luigidemasi.camelkit.ship.security.StagedArtifactSource;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,7 @@ class ShipWorkspaceServiceTest {
 
         StageResultValidationException error = assertThrows(
                 StageResultValidationException.class,
-                () -> ShipWorkspaceService.accept(request, forged, output, blobs));
+                () -> accept(request, forged));
 
         org.junit.jupiter.api.Assertions.assertTrue(error.getMessage().contains("challenge"));
         assertEquals(0, entryCount(runRoot.resolve("blobs")));
@@ -91,7 +92,7 @@ class ShipWorkspaceServiceTest {
         StageRequest request = request();
         StageResult result = result(request, artifact);
 
-        ShipWorkspaceService.AcceptedWorkspace workspace = ShipWorkspaceService.accept(request, result, output, blobs);
+        ShipWorkspaceService.AcceptedWorkspace workspace = accept(request, result);
         Files.writeString(output.resolve("design.md"), "mutated after acceptance");
 
         assertEquals(RUN_ID, workspace.runId());
@@ -158,6 +159,40 @@ class ShipWorkspaceServiceTest {
                 null,
                 null,
                 null);
+    }
+
+    private ShipWorkspaceService.AcceptedWorkspace accept(
+            StageRequest request, StageResult result)
+            throws Exception {
+        byte[] encoded = ShipJson.mapper().writeValueAsBytes(result);
+        ShipProtectedWorkerBroker broker = new ShipProtectedWorkerBroker(
+                new ShipController(temporaryDirectory.resolve("unused-controller")),
+                ignored -> new ShipProtectedWorkerBroker.Custody() {
+                    @Override
+                    public void requireExactAttempt(StageRequest expected) {
+                    }
+
+                    @Override
+                    public byte[] readResultBytes() {
+                        return encoded;
+                    }
+
+                    @Override
+                    public StagedArtifactSource.Session openArtifactSource() throws java.io.IOException {
+                        return StagedArtifactSource.open(output);
+                    }
+
+                    @Override
+                    public void close() {
+                    }
+                });
+        try (ShipProtectedWorkerBroker.CompletedAttempt completed = broker.acquire(request);
+             ShipBlobStore.Transaction transaction = blobs.beginTransaction()) {
+            ShipWorkspaceService.AcceptedWorkspace workspace = ShipWorkspaceService.accept(
+                    request, result, completed, blobs, transaction);
+            transaction.commit();
+            return workspace;
+        }
     }
 
     private static long entryCount(Path directory) throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -90,9 +90,24 @@ class EvidenceRunnerTest {
         EvidenceRunner.cleanupEphemeral(controllerRoot.resolve("evidence"), command, result);
         assertFalse(Files.exists(rawStdout));
         assertFalse(Files.exists(rawStderr));
-        try (var entries = Files.list(controllerRoot.resolve("evidence"))) {
-            assertTrue(entries.noneMatch(path -> path.getFileName().toString().contains("-sandbox-")));
-        }
+        assertFalse(Files.exists(controllerRoot.resolve("evidence")));
+    }
+
+    @Test
+    void abandonedEvidenceCleanupDoesNotFollowLinksOutsideItsExclusiveRoot() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path evidenceDirectory = Files.createDirectory(tempDir.resolve("partial-evidence"));
+        Path outside = Files.createDirectory(tempDir.resolve("outside"));
+        Path sentinel = Files.writeString(outside.resolve("sentinel"), "preserve");
+        Files.writeString(evidenceDirectory.resolve("partial.log"), "partial");
+        Files.createSymbolicLink(evidenceDirectory.resolve("outside-link"), outside);
+
+        EvidenceRunner.cleanupAbandoned(
+                evidenceDirectory,
+                command(project, "partial-check", Duration.ofSeconds(2)));
+
+        assertFalse(Files.exists(evidenceDirectory, java.nio.file.LinkOption.NOFOLLOW_LINKS));
+        assertEquals("preserve", Files.readString(sentinel));
     }
 
     @Test
@@ -327,9 +342,7 @@ class EvidenceRunnerTest {
                 new FixtureToolchainResolver(), new FixtureJdkResolver());
         assertThrows(Exception.class, () -> missingSandbox.run(
                 project, tempDir.resolve("evidence-a"), command));
-        try (var entries = Files.list(tempDir.resolve("evidence-a"))) {
-            assertTrue(entries.noneMatch(path -> path.getFileName().toString().contains("-sandbox-")));
-        }
+        assertFalse(Files.exists(tempDir.resolve("evidence-a")));
 
         Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
         RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);


### PR DESCRIPTION
## Summary

- introduce a controller-owned protected worker broker and transactional artifact import into protected content-addressed storage
- retain canonical validation reports, command evidence, logs, and candidate-integrity observations for independent replay
- derive PASS and exact-policy waiver Stamps from controller evidence rather than worker self-attestation
- publish completed output with a recoverable journal and atomic protected-store operations
- wire the new evidence, Stamp, publication, projector, and artifact-import paths through the controller

## Review hardening

- own staged candidates through event commit, clean definite failures, and reconcile crash or ambiguous leftovers against the exact authenticated replay history
- directly test live-publication rollback, predecessor and committed recovery, unknown mixtures, journal metadata and identity rejection, all append-outcome branches, broker custody closure, protected PASS completion, and the WAIVABLE protected-interaction boundary
- clean abandoned evidence roots, use typed validation bindings and named event factories, bump the evidence-bound Stamp schema to version 2, and remove redundant replay work
- preserve the four accepted-candidate lifetime bound required by full historical replay

## Round-two crash recovery

- sweep only securely validated private `.live-publication.json-*` write-ahead temps before candidate reconciliation
- bind one exact per-artifact live-project temp path into publication journal schema v2 before mutation and reuse it for both forward publication and rollback
- recover only journal-bound live temps, reject unsafe metadata, and preserve unbound `.camel-kit-publish-*` user material
- directly cover pre-journal and post-journal crash residues, interrupted rollback, completed and predecessor recovery, symlink rejection, and unbound user material
- drive waived completion through the real controller API and pin terminal FAIL for non-Citrus and multiple mandatory failures
- group replay verification arguments in typed `VerificationInputs` and remove the remaining inline fully-qualified names

## Validation

- `./mvnw -B clean install`
- all seven reactor modules passed
- 889 Core tests passed with zero failures, errors, or skips
- JBang plugin tests and artifact-import integration tests passed
- formatting, import ordering, isolation suites, and forbidden-API checks passed

## Website impact

Not required for this internal controller implementation slice. Issue #149 still has required website work for the eventual public command, migration, support-matrix, and completion behavior.

Refs #149
