### PR TITLE
Bind Ship admission to immutable runtime closures

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifier.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifier.java
@@ -40,6 +40,9 @@ public final class AdapterCertificationVerifier {
     private static final Pattern VERSION = Pattern.compile("[A-Za-z0-9][A-Za-z0-9+._-]{0,127}");
     private static final Set<String> REQUIRED_COMPONENTS = Set.of(
             "runtime",
+            "language-runtime",
+            "package-closure",
+            "abi",
             "adapter",
             "ingress",
             "interaction",
@@ -83,11 +86,12 @@ public final class AdapterCertificationVerifier {
         validate(pack, manifest);
 
         Map<String, Component> components = verifyComponents(pack.components(), blobs);
+        Set<String> closureDigests = verifyPackageClosure(components.get("package-closure"), blobs);
         ParsedEvidence evidence = AdapterConformanceEvidenceVerifier.verify(
                 resolve(blobs, pack.conformanceEvidenceDigest(), MAX_MANIFEST_BYTES, "conformance evidence"));
         bind(evidence, components, pack);
         verifyEvidenceBlobs(evidence, blobs);
-        verifyInventory(manifest, pack, evidence, components, blobs);
+        verifyInventory(manifest, pack, evidence, components, closureDigests, blobs);
 
         return new VerifiedLaunchDescriptor(
                 manifest.releaseId(),
@@ -103,6 +107,11 @@ public final class AdapterCertificationVerifier {
                 evidence.architecture(),
                 evidence.launchProfile(),
                 evidence.runtimeProfile(),
+                evidence.languageRuntimeVersion(),
+                evidence.languageRuntimeArtifactDigest(),
+                evidence.packageClosureDigest(),
+                evidence.abiId(),
+                evidence.abiVersion(),
                 Map.copyOf(components));
     }
 
@@ -187,11 +196,37 @@ public final class AdapterCertificationVerifier {
         return components;
     }
 
+    private static Set<String> verifyPackageClosure(Component component, BlobResolver blobs) {
+        byte[] encoded = resolve(
+                blobs,
+                component.digest(),
+                Math.toIntExact(component.byteSize()),
+                "package closure manifest");
+        RuntimeClosureManifest manifest = read(
+                encoded, RuntimeClosureManifest.class, "package closure manifest");
+        Set<String> digests = new LinkedHashSet<>();
+        for (RuntimeClosureManifest.RuntimeFile file : manifest.files()) {
+            byte[] content = resolveAllowEmpty(
+                    blobs,
+                    file.digest(),
+                    Math.toIntExact(file.byteSize()),
+                    "package closure file " + file.rootId() + "/" + file.relativePath());
+            if (content.length != file.byteSize()) {
+                throw invalid("package closure file byteSize does not match its blob", null);
+            }
+            digests.add(file.digest());
+        }
+        return Set.copyOf(digests);
+    }
+
     private static void bind(
             ParsedEvidence evidence,
             Map<String, Component> components,
             CertificationPack pack) {
         Component runtime = components.get("runtime");
+        Component languageRuntime = components.get("language-runtime");
+        Component packageClosure = components.get("package-closure");
+        Component abi = components.get("abi");
         Component adapter = components.get("adapter");
         Component ingress = components.get("ingress");
         Component protocol = components.get("protocol");
@@ -199,6 +234,23 @@ public final class AdapterCertificationVerifier {
         List<String> failures = new java.util.ArrayList<>();
         requireEqual(evidence.harnessVersion(), runtime.version(), "runtime version", failures);
         requireEqual(evidence.runtimeArtifactDigest(), runtime.digest(), "runtime digest", failures);
+        requireEqual(
+                evidence.languageRuntimeVersion(),
+                languageRuntime.version(),
+                "language runtime version",
+                failures);
+        requireEqual(
+                evidence.languageRuntimeArtifactDigest(),
+                languageRuntime.digest(),
+                "language runtime digest",
+                failures);
+        requireEqual(
+                evidence.packageClosureDigest(),
+                packageClosure.digest(),
+                "package closure digest",
+                failures);
+        requireEqual(evidence.abiId(), abi.id(), "ABI ID", failures);
+        requireEqual(evidence.abiVersion(), abi.version(), "ABI version", failures);
         requireEqual(evidence.adapterId(), adapter.id(), "adapter ID", failures);
         requireEqual(evidence.adapterVersion(), adapter.version(), "adapter version", failures);
         requireEqual(evidence.driverDigest(), adapter.digest(), "adapter digest", failures);
@@ -227,11 +279,13 @@ public final class AdapterCertificationVerifier {
             CertificationPack pack,
             ParsedEvidence evidence,
             Map<String, Component> components,
+            Set<String> closureDigests,
             BlobResolver blobs) {
         Set<String> expected = new LinkedHashSet<>();
         expected.add(manifest.packDigest());
         expected.add(pack.conformanceEvidenceDigest());
         components.values().stream().map(Component::digest).forEach(expected::add);
+        expected.addAll(closureDigests);
         evidence.checks().stream().map(check -> check.evidenceDigest()).forEach(expected::add);
 
         Set<String> actual;
@@ -279,13 +333,22 @@ public final class AdapterCertificationVerifier {
 
     private static byte[] resolve(
             BlobResolver blobs, String digest, int maximumBytes, String label) {
+        byte[] content = resolveAllowEmpty(blobs, digest, maximumBytes, label);
+        requireBytes(content, maximumBytes, label);
+        return content;
+    }
+
+    private static byte[] resolveAllowEmpty(
+            BlobResolver blobs, String digest, int maximumBytes, String label) {
         byte[] content;
         try {
             content = blobs.resolve(digest, maximumBytes);
         } catch (IOException | RuntimeException e) {
             throw invalid(label + " could not be resolved", e);
         }
-        requireBytes(content, maximumBytes, label);
+        if (content == null || content.length > maximumBytes) {
+            throw invalid(label + " must contain 0.." + maximumBytes + " bytes", null);
+        }
         if (!digest.equals(ShipDigest.sha256(content))) {
             throw invalid(label + " digest does not match its content", null);
         }
@@ -387,6 +450,11 @@ public final class AdapterCertificationVerifier {
             String architecture,
             String launchProfile,
             String runtimeProfile,
+            String languageRuntimeVersion,
+            String languageRuntimeArtifactDigest,
+            String packageClosureDigest,
+            String abiId,
+            String abiVersion,
             Map<String, Component> components) {
 
         public VerifiedLaunchDescriptor {
@@ -422,4 +490,5 @@ public final class AdapterCertificationVerifier {
             String conformanceEvidenceDigest,
             List<Component> components) {
     }
+
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifier.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifier.java
@@ -62,6 +62,11 @@ public final class AdapterConformanceEvidenceVerifier {
                 raw.launchProfile(),
                 raw.runtimeProfile(),
                 raw.runtimeArtifactDigest(),
+                raw.languageRuntimeVersion(),
+                raw.languageRuntimeArtifactDigest(),
+                raw.packageClosureDigest(),
+                raw.abiId(),
+                raw.abiVersion(),
                 raw.driverDigest(),
                 raw.ingressDigest(),
                 raw.testSuiteDigest(),
@@ -84,6 +89,11 @@ public final class AdapterConformanceEvidenceVerifier {
         require(raw.launchProfile(), PROFILE, "launchProfile");
         require(raw.runtimeProfile(), PROFILE, "runtimeProfile");
         requireDigest(raw.runtimeArtifactDigest(), "runtimeArtifactDigest");
+        require(raw.languageRuntimeVersion(), VERSION, "languageRuntimeVersion");
+        requireDigest(raw.languageRuntimeArtifactDigest(), "languageRuntimeArtifactDigest");
+        requireDigest(raw.packageClosureDigest(), "packageClosureDigest");
+        require(raw.abiId(), ID, "abiId");
+        require(raw.abiVersion(), VERSION, "abiVersion");
         requireDigest(raw.driverDigest(), "driverDigest");
         requireDigest(raw.ingressDigest(), "ingressDigest");
         if (!suite.digest().equals(raw.testSuiteDigest())) {
@@ -184,6 +194,11 @@ public final class AdapterConformanceEvidenceVerifier {
             String launchProfile,
             String runtimeProfile,
             String runtimeArtifactDigest,
+            String languageRuntimeVersion,
+            String languageRuntimeArtifactDigest,
+            String packageClosureDigest,
+            String abiId,
+            String abiVersion,
             String driverDigest,
             String ingressDigest,
             String testSuiteDigest,
@@ -210,6 +225,11 @@ public final class AdapterConformanceEvidenceVerifier {
             String launchProfile,
             String runtimeProfile,
             String runtimeArtifactDigest,
+            String languageRuntimeVersion,
+            String languageRuntimeArtifactDigest,
+            String packageClosureDigest,
+            String abiId,
+            String abiVersion,
             String driverDigest,
             String ingressDigest,
             String testSuiteDigest,

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/RuntimeClosureManifest.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/RuntimeClosureManifest.java
@@ -1,0 +1,121 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+
+/** Portable, path-free identity of one snapshotted runtime package tree and its launch entry point. */
+public record RuntimeClosureManifest(
+        int schemaVersion,
+        EntryPoint entryPoint,
+        List<RuntimeFile> files) {
+
+    public static final int SCHEMA_VERSION = 1;
+    public static final int MAX_FILES = 50_000;
+    public static final long MAX_FILE_BYTES = 256L * 1024 * 1024;
+    public static final long MAX_AGGREGATE_BYTES = 1024L * 1024 * 1024;
+
+    private static final Pattern ID = Pattern.compile("[a-z][a-z0-9-]{0,63}");
+    private static final Comparator<RuntimeFile> ORDER = Comparator
+            .comparing(RuntimeFile::rootId)
+            .thenComparing(RuntimeFile::relativePath);
+
+    public RuntimeClosureManifest {
+        if (schemaVersion != SCHEMA_VERSION) {
+            throw new IllegalArgumentException(
+                    "Runtime closure schemaVersion must be " + SCHEMA_VERSION);
+        }
+        Objects.requireNonNull(entryPoint, "runtime closure entry point");
+        files = List.copyOf(Objects.requireNonNull(files, "runtime closure files"));
+        if (files.isEmpty() || files.size() > MAX_FILES
+                || files.stream().anyMatch(Objects::isNull)
+                || !files.equals(files.stream().sorted(ORDER).toList())) {
+            throw new IllegalArgumentException(
+                    "Runtime closure files must be nonempty, bounded, and canonically ordered");
+        }
+        Set<String> identities = new HashSet<>();
+        long aggregate = 0;
+        boolean foundEntryPoint = false;
+        for (RuntimeFile file : files) {
+            if (!identities.add(file.rootId() + "\0" + file.relativePath())) {
+                throw new IllegalArgumentException("Runtime closure contains a duplicate file identity");
+            }
+            try {
+                aggregate = Math.addExact(aggregate, file.byteSize());
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException("Runtime closure aggregate size overflowed", e);
+            }
+            if (aggregate > MAX_AGGREGATE_BYTES) {
+                throw new IllegalArgumentException("Runtime closure exceeds its aggregate byte limit");
+            }
+            if (entryPoint.rootId().equals(file.rootId())
+                    && entryPoint.relativePath().equals(file.relativePath())
+                    && entryPoint.digest().equals(file.digest())) {
+                if (!file.executable()) {
+                    throw new IllegalArgumentException("Runtime closure entry point is not executable");
+                }
+                foundEntryPoint = true;
+            }
+        }
+        if (!foundEntryPoint) {
+            throw new IllegalArgumentException(
+                    "Runtime closure entry point does not identify an executable file");
+        }
+    }
+
+    public record EntryPoint(
+            String rootId,
+            String relativePath,
+            String digest) {
+
+        public EntryPoint {
+            requireId(rootId, "runtime closure entry-point root ID");
+            relativePath = requirePath(relativePath, "runtime closure entry-point path");
+            requireDigest(digest, "runtime closure entry-point digest");
+        }
+    }
+
+    public record RuntimeFile(
+            String rootId,
+            String relativePath,
+            String digest,
+            long byteSize,
+            boolean executable) {
+
+        public RuntimeFile {
+            requireId(rootId, "runtime closure root ID");
+            relativePath = requirePath(relativePath, "runtime closure file path");
+            requireDigest(digest, "runtime closure file digest");
+            if (byteSize < 0 || byteSize > MAX_FILE_BYTES) {
+                throw new IllegalArgumentException(
+                        "Runtime closure file byte size is outside its bounded range");
+            }
+        }
+    }
+
+    private static void requireId(String value, String label) {
+        if (value == null || !ID.matcher(value).matches()) {
+            throw new IllegalArgumentException(label + " is not canonical");
+        }
+    }
+
+    private static String requirePath(String value, String label) {
+        try {
+            return ShipTreePolicy.requireCanonicalRelativePath(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(label + " is not canonical", e);
+        }
+    }
+
+    private static void requireDigest(String value, String label) {
+        if (!ShipDigest.isSha256(value)) {
+            throw new IllegalArgumentException(label + " is not a SHA-256 content address");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/RuntimeClosureSnapshotter.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/conformance/RuntimeClosureSnapshotter.java
@@ -1,0 +1,396 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.conformance.RuntimeClosureManifest.EntryPoint;
+import io.github.luigidemasi.camelkit.ship.conformance.RuntimeClosureManifest.RuntimeFile;
+import io.github.luigidemasi.camelkit.ship.controller.ShipJson;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+
+/**
+ * Copies a probed runtime tree into a caller-owned content-addressed sink and emits no host installation paths.
+ *
+ * <p>
+ * Launchers must use the copied blobs described by the returned manifest. They must never re-resolve the supplied
+ * mutable paths.
+ */
+public final class RuntimeClosureSnapshotter {
+
+    private static final int MAX_ROOTS = 16;
+    private static final int MAX_SYMLINKS = 32;
+    private static final Pattern ID = Pattern.compile("[a-z][a-z0-9-]{0,63}");
+    private static final Set<OpenOption> READ_OPTIONS = Set.of(
+            StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+    private static final String UNIX_ATTRIBUTES
+            = "unix:dev,ino,nlink,size,lastModifiedTime,ctime,mode";
+
+    private RuntimeClosureSnapshotter() {
+    }
+
+    public static Snapshot capture(
+            Path entryPoint,
+            Map<String, Path> roots,
+            BlobSink sink)
+            throws IOException {
+        Objects.requireNonNull(sink, "runtime closure blob sink");
+        Map<String, Path> canonicalRoots = canonicalRoots(roots);
+        Path resolvedEntryPoint = resolveEntryPoint(entryPoint, canonicalRoots.values());
+
+        List<RuntimeFile> files = new ArrayList<>();
+        Map<String, CapturedSource> captured = new LinkedHashMap<>();
+        String entryRoot = null;
+        String entryRelative = null;
+        for (Map.Entry<String, Path> root : canonicalRoots.entrySet()) {
+            if (resolvedEntryPoint.startsWith(root.getValue())) {
+                entryRoot = root.getKey();
+                entryRelative = root.getValue().relativize(resolvedEntryPoint)
+                        .toString()
+                        .replace('\\', '/');
+                break;
+            }
+        }
+        String entryDigest = null;
+        for (Map.Entry<String, Path> root : canonicalRoots.entrySet()) {
+            FileIdentity rootBefore = identity(root.getValue(), true);
+            List<String> beforePaths = listPaths(root.getValue());
+            for (String relative : beforePaths) {
+                Path lexical = root.getValue().resolve(relative);
+                BasicFileAttributes lexicalAttributes = Files.readAttributes(
+                        lexical, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                if (lexicalAttributes.isDirectory()) {
+                    continue;
+                }
+                Path resolved = resolveWithin(root.getValue(), lexical);
+                StableBytes stable = readStable(resolved);
+                sink.store(stable.digest(), stable.content().clone());
+                boolean executable = (stable.identity().mode() & 0111) != 0;
+                files.add(new RuntimeFile(
+                        root.getKey(), relative, stable.digest(), stable.content().length, executable));
+                captured.put(root.getKey() + "\0" + relative,
+                        new CapturedSource(root.getValue(), lexical, resolved, stable.identity()));
+                if (root.getKey().equals(entryRoot) && relative.equals(entryRelative)) {
+                    entryDigest = stable.digest();
+                }
+            }
+            verifyUnchanged(root.getValue(), rootBefore, beforePaths, captured);
+        }
+        if (entryRoot == null || entryDigest == null) {
+            throw new IOException("Runtime entry point is absent from the captured closure");
+        }
+        RuntimeClosureManifest manifest = new RuntimeClosureManifest(
+                RuntimeClosureManifest.SCHEMA_VERSION,
+                new EntryPoint(entryRoot, entryRelative, entryDigest),
+                files);
+        byte[] encoded = ShipJson.mapper().writeValueAsBytes(manifest);
+        String digest = ShipDigest.sha256(encoded);
+        sink.store(digest, encoded.clone());
+        return new Snapshot(encoded, digest);
+    }
+
+    private static Map<String, Path> canonicalRoots(Map<String, Path> supplied) throws IOException {
+        Objects.requireNonNull(supplied, "runtime closure roots");
+        if (supplied.isEmpty() || supplied.size() > MAX_ROOTS) {
+            throw new IllegalArgumentException("Runtime closure must have 1.." + MAX_ROOTS + " roots");
+        }
+        TreeMap<String, Path> roots = new TreeMap<>();
+        for (Map.Entry<String, Path> entry : supplied.entrySet()) {
+            if (entry.getKey() == null || !ID.matcher(entry.getKey()).matches()) {
+                throw new IllegalArgumentException("Runtime closure root ID is not canonical");
+            }
+            Path root = requireRealDirectory(entry.getValue());
+            if (roots.putIfAbsent(entry.getKey(), root) != null) {
+                throw new IllegalArgumentException("Runtime closure root IDs must be unique");
+            }
+        }
+        List<Path> paths = List.copyOf(roots.values());
+        for (int left = 0; left < paths.size(); left++) {
+            for (int right = left + 1; right < paths.size(); right++) {
+                if (paths.get(left).startsWith(paths.get(right))
+                        || paths.get(right).startsWith(paths.get(left))) {
+                    throw new IOException("Runtime closure roots must not overlap");
+                }
+            }
+        }
+        return Collections.unmodifiableMap(roots);
+    }
+
+    private static Path requireRealDirectory(Path supplied) throws IOException {
+        if (supplied == null) {
+            throw new IllegalArgumentException("Runtime closure root is required");
+        }
+        Path root = supplied.toAbsolutePath().normalize();
+        rejectSymbolicParents(root);
+        if (Files.isSymbolicLink(root)
+                || !Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)
+                || !root.toRealPath(LinkOption.NOFOLLOW_LINKS).equals(root)) {
+            throw new IOException("Runtime closure root must be a link-free real directory");
+        }
+        identity(root, true);
+        return root;
+    }
+
+    private static void rejectSymbolicParents(Path path) throws IOException {
+        Path current = path.getRoot();
+        for (Path component : path) {
+            current = current == null ? component : current.resolve(component);
+            if (Files.isSymbolicLink(current)) {
+                throw new IOException("Runtime closure path contains a symbolic directory");
+            }
+        }
+    }
+
+    private static Path resolveEntryPoint(Path supplied, Iterable<Path> roots) throws IOException {
+        if (supplied == null) {
+            throw new IllegalArgumentException("Runtime entry point is required");
+        }
+        Path resolved = resolveSymlinks(supplied.toAbsolutePath().normalize(), null);
+        for (Path root : roots) {
+            if (resolved.startsWith(root)) {
+                return resolved;
+            }
+        }
+        throw new IOException("Runtime entry point resolves outside the declared closure roots");
+    }
+
+    private static Path resolveWithin(Path root, Path lexical) throws IOException {
+        Path resolved = resolveSymlinks(lexical, root);
+        if (!resolved.startsWith(root)) {
+            throw new IOException("Runtime closure symlink escapes its declared root");
+        }
+        return resolved;
+    }
+
+    private static Path resolveSymlinks(Path supplied, Path requiredRoot) throws IOException {
+        Path current = supplied;
+        Set<Path> seen = new HashSet<>();
+        for (int links = 0; links <= MAX_SYMLINKS; links++) {
+            if (!seen.add(current)) {
+                throw new IOException("Runtime closure contains a symbolic-link cycle");
+            }
+            BasicFileAttributes attributes = Files.readAttributes(
+                    current, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!attributes.isSymbolicLink()) {
+                if (!attributes.isRegularFile()) {
+                    throw new IOException("Runtime closure entry is not a regular file");
+                }
+                Path real = current.toRealPath(LinkOption.NOFOLLOW_LINKS);
+                if (!real.equals(current)
+                        || requiredRoot != null && !real.startsWith(requiredRoot)) {
+                    throw new IOException("Runtime closure entry changed while resolving links");
+                }
+                return real;
+            }
+            if (links == MAX_SYMLINKS) {
+                throw new IOException("Runtime closure symbolic-link chain is too deep");
+            }
+            Path target = Files.readSymbolicLink(current);
+            if (target.isAbsolute()) {
+                throw new IOException("Runtime closure symbolic links must be relative");
+            }
+            current = current.getParent().resolve(target).normalize();
+            if (requiredRoot != null && !current.startsWith(requiredRoot)) {
+                throw new IOException("Runtime closure symlink escapes its declared root");
+            }
+        }
+        throw new IOException("Runtime closure symbolic-link resolution failed");
+    }
+
+    private static List<String> listPaths(Path root) throws IOException {
+        try (Stream<Path> paths = Files.walk(root)) {
+            List<String> result = paths
+                    .filter(path -> !path.equals(root))
+                    .map(root::relativize)
+                    .map(Path::toString)
+                    .map(value -> value.replace('\\', '/'))
+                    .sorted()
+                    .toList();
+            if (result.size() > RuntimeClosureManifest.MAX_FILES) {
+                throw new IOException("Runtime closure exceeds its entry-count limit");
+            }
+            result.forEach(ShipTreePolicy::requireCanonicalRelativePath);
+            return result;
+        }
+    }
+
+    private static StableBytes readStable(Path path) throws IOException {
+        FileIdentity before = identity(path, false);
+        if (before.size() > RuntimeClosureManifest.MAX_FILE_BYTES
+                || before.size() > Integer.MAX_VALUE) {
+            throw new IOException("Runtime closure file exceeds its per-file byte limit");
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.toIntExact(before.size()));
+        try (SeekableByteChannel input = Files.newByteChannel(path, READ_OPTIONS)) {
+            ByteBuffer buffer = ByteBuffer.allocate(8192);
+            long total = 0;
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                if (read == 0) {
+                    continue;
+                }
+                total = Math.addExact(total, read);
+                if (total > before.size()) {
+                    throw new IOException("Runtime closure file grew while it was read");
+                }
+                output.write(buffer.array(), 0, read);
+                buffer.clear();
+            }
+        }
+        FileIdentity after = identity(path, false);
+        if (!before.equals(after) || output.size() != before.size()) {
+            throw new IOException("Runtime closure file changed while it was read");
+        }
+        byte[] content = output.toByteArray();
+        return new StableBytes(content, ShipDigest.sha256(content), after);
+    }
+
+    private static void verifyUnchanged(
+            Path root,
+            FileIdentity rootBefore,
+            List<String> beforePaths,
+            Map<String, CapturedSource> captured)
+            throws IOException {
+        if (!rootBefore.equals(identity(root, true)) || !beforePaths.equals(listPaths(root))) {
+            throw new IOException("Runtime closure root changed while it was captured");
+        }
+        for (CapturedSource source : captured.values()) {
+            if (!source.root().equals(root)) {
+                continue;
+            }
+            Path rebound = resolveWithin(root, source.lexical());
+            if (!source.resolved().equals(rebound)
+                    || !source.identity().equals(identity(rebound, false))) {
+                throw new IOException("Runtime closure file changed while it was captured");
+            }
+        }
+    }
+
+    private static FileIdentity identity(Path path, boolean directory) throws IOException {
+        BasicFileAttributes before = Files.readAttributes(
+                path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (before.fileKey() == null
+                || directory && !before.isDirectory()
+                || !directory && !before.isRegularFile()) {
+            throw new IOException("Runtime closure lacks a stable regular filesystem identity");
+        }
+        Map<String, Object> unix = Files.readAttributes(
+                path, UNIX_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
+        BasicFileAttributes after = Files.readAttributes(
+                path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        Map<String, Object> unixAfter = Files.readAttributes(
+                path, UNIX_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
+        BasicFileAttributes rebound = Files.readAttributes(
+                path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        FileIdentity identity = fileIdentity(before.fileKey(), unix);
+        FileIdentity reboundIdentity = fileIdentity(rebound.fileKey(), unixAfter);
+        if (!before.fileKey().equals(after.fileKey())
+                || !before.fileKey().equals(rebound.fileKey())
+                || !identity.equals(reboundIdentity)
+                || identity.size() != before.size()
+                || identity.size() != after.size()
+                || identity.size() != rebound.size()
+                || identity.modifiedNanos()
+                   != before.lastModifiedTime().to(TimeUnit.NANOSECONDS)
+                || identity.modifiedNanos()
+                   != after.lastModifiedTime().to(TimeUnit.NANOSECONDS)
+                || identity.modifiedNanos()
+                   != rebound.lastModifiedTime().to(TimeUnit.NANOSECONDS)
+                || !directory && identity.linkCount() != 1) {
+            throw new IOException("Runtime closure filesystem identity is mutable or aliased");
+        }
+        return identity;
+    }
+
+    private static FileIdentity fileIdentity(Object fileKey, Map<String, Object> unix)
+            throws IOException {
+        return new FileIdentity(
+                fileKey,
+                number(unix, "dev"),
+                number(unix, "ino"),
+                number(unix, "nlink"),
+                number(unix, "size"),
+                time(unix, "lastModifiedTime"),
+                time(unix, "ctime"),
+                Math.toIntExact(number(unix, "mode")));
+    }
+
+    private static long number(Map<String, Object> values, String name) throws IOException {
+        Object value = values.get(name);
+        if (!(value instanceof Number number)) {
+            throw new IOException("Runtime closure filesystem lacks Unix attribute " + name);
+        }
+        return number.longValue();
+    }
+
+    private static long time(Map<String, Object> values, String name) throws IOException {
+        Object value = values.get(name);
+        if (!(value instanceof FileTime time)) {
+            throw new IOException("Runtime closure filesystem lacks Unix attribute " + name);
+        }
+        return time.to(TimeUnit.NANOSECONDS);
+    }
+
+    @FunctionalInterface
+    public interface BlobSink {
+
+        void store(String digest, byte[] content) throws IOException;
+    }
+
+    public record Snapshot(byte[] manifest, String digest) {
+
+        public Snapshot {
+            manifest = manifest.clone();
+            if (!digest.equals(ShipDigest.sha256(manifest))) {
+                throw new IllegalArgumentException("Runtime closure snapshot digest does not match its manifest");
+            }
+        }
+
+        @Override
+        public byte[] manifest() {
+            return manifest.clone();
+        }
+    }
+
+    private record StableBytes(byte[] content, String digest, FileIdentity identity) {
+    }
+
+    private record CapturedSource(
+            Path root,
+            Path lexical,
+            Path resolved,
+            FileIdentity identity) {
+    }
+
+    private record FileIdentity(
+            Object fileKey,
+            long device,
+            long inode,
+            long linkCount,
+            long size,
+            long modifiedNanos,
+            long changedNanos,
+            int mode) {
+    }
+}

--- a/camel-kit-core/src/main/resources/ship/schema/adapter-certification-pack.schema.json
+++ b/camel-kit-core/src/main/resources/ship/schema/adapter-certification-pack.schema.json
@@ -21,8 +21,8 @@
     "conformanceEvidenceDigest": { "$ref": "#/$defs/digest" },
     "components": {
       "type": "array",
-      "minItems": 11,
-      "maxItems": 11,
+      "minItems": 14,
+      "maxItems": 14,
       "items": { "$ref": "#/$defs/component" }
     }
   },
@@ -41,6 +41,9 @@
         "kind": {
           "enum": [
             "runtime",
+            "language-runtime",
+            "package-closure",
+            "abi",
             "adapter",
             "ingress",
             "interaction",

--- a/camel-kit-core/src/main/resources/ship/schema/adapter-conformance-evidence.schema.json
+++ b/camel-kit-core/src/main/resources/ship/schema/adapter-conformance-evidence.schema.json
@@ -17,6 +17,11 @@
     "launchProfile",
     "runtimeProfile",
     "runtimeArtifactDigest",
+    "languageRuntimeVersion",
+    "languageRuntimeArtifactDigest",
+    "packageClosureDigest",
+    "abiId",
+    "abiVersion",
     "driverDigest",
     "ingressDigest",
     "testSuiteDigest",
@@ -59,6 +64,21 @@
     },
     "runtimeArtifactDigest": {
       "$ref": "#/$defs/digest"
+    },
+    "languageRuntimeVersion": {
+      "$ref": "#/$defs/version"
+    },
+    "languageRuntimeArtifactDigest": {
+      "$ref": "#/$defs/digest"
+    },
+    "packageClosureDigest": {
+      "$ref": "#/$defs/digest"
+    },
+    "abiId": {
+      "$ref": "#/$defs/id"
+    },
+    "abiVersion": {
+      "$ref": "#/$defs/version"
     },
     "driverDigest": {
       "$ref": "#/$defs/digest"

--- a/camel-kit-core/src/main/resources/ship/schema/runtime-closure.schema.json
+++ b/camel-kit-core/src/main/resources/ship/schema/runtime-closure.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luigidemasi/camel-kit/schemas/ship/v1/runtime-closure.schema.json",
+  "title": "Camel Ship portable runtime closure",
+  "description": "Path-free file identities for one exact immutable runtime and package closure.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "entryPoint",
+    "files"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "entryPoint": { "$ref": "#/$defs/entryPoint" },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50000,
+      "items": { "$ref": "#/$defs/file" }
+    }
+  },
+  "$defs": {
+    "entryPoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rootId",
+        "relativePath",
+        "digest"
+      ],
+      "properties": {
+        "rootId": { "$ref": "#/$defs/rootId" },
+        "relativePath": { "$ref": "#/$defs/relativePath" },
+        "digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rootId",
+        "relativePath",
+        "digest",
+        "byteSize",
+        "executable"
+      ],
+      "properties": {
+        "rootId": {
+          "$ref": "#/$defs/rootId"
+        },
+        "relativePath": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "byteSize": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 268435456
+        },
+        "executable": {
+          "type": "boolean"
+        }
+      }
+    },
+    "rootId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{0,63}$"
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "pattern": "^(?!/)(?!.*\\\\)(?!\\.{1,2}(?:/|$))(?!.*(?:/\\.{1,2})(?:/|$))(?!.*//)[^\\u0000-\\u001f\\u007f/]+(?:/[^\\u0000-\\u001f\\u007f/]+)*$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifierTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterCertificationVerifierTest.java
@@ -56,6 +56,9 @@ class AdapterCertificationVerifierTest {
         blobs = new LinkedHashMap<>();
         components = new ArrayList<>();
         component("runtime", "pi", "0.80.6", "pi-runtime");
+        component("language-runtime", "node", "22.22.2", "node-runtime");
+        component("package-closure", "pi-package-tree", "1", packageClosure());
+        component("abi", "glibc", "2.42", "glibc-abi");
         component("adapter", "pi-native", "1.0.0", "pi-driver");
         component("ingress", "pi-ingress", "1.0.0", "pi-ingress");
         component("interaction", "gnome-polkit-fingerprint", "1.0.0", "interaction");
@@ -79,7 +82,10 @@ class AdapterCertificationVerifierTest {
         assertEquals("pi-native", descriptor.adapterId());
         assertEquals("linux", descriptor.operatingSystem());
         assertEquals("x86_64", descriptor.architecture());
-        assertEquals(11, descriptor.components().size());
+        assertEquals("22.22.2", descriptor.languageRuntimeVersion());
+        assertEquals("glibc", descriptor.abiId());
+        assertEquals("2.42", descriptor.abiVersion());
+        assertEquals(14, descriptor.components().size());
         assertFalse(descriptor.components().values().stream()
                 .map(Component::digest)
                 .anyMatch(value -> !ShipDigest.isSha256(value)));
@@ -154,6 +160,21 @@ class AdapterCertificationVerifierTest {
         bundle = bundle(7, "2", components, validEvidence(false));
         blobs.put(digest("unreferenced"), "unreferenced".getBytes(StandardCharsets.UTF_8));
         assertInvalid(bundle, policy(7, "2"));
+    }
+
+    @Test
+    void resolvesEveryPortablePackageFileAndRejectsClosureSubstitution() throws Exception {
+        Bundle bundle = bundle(7, "2", components, validEvidence(false));
+        blobs.remove(digest("package-json"));
+        assertInvalid(bundle, policy(7, "2"));
+
+        setUp();
+        List<Component> substituted = new ArrayList<>(components);
+        Component closure = substituted.get(2);
+        substituted.set(2, new Component(
+                closure.kind(), closure.id(), closure.version(), digest("different"), 9));
+        blobs.put(digest("different"), "different".getBytes(StandardCharsets.UTF_8));
+        assertInvalid(bundle(7, "2", substituted, validEvidence(false)), policy(7, "2"));
     }
 
     private VerifiedLaunchDescriptor verify(Bundle bundle, TrustPolicy policy) {
@@ -277,6 +298,11 @@ class AdapterCertificationVerifierTest {
                   "launchProfile": "systemd-bwrap-v1",
                   "runtimeProfile": "fedora-43-node-24",
                   "runtimeArtifactDigest": "%s",
+                  "languageRuntimeVersion": "%s",
+                  "languageRuntimeArtifactDigest": "%s",
+                  "packageClosureDigest": "%s",
+                  "abiId": "%s",
+                  "abiVersion": "%s",
                   "driverDigest": "%s",
                   "ingressDigest": "%s",
                   "testSuiteDigest": "%s",
@@ -290,10 +316,43 @@ class AdapterCertificationVerifierTest {
                 byKind.get("adapter").version(),
                 byKind.get("protocol").version(),
                 byKind.get("runtime").digest(),
+                byKind.get("language-runtime").version(),
+                byKind.get("language-runtime").digest(),
+                byKind.get("package-closure").digest(),
+                byKind.get("abi").id(),
+                byKind.get("abi").version(),
                 byKind.get("adapter").digest(),
                 byKind.get("ingress").digest(),
                 byKind.get("conformance-suite").digest(),
                 checks);
+    }
+
+    private String packageClosure() throws Exception {
+        byte[] packageJson = "package-json".getBytes(StandardCharsets.UTF_8);
+        byte[] empty = new byte[0];
+        blobs.put(ShipDigest.sha256(packageJson), packageJson);
+        blobs.put(ShipDigest.sha256(empty), empty);
+        return new String(
+                ShipJson.mapper().writeValueAsBytes(Map.of(
+                        "schemaVersion", 1,
+                        "entryPoint", Map.of(
+                                "rootId", "pi",
+                                "relativePath", "package.json",
+                                "digest", ShipDigest.sha256(packageJson)),
+                        "files", List.of(
+                                Map.of(
+                                        "rootId", "pi",
+                                        "relativePath", "package.json",
+                                        "digest", ShipDigest.sha256(packageJson),
+                                        "byteSize", packageJson.length,
+                                        "executable", true),
+                                Map.of(
+                                        "rootId", "pi",
+                                        "relativePath", "resources/empty",
+                                        "digest", ShipDigest.sha256(empty),
+                                        "byteSize", 0,
+                                        "executable", false)))),
+                StandardCharsets.UTF_8);
     }
 
     private static String suite() throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifierTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/AdapterConformanceEvidenceVerifierTest.java
@@ -47,6 +47,9 @@ class AdapterConformanceEvidenceVerifierTest {
         assertEquals("amd64", evidence.architecture());
         assertEquals("native-v1", evidence.launchProfile());
         assertEquals("camel-main-v1", evidence.runtimeProfile());
+        assertEquals("22.22.2", evidence.languageRuntimeVersion());
+        assertEquals("glibc", evidence.abiId());
+        assertEquals("2.42", evidence.abiVersion());
         assertEquals(CHECKS, evidence.checks().stream().map(check -> check.checkId()).toList());
         assertEquals(12, evidence.checks().size());
     }
@@ -144,6 +147,11 @@ class AdapterConformanceEvidenceVerifierTest {
                   "launchProfile": "native-v1",
                   "runtimeProfile": "camel-main-v1",
                   "runtimeArtifactDigest": "%s",
+                  "languageRuntimeVersion": "22.22.2",
+                  "languageRuntimeArtifactDigest": "%s",
+                  "packageClosureDigest": "%s",
+                  "abiId": "glibc",
+                  "abiVersion": "2.42",
                   "driverDigest": "%s",
                   "ingressDigest": "%s",
                   "testSuiteDigest": "%s",
@@ -151,7 +159,7 @@ class AdapterConformanceEvidenceVerifierTest {
                 %s
                   ]
                 }
-                """, DIGEST, DIGEST, DIGEST, suiteDigest(), checkRows);
+                """, DIGEST, DIGEST, DIGEST, DIGEST, DIGEST, suiteDigest(), checkRows);
     }
 
     private static String suiteDigest() throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/RuntimeClosureSnapshotterTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/conformance/RuntimeClosureSnapshotterTest.java
@@ -1,0 +1,90 @@
+package io.github.luigidemasi.camelkit.ship.conformance;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipJson;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class RuntimeClosureSnapshotterTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void snapshotsAPathFreeClosureAndResolvesInternalAndEntrypointLinks() throws Exception {
+        Path root = Files.createDirectory(temporaryDirectory.resolve("package")).toRealPath();
+        Path dist = Files.createDirectory(root.resolve("dist"));
+        Path bin = Files.createDirectory(root.resolve("bin"));
+        Path cli = Files.writeString(dist.resolve("cli.js"), "#!/usr/bin/env node\n");
+        Files.setPosixFilePermissions(cli, PosixFilePermissions.fromString("rwxr-xr-x"));
+        Files.writeString(root.resolve("package.json"), "{\"version\":\"0.81.1\"}\n");
+        Files.write(root.resolve("empty"), new byte[0]);
+        Files.createSymbolicLink(bin.resolve("pi"), Path.of("../dist/cli.js"));
+        Path external = temporaryDirectory.resolve("pi");
+        Files.createSymbolicLink(external, external.getParent().relativize(cli));
+        Map<String, byte[]> blobs = new LinkedHashMap<>();
+
+        RuntimeClosureSnapshotter.Snapshot snapshot = RuntimeClosureSnapshotter.capture(
+                external, Map.of("pi", root), (digest, content) -> blobs.put(digest, content));
+
+        RuntimeClosureManifest manifest = ShipJson.mapper().readValue(
+                snapshot.manifest(), RuntimeClosureManifest.class);
+        assertEquals("pi", manifest.entryPoint().rootId());
+        assertEquals("dist/cli.js", manifest.entryPoint().relativePath());
+        assertEquals(4, manifest.files().size());
+        assertEquals(snapshot.digest(), ShipDigest.sha256(snapshot.manifest()));
+        assertEquals(snapshot.manifest().length, blobs.get(snapshot.digest()).length);
+        assertFalse(new String(snapshot.manifest(), StandardCharsets.UTF_8)
+                .contains(temporaryDirectory.toString()));
+        assertTrue(manifest.files().stream()
+                .filter(file -> file.relativePath().equals("bin/pi"))
+                .findFirst()
+                .orElseThrow()
+                .executable());
+    }
+
+    @Test
+    void rejectsCyclesEscapesAndMutationDuringCapture() throws Exception {
+        Path root = Files.createDirectory(temporaryDirectory.resolve("package")).toRealPath();
+        Path cli = Files.writeString(root.resolve("cli.js"), "cli");
+        Files.setPosixFilePermissions(cli, PosixFilePermissions.fromString("rwx------"));
+        Path cycle = root.resolve("cycle");
+        Files.createSymbolicLink(cycle, Path.of("cycle"));
+        assertThrows(IOException.class, () -> RuntimeClosureSnapshotter.capture(
+                cli, Map.of("pi", root), (digest, content) -> {
+                }));
+
+        Files.delete(cycle);
+        Path outside = Files.writeString(temporaryDirectory.resolve("outside"), "outside");
+        Files.createSymbolicLink(root.resolve("escape"), Path.of("../outside"));
+        assertThrows(IOException.class, () -> RuntimeClosureSnapshotter.capture(
+                cli, Map.of("pi", root), (digest, content) -> {
+                }));
+
+        Files.delete(root.resolve("escape"));
+        Path mutable = Files.writeString(root.resolve("package.json"), "{}");
+        assertThrows(IOException.class, () -> RuntimeClosureSnapshotter.capture(
+                cli, Map.of("pi", root), (digest, content) -> {
+                    if (new String(content, StandardCharsets.UTF_8).equals("{}")) {
+                        Files.writeString(mutable, "{\"changed\":true}");
+                    }
+                }));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/schema/ShipSchemaResourceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/schema/ShipSchemaResourceTest.java
@@ -19,6 +19,7 @@ import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord;
+import io.github.luigidemasi.camelkit.ship.conformance.RuntimeClosureManifest;
 import io.github.luigidemasi.camelkit.ship.context.InitialContext;
 import io.github.luigidemasi.camelkit.ship.controller.ShipEventType;
 import io.github.luigidemasi.camelkit.ship.controller.ShipInteractionBundle;
@@ -67,6 +68,7 @@ class ShipSchemaResourceTest {
             "initial-context.schema.json",
             "interaction-bundle.schema.json",
             "interaction.schema.json",
+            "runtime-closure.schema.json",
             "ship-event.schema.json",
             "ship-stamp.schema.json",
             "stage-request.schema.json",
@@ -474,6 +476,11 @@ class ShipSchemaResourceTest {
                 "launchProfile",
                 "runtimeProfile",
                 "runtimeArtifactDigest",
+                "languageRuntimeVersion",
+                "languageRuntimeArtifactDigest",
+                "packageClosureDigest",
+                "abiId",
+                "abiVersion",
                 "driverDigest",
                 "ingressDigest",
                 "testSuiteDigest",
@@ -523,13 +530,16 @@ class ShipSchemaResourceTest {
                 "protocolVersion",
                 "conformanceEvidenceDigest",
                 "components"), fieldNames(pack.path("properties")));
-        assertEquals(11, pack.at("/properties/components/minItems").intValue());
-        assertEquals(11, pack.at("/properties/components/maxItems").intValue());
+        assertEquals(14, pack.at("/properties/components/minItems").intValue());
+        assertEquals(14, pack.at("/properties/components/maxItems").intValue());
         Set<String> componentKinds = new LinkedHashSet<>();
         pack.at("/$defs/component/properties/kind/enum")
                 .forEach(value -> componentKinds.add(value.asText()));
         assertEquals(Set.of(
                 "runtime",
+                "language-runtime",
+                "package-closure",
+                "abi",
                 "adapter",
                 "ingress",
                 "interaction",
@@ -540,6 +550,21 @@ class ShipSchemaResourceTest {
                 "controller",
                 "protocol",
                 "conformance-suite"), componentKinds);
+
+        JsonNode closure = readSchema("runtime-closure.schema.json");
+        assertEquals(
+                Set.of("schemaVersion", "entryPoint", "files"),
+                fieldNames(closure.path("properties")));
+        assertEquals(
+                Set.of("rootId", "relativePath", "digest"),
+                fieldNames(closure.at("/$defs/entryPoint/properties")));
+        assertEquals(
+                Set.of("rootId", "relativePath", "digest", "byteSize", "executable"),
+                fieldNames(closure.at("/$defs/file/properties")));
+        assertRecordShape(closure, "", RuntimeClosureManifest.class);
+        assertRecordShape(closure, "/$defs/entryPoint", RuntimeClosureManifest.EntryPoint.class);
+        assertRecordShape(closure, "/$defs/file", RuntimeClosureManifest.RuntimeFile.class);
+        assertEquals(50_000, closure.at("/properties/files/maxItems").intValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- extend exact-tuple evidence with Node runtime, package-closure, and ABI identities
- define a closed portable runtime-closure manifest with a content-bound executable entry point
- snapshot mutable package-manager installations into a caller-owned content-addressed sink
- reject symlink cycles and escapes, hard links, overlapping roots, concurrent mutation, path leakage, and incomplete blob inventories

## Verification

- `./mvnw -B clean install`
- focused closure/certification/schema suite: 26 tests passed after the final filesystem identity hardening
- 910 core tests passed; all reactor, forbidden-API, resolver isolation, controller isolation, and artifact-import wiring gates passed

## Stack

This PR is stacked on #162 and is another internal prerequisite for #149. It does not launch Pi, change the support registry, or register `camel-kit ship`.

Website impact for this internal slice: **not required**. Issue #149's eventual certified tuple and public cutover remain **required**.

## Summary by Sourcery

Bind adapter certification to a closed runtime package-closure and extended exact tuple evidence including language runtime and ABI identities.

New Features:
- Introduce runtime closure manifest and snapshotter to capture a portable, path-free snapshot of runtime package trees with a verified executable entry point.

Bug Fixes:
- Ensure runtime adapter certification rejects substituted or missing package files and unreferenced blob content in the closure inventory.

Enhancements:
- Extend adapter certification components and evidence tuple to include language runtime, package-closure, and ABI identities and digests, and incorporate closure files into the verified blob inventory.
- Harden blob resolution to allow empty runtime closure files while still enforcing size limits and digest integrity.
- Extend JSON schema definitions to cover runtime closures and updated adapter certification/conformance evidence fields, keeping schemas closed and canonically bounded.

Tests:
- Add runtime closure snapshotter tests to verify path-free closure creation, symlink resolution, and rejection of cycles, escapes, and mutation during capture.
- Extend adapter certification and conformance evidence tests to cover language runtime and ABI fields and validation of runtime package closure integrity and inventory.