### PR TITLE
Add Ship legacy cutover and conformance evidence

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifier.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifier.java
@@ -1,0 +1,235 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipJson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Strict parser for raw, non-admitting evidence from one exact adapter tuple. */
+public final class AdapterConformanceEvidenceVerifier {
+
+    private static final String SUITE_RESOURCE = "ship/adapter-conformance-suite.json";
+    private static final int EVIDENCE_SCHEMA_VERSION = 2;
+    private static final int SUITE_SCHEMA_VERSION = 1;
+    private static final int MAX_EVIDENCE_BYTES = 64 * 1024;
+    private static final int MAX_SUITE_BYTES = 16 * 1024;
+    private static final int MAX_CHECKS = 64;
+    private static final Pattern ID = Pattern.compile("[a-z][a-z0-9-]{0,63}");
+    private static final Pattern VERSION = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
+    private static final Pattern PROFILE = Pattern.compile("[a-z0-9][a-z0-9._-]{0,127}");
+    private static final Set<String> OPERATING_SYSTEMS = Set.of("linux", "macos", "windows");
+    private static final ObjectMapper JSON = ShipJson.mapper();
+
+    private AdapterConformanceEvidenceVerifier() {
+    }
+
+    /** Parses and verifies raw conformance evidence without deriving support or runtime admission. */
+    public static ParsedEvidence verify(byte[] encoded) {
+        if (encoded == null || encoded.length == 0) {
+            throw invalid("evidence must not be empty", null);
+        }
+        if (encoded.length > MAX_EVIDENCE_BYTES) {
+            throw invalid("evidence exceeds " + MAX_EVIDENCE_BYTES + " bytes", null);
+        }
+
+        RawEvidence raw;
+        try {
+            raw = JSON.readValue(encoded, RawEvidence.class);
+        } catch (IOException | IllegalArgumentException e) {
+            throw invalid("could not parse evidence", e);
+        }
+        Suite suite = SuiteHolder.SUITE;
+        validateTuple(raw, suite);
+        List<CheckEvidence> checks = raw.checks().stream()
+                .map(check -> new CheckEvidence(check.checkId(), check.result(), check.evidenceDigest()))
+                .toList();
+        return new ParsedEvidence(
+                raw.harnessFamily(),
+                raw.harnessVersion(),
+                raw.adapterId(),
+                raw.adapterVersion(),
+                raw.protocolVersion(),
+                raw.operatingSystem(),
+                raw.architecture(),
+                raw.launchProfile(),
+                raw.runtimeProfile(),
+                raw.runtimeArtifactDigest(),
+                raw.driverDigest(),
+                raw.ingressDigest(),
+                raw.testSuiteDigest(),
+                checks);
+    }
+
+    private static void validateTuple(RawEvidence raw, Suite suite) {
+        if (raw == null || raw.schemaVersion() != EVIDENCE_SCHEMA_VERSION) {
+            throw invalid("schemaVersion must be " + EVIDENCE_SCHEMA_VERSION, null);
+        }
+        require(raw.harnessFamily(), ID, "harnessFamily");
+        require(raw.harnessVersion(), VERSION, "harnessVersion");
+        require(raw.adapterId(), ID, "adapterId");
+        require(raw.adapterVersion(), VERSION, "adapterVersion");
+        require(raw.protocolVersion(), VERSION, "protocolVersion");
+        if (!OPERATING_SYSTEMS.contains(raw.operatingSystem())) {
+            throw invalid("operatingSystem is not canonical", null);
+        }
+        require(raw.architecture(), PROFILE, "architecture");
+        require(raw.launchProfile(), PROFILE, "launchProfile");
+        require(raw.runtimeProfile(), PROFILE, "runtimeProfile");
+        requireDigest(raw.runtimeArtifactDigest(), "runtimeArtifactDigest");
+        requireDigest(raw.driverDigest(), "driverDigest");
+        requireDigest(raw.ingressDigest(), "ingressDigest");
+        if (!suite.digest().equals(raw.testSuiteDigest())) {
+            throw invalid("testSuiteDigest does not match the bundled mandatory suite", null);
+        }
+        validateChecks(raw.checks(), suite.mandatoryChecks());
+    }
+
+    private static void validateChecks(List<RawCheck> checks, List<String> mandatoryChecks) {
+        if (checks == null || checks.size() > MAX_CHECKS) {
+            throw invalid("checks must be a bounded array", null);
+        }
+        Set<String> seen = new HashSet<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (RawCheck check : checks) {
+            if (check == null) {
+                throw invalid("checks must not contain null", null);
+            }
+            require(check.checkId(), ID, "checkId");
+            if (!seen.add(check.checkId())) {
+                duplicates.add(check.checkId());
+            }
+            if (!"pass".equals(check.result()) && !"fail".equals(check.result())) {
+                throw invalid("check result must be pass or fail", null);
+            }
+            requireDigest(check.evidenceDigest(), "evidenceDigest");
+        }
+        if (!duplicates.isEmpty()) {
+            throw invalid("duplicate mandatory checks " + duplicates, null);
+        }
+        Set<String> missing = new LinkedHashSet<>(mandatoryChecks);
+        missing.removeAll(seen);
+        Set<String> unknown = new LinkedHashSet<>(seen);
+        unknown.removeAll(mandatoryChecks);
+        if (!missing.isEmpty() || !unknown.isEmpty()) {
+            throw invalid("mandatory check mismatch; missing=" + missing + ", unknown=" + unknown, null);
+        }
+        if (!checks.stream().map(RawCheck::checkId).toList().equals(mandatoryChecks)) {
+            throw invalid("mandatory checks are not in suite order", null);
+        }
+    }
+
+    private static void require(String value, Pattern pattern, String field) {
+        if (value == null || !pattern.matcher(value).matches()) {
+            throw invalid(field + " is not canonical or contains path syntax", null);
+        }
+    }
+
+    private static void requireDigest(String value, String field) {
+        if (!ShipDigest.isSha256(value)) {
+            throw invalid(field + " must be a canonical SHA-256 digest", null);
+        }
+    }
+
+    private static Suite loadSuite() {
+        InputStream input = AdapterConformanceEvidenceVerifier.class.getClassLoader()
+                .getResourceAsStream(SUITE_RESOURCE);
+        if (input == null) {
+            throw new IllegalStateException("Ship adapter conformance suite not found: " + SUITE_RESOURCE);
+        }
+        try (input) {
+            byte[] encoded = input.readNBytes(MAX_SUITE_BYTES + 1);
+            if (encoded.length == 0 || encoded.length > MAX_SUITE_BYTES) {
+                throw new IllegalStateException("Ship adapter conformance suite is empty or oversized");
+            }
+            SuiteManifest manifest = JSON.readValue(encoded, SuiteManifest.class);
+            if (manifest.suiteSchemaVersion() != SUITE_SCHEMA_VERSION
+                    || manifest.mandatoryChecks() == null
+                    || manifest.mandatoryChecks().isEmpty()
+                    || manifest.mandatoryChecks().size() > MAX_CHECKS) {
+                throw new IllegalStateException("Invalid Ship adapter conformance suite identity");
+            }
+            List<String> checks = List.copyOf(manifest.mandatoryChecks());
+            Set<String> unique = new HashSet<>();
+            if (checks.stream().anyMatch(check -> check == null || !ID.matcher(check).matches())
+                    || !checks.stream().allMatch(unique::add)) {
+                throw new IllegalStateException("Invalid Ship adapter conformance suite checks");
+            }
+            return new Suite(checks, ShipDigest.sha256(encoded));
+        } catch (IOException | IllegalArgumentException e) {
+            throw new IllegalStateException("Could not parse Ship adapter conformance suite", e);
+        }
+    }
+
+    private static IllegalArgumentException invalid(String message, Throwable cause) {
+        return new IllegalArgumentException("Invalid Ship adapter conformance evidence: " + message, cause);
+    }
+
+    /** Parsed raw evidence. This value is neither a support decision nor an admission capability. */
+    public record ParsedEvidence(
+            String harnessFamily,
+            String harnessVersion,
+            String adapterId,
+            String adapterVersion,
+            String protocolVersion,
+            String operatingSystem,
+            String architecture,
+            String launchProfile,
+            String runtimeProfile,
+            String runtimeArtifactDigest,
+            String driverDigest,
+            String ingressDigest,
+            String testSuiteDigest,
+            List<CheckEvidence> checks) {
+
+        public ParsedEvidence {
+            checks = List.copyOf(checks);
+        }
+    }
+
+    /** One bounded raw check outcome and the digest of its separately retained evidence. */
+    public record CheckEvidence(String checkId, String result, String evidenceDigest) {
+    }
+
+    private record RawEvidence(
+            int schemaVersion,
+            String harnessFamily,
+            String harnessVersion,
+            String adapterId,
+            String adapterVersion,
+            String protocolVersion,
+            String operatingSystem,
+            String architecture,
+            String launchProfile,
+            String runtimeProfile,
+            String runtimeArtifactDigest,
+            String driverDigest,
+            String ingressDigest,
+            String testSuiteDigest,
+            List<RawCheck> checks) {
+    }
+
+    private record RawCheck(String checkId, String result, String evidenceDigest) {
+    }
+
+    private record SuiteManifest(int suiteSchemaVersion, List<String> mandatoryChecks) {
+    }
+
+    private record Suite(List<String> mandatoryChecks, String digest) {
+    }
+
+    private static final class SuiteHolder {
+
+        private static final Suite SUITE = loadSuite();
+
+        private SuiteHolder() {
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -94,6 +94,7 @@ final class ShipController {
                     = ShipOperationLock.acquireRun(stateRoot, authority.id().toString());
                  ShipOperationLock.Lease project
                          = ShipOperationLock.acquireProject(stateRoot, prepared.projectRoot())) {
+                ShipLegacyStateGuard.requireStartable(prepared.projectRoot());
                 Path sourceDirectory = ShipControllerPaths.requireRunRoot(
                         stateRoot, authority.id()).resolve("source");
                 Files.createDirectory(
@@ -123,15 +124,15 @@ final class ShipController {
                         manifest,
                         sourceDirectory.toString());
                 projector(events, blobs, signer).preflightCreated(authority, data);
-                events.appendIfLatest(
-                        ShipEventHead.genesis(),
-                        new ShipEventDraft(
-                                ShipEventType.RUN_CREATED,
-                                ShipState.CREATED,
-                                null,
-                                authority.head(),
-                                now(),
-                                ShipStoredEventCodec.encode(command, data)));
+                ShipEventDraft draft = new ShipEventDraft(
+                        ShipEventType.RUN_CREATED,
+                        ShipState.CREATED,
+                        null,
+                        authority.head(),
+                        now(),
+                        ShipStoredEventCodec.encode(command, data));
+                ShipLegacyStateGuard.requireStartable(prepared.projectRoot());
+                events.appendIfLatest(ShipEventHead.genesis(), draft);
                 committed = true;
             }
             return projector(events, blobs, signer).replay();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipLegacyStateGuard.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipLegacyStateGuard.java
@@ -1,0 +1,205 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Rejects unsupported pre-release Ship state without changing user material. */
+final class ShipLegacyStateGuard {
+
+    static final int MAX_PIPELINE_BYTES = 1024 * 1024;
+
+    private static final Path CAMEL_KIT = Path.of(".camel-kit");
+    private static final Path PIPELINE = Path.of("pipeline.json");
+    private static final Path SHIP_STATE = Path.of("ship-state.json");
+
+    private ShipLegacyStateGuard() {
+    }
+
+    static void requireStartable(Path projectRoot) throws IOException {
+        Path root = Objects.requireNonNull(projectRoot, "projectRoot");
+        if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        BasicFileAttributes rootBefore = Files.readAttributes(
+                root, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!safeDirectory(rootBefore)) {
+            throw rejection(CAMEL_KIT, null);
+        }
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(root)) {
+            if (!(entries instanceof SecureDirectoryStream<Path> secureRoot)) {
+                throw rejection(CAMEL_KIT, null);
+            }
+            BasicFileAttributes camelKitBefore = optionalAttributes(secureRoot, CAMEL_KIT);
+            if (camelKitBefore == null) {
+                return;
+            }
+            if (!camelKitBefore.isDirectory()) {
+                if (camelKitBefore.isSymbolicLink()) {
+                    throw rejection(CAMEL_KIT, null);
+                }
+                return;
+            }
+            if (camelKitBefore.fileKey() == null) {
+                throw rejection(CAMEL_KIT, null);
+            }
+            try (SecureDirectoryStream<Path> camelKit
+                    = secureRoot.newDirectoryStream(CAMEL_KIT, LinkOption.NOFOLLOW_LINKS)) {
+                if (optionalAttributes(camelKit, SHIP_STATE) != null) {
+                    throw rejection(CAMEL_KIT.resolve(SHIP_STATE), null);
+                }
+                BasicFileAttributes pipelineBefore = optionalAttributes(camelKit, PIPELINE);
+                if (pipelineBefore == null) {
+                    return;
+                }
+                Path pipelinePath = root.resolve(CAMEL_KIT).resolve(PIPELINE);
+                requireSafePipeline(pipelinePath, pipelineBefore);
+                byte[] encoded = readBounded(camelKit);
+                BasicFileAttributes pipelineAfter = attributes(camelKit, PIPELINE);
+                requireUnchangedPipeline(pipelinePath, pipelineBefore, pipelineAfter, encoded.length);
+                requireManualPipeline(encoded);
+            } catch (ShipControllerException e) {
+                throw e;
+            } catch (IOException | RuntimeException e) {
+                throw rejection(CAMEL_KIT.resolve(PIPELINE), e);
+            }
+            BasicFileAttributes camelKitAfter = attributes(secureRoot, CAMEL_KIT);
+            if (!sameDirectory(camelKitBefore, camelKitAfter)) {
+                throw rejection(CAMEL_KIT, null);
+            }
+        } catch (ShipControllerException e) {
+            throw e;
+        } catch (IOException | RuntimeException e) {
+            throw rejection(CAMEL_KIT, e);
+        }
+        BasicFileAttributes rootAfter = Files.readAttributes(
+                root, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!sameDirectory(rootBefore, rootAfter)) {
+            throw rejection(CAMEL_KIT, null);
+        }
+    }
+
+    private static byte[] readBounded(SecureDirectoryStream<Path> camelKit) throws IOException {
+        Set<OpenOption> options = Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+        try (SeekableByteChannel channel = camelKit.newByteChannel(PIPELINE, options);
+             ByteArrayOutputStream content = new ByteArrayOutputStream()) {
+            ByteBuffer buffer = ByteBuffer.allocate(8192);
+            int total = 0;
+            int read;
+            while ((read = channel.read(buffer)) >= 0) {
+                if (read == 0) {
+                    continue;
+                }
+                total += read;
+                if (total > MAX_PIPELINE_BYTES) {
+                    throw rejection(CAMEL_KIT.resolve(PIPELINE), null);
+                }
+                content.write(buffer.array(), 0, read);
+                buffer.clear();
+            }
+            return content.toByteArray();
+        }
+    }
+
+    private static void requireManualPipeline(byte[] encoded) throws IOException {
+        JsonNode document = ShipJson.mapper().readTree(encoded);
+        JsonNode mode = document != null && document.isObject() ? document.get("mode") : null;
+        if (mode == null || !mode.isTextual() || !"manual".equals(mode.textValue())) {
+            throw rejection(CAMEL_KIT.resolve(PIPELINE), null);
+        }
+    }
+
+    private static void requireSafePipeline(
+            Path pipeline, BasicFileAttributes attributes)
+            throws IOException {
+        if (!attributes.isRegularFile()
+                || attributes.isSymbolicLink()
+                || attributes.fileKey() == null
+                || attributes.size() < 0
+                || attributes.size() > MAX_PIPELINE_BYTES
+                || linkCount(pipeline) != 1) {
+            throw rejection(CAMEL_KIT.resolve(PIPELINE), null);
+        }
+    }
+
+    private static void requireUnchangedPipeline(
+            Path pipeline,
+            BasicFileAttributes before,
+            BasicFileAttributes after,
+            int bytesRead)
+            throws IOException {
+        if (!after.isRegularFile()
+                || after.isSymbolicLink()
+                || after.fileKey() == null
+                || !before.fileKey().equals(after.fileKey())
+                || before.size() != after.size()
+                || after.size() != bytesRead
+                || !before.lastModifiedTime().equals(after.lastModifiedTime())
+                || linkCount(pipeline) != 1) {
+            throw rejection(CAMEL_KIT.resolve(PIPELINE), null);
+        }
+    }
+
+    private static long linkCount(Path path) throws IOException {
+        Object value = Files.getAttribute(path, "unix:nlink", LinkOption.NOFOLLOW_LINKS);
+        if (!(value instanceof Number number)) {
+            throw rejection(CAMEL_KIT.resolve(PIPELINE), null);
+        }
+        return number.longValue();
+    }
+
+    private static BasicFileAttributes optionalAttributes(
+            SecureDirectoryStream<Path> directory, Path name)
+            throws IOException {
+        try {
+            return attributes(directory, name);
+        } catch (NoSuchFileException e) {
+            return null;
+        }
+    }
+
+    private static BasicFileAttributes attributes(
+            SecureDirectoryStream<Path> directory, Path name)
+            throws IOException {
+        BasicFileAttributeView view = directory.getFileAttributeView(
+                name, BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        if (view == null) {
+            throw rejection(CAMEL_KIT.resolve(name), null);
+        }
+        return view.readAttributes();
+    }
+
+    private static boolean safeDirectory(BasicFileAttributes attributes) {
+        return attributes.isDirectory()
+                && !attributes.isSymbolicLink()
+                && attributes.fileKey() != null;
+    }
+
+    private static boolean sameDirectory(
+            BasicFileAttributes before, BasicFileAttributes after) {
+        return safeDirectory(after) && before.fileKey().equals(after.fileKey());
+    }
+
+    private static ShipControllerException rejection(Path relative, Throwable cause) {
+        String message = "Pre-release Ship state at " + relative
+                         + " is unsupported. Archive or move it outside the project and start a fresh controller run.";
+        return cause == null
+                ? new ShipControllerException("pre-release-ship-state", message)
+                : new ShipControllerException("pre-release-ship-state", message, cause);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipTreePolicy.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 /** One versioned classification and quota policy for every Ship project tree boundary. */
 public final class ShipTreePolicy {
 
-    private static final int SCHEMA_VERSION = 5;
+    private static final int SCHEMA_VERSION = 6;
     public static final int DEFAULT_MAX_FILE_COUNT = 20_000;
     public static final long DEFAULT_MAX_FILE_BYTES = 64L * 1024 * 1024;
     public static final long DEFAULT_MAX_AGGREGATE_BYTES = 1024L * 1024 * 1024;
@@ -25,7 +25,8 @@ public final class ShipTreePolicy {
             "denied:**/.git/**",
             "protected:**/.idea/**",
             "protected:**/.vscode/**",
-            "denied:**/.camel-kit/pipeline.json/**,**/.camel-kit/ship-projection.json/**",
+            "denied:**/.camel-kit/pipeline.json/**,**/.camel-kit/ship-state.json/**,"
+                                       + "**/.camel-kit/ship-projection.json/**",
             "volatile:**/.camel-kit/.cache/**,**/.camel-kit/mcp/**",
             "denied:credential directories .ssh,.gnupg,.aws,.azure,.kube,.docker",
             "denied:credential files .env,.env.* except final .env.example,.npmrc,.pypirc,.netrc",
@@ -111,6 +112,7 @@ public final class ShipTreePolicy {
         String folded = path.toLowerCase(Locale.ROOT);
         if (subtreeAtAnyDepth(folded, ".git")
                 || subtreeAtAnyDepth(folded, ".camel-kit/pipeline.json")
+                || subtreeAtAnyDepth(folded, ".camel-kit/ship-state.json")
                 || subtreeAtAnyDepth(folded, ".camel-kit/ship-projection.json")
                 || isCredentialPath(folded)) {
             return Classification.DENIED;
@@ -274,7 +276,7 @@ public final class ShipTreePolicy {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 is unavailable", e);
         }
-        update(hash, "camel-kit.ship.tree-policy.v5");
+        update(hash, "camel-kit.ship.tree-policy.v6");
         update(hash, Integer.toString(SCHEMA_VERSION));
         update(hash, Integer.toString(maxFileCount));
         update(hash, Long.toString(maxFileBytes));

--- a/camel-kit-core/src/main/resources/ship/adapter-conformance-suite.json
+++ b/camel-kit-core/src/main/resources/ship/adapter-conformance-suite.json
@@ -1,0 +1,17 @@
+{
+  "suiteSchemaVersion": 1,
+  "mandatoryChecks": [
+    "native-ingress",
+    "optional-context-transport",
+    "protected-interaction-binding",
+    "immutable-launch",
+    "capability-isolation",
+    "worker-cancellation",
+    "stopped-process-tree",
+    "exclusive-output-custody",
+    "artifact-import",
+    "crash-resume-replay",
+    "adversarial-containment",
+    "live-e2e"
+  ]
+}

--- a/camel-kit-core/src/main/resources/ship/schema/adapter-conformance-evidence.schema.json
+++ b/camel-kit-core/src/main/resources/ship/schema/adapter-conformance-evidence.schema.json
@@ -1,38 +1,61 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/luigidemasi/camel-kit/schemas/ship/v1/adapter-conformance-evidence.schema.json",
-  "title": "Camel Ship adapter conformance evidence",
-  "description": "Closed archival shape only. Positive runtime admission requires the later signed evidence-v2 verifier.",
+  "$id": "https://github.com/luigidemasi/camel-kit/schemas/ship/v2/adapter-conformance-evidence.schema.json",
+  "title": "Camel Ship adapter conformance evidence v2",
+  "description": "Closed raw evidence-v2 tuple. It neither declares nor grants support status or runtime admission.",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schemaVersion",
-    "harnessId",
+    "harnessFamily",
     "harnessVersion",
+    "adapterId",
+    "adapterVersion",
+    "protocolVersion",
+    "operatingSystem",
+    "architecture",
+    "launchProfile",
+    "runtimeProfile",
     "runtimeArtifactDigest",
     "driverDigest",
     "ingressDigest",
-    "ingressMode",
-    "interactionProfile",
-    "launcherProfile",
-    "sandboxProfile",
-    "providerProfile",
-    "protocolProfile",
-    "evidenceProfile",
     "testSuiteDigest",
-    "operatingSystem",
     "checks"
   ],
   "properties": {
     "schemaVersion": {
-      "const": 1
+      "const": 2
     },
-    "harnessId": {
-      "type": "string",
-      "pattern": "^[a-z][a-z0-9-]{0,63}$"
+    "harnessFamily": {
+      "$ref": "#/$defs/id"
     },
     "harnessVersion": {
       "$ref": "#/$defs/version"
+    },
+    "adapterId": {
+      "$ref": "#/$defs/id"
+    },
+    "adapterVersion": {
+      "$ref": "#/$defs/version"
+    },
+    "protocolVersion": {
+      "$ref": "#/$defs/version"
+    },
+    "operatingSystem": {
+      "enum": [
+        "linux",
+        "macos",
+        "windows"
+      ]
+    },
+    "architecture": {
+      "$ref": "#/$defs/profile"
+    },
+    "launchProfile": {
+      "$ref": "#/$defs/profile"
+    },
+    "runtimeProfile": {
+      "$ref": "#/$defs/profile"
     },
     "runtimeArtifactDigest": {
       "$ref": "#/$defs/digest"
@@ -43,51 +66,98 @@
     "ingressDigest": {
       "$ref": "#/$defs/digest"
     },
-    "ingressMode": {
-      "$ref": "#/$defs/profile"
-    },
-    "interactionProfile": {
-      "$ref": "#/$defs/profile"
-    },
-    "launcherProfile": {
-      "$ref": "#/$defs/profile"
-    },
-    "sandboxProfile": {
-      "$ref": "#/$defs/profile"
-    },
-    "providerProfile": {
-      "$ref": "#/$defs/profile"
-    },
-    "protocolProfile": {
-      "$ref": "#/$defs/profile"
-    },
-    "evidenceProfile": {
-      "$ref": "#/$defs/profile"
-    },
     "testSuiteDigest": {
       "$ref": "#/$defs/digest"
     },
-    "operatingSystem": {
-      "enum": [
-        "linux",
-        "macos",
-        "windows"
-      ]
-    },
     "checks": {
       "type": "array",
-      "minItems": 1,
-      "maxItems": 64,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/$defs/checkResult"
-      }
+      "minItems": 12,
+      "maxItems": 12,
+      "prefixItems": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "native-ingress" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "optional-context-transport" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "protected-interaction-binding" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "immutable-launch" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "capability-isolation" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "worker-cancellation" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "stopped-process-tree" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "exclusive-output-custody" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "artifact-import" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "crash-resume-replay" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "adversarial-containment" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/checkResult" },
+            { "properties": { "checkId": { "const": "live-e2e" } } }
+          ]
+        }
+      ],
+      "items": false
     }
   },
   "$defs": {
     "digest": {
       "type": "string",
       "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{0,63}$"
     },
     "profile": {
       "type": "string",
@@ -103,14 +173,14 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "check",
+        "checkId",
         "result",
         "evidenceDigest"
       ],
       "properties": {
-        "check": {
+        "checkId": {
           "type": "string",
-          "pattern": "^[a-z][a-z0-9_-]{0,127}$"
+          "pattern": "^[a-z][a-z0-9-]{0,63}$"
         },
         "result": {
           "enum": [

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifierTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifierTest.java
@@ -100,6 +100,19 @@ class AdapterConformanceEvidenceVerifierTest {
                 () -> AdapterConformanceEvidenceVerifier.verify(new byte[64 * 1024 + 1]));
     }
 
+    @Test
+    void rejectsNullAndEmptyEvidence() {
+        IllegalArgumentException nullEvidence = assertThrows(IllegalArgumentException.class,
+                () -> AdapterConformanceEvidenceVerifier.verify(null));
+        IllegalArgumentException emptyEvidence = assertThrows(IllegalArgumentException.class,
+                () -> AdapterConformanceEvidenceVerifier.verify(new byte[0]));
+
+        assertEquals("Invalid Ship adapter conformance evidence: evidence must not be empty",
+                nullEvidence.getMessage());
+        assertEquals("Invalid Ship adapter conformance evidence: evidence must not be empty",
+                emptyEvidence.getMessage());
+    }
+
     private static ParsedEvidence verify(String raw) {
         return AdapterConformanceEvidenceVerifier.verify(raw.getBytes(StandardCharsets.UTF_8));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifierTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifierTest.java
@@ -1,0 +1,153 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.conformance.AdapterConformanceEvidenceVerifier.ParsedEvidence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AdapterConformanceEvidenceVerifierTest {
+
+    private static final String SUITE_RESOURCE = "ship/adapter-conformance-suite.json";
+    private static final String DIGEST = "sha256:" + "a".repeat(64);
+    private static final List<String> CHECKS = List.of(
+            "native-ingress",
+            "optional-context-transport",
+            "protected-interaction-binding",
+            "immutable-launch",
+            "capability-isolation",
+            "worker-cancellation",
+            "stopped-process-tree",
+            "exclusive-output-custody",
+            "artifact-import",
+            "crash-resume-replay",
+            "adversarial-containment",
+            "live-e2e");
+
+    @Test
+    void parsesTheCompleteExactTupleWithoutDerivingStatus() throws Exception {
+        ParsedEvidence evidence = verify(validEvidence(CHECKS));
+
+        assertEquals("codex", evidence.harnessFamily());
+        assertEquals("1.2.3", evidence.harnessVersion());
+        assertEquals("codex-native", evidence.adapterId());
+        assertEquals("2.0.0", evidence.adapterVersion());
+        assertEquals("2", evidence.protocolVersion());
+        assertEquals("linux", evidence.operatingSystem());
+        assertEquals("amd64", evidence.architecture());
+        assertEquals("native-v1", evidence.launchProfile());
+        assertEquals("camel-main-v1", evidence.runtimeProfile());
+        assertEquals(CHECKS, evidence.checks().stream().map(check -> check.checkId()).toList());
+        assertEquals(12, evidence.checks().size());
+    }
+
+    @Test
+    void acceptsFailedRawChecksWithoutTurningThemIntoAnAdmissionDecision() throws Exception {
+        String raw = validEvidence(CHECKS).replaceFirst("\"result\": \"pass\"", "\"result\": \"fail\"");
+
+        assertEquals("fail", verify(raw).checks().get(0).result());
+    }
+
+    @Test
+    void rejectsMissingUnknownDuplicateAndReorderedMandatoryChecks() throws Exception {
+        assertInvalid(validEvidence(CHECKS.subList(0, CHECKS.size() - 1)));
+
+        List<String> unknown = new ArrayList<>(CHECKS);
+        unknown.set(unknown.size() - 1, "unknown-check");
+        assertInvalid(validEvidence(unknown));
+
+        List<String> duplicate = new ArrayList<>(CHECKS);
+        duplicate.set(duplicate.size() - 1, CHECKS.get(0));
+        assertInvalid(validEvidence(duplicate));
+
+        List<String> reordered = new ArrayList<>(CHECKS);
+        String first = reordered.set(1, reordered.get(0));
+        reordered.set(0, first);
+        assertInvalid(validEvidence(reordered));
+    }
+
+    @Test
+    void rejectsMissingDimensionsPathsRawStatusAndDigestMismatch() throws Exception {
+        String valid = validEvidence(CHECKS);
+        assertInvalid(valid.replace("  \"architecture\": \"amd64\",\n", ""));
+        assertInvalid(valid.replace("\"harnessVersion\": \"1.2.3\"",
+                "\"harnessVersion\": \"../1.2.3\""));
+        assertInvalid(valid.replace("  \"schemaVersion\": 2,",
+                "  \"schemaVersion\": 2,\n  \"runtimeArtifactPath\": \"/tmp/runtime.jar\","));
+        assertInvalid(valid.replace("  \"schemaVersion\": 2,",
+                "  \"schemaVersion\": 2,\n  \"status\": \"supported\","));
+        assertInvalid(valid.replace(suiteDigest(), "sha256:" + "0".repeat(64)));
+        assertInvalid(valid.replaceFirst(DIGEST, "sha256:invalid"));
+    }
+
+    @Test
+    void rejectsDuplicateFieldsTrailingDocumentsAndOversizedInput() throws Exception {
+        String valid = validEvidence(CHECKS);
+        assertInvalid(valid.replace("  \"schemaVersion\": 2,",
+                "  \"schemaVersion\": 2,\n  \"schemaVersion\": 2,"));
+        assertInvalid(valid + "{}");
+        assertThrows(IllegalArgumentException.class,
+                () -> AdapterConformanceEvidenceVerifier.verify(new byte[64 * 1024 + 1]));
+    }
+
+    private static ParsedEvidence verify(String raw) {
+        return AdapterConformanceEvidenceVerifier.verify(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void assertInvalid(String raw) {
+        assertThrows(IllegalArgumentException.class, () -> verify(raw));
+    }
+
+    private static String validEvidence(List<String> checks) throws IOException {
+        String checkRows = checks.stream()
+                .map(check -> String.format(Locale.ROOT, """
+                          {
+                            "checkId": "%s",
+                            "result": "pass",
+                            "evidenceDigest": "%s"
+                          }
+                        """, check, DIGEST).strip())
+                .collect(Collectors.joining(",\n"));
+        return String.format(Locale.ROOT, """
+                {
+                  "schemaVersion": 2,
+                  "harnessFamily": "codex",
+                  "harnessVersion": "1.2.3",
+                  "adapterId": "codex-native",
+                  "adapterVersion": "2.0.0",
+                  "protocolVersion": "2",
+                  "operatingSystem": "linux",
+                  "architecture": "amd64",
+                  "launchProfile": "native-v1",
+                  "runtimeProfile": "camel-main-v1",
+                  "runtimeArtifactDigest": "%s",
+                  "driverDigest": "%s",
+                  "ingressDigest": "%s",
+                  "testSuiteDigest": "%s",
+                  "checks": [
+                %s
+                  ]
+                }
+                """, DIGEST, DIGEST, DIGEST, suiteDigest(), checkRows);
+    }
+
+    private static String suiteDigest() throws IOException {
+        try (InputStream input = AdapterConformanceEvidenceVerifierTest.class.getClassLoader()
+                .getResourceAsStream(SUITE_RESOURCE)) {
+            if (input == null) {
+                throw new IOException("Missing test suite resource: " + SUITE_RESOURCE);
+            }
+            return ShipDigest.sha256(input.readAllBytes());
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -1,10 +1,14 @@
 package io.github.luigidemasi.camelkit.ship.controller;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -461,6 +466,169 @@ class ShipControllerTest {
     }
 
     @Test
+    void validManualPipelineStateIsPreservedAndExcludedFromTheRunSource() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("manual-pipeline-project"))
+                .toAbsolutePath().normalize();
+        Path state = temporaryDirectory.resolve("manual-pipeline-state")
+                .toAbsolutePath().normalize();
+        Path pipeline = Files.createDirectories(project.resolve(".camel-kit"))
+                .resolve("pipeline.json");
+        byte[] content = "{\"mode\":\"manual\",\"phase\":\"design\"}"
+                .getBytes(StandardCharsets.UTF_8);
+        Files.write(pipeline, content);
+
+        ShipRunView created = controller(state).start(prepared(project));
+
+        assertEquals(ShipState.CREATED, created.state());
+        assertArrayEquals(content, Files.readAllBytes(pipeline));
+        assertFalse(Files.exists(
+                created.sourceDirectory().resolve(".camel-kit/pipeline.json"),
+                LinkOption.NOFOLLOW_LINKS));
+    }
+
+    @Test
+    void preReleasePipelineStatesAreRejectedAndPreservedBeforeRunCreation() throws Exception {
+        List<String> rejected = List.of(
+                "{\"mode\":\"ship\"}",
+                "{\"mode\":\"manual\",\"mode\":\"manual\"}",
+                "{\"mode\":\"manual\"} trailing",
+                "{}",
+                "[]",
+                "{\"mode\":1}",
+                "{\"mode\":\"unknown\"}");
+        for (int index = 0; index < rejected.size(); index++) {
+            Path project = Files.createDirectory(
+                    temporaryDirectory.resolve("rejected-pipeline-project-" + index))
+                    .toAbsolutePath().normalize();
+            Path state = temporaryDirectory.resolve("rejected-pipeline-state-" + index)
+                    .toAbsolutePath().normalize();
+            Path pipeline = Files.createDirectories(project.resolve(".camel-kit"))
+                    .resolve("pipeline.json");
+            byte[] content = rejected.get(index).getBytes(StandardCharsets.UTF_8);
+            Files.write(pipeline, content);
+
+            ShipControllerException failure = assertThrows(
+                    ShipControllerException.class,
+                    () -> controller(state).start(prepared(project)));
+
+            assertEquals("pre-release-ship-state", failure.code());
+            assertTrue(failure.getMessage().contains("Archive or move it outside the project"));
+            assertArrayEquals(content, Files.readAllBytes(pipeline));
+            assertNoRunRoot(state);
+        }
+    }
+
+    @Test
+    void oversizedAndUnsafePipelineStateIsRejectedWithoutFollowingOrChangingIt() throws Exception {
+        Path oversizedProject = Files.createDirectory(temporaryDirectory.resolve("oversized-pipeline-project"))
+                .toAbsolutePath().normalize();
+        Path oversizedState = temporaryDirectory.resolve("oversized-pipeline-state")
+                .toAbsolutePath().normalize();
+        Path oversized = Files.createDirectories(oversizedProject.resolve(".camel-kit"))
+                .resolve("pipeline.json");
+        byte[] oversizedContent = ("{\"mode\":\"manual\",\"padding\":\""
+                                   + "x".repeat(ShipLegacyStateGuard.MAX_PIPELINE_BYTES) + "\"}")
+                .getBytes(StandardCharsets.UTF_8);
+        Files.write(oversized, oversizedContent);
+
+        ShipControllerException oversizedFailure = assertThrows(
+                ShipControllerException.class,
+                () -> controller(oversizedState).start(prepared(oversizedProject)));
+        assertEquals("pre-release-ship-state", oversizedFailure.code());
+        assertArrayEquals(oversizedContent, Files.readAllBytes(oversized));
+        assertNoRunRoot(oversizedState);
+
+        Path linkedProject = Files.createDirectory(temporaryDirectory.resolve("linked-pipeline-project"))
+                .toAbsolutePath().normalize();
+        Path linkedState = temporaryDirectory.resolve("linked-pipeline-state")
+                .toAbsolutePath().normalize();
+        Path external = temporaryDirectory.resolve("external-pipeline.json");
+        byte[] externalContent = "{\"mode\":\"manual\"}".getBytes(StandardCharsets.UTF_8);
+        Files.write(external, externalContent);
+        Path linked = Files.createDirectories(linkedProject.resolve(".camel-kit"))
+                .resolve("pipeline.json");
+        Files.createSymbolicLink(linked, external);
+
+        ShipControllerException linkedFailure = assertThrows(
+                ShipControllerException.class,
+                () -> controller(linkedState).start(prepared(linkedProject)));
+        assertEquals("pre-release-ship-state", linkedFailure.code());
+        assertTrue(Files.isSymbolicLink(linked));
+        assertArrayEquals(externalContent, Files.readAllBytes(external));
+        assertNoRunRoot(linkedState);
+    }
+
+    @Test
+    void anyShipStateEntryIsRejectedAndPreservedBeforeRunCreation() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("ship-state-project"))
+                .toAbsolutePath().normalize();
+        Path state = temporaryDirectory.resolve("ship-state-controller")
+                .toAbsolutePath().normalize();
+        Path shipState = Files.createDirectories(
+                project.resolve(".camel-kit/ship-state.json"));
+        Path sentinel = Files.writeString(shipState.resolve("sentinel"), "preserve");
+
+        ShipControllerException failure = assertThrows(
+                ShipControllerException.class,
+                () -> controller(state).start(prepared(project)));
+
+        assertEquals("pre-release-ship-state", failure.code());
+        assertEquals("preserve", Files.readString(sentinel));
+        assertNoRunRoot(state);
+    }
+
+    @Test
+    void startRechecksLegacyStateImmediatelyBeforeCommitting() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("rechecked-pipeline-project"))
+                .toAbsolutePath().normalize();
+        Path state = temporaryDirectory.resolve("rechecked-pipeline-state")
+                .toAbsolutePath().normalize();
+        Path pipeline = Files.createDirectories(project.resolve(".camel-kit"))
+                .resolve("pipeline.json");
+        byte[] manual = "{\"mode\":\"manual\"}".getBytes(StandardCharsets.UTF_8);
+        byte[] ship = "{\"mode\":\"ship\"}".getBytes(StandardCharsets.UTF_8);
+        Files.write(pipeline, manual);
+        Clock mutatingClock = new Clock() {
+            @Override
+            public ZoneId getZone() {
+                return ZoneOffset.UTC;
+            }
+
+            @Override
+            public Clock withZone(ZoneId zone) {
+                return this;
+            }
+
+            @Override
+            public Instant instant() {
+                try {
+                    Files.write(pipeline, ship);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                return Instant.parse("2025-01-01T00:00:00Z");
+            }
+        };
+
+        ShipControllerException failure = assertThrows(
+                ShipControllerException.class,
+                () -> new ShipController(state, mutatingClock).start(prepared(project)));
+
+        assertEquals("pre-release-ship-state", failure.code());
+        assertArrayEquals(ship, Files.readAllBytes(pipeline));
+        assertNoRunRoot(state);
+    }
+
+    private static void assertNoRunRoot(Path state) throws IOException {
+        assertTrue(Files.isDirectory(state, LinkOption.NOFOLLOW_LINKS));
+        try (Stream<Path> entries = Files.list(state)) {
+            assertEquals(0, entries
+                    .filter(path -> path.getFileName().toString().startsWith("ship-"))
+                    .count());
+        }
+    }
+
+    @Test
     void controllerStateAndProjectRootsMustBeDisjointBeforeCreation() throws Exception {
         Path project = Files.createDirectory(temporaryDirectory.resolve("overlap-project"))
                 .toAbsolutePath().normalize();
@@ -470,7 +638,7 @@ class ShipControllerTest {
                 ShipControllerException.class,
                 () -> controller(stateInsideProject).start(prepared(project)));
         assertEquals("state-project-overlap", nestedState.code());
-        assertFalse(Files.exists(stateInsideProject, java.nio.file.LinkOption.NOFOLLOW_LINKS));
+        assertFalse(Files.exists(stateInsideProject, LinkOption.NOFOLLOW_LINKS));
 
         Path state = Files.createDirectory(temporaryDirectory.resolve("overlap-state"))
                 .toAbsolutePath().normalize();

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/schema/ShipSchemaResourceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/schema/ShipSchemaResourceTest.java
@@ -53,6 +53,7 @@ class ShipSchemaResourceTest {
 
     private static final String DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
     private static final String ID_BASE = "https://github.com/luigidemasi/camel-kit/schemas/ship/v1/";
+    private static final String ID_BASE_V2 = "https://github.com/luigidemasi/camel-kit/schemas/ship/v2/";
     private static final String RESOURCE_BASE = "ship/schema/";
     private static final List<String> FILES = List.of(
             "adapter-conformance-evidence.schema.json",
@@ -79,7 +80,8 @@ class ShipSchemaResourceTest {
         for (String file : FILES) {
             JsonNode schema = readSchema(file);
             assertEquals(DRAFT_2020_12, schema.path("$schema").asText(), file);
-            assertEquals(ID_BASE + file, schema.path("$id").asText(), file);
+            String idBase = file.equals("adapter-conformance-evidence.schema.json") ? ID_BASE_V2 : ID_BASE;
+            assertEquals(idBase + file, schema.path("$id").asText(), file);
             assertStrictObjectSchemas(schema, file);
         }
     }
@@ -454,19 +456,45 @@ class ShipSchemaResourceTest {
     }
 
     @Test
-    void archivalAdapterSchemaCannotBeMistakenForRuntimeAdmission() throws Exception {
+    void adapterConformanceSchemaIsAClosedRawExactTuple() throws Exception {
         JsonNode schema = readSchema("adapter-conformance-evidence.schema.json");
         assertTrue(schema.path("description").asText().contains("evidence-v2"));
         Set<String> fields = fieldNames(schema.path("properties"));
-        assertFalse(fields.stream().anyMatch(field -> field.endsWith("RealPath")));
-        assertTrue(fields.containsAll(Set.of(
-                "ingressMode",
-                "interactionProfile",
-                "launcherProfile",
-                "sandboxProfile",
-                "providerProfile",
-                "protocolProfile",
-                "evidenceProfile")));
+        assertEquals(Set.of(
+                "schemaVersion",
+                "harnessFamily",
+                "harnessVersion",
+                "adapterId",
+                "adapterVersion",
+                "protocolVersion",
+                "operatingSystem",
+                "architecture",
+                "launchProfile",
+                "runtimeProfile",
+                "runtimeArtifactDigest",
+                "driverDigest",
+                "ingressDigest",
+                "testSuiteDigest",
+                "checks"), fields);
+        assertEquals(2, schema.at("/properties/schemaVersion/const").intValue());
+        assertFalse(schema.path("additionalProperties").booleanValue());
+        assertFalse(fields.stream().anyMatch(field -> field.toLowerCase(Locale.ROOT).contains("status")));
+        assertFalse(fields.stream().anyMatch(field -> field.toLowerCase(Locale.ROOT).contains("path")));
+        assertEquals(12, schema.at("/properties/checks/minItems").intValue());
+        assertEquals(12, schema.at("/properties/checks/maxItems").intValue());
+        assertEquals(List.of(
+                "native-ingress",
+                "optional-context-transport",
+                "protected-interaction-binding",
+                "immutable-launch",
+                "capability-isolation",
+                "worker-cancellation",
+                "stopped-process-tree",
+                "exclusive-output-custody",
+                "artifact-import",
+                "crash-resume-replay",
+                "adversarial-containment",
+                "live-e2e"), schema.at("/properties/checks/prefixItems").findValuesAsText("const"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -53,6 +53,7 @@ class ProjectSnapshotServiceTest {
         write(project, ".git/objects/01/object", "volatile");
         write(project, ".git/HEAD", "protected");
         write(project, ".camel-kit/pipeline.json", "protected");
+        write(project, ".camel-kit/ship-state.json", "protected");
         write(project, ".camel-kit/config.properties", "project.runtime=main");
         write(project, ".camel-kit/.cache/generated.json", "volatile");
         write(project, ".idea/workspace.xml", "protected metadata");
@@ -74,6 +75,7 @@ class ProjectSnapshotServiceTest {
         assertFalse(snapshot.files().containsKey(".git/objects/01/object"));
         assertFalse(snapshot.files().containsKey(".git/HEAD"));
         assertFalse(snapshot.files().containsKey(".camel-kit/pipeline.json"));
+        assertFalse(snapshot.files().containsKey(".camel-kit/ship-state.json"));
         assertFalse(snapshot.files().containsKey(".ssh/config"));
         assertFalse(snapshot.files().containsKey(".env"));
         assertFalse(snapshot.files().containsKey(".camel-kit/.cache/generated.json"));
@@ -161,6 +163,7 @@ class ProjectSnapshotServiceTest {
         Path project = project();
         Path material = write(project, "requirements.md", "requirements");
         write(project, ".camel-kit/pipeline.json", "private");
+        write(project, ".camel-kit/ship-state.json", "private");
         write(project, "target/generated.txt", "generated");
 
         try (ShipSecureFilesystem.SecureRoot root = ShipSecureFilesystem.open(
@@ -168,6 +171,8 @@ class ProjectSnapshotServiceTest {
             assertArrayEquals(Files.readAllBytes(material), root.readMaterialBytes("requirements.md", 1024));
             assertCode(ShipFilesystemException.UNSAFE_ENTRY,
                     () -> root.readMaterialBytes(".camel-kit/pipeline.json", 1024));
+            assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                    () -> root.readMaterialBytes(".camel-kit/ship-state.json", 1024));
             assertCode(ShipFilesystemException.UNSAFE_ENTRY,
                     () -> root.readMaterialBytes("target/generated.txt", 1024));
             assertCode(ShipFilesystemException.TREE_QUOTA_EXCEEDED,
@@ -365,11 +370,13 @@ class ProjectSnapshotServiceTest {
         ShipTreePolicy policy = ShipTreePolicy.current();
 
         assertEquals(
-                "sha256:227072c330ffc7cae2e53a3f68b697dfa4614d8963b9461ebf91db2146c63204",
+                "sha256:a54ede7e7e8598c1cf8677eb2dbf0af95fc5b1178fab8111543d049a747301c5",
                 policy.digest());
         assertEquals(Classification.MATERIAL, policy.classify(".camel-kit/config.properties"));
         assertEquals(Classification.DENIED, policy.classify(".camel-kit/pipeline.json"));
         assertEquals(Classification.DENIED, policy.classify(".CAMEL-KIT/PIPELINE.JSON"));
+        assertEquals(Classification.DENIED, policy.classify(".camel-kit/ship-state.json"));
+        assertEquals(Classification.DENIED, policy.classify(".CAMEL-KIT/SHIP-STATE.JSON"));
         assertEquals(Classification.DENIED, policy.classify(".SSH/id_rsa"));
         assertEquals(Classification.DENIED, policy.classify(".ENV"));
         assertEquals(Classification.DENIED, policy.classify("module/.m2/settings.xml"));
@@ -379,6 +386,7 @@ class ProjectSnapshotServiceTest {
         assertEquals(Classification.DENIED, policy.classify("module/.config/gh/hosts.yml/secret"));
         assertEquals(Classification.DENIED, policy.classify("module/.m2/settings.xml/secret"));
         assertEquals(Classification.DENIED, policy.classify("module/.camel-kit/pipeline.json/secret"));
+        assertEquals(Classification.DENIED, policy.classify("module/.camel-kit/ship-state.json/secret"));
         assertEquals(Classification.DENIED, policy.classify("module/.GIT/HEAD"));
         assertEquals(Classification.DENIED, policy.classify("module/.env.example/secret"));
         assertEquals(Classification.MATERIAL, policy.classify("module/.env.example"));


### PR DESCRIPTION
## Summary

- reject and preserve pre-release Ship state instead of attempting an unreleased-state migration
- define strict exact-tuple adapter conformance evidence v2 with a bounded verifier and mandatory suite
- bind legacy-state checks to the project lease and recheck immediately before the first durable event append

Refs #149

## Testing

- `./mvnw -B clean install`

## Website impact

Not required for this internal fail-closed slice. Issue #149 remains website-impact `required`; public documentation stays tracked until the CLI and evidence-backed runtime matrix land.

## Summary by Sourcery

Guard Ship controller runs against unsupported pre-release project state and introduce bounded verification for adapter conformance evidence.

New Features:
- Add legacy state guard that rejects and preserves unsupported pre-release Ship state before and immediately prior to run creation.
- Introduce a strict adapter conformance evidence verifier backed by a bundled mandatory check suite and exact adapter tuple schema v2.

Enhancements:
- Update Ship tree policy to treat ship-state metadata as denied state and bump its schema version and digest.
- Tighten JSON schema IDs and structure for adapter conformance evidence to enforce closed, exact-tuple semantics.

Tests:
- Extend Ship controller, schema, security, and snapshot tests for legacy state handling and unsafe entries.
- Add dedicated tests for the adapter conformance evidence verifier and its mandatory checks suite.