### PR TITLE
Add signed Ship adapter certification admission

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifier.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifier.java
@@ -1,0 +1,425 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.conformance.AdapterConformanceEvidenceVerifier.ParsedEvidence;
+import io.github.luigidemasi.camelkit.ship.controller.ShipJson;
+
+/**
+ * Verifies one release-rooted adapter certification pack and returns a path-free launch identity.
+ *
+ * <p>
+ * This verifier neither resolves a mutable installation nor launches a process. A production probe must first snapshot
+ * the exact installation into immutable storage and match that snapshot to the returned component digests.
+ */
+public final class AdapterCertificationVerifier {
+
+    static final int RELEASE_MANIFEST_SCHEMA_VERSION = 1;
+    static final int PACK_SCHEMA_VERSION = 1;
+    static final int MAX_MANIFEST_BYTES = 64 * 1024;
+    static final int MAX_PACK_BYTES = 256 * 1024;
+    static final int MAX_COMPONENT_BYTES = 256 * 1024 * 1024;
+    static final int MAX_SIGNATURE_BYTES = 128;
+
+    private static final Pattern ID = Pattern.compile("[a-z][a-z0-9-]{0,63}");
+    private static final Pattern VERSION = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
+    private static final Set<String> REQUIRED_COMPONENTS = Set.of(
+            "runtime",
+            "adapter",
+            "ingress",
+            "interaction",
+            "launcher",
+            "runner",
+            "sandbox",
+            "provider-broker",
+            "controller",
+            "protocol",
+            "conformance-suite");
+
+    private AdapterCertificationVerifier() {
+    }
+
+    public static VerifiedLaunchDescriptor verify(
+            byte[] releaseManifest,
+            byte[] releaseSignature,
+            BlobResolver blobs,
+            TrustPolicy trustPolicy) {
+        return verify(releaseManifest, releaseSignature, blobs, trustPolicy, Clock.systemUTC());
+    }
+
+    static VerifiedLaunchDescriptor verify(
+            byte[] releaseManifest,
+            byte[] releaseSignature,
+            BlobResolver blobs,
+            TrustPolicy trustPolicy,
+            Clock clock) {
+        Objects.requireNonNull(blobs, "certification blob resolver");
+        Objects.requireNonNull(trustPolicy, "certification trust policy");
+        Objects.requireNonNull(clock, "certification clock");
+        requireBytes(releaseManifest, MAX_MANIFEST_BYTES, "release manifest");
+        requireBytes(releaseSignature, MAX_SIGNATURE_BYTES, "release signature");
+
+        ReleaseManifest manifest = read(releaseManifest, ReleaseManifest.class, "release manifest");
+        validate(manifest, trustPolicy, clock.instant());
+        verifySignature(releaseManifest, releaseSignature, trustPolicy.key(manifest.keyId()));
+
+        byte[] packBytes = resolve(blobs, manifest.packDigest(), MAX_PACK_BYTES, "certification pack");
+        CertificationPack pack = read(packBytes, CertificationPack.class, "certification pack");
+        validate(pack, manifest);
+
+        Map<String, Component> components = verifyComponents(pack.components(), blobs);
+        ParsedEvidence evidence = AdapterConformanceEvidenceVerifier.verify(
+                resolve(blobs, pack.conformanceEvidenceDigest(), MAX_MANIFEST_BYTES, "conformance evidence"));
+        bind(evidence, components, pack);
+        verifyEvidenceBlobs(evidence, blobs);
+        verifyInventory(manifest, pack, evidence, components, blobs);
+
+        return new VerifiedLaunchDescriptor(
+                manifest.releaseId(),
+                manifest.releaseVersion(),
+                manifest.releaseSequence(),
+                manifest.packDigest(),
+                evidence.harnessFamily(),
+                evidence.harnessVersion(),
+                evidence.adapterId(),
+                evidence.adapterVersion(),
+                evidence.protocolVersion(),
+                evidence.operatingSystem(),
+                evidence.architecture(),
+                evidence.launchProfile(),
+                evidence.runtimeProfile(),
+                Map.copyOf(components));
+    }
+
+    private static void validate(ReleaseManifest manifest, TrustPolicy policy, Instant now) {
+        if (manifest == null || manifest.schemaVersion() != RELEASE_MANIFEST_SCHEMA_VERSION) {
+            throw invalid("release manifest schemaVersion must be " + RELEASE_MANIFEST_SCHEMA_VERSION, null);
+        }
+        requireId(manifest.releaseId(), "releaseId");
+        requireVersion(manifest.releaseVersion(), "releaseVersion");
+        requireId(manifest.keyId(), "keyId");
+        requireVersion(manifest.protocolVersion(), "protocolVersion");
+        requireDigest(manifest.packDigest(), "packDigest");
+        if (manifest.releaseSequence() < policy.minimumReleaseSequence()) {
+            throw invalid("release manifest is below the anti-downgrade floor", null);
+        }
+        if (!policy.minimumProtocolVersion().equals(manifest.protocolVersion())) {
+            throw invalid("release manifest protocol version is not trusted", null);
+        }
+        if (manifest.issuedAt() == null
+                || manifest.expiresAt() == null
+                || !manifest.issuedAt().isBefore(manifest.expiresAt())
+                || now.isBefore(manifest.issuedAt())
+                || !now.isBefore(manifest.expiresAt())) {
+            throw invalid("release manifest is outside its validity interval", null);
+        }
+        if (policy.revokedKeyIds().contains(manifest.keyId())
+                || policy.revokedPackDigests().contains(manifest.packDigest())) {
+            throw invalid("release manifest is revoked", null);
+        }
+    }
+
+    private static void validate(CertificationPack pack, ReleaseManifest manifest) {
+        if (pack == null || pack.schemaVersion() != PACK_SCHEMA_VERSION) {
+            throw invalid("certification pack schemaVersion must be " + PACK_SCHEMA_VERSION, null);
+        }
+        if (!manifest.releaseId().equals(pack.releaseId())
+                || !manifest.releaseVersion().equals(pack.releaseVersion())
+                || !manifest.protocolVersion().equals(pack.protocolVersion())) {
+            throw invalid("certification pack does not match its signed release manifest", null);
+        }
+        requireDigest(pack.conformanceEvidenceDigest(), "conformanceEvidenceDigest");
+        if (pack.components() == null || pack.components().size() != REQUIRED_COMPONENTS.size()) {
+            throw invalid("certification pack must bind the complete component closure", null);
+        }
+    }
+
+    private static Map<String, Component> verifyComponents(
+            List<Component> declared, BlobResolver blobs) {
+        Map<String, Component> components = new LinkedHashMap<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (Component component : declared) {
+            if (component == null) {
+                throw invalid("certification components must not contain null", null);
+            }
+            requireId(component.kind(), "component kind");
+            requireId(component.id(), "component id");
+            requireVersion(component.version(), "component version");
+            requireDigest(component.digest(), "component digest");
+            if (component.byteSize() < 1 || component.byteSize() > MAX_COMPONENT_BYTES) {
+                throw invalid("component byteSize is outside its bounded range", null);
+            }
+            if (components.putIfAbsent(component.kind(), component) != null) {
+                duplicates.add(component.kind());
+            }
+            byte[] content = resolve(
+                    blobs, component.digest(), Math.toIntExact(component.byteSize()),
+                    "component " + component.kind());
+            if (content.length != component.byteSize()) {
+                throw invalid("component " + component.kind() + " byteSize does not match its blob", null);
+            }
+        }
+        if (!duplicates.isEmpty()) {
+            throw invalid("duplicate certification components " + duplicates, null);
+        }
+        Set<String> missing = new LinkedHashSet<>(REQUIRED_COMPONENTS);
+        missing.removeAll(components.keySet());
+        Set<String> unknown = new LinkedHashSet<>(components.keySet());
+        unknown.removeAll(REQUIRED_COMPONENTS);
+        if (!missing.isEmpty() || !unknown.isEmpty()) {
+            throw invalid("component closure mismatch; missing=" + missing + ", unknown=" + unknown, null);
+        }
+        return components;
+    }
+
+    private static void bind(
+            ParsedEvidence evidence,
+            Map<String, Component> components,
+            CertificationPack pack) {
+        Component runtime = components.get("runtime");
+        Component adapter = components.get("adapter");
+        Component ingress = components.get("ingress");
+        Component protocol = components.get("protocol");
+        Component suite = components.get("conformance-suite");
+        List<String> failures = new java.util.ArrayList<>();
+        requireEqual(evidence.harnessVersion(), runtime.version(), "runtime version", failures);
+        requireEqual(evidence.runtimeArtifactDigest(), runtime.digest(), "runtime digest", failures);
+        requireEqual(evidence.adapterId(), adapter.id(), "adapter ID", failures);
+        requireEqual(evidence.adapterVersion(), adapter.version(), "adapter version", failures);
+        requireEqual(evidence.driverDigest(), adapter.digest(), "adapter digest", failures);
+        requireEqual(evidence.ingressDigest(), ingress.digest(), "ingress digest", failures);
+        requireEqual(evidence.protocolVersion(), protocol.version(), "protocol version", failures);
+        requireEqual(evidence.testSuiteDigest(), suite.digest(), "conformance suite digest", failures);
+        requireEqual(evidence.protocolVersion(), pack.protocolVersion(), "pack protocol version", failures);
+        evidence.checks().stream()
+                .filter(check -> !"pass".equals(check.result()))
+                .forEach(check -> failures.add("mandatory check failed: " + check.checkId()));
+        if (!failures.isEmpty()) {
+            throw invalid("certification evidence is not admissible:\n- " + String.join("\n- ", failures), null);
+        }
+    }
+
+    private static void verifyEvidenceBlobs(ParsedEvidence evidence, BlobResolver blobs) {
+        evidence.checks().forEach(check -> resolve(
+                blobs,
+                check.evidenceDigest(),
+                MAX_COMPONENT_BYTES,
+                "evidence for mandatory check " + check.checkId()));
+    }
+
+    private static void verifyInventory(
+            ReleaseManifest manifest,
+            CertificationPack pack,
+            ParsedEvidence evidence,
+            Map<String, Component> components,
+            BlobResolver blobs) {
+        Set<String> expected = new LinkedHashSet<>();
+        expected.add(manifest.packDigest());
+        expected.add(pack.conformanceEvidenceDigest());
+        components.values().stream().map(Component::digest).forEach(expected::add);
+        evidence.checks().stream().map(check -> check.evidenceDigest()).forEach(expected::add);
+
+        Set<String> actual;
+        try {
+            actual = Set.copyOf(blobs.digests());
+        } catch (IOException | RuntimeException e) {
+            throw invalid("certification blob inventory could not be resolved", e);
+        }
+        actual.forEach(digest -> requireDigest(digest, "certification blob inventory digest"));
+        if (!actual.equals(expected)) {
+            Set<String> missing = new LinkedHashSet<>(expected);
+            missing.removeAll(actual);
+            Set<String> unreferenced = new LinkedHashSet<>(actual);
+            unreferenced.removeAll(expected);
+            throw invalid("certification blob inventory mismatch; missing=" + missing
+                          + ", unreferenced=" + unreferenced,
+                    null);
+        }
+    }
+
+    private static void requireEqual(
+            String actual, String expected, String label, List<String> failures) {
+        if (!Objects.equals(actual, expected)) {
+            failures.add(label + " does not match the certified closure");
+        }
+    }
+
+    private static void verifySignature(byte[] content, byte[] signature, byte[] encodedKey) {
+        if (encodedKey == null || encodedKey.length == 0) {
+            throw invalid("release signing key is not trusted", null);
+        }
+        try {
+            PublicKey key = KeyFactory.getInstance("Ed25519")
+                    .generatePublic(new X509EncodedKeySpec(encodedKey));
+            Signature verifier = Signature.getInstance("Ed25519");
+            verifier.initVerify(key);
+            verifier.update(content);
+            if (!verifier.verify(signature)) {
+                throw invalid("release manifest signature is invalid", null);
+            }
+        } catch (GeneralSecurityException e) {
+            throw invalid("release manifest signature could not be verified", e);
+        }
+    }
+
+    private static byte[] resolve(
+            BlobResolver blobs, String digest, int maximumBytes, String label) {
+        byte[] content;
+        try {
+            content = blobs.resolve(digest, maximumBytes);
+        } catch (IOException | RuntimeException e) {
+            throw invalid(label + " could not be resolved", e);
+        }
+        requireBytes(content, maximumBytes, label);
+        if (!digest.equals(ShipDigest.sha256(content))) {
+            throw invalid(label + " digest does not match its content", null);
+        }
+        return content;
+    }
+
+    private static <T> T read(byte[] content, Class<T> type, String label) {
+        try {
+            return ShipJson.mapper().readValue(content, type);
+        } catch (IOException | IllegalArgumentException e) {
+            throw invalid(label + " is not strict canonical JSON", e);
+        }
+    }
+
+    private static void requireBytes(byte[] value, int maximumBytes, String label) {
+        if (value == null || value.length < 1 || value.length > maximumBytes) {
+            throw invalid(label + " must contain 1.." + maximumBytes + " bytes", null);
+        }
+    }
+
+    private static void requireId(String value, String field) {
+        if (value == null || !ID.matcher(value).matches()) {
+            throw invalid(field + " is not a canonical identifier", null);
+        }
+    }
+
+    private static void requireVersion(String value, String field) {
+        if (value == null || !VERSION.matcher(value).matches()) {
+            throw invalid(field + " is not a canonical version", null);
+        }
+    }
+
+    private static void requireDigest(String value, String field) {
+        if (!ShipDigest.isSha256(value)) {
+            throw invalid(field + " must be a canonical SHA-256 digest", null);
+        }
+    }
+
+    private static IllegalArgumentException invalid(String message, Throwable cause) {
+        return new IllegalArgumentException("Invalid Ship adapter certification: " + message, cause);
+    }
+
+    public interface BlobResolver {
+
+        byte[] resolve(String digest, int maximumBytes) throws IOException;
+
+        Set<String> digests() throws IOException;
+    }
+
+    public record TrustPolicy(
+            long minimumReleaseSequence,
+            String minimumProtocolVersion,
+            Map<String, byte[]> trustedKeys,
+            Set<String> revokedKeyIds,
+            Set<String> revokedPackDigests) {
+
+        public TrustPolicy {
+            if (minimumReleaseSequence < 1) {
+                throw new IllegalArgumentException("Trust policy release floor must be positive");
+            }
+            requireVersion(minimumProtocolVersion, "minimumProtocolVersion");
+            trustedKeys = copyKeys(trustedKeys);
+            revokedKeyIds = Set.copyOf(Objects.requireNonNull(revokedKeyIds, "revoked key IDs"));
+            revokedPackDigests = Set.copyOf(Objects.requireNonNull(revokedPackDigests, "revoked pack digests"));
+            revokedKeyIds.forEach(value -> requireId(value, "revoked key ID"));
+            revokedPackDigests.forEach(value -> requireDigest(value, "revoked pack digest"));
+        }
+
+        byte[] key(String keyId) {
+            byte[] value = trustedKeys.get(keyId);
+            return value == null ? null : value.clone();
+        }
+
+        private static Map<String, byte[]> copyKeys(Map<String, byte[]> values) {
+            Objects.requireNonNull(values, "trusted keys");
+            Map<String, byte[]> copy = new LinkedHashMap<>();
+            values.forEach((key, value) -> {
+                requireId(key, "trusted key ID");
+                if (value == null || value.length == 0) {
+                    throw new IllegalArgumentException("Trusted key material must not be empty");
+                }
+                copy.put(key, value.clone());
+            });
+            return Map.copyOf(copy);
+        }
+    }
+
+    public record VerifiedLaunchDescriptor(
+            String releaseId,
+            String releaseVersion,
+            long releaseSequence,
+            String certificationPackDigest,
+            String harnessFamily,
+            String harnessVersion,
+            String adapterId,
+            String adapterVersion,
+            String protocolVersion,
+            String operatingSystem,
+            String architecture,
+            String launchProfile,
+            String runtimeProfile,
+            Map<String, Component> components) {
+
+        public VerifiedLaunchDescriptor {
+            components = Map.copyOf(components);
+        }
+    }
+
+    public record Component(
+            String kind,
+            String id,
+            String version,
+            String digest,
+            long byteSize) {
+    }
+
+    private record ReleaseManifest(
+            int schemaVersion,
+            String releaseId,
+            String releaseVersion,
+            long releaseSequence,
+            String protocolVersion,
+            String keyId,
+            Instant issuedAt,
+            Instant expiresAt,
+            String packDigest) {
+    }
+
+    private record CertificationPack(
+            int schemaVersion,
+            String releaseId,
+            String releaseVersion,
+            String protocolVersion,
+            String conformanceEvidenceDigest,
+            List<Component> components) {
+    }
+}

--- a/camel-kit-core/src/main/resources/ship/schema/adapter-certification-pack.schema.json
+++ b/camel-kit-core/src/main/resources/ship/schema/adapter-certification-pack.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luigidemasi/camel-kit/schemas/ship/v1/adapter-certification-pack.schema.json",
+  "title": "Camel Ship adapter certification pack",
+  "description": "Closed content-addressed certification closure for one exact runtime tuple.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "releaseId",
+    "releaseVersion",
+    "protocolVersion",
+    "conformanceEvidenceDigest",
+    "components"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "releaseId": { "$ref": "#/$defs/id" },
+    "releaseVersion": { "$ref": "#/$defs/version" },
+    "protocolVersion": { "$ref": "#/$defs/version" },
+    "conformanceEvidenceDigest": { "$ref": "#/$defs/digest" },
+    "components": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "items": { "$ref": "#/$defs/component" }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "version",
+        "digest",
+        "byteSize"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "runtime",
+            "adapter",
+            "ingress",
+            "interaction",
+            "launcher",
+            "runner",
+            "sandbox",
+            "provider-broker",
+            "controller",
+            "protocol",
+            "conformance-suite"
+          ]
+        },
+        "id": { "$ref": "#/$defs/id" },
+        "version": { "$ref": "#/$defs/version" },
+        "digest": { "$ref": "#/$defs/digest" },
+        "byteSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 268435456
+        }
+      }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{0,63}$"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9+._-]{0,127}$"
+    }
+  }
+}

--- a/camel-kit-core/src/main/resources/ship/schema/adapter-certification-release.schema.json
+++ b/camel-kit-core/src/main/resources/ship/schema/adapter-certification-release.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luigidemasi/camel-kit/schemas/ship/v1/adapter-certification-release.schema.json",
+  "title": "Camel Ship adapter certification release manifest",
+  "description": "The exact bytes of this closed manifest are signed by a trusted release key.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "releaseId",
+    "releaseVersion",
+    "releaseSequence",
+    "protocolVersion",
+    "keyId",
+    "issuedAt",
+    "expiresAt",
+    "packDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "releaseId": { "$ref": "#/$defs/id" },
+    "releaseVersion": { "$ref": "#/$defs/version" },
+    "releaseSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "protocolVersion": { "$ref": "#/$defs/version" },
+    "keyId": { "$ref": "#/$defs/id" },
+    "issuedAt": { "$ref": "#/$defs/timestamp" },
+    "expiresAt": { "$ref": "#/$defs/timestamp" },
+    "packDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{0,63}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 64
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9+._-]{0,127}$"
+    }
+  }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifierTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifierTest.java
@@ -1,0 +1,321 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.conformance.AdapterCertificationVerifier.Component;
+import io.github.luigidemasi.camelkit.ship.conformance.AdapterCertificationVerifier.TrustPolicy;
+import io.github.luigidemasi.camelkit.ship.conformance.AdapterCertificationVerifier.VerifiedLaunchDescriptor;
+import io.github.luigidemasi.camelkit.ship.controller.ShipJson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AdapterCertificationVerifierTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-23T12:00:00Z");
+    private static final List<String> CHECKS = List.of(
+            "native-ingress",
+            "optional-context-transport",
+            "protected-interaction-binding",
+            "immutable-launch",
+            "capability-isolation",
+            "worker-cancellation",
+            "stopped-process-tree",
+            "exclusive-output-custody",
+            "artifact-import",
+            "crash-resume-replay",
+            "adversarial-containment",
+            "live-e2e");
+
+    private KeyPair signingKey;
+    private Map<String, byte[]> blobs;
+    private List<Component> components;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        signingKey = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        blobs = new LinkedHashMap<>();
+        components = new ArrayList<>();
+        component("runtime", "pi", "0.80.6", "pi-runtime");
+        component("adapter", "pi-native", "1.0.0", "pi-driver");
+        component("ingress", "pi-ingress", "1.0.0", "pi-ingress");
+        component("interaction", "gnome-polkit-fingerprint", "1.0.0", "interaction");
+        component("launcher", "systemd-exec", "258.9", "launcher");
+        component("runner", "pi-stage-runner", "1.0.0", "runner");
+        component("sandbox", "bubblewrap", "0.11.0", "sandbox");
+        component("provider-broker", "pi-provider-broker", "1.0.0", "provider");
+        component("controller", "camel-kit-ship-controller", "0.3.2", "controller");
+        component("protocol", "camel-kit-ship", "2", "protocol");
+        component("conformance-suite", "camel-kit-ship-suite", "1", suite());
+    }
+
+    @Test
+    void admitsOnlyTheCompleteSignedReleaseClosure() throws Exception {
+        Bundle bundle = bundle(7, "2", components, validEvidence(false));
+
+        VerifiedLaunchDescriptor descriptor = verify(bundle, policy(7, "2"));
+
+        assertEquals("pi", descriptor.harnessFamily());
+        assertEquals("0.80.6", descriptor.harnessVersion());
+        assertEquals("pi-native", descriptor.adapterId());
+        assertEquals("linux", descriptor.operatingSystem());
+        assertEquals("x86_64", descriptor.architecture());
+        assertEquals(11, descriptor.components().size());
+        assertFalse(descriptor.components().values().stream()
+                .map(Component::digest)
+                .anyMatch(value -> !ShipDigest.isSha256(value)));
+    }
+
+    @Test
+    void rejectsTamperedSignaturesAndUnsignedReplacementPacks() throws Exception {
+        Bundle bundle = bundle(7, "2", components, validEvidence(false));
+        byte[] tamperedSignature = bundle.signature().clone();
+        tamperedSignature[0] ^= 1;
+        assertInvalid(new Bundle(bundle.manifest(), tamperedSignature), policy(7, "2"));
+
+        byte[] replacement = "{}".getBytes(StandardCharsets.UTF_8);
+        blobs.put(ShipDigest.sha256(replacement), replacement);
+        String manifest = new String(bundle.manifest(), StandardCharsets.UTF_8)
+                .replace(bundle.packDigest(), ShipDigest.sha256(replacement));
+        assertInvalid(new Bundle(manifest.getBytes(StandardCharsets.UTF_8), bundle.signature()), policy(7, "2"));
+    }
+
+    @Test
+    void enforcesAntiDowngradeExpiryAndRevocation() throws Exception {
+        Bundle bundle = bundle(7, "2", components, validEvidence(false));
+        assertInvalid(bundle, policy(8, "2"));
+        assertInvalid(bundle, policy(7, "3"));
+        assertInvalid(bundle, new TrustPolicy(
+                7, "2", Map.of("release-2026", signingKey.getPublic().getEncoded()),
+                Set.of("release-2026"), Set.of()));
+        assertInvalid(bundle, new TrustPolicy(
+                7, "2", Map.of("release-2026", signingKey.getPublic().getEncoded()),
+                Set.of(), Set.of(bundle.packDigest())));
+
+        byte[] expiredManifest = manifest(bundle.packDigest(), 7, "2",
+                "2026-07-20T00:00:00Z", "2026-07-21T00:00:00Z");
+        assertInvalid(new Bundle(expiredManifest, sign(expiredManifest)), policy(7, "2"));
+    }
+
+    @Test
+    void rejectsMissingDuplicateUnknownAndUnresolvedComponents() throws Exception {
+        List<Component> missing = new ArrayList<>(components);
+        missing.remove(0);
+        assertInvalid(bundle(7, "2", missing, validEvidence(false)), policy(7, "2"));
+
+        List<Component> duplicate = new ArrayList<>(components);
+        duplicate.set(0, duplicate.get(1));
+        assertInvalid(bundle(7, "2", duplicate, validEvidence(false)), policy(7, "2"));
+
+        List<Component> unknown = new ArrayList<>(components);
+        unknown.set(0, new Component("unknown", "unknown", "1", digest("unknown"), 7));
+        blobs.put(digest("unknown"), "unknown".getBytes(StandardCharsets.UTF_8));
+        assertInvalid(bundle(7, "2", unknown, validEvidence(false)), policy(7, "2"));
+
+        Component runtime = components.get(0);
+        blobs.remove(runtime.digest());
+        assertInvalid(bundle(7, "2", components, validEvidence(false)), policy(7, "2"));
+    }
+
+    @Test
+    void rejectsTupleSubstitutionAndAnyFailedMandatoryCheck() throws Exception {
+        assertInvalid(bundle(7, "2", components,
+                validEvidence(false).replace("\"harnessVersion\": \"0.80.6\"",
+                        "\"harnessVersion\": \"0.80.5\"")),
+                policy(7, "2"));
+        assertInvalid(bundle(7, "2", components, validEvidence(true)), policy(7, "2"));
+    }
+
+    @Test
+    void resolvesEveryCheckEvidenceBlobAndRejectsUnreferencedPackContent() throws Exception {
+        Bundle bundle = bundle(7, "2", components, validEvidence(false));
+        blobs.remove(digest("live-e2e"));
+        assertInvalid(bundle, policy(7, "2"));
+
+        bundle = bundle(7, "2", components, validEvidence(false));
+        blobs.put(digest("unreferenced"), "unreferenced".getBytes(StandardCharsets.UTF_8));
+        assertInvalid(bundle, policy(7, "2"));
+    }
+
+    private VerifiedLaunchDescriptor verify(Bundle bundle, TrustPolicy policy) {
+        return AdapterCertificationVerifier.verify(
+                bundle.manifest(),
+                bundle.signature(),
+                new AdapterCertificationVerifier.BlobResolver() {
+                    @Override
+                    public byte[] resolve(String digest, int maximumBytes) throws java.io.IOException {
+                        byte[] value = blobs.get(digest);
+                        if (value == null) {
+                            throw new java.io.IOException("missing");
+                        }
+                        if (value.length > maximumBytes) {
+                            throw new java.io.IOException("oversized");
+                        }
+                        return value.clone();
+                    }
+
+                    @Override
+                    public Set<String> digests() {
+                        return Set.copyOf(blobs.keySet());
+                    }
+                },
+                policy,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    private void assertInvalid(Bundle bundle, TrustPolicy policy) {
+        assertThrows(IllegalArgumentException.class, () -> verify(bundle, policy));
+    }
+
+    private TrustPolicy policy(long floor, String protocol) {
+        return new TrustPolicy(
+                floor,
+                protocol,
+                Map.of("release-2026", signingKey.getPublic().getEncoded()),
+                Set.of(),
+                Set.of());
+    }
+
+    private Bundle bundle(
+            long sequence, String protocol, List<Component> declared, String evidence)
+            throws Exception {
+        byte[] evidenceBytes = evidence.getBytes(StandardCharsets.UTF_8);
+        String evidenceDigest = ShipDigest.sha256(evidenceBytes);
+        blobs.put(evidenceDigest, evidenceBytes);
+        byte[] pack = ShipJson.mapper().writeValueAsBytes(Map.of(
+                "schemaVersion", 1,
+                "releaseId", "camel-kit-0-3-2",
+                "releaseVersion", "0.3.2",
+                "protocolVersion", protocol,
+                "conformanceEvidenceDigest", evidenceDigest,
+                "components", declared));
+        String packDigest = ShipDigest.sha256(pack);
+        blobs.put(packDigest, pack);
+        byte[] manifest = manifest(
+                packDigest, sequence, protocol,
+                "2026-07-23T00:00:00Z", "2026-08-23T00:00:00Z");
+        return new Bundle(manifest, sign(manifest));
+    }
+
+    private byte[] manifest(
+            String packDigest,
+            long sequence,
+            String protocol,
+            String issuedAt,
+            String expiresAt)
+            throws Exception {
+        return ShipJson.mapper().writeValueAsBytes(Map.of(
+                "schemaVersion", 1,
+                "releaseId", "camel-kit-0-3-2",
+                "releaseVersion", "0.3.2",
+                "releaseSequence", sequence,
+                "protocolVersion", protocol,
+                "keyId", "release-2026",
+                "issuedAt", issuedAt,
+                "expiresAt", expiresAt,
+                "packDigest", packDigest));
+    }
+
+    private byte[] sign(byte[] manifest) throws Exception {
+        Signature signer = Signature.getInstance("Ed25519");
+        signer.initSign(signingKey.getPrivate());
+        signer.update(manifest);
+        return signer.sign();
+    }
+
+    private void component(String kind, String id, String version, String content) {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        String digest = ShipDigest.sha256(bytes);
+        blobs.put(digest, bytes);
+        components.add(new Component(kind, id, version, digest, bytes.length));
+    }
+
+    private String validEvidence(boolean failed) {
+        Map<String, Component> byKind = components.stream()
+                .collect(Collectors.toMap(Component::kind, value -> value));
+        String checks = CHECKS.stream()
+                .map(check -> {
+                    blobs.put(digest(check), check.getBytes(StandardCharsets.UTF_8));
+                    return String.format(Locale.ROOT, """
+                            {
+                              "checkId": "%s",
+                              "result": "%s",
+                              "evidenceDigest": "%s"
+                            }
+                            """, check, failed && check.equals("live-e2e") ? "fail" : "pass", digest(check)).strip();
+                })
+                .collect(Collectors.joining(",\n"));
+        return String.format(Locale.ROOT, """
+                {
+                  "schemaVersion": 2,
+                  "harnessFamily": "pi",
+                  "harnessVersion": "%s",
+                  "adapterId": "%s",
+                  "adapterVersion": "%s",
+                  "protocolVersion": "%s",
+                  "operatingSystem": "linux",
+                  "architecture": "x86_64",
+                  "launchProfile": "systemd-bwrap-v1",
+                  "runtimeProfile": "fedora-43-node-24",
+                  "runtimeArtifactDigest": "%s",
+                  "driverDigest": "%s",
+                  "ingressDigest": "%s",
+                  "testSuiteDigest": "%s",
+                  "checks": [
+                %s
+                  ]
+                }
+                """,
+                byKind.get("runtime").version(),
+                byKind.get("adapter").id(),
+                byKind.get("adapter").version(),
+                byKind.get("protocol").version(),
+                byKind.get("runtime").digest(),
+                byKind.get("adapter").digest(),
+                byKind.get("ingress").digest(),
+                byKind.get("conformance-suite").digest(),
+                checks);
+    }
+
+    private static String suite() throws Exception {
+        try (InputStream input = AdapterCertificationVerifierTest.class.getClassLoader()
+                .getResourceAsStream("ship/adapter-conformance-suite.json")) {
+            if (input == null) {
+                throw new IllegalStateException("missing suite");
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private record Bundle(byte[] manifest, byte[] signature) {
+
+        private String packDigest() throws Exception {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> value = ShipJson.mapper().readValue(manifest, Map.class);
+            return value.get("packDigest").toString();
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/schema/ShipSchemaResourceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/schema/ShipSchemaResourceTest.java
@@ -56,6 +56,8 @@ class ShipSchemaResourceTest {
     private static final String ID_BASE_V2 = "https://github.com/luigidemasi/camel-kit/schemas/ship/v2/";
     private static final String RESOURCE_BASE = "ship/schema/";
     private static final List<String> FILES = List.of(
+            "adapter-certification-pack.schema.json",
+            "adapter-certification-release.schema.json",
             "adapter-conformance-evidence.schema.json",
             "artifact-manifest.schema.json",
             "catalog-evidence.schema.json",
@@ -495,6 +497,49 @@ class ShipSchemaResourceTest {
                 "crash-resume-replay",
                 "adversarial-containment",
                 "live-e2e"), schema.at("/properties/checks/prefixItems").findValuesAsText("const"));
+    }
+
+    @Test
+    void certificationSchemasBindOneClosedReleaseRootedComponentSet() throws Exception {
+        JsonNode release = readSchema("adapter-certification-release.schema.json");
+        assertEquals(Set.of(
+                "schemaVersion",
+                "releaseId",
+                "releaseVersion",
+                "releaseSequence",
+                "protocolVersion",
+                "keyId",
+                "issuedAt",
+                "expiresAt",
+                "packDigest"), fieldNames(release.path("properties")));
+        assertEquals(1, release.at("/properties/schemaVersion/const").intValue());
+        assertFalse(release.path("additionalProperties").booleanValue());
+
+        JsonNode pack = readSchema("adapter-certification-pack.schema.json");
+        assertEquals(Set.of(
+                "schemaVersion",
+                "releaseId",
+                "releaseVersion",
+                "protocolVersion",
+                "conformanceEvidenceDigest",
+                "components"), fieldNames(pack.path("properties")));
+        assertEquals(11, pack.at("/properties/components/minItems").intValue());
+        assertEquals(11, pack.at("/properties/components/maxItems").intValue());
+        Set<String> componentKinds = new LinkedHashSet<>();
+        pack.at("/$defs/component/properties/kind/enum")
+                .forEach(value -> componentKinds.add(value.asText()));
+        assertEquals(Set.of(
+                "runtime",
+                "adapter",
+                "ingress",
+                "interaction",
+                "launcher",
+                "runner",
+                "sandbox",
+                "provider-broker",
+                "controller",
+                "protocol",
+                "conformance-suite"), componentKinds);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add strict signed release manifests for Ship adapter certification packs
- bind the complete runtime, adapter, ingress, interaction, launcher, runner, sandbox, broker, controller, protocol, and conformance-suite closure
- resolve every per-check evidence blob and reject missing or unreferenced pack content
- enforce Ed25519 trust roots, validity windows, revocation, and release-sequence anti-downgrade

## Verification

- `./mvnw -B clean install`
- 907 core tests passed; all reactor, forbidden-API, resolver isolation, controller isolation, and artifact-import wiring gates passed

## Scope

This is a prerequisite slice of #149. It does not register `camel-kit ship`, admit a Pi tuple, or change the adapter registry.

Website impact for #149 remains **required**. This internal admission slice does not yet document unimplemented public behavior.

## Summary by Sourcery

Introduce strict verification for signed Ship adapter certification packs and their release manifests.

New Features:
- Add schema definitions and validation for adapter certification release manifests and packs binding a fixed set of components.
- Provide an adapter certification verifier that validates signatures, trust policy, component closure, and conformance evidence to produce a verified launch descriptor.

Tests:
- Add schema tests for certification pack and release manifest resources and comprehensive unit tests for adapter certification verification behavior, including trust, closure, evidence, and inventory checks.