### PR TITLE
Add compact local Ship controller substrate

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -1,0 +1,176 @@
+package io.github.luigidemasi.camelkit.command.ship;
+
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+import io.github.luigidemasi.camelkit.ship.controller.ShipController;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+
+import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
+import picocli.CommandLine.TypeConversionException;
+
+/** Local Ship controller command. Kept unregistered until the worker path passes its live gates. */
+@Command(
+         name = "ship",
+         mixinStandardHelpOptions = true,
+         description = "Start, inspect, resume, or abort a local Camel Ship run")
+public final class ShipCommand implements Callable<Integer> {
+
+    private final ShipController controller;
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @ArgGroup(exclusive = true, multiplicity = "0..1")
+    Operation operation;
+
+    @ArgGroup(exclusive = true, multiplicity = "0..*")
+    List<ContextArgument> contextArguments = new ArrayList<>();
+
+    @Option(
+            names = "--ask",
+            paramLabel = "POLICY",
+            converter = OversightConverter.class,
+            description = "Oversight policy: always, smart, or never")
+    Oversight oversight;
+
+    @Option(names = "--project-dir", defaultValue = ".", hidden = true)
+    Path projectDirectory;
+
+    public ShipCommand() {
+        this(new ShipController(ShipController.defaultStateRoot()));
+    }
+
+    ShipCommand(ShipController controller) {
+        this.controller = controller;
+    }
+
+    @Override
+    public Integer call() {
+        validateArguments();
+        try {
+            ShipRun run = execute();
+            printSummary(run);
+            return 0;
+        } catch (ShipController.Failure e) {
+            PrintWriter writer = spec.commandLine().getErr();
+            writer.println("Error [" + e.code() + "]: " + e.getMessage());
+            writer.flush();
+            return 1;
+        }
+    }
+
+    private ShipRun execute() {
+        if (operation == null) {
+            return controller.start(projectDirectory, selectedOversight(), inputs());
+        }
+        if (operation.resume != null) {
+            return controller.resume(operation.resume);
+        }
+        if (operation.status != null) {
+            return controller.status(operation.status);
+        }
+        if (operation.abort != null) {
+            return controller.abort(operation.abort);
+        }
+        return controller.startFrom(projectDirectory, operation.startFrom, selectedOversight(), inputs());
+    }
+
+    private void validateArguments() {
+        if (operation != null && operation.startFrom == null
+                && (oversight != null || !contextArguments.isEmpty())) {
+            throw new ParameterException(
+                    spec.commandLine(),
+                    "--ask, --text, and --document are only valid when starting a run");
+        }
+    }
+
+    private Oversight selectedOversight() {
+        return oversight == null ? Oversight.SMART : oversight;
+    }
+
+    private List<ShipContext.Input> inputs() {
+        return contextArguments.stream().map(ContextArgument::input).toList();
+    }
+
+    private void printSummary(ShipRun run) {
+        PrintWriter writer = spec.commandLine().getOut();
+        writer.println("Run: " + run.id());
+        writer.println("Status: " + run.status());
+        writer.println("Stage: " + run.currentStage());
+        writer.println("Oversight: " + run.oversight());
+        writer.flush();
+    }
+
+    static final class Operation {
+
+        @Option(names = "--resume", paramLabel = "RUN_ID", description = "Resume an existing run")
+        String resume;
+
+        @Option(
+                names = "--start-from",
+                paramLabel = "STAGE",
+                converter = StageConverter.class,
+                description = "Start at discovery, design, plan, execute, or validate")
+        Stage startFrom;
+
+        @Option(names = "--status", paramLabel = "RUN_ID", description = "Show an existing run")
+        String status;
+
+        @Option(names = "--abort", paramLabel = "RUN_ID", description = "Abort an existing run")
+        String abort;
+    }
+
+    static final class ContextArgument {
+
+        @Option(names = "--text", paramLabel = "TEXT", description = "Add text context")
+        String text;
+
+        @Option(names = "--document", paramLabel = "PATH", description = "Add document context")
+        Path document;
+
+        ShipContext.Input input() {
+            return document == null
+                    ? new ShipContext.TextInput(text)
+                    : new ShipContext.DocumentInput(document);
+        }
+    }
+
+    static final class OversightConverter implements ITypeConverter<Oversight> {
+
+        @Override
+        public Oversight convert(String value) {
+            try {
+                return Oversight.valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new TypeConversionException("expected always, smart, or never");
+            }
+        }
+    }
+
+    static final class StageConverter implements ITypeConverter<Stage> {
+
+        @Override
+        public Stage convert(String value) {
+            try {
+                return Stage.valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new TypeConversionException(
+                        "expected discovery, design, plan, execute, or validate");
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/context/ShipContext.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/context/ShipContext.java
@@ -1,0 +1,461 @@
+package io.github.luigidemasi.camelkit.ship.context;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+
+/** Ordered, content-addressed initial input for one local Ship run. */
+public record ShipContext(List<Source> sources, String digest) {
+
+    public static final int MAX_SOURCES = 256;
+    public static final int MAX_DOCUMENT_BYTES = 4 * 1024 * 1024;
+    public static final int MAX_TOTAL_BYTES = 8 * 1024 * 1024;
+
+    private static final String DIGEST_VERSION = "camel-kit.ship.context.v1";
+
+    public ShipContext {
+        sources = List.copyOf(Objects.requireNonNull(sources, "context sources"));
+        if (sources.size() > MAX_SOURCES) {
+            throw new IllegalArgumentException("Ship context exceeds the source-count limit");
+        }
+        long total = 0;
+        for (Source source : sources) {
+            Objects.requireNonNull(source, "context source");
+            total += source.byteCount();
+            if (total > MAX_TOTAL_BYTES) {
+                throw new IllegalArgumentException("Ship context exceeds the aggregate-byte limit");
+            }
+        }
+        if (!ShipDigest.isSha256(digest) || !aggregateDigest(sources).equals(digest)) {
+            throw new IllegalArgumentException("Ship context digest does not match its ordered sources");
+        }
+    }
+
+    /** Returns the stable representation of a bare invocation. */
+    public static ShipContext none() {
+        return fromSources(List.of());
+    }
+
+    /**
+     * Resolves ordered text and document input. Relative documents are resolved from {@code projectRoot}; recorded
+     * document paths are normalized and absolute.
+     */
+    public static ShipContext resolve(Path projectRoot, List<? extends Input> inputs)
+            throws Failure {
+        Objects.requireNonNull(projectRoot, "project root");
+        Objects.requireNonNull(inputs, "context inputs");
+        if (inputs.size() > MAX_SOURCES) {
+            throw failure(
+                    Failure.Code.CONTEXT_TOO_LARGE,
+                    "sources",
+                    "Ship context exceeds the " + MAX_SOURCES + "-source limit");
+        }
+
+        Path root;
+        try {
+            root = projectRoot.toAbsolutePath().normalize();
+        } catch (SecurityException e) {
+            throw failure(
+                    Failure.Code.UNREADABLE,
+                    "project-root",
+                    "Ship project root cannot be accessed",
+                    e);
+        }
+
+        List<Source> resolved = new ArrayList<>(inputs.size());
+        long total = 0;
+        for (int ordinal = 0; ordinal < inputs.size(); ordinal++) {
+            Input input = inputs.get(ordinal);
+            if (input == null) {
+                throw failure(
+                        Failure.Code.MALFORMED,
+                        "source-" + ordinal,
+                        "Ship context contains a null source");
+            }
+            Source source = input instanceof TextInput text
+                    ? resolveText(text, ordinal)
+                    : resolveDocument(root, (DocumentInput) input, ordinal);
+            total = addToTotal(total, source.byteCount(), sourceLabel(source, ordinal));
+            resolved.add(source);
+        }
+        return fromSources(resolved);
+    }
+
+    /** Re-reads every recorded document and returns context with current source and aggregate digests. */
+    public ShipContext refresh() throws Failure {
+        List<Source> refreshed = new ArrayList<>(sources.size());
+        long total = 0;
+        for (int ordinal = 0; ordinal < sources.size(); ordinal++) {
+            Source existing = sources.get(ordinal);
+            Source source;
+            if (existing.kind() == Kind.TEXT) {
+                source = existing;
+            } else {
+                Path path;
+                try {
+                    path = Path.of(existing.value());
+                } catch (InvalidPathException e) {
+                    throw failure(
+                            Failure.Code.MALFORMED,
+                            "document-" + ordinal,
+                            "Recorded Ship document path is malformed",
+                            e);
+                }
+                source = documentSource(path);
+            }
+            total = addToTotal(total, source.byteCount(), sourceLabel(source, ordinal));
+            refreshed.add(source);
+        }
+        return fromSources(refreshed);
+    }
+
+    public sealed interface Input permits TextInput, DocumentInput {
+    }
+
+    /** Exact inline text. Empty text is valid and remains distinct from absent context. */
+    public record TextInput(String text) implements Input {
+        public TextInput {
+            Objects.requireNonNull(text, "context text");
+        }
+
+        @Override
+        public String toString() {
+            return "TextInput[text=<redacted>]";
+        }
+    }
+
+    /** A document path, absolute or relative to the project root supplied to {@link #resolve}. */
+    public record DocumentInput(String path) implements Input {
+        public DocumentInput {
+            Objects.requireNonNull(path, "document path");
+        }
+
+        public DocumentInput(Path path) {
+            this(Objects.requireNonNull(path, "document path").toString());
+        }
+    }
+
+    public enum Kind {
+        TEXT,
+        DOCUMENT
+    }
+
+    /**
+     * Durable source identity. {@link #value} is exact inline text for {@link Kind#TEXT} and a normalized absolute path
+     * for {@link Kind#DOCUMENT}; document content is not persisted.
+     */
+    public record Source(Kind kind, String value, long byteCount, String digest) {
+        public Source {
+            Objects.requireNonNull(kind, "source kind");
+            Objects.requireNonNull(value, "source value");
+            if (!ShipDigest.isSha256(digest)) {
+                throw new IllegalArgumentException("Ship context source digest must be SHA-256");
+            }
+            if (kind == Kind.TEXT) {
+                if (value.indexOf('\0') >= 0 || value.length() > MAX_TOTAL_BYTES) {
+                    throw new IllegalArgumentException("Ship text source is malformed or too large");
+                }
+                byte[] bytes;
+                try {
+                    bytes = strictUtf8(value);
+                } catch (CharacterCodingException e) {
+                    throw new IllegalArgumentException("Ship text source is not strict UTF-8", e);
+                }
+                if (bytes.length > MAX_TOTAL_BYTES
+                        || byteCount != bytes.length
+                        || !digest.equals(ShipDigest.sha256(bytes))) {
+                    throw new IllegalArgumentException("Ship text source identity does not match its content");
+                }
+            } else {
+                Path path;
+                try {
+                    path = Path.of(value);
+                } catch (InvalidPathException e) {
+                    throw new IllegalArgumentException("Ship document source path is malformed", e);
+                }
+                if (!path.isAbsolute()
+                        || !path.normalize().equals(path)
+                        || !path.toString().equals(value)) {
+                    throw new IllegalArgumentException(
+                            "Ship document source path must be normalized and absolute");
+                }
+                if (byteCount < 1 || byteCount > MAX_DOCUMENT_BYTES) {
+                    throw new IllegalArgumentException(
+                            "Ship document source byte count is outside its bounds");
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Source[kind=" + kind
+                   + ", value=" + (kind == Kind.TEXT ? "<redacted>" : value)
+                   + ", byteCount=" + byteCount
+                   + ", digest=" + digest + ']';
+        }
+    }
+
+    /** An actionable failure while resolving or refreshing context. */
+    public static final class Failure extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Code code;
+        private final String input;
+
+        private Failure(Code code, String input, String message) {
+            super(message);
+            this.code = Objects.requireNonNull(code, "failure code");
+            this.input = Objects.requireNonNull(input, "failure input");
+        }
+
+        private Failure(Code code, String input, String message, Throwable cause) {
+            super(message, cause);
+            this.code = Objects.requireNonNull(code, "failure code");
+            this.input = Objects.requireNonNull(input, "failure input");
+        }
+
+        public Code code() {
+            return code;
+        }
+
+        public String input() {
+            return input;
+        }
+
+        public enum Code {
+            MISSING,
+            EMPTY,
+            MALFORMED,
+            UNREADABLE,
+            DOCUMENT_TOO_LARGE,
+            CONTEXT_TOO_LARGE
+        }
+    }
+
+    private static Source resolveText(TextInput input, int ordinal) throws Failure {
+        String text = input.text();
+        if (text.indexOf('\0') >= 0) {
+            throw failure(
+                    Failure.Code.MALFORMED,
+                    "text-" + ordinal,
+                    "Ship text context must not contain NUL");
+        }
+        if (text.length() > MAX_TOTAL_BYTES) {
+            throw contextTooLarge("text-" + ordinal);
+        }
+        byte[] bytes;
+        try {
+            bytes = strictUtf8(text);
+        } catch (CharacterCodingException e) {
+            throw failure(
+                    Failure.Code.MALFORMED,
+                    "text-" + ordinal,
+                    "Ship text context is not strict UTF-8",
+                    e);
+        }
+        if (bytes.length > MAX_TOTAL_BYTES) {
+            throw contextTooLarge("text-" + ordinal);
+        }
+        return new Source(Kind.TEXT, text, bytes.length, ShipDigest.sha256(bytes));
+    }
+
+    private static Source resolveDocument(Path root, DocumentInput input, int ordinal)
+            throws Failure {
+        String value = input.path();
+        if (value.isBlank() || value.indexOf('\0') >= 0) {
+            throw failure(
+                    Failure.Code.MALFORMED,
+                    "document-" + ordinal,
+                    "Ship document path is malformed");
+        }
+        Path supplied;
+        try {
+            supplied = Path.of(value);
+        } catch (InvalidPathException e) {
+            throw failure(
+                    Failure.Code.MALFORMED,
+                    "document-" + ordinal,
+                    "Ship document path is malformed",
+                    e);
+        }
+        Path path;
+        try {
+            path = (supplied.isAbsolute() ? supplied : root.resolve(supplied))
+                    .toAbsolutePath()
+                    .normalize();
+        } catch (SecurityException e) {
+            throw failure(
+                    Failure.Code.UNREADABLE,
+                    "document-" + ordinal,
+                    "Ship document path cannot be accessed",
+                    e);
+        }
+        return documentSource(path);
+    }
+
+    private static Source documentSource(Path path) throws Failure {
+        byte[] bytes = readDocument(path);
+        return new Source(
+                Kind.DOCUMENT, path.toString(), bytes.length, ShipDigest.sha256(bytes));
+    }
+
+    private static byte[] readDocument(Path path) throws Failure {
+        String input = path.toString();
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+            if (!attributes.isRegularFile()) {
+                throw failure(
+                        Failure.Code.MALFORMED,
+                        input,
+                        "Ship document must be a regular file: " + input);
+            }
+            if (!Files.isReadable(path)) {
+                throw failure(
+                        Failure.Code.UNREADABLE,
+                        input,
+                        "Ship document is not readable: " + input);
+            }
+            if (attributes.size() > MAX_DOCUMENT_BYTES) {
+                throw documentTooLarge(input);
+            }
+
+            byte[] bytes;
+            try (InputStream stream = Files.newInputStream(path)) {
+                bytes = stream.readNBytes(MAX_DOCUMENT_BYTES + 1);
+            }
+            if (bytes.length == 0) {
+                throw failure(
+                        Failure.Code.EMPTY,
+                        input,
+                        "Ship document is empty: " + input);
+            }
+            if (bytes.length > MAX_DOCUMENT_BYTES) {
+                throw documentTooLarge(input);
+            }
+            for (byte value : bytes) {
+                if (value == 0) {
+                    throw failure(
+                            Failure.Code.MALFORMED,
+                            input,
+                            "Ship document must not contain NUL: " + input);
+                }
+            }
+            try {
+                StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT)
+                        .decode(ByteBuffer.wrap(bytes));
+            } catch (CharacterCodingException e) {
+                throw failure(
+                        Failure.Code.MALFORMED,
+                        input,
+                        "Ship document is not strict UTF-8: " + input,
+                        e);
+            }
+            return bytes;
+        } catch (Failure e) {
+            throw e;
+        } catch (NoSuchFileException | FileNotFoundException e) {
+            throw failure(
+                    Failure.Code.MISSING,
+                    input,
+                    "Ship document does not exist: " + input,
+                    e);
+        } catch (AccessDeniedException e) {
+            throw failure(
+                    Failure.Code.UNREADABLE,
+                    input,
+                    "Ship document is not readable: " + input,
+                    e);
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    Failure.Code.UNREADABLE,
+                    input,
+                    "Ship document could not be read: " + input,
+                    e);
+        }
+    }
+
+    private static long addToTotal(long current, long additional, String input)
+            throws Failure {
+        long total = current + additional;
+        if (total > MAX_TOTAL_BYTES) {
+            throw contextTooLarge(input);
+        }
+        return total;
+    }
+
+    private static String sourceLabel(Source source, int ordinal) {
+        return source.kind() == Kind.TEXT ? "text-" + ordinal : source.value();
+    }
+
+    private static ShipContext fromSources(List<Source> sources) {
+        List<Source> copy = List.copyOf(sources);
+        return new ShipContext(copy, aggregateDigest(copy));
+    }
+
+    private static String aggregateDigest(List<Source> sources) {
+        StringBuilder identity = new StringBuilder(DIGEST_VERSION);
+        for (Source source : sources) {
+            identity.append('\0').append(source.kind());
+            identity.append('\0');
+            if (source.kind() == Kind.DOCUMENT) {
+                identity.append(source.value());
+            }
+            identity.append('\0').append(source.byteCount());
+            identity.append('\0').append(source.digest());
+        }
+        return ShipDigest.sha256(identity.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static byte[] strictUtf8(String value) throws CharacterCodingException {
+        ByteBuffer encoded = StandardCharsets.UTF_8.newEncoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .encode(CharBuffer.wrap(value));
+        byte[] bytes = new byte[encoded.remaining()];
+        encoded.get(bytes);
+        return bytes;
+    }
+
+    private static Failure documentTooLarge(String input) {
+        return failure(
+                Failure.Code.DOCUMENT_TOO_LARGE,
+                input,
+                "Ship document exceeds the " + MAX_DOCUMENT_BYTES + "-byte limit: " + input);
+    }
+
+    private static Failure contextTooLarge(String input) {
+        return failure(
+                Failure.Code.CONTEXT_TOO_LARGE,
+                input,
+                "Ship context exceeds the " + MAX_TOTAL_BYTES + "-byte limit");
+    }
+
+    private static Failure failure(
+            Failure.Code code, String input, String message) {
+        return new Failure(code, input, message);
+    }
+
+    private static Failure failure(
+            Failure.Code code, String input, String message, Throwable cause) {
+        return new Failure(code, input, message, cause);
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -1,0 +1,725 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.Input;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.ArtifactRef;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageRecord;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Compact local lifecycle service for Ship runs. */
+public final class ShipController {
+
+    private static final int MAX_PROJECT_STATE_BYTES = 1024 * 1024;
+    private static final int MAX_ARTIFACT_BYTES = 64 * 1024 * 1024;
+    private static final String ABORT_MESSAGE = "Run aborted by user";
+    private static final ObjectMapper PROJECT_JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+    private final ShipRunStore store;
+
+    public ShipController(Path stateRoot) {
+        this.store = new ShipRunStore(Objects.requireNonNull(stateRoot, "state root"));
+    }
+
+    /** Resolves the conventional user-owned Ship state directory. */
+    public static Path defaultStateRoot() {
+        String configured = System.getenv("CAMEL_KIT_SHIP_STATE_HOME");
+        if (configured != null && !configured.isBlank()) {
+            return Path.of(configured).toAbsolutePath().normalize();
+        }
+        String xdgState = System.getenv("XDG_STATE_HOME");
+        if (xdgState != null && !xdgState.isBlank()) {
+            return Path.of(xdgState).resolve("camel-kit/ship").toAbsolutePath().normalize();
+        }
+        String userHome = System.getProperty("user.home");
+        if (userHome == null || userHome.isBlank()) {
+            throw new IllegalStateException("Cannot resolve the user state directory");
+        }
+        return Path.of(userHome)
+                .resolve(".local/state/camel-kit/ship")
+                .toAbsolutePath()
+                .normalize();
+    }
+
+    public ShipRun start(
+            Path projectDirectory, Oversight oversight, List<? extends Input> inputs) {
+        String runId = newRunId();
+        Path project = requireProject(projectDirectory);
+        String pipelineId = inspectProjectState(project);
+        ShipContext context = resolveContext(project, inputs);
+        List<StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
+        stages.set(
+                Stage.DISCOVERY.ordinal(),
+                stages.get(Stage.DISCOVERY.ordinal())
+                        .start(ShipRun.inputDigest(context, stages, Stage.DISCOVERY)));
+        ShipRun run = newRun(
+                runId,
+                project,
+                pipelineId,
+                oversight,
+                Stage.DISCOVERY,
+                context,
+                stages);
+        create(run);
+        return run;
+    }
+
+    public ShipRun startFrom(
+            Path projectDirectory,
+            Stage target,
+            Oversight oversight,
+            List<? extends Input> inputs) {
+        String runId = newRunId();
+        Path project = requireProject(projectDirectory);
+        Stage startStage = Objects.requireNonNull(target, "start stage");
+        String pipelineId = inspectProjectState(project);
+        ShipContext context = resolveContext(project, inputs);
+        if (startStage == Stage.DESIGN && context.sources().isEmpty()) {
+            throw failure(
+                    "start-from-context-missing",
+                    "Starting from DESIGN requires text or document context");
+        }
+        List<StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
+
+        for (Stage stage : Stage.values()) {
+            if (stage.ordinal() >= startStage.ordinal()) {
+                break;
+            }
+            String inputDigest = ShipRun.inputDigest(context, stages, stage);
+            List<ArtifactRef> artifacts = importedArtifacts(project, pipelineId, stage);
+            String outputDigest = artifacts.isEmpty()
+                    ? context.digest()
+                    : artifacts.get(0).digest();
+            stages.set(
+                    stage.ordinal(),
+                    stages.get(stage.ordinal()).imported(inputDigest, outputDigest, artifacts));
+        }
+
+        stages.set(
+                startStage.ordinal(),
+                stages.get(startStage.ordinal())
+                        .start(ShipRun.inputDigest(context, stages, startStage)));
+        ShipRun run = newRun(
+                runId,
+                project,
+                pipelineId,
+                oversight,
+                startStage,
+                context,
+                stages);
+        create(run);
+        return run;
+    }
+
+    /** Reads one atomic state snapshot without taking the mutation lock. */
+    public ShipRun status(String runId) {
+        try {
+            return store.read(runId);
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure("state-read-failed", "Could not read Ship run " + runId, e);
+        }
+    }
+
+    /**
+     * Re-reads mutable inputs and restarts the earliest stale or incomplete stage with a fresh attempt.
+     */
+    public ShipRun resume(String runId) {
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            if (current.status() == RunStatus.ABORTED) {
+                throw failure("run-aborted", "Ship run is aborted and cannot resume: " + runId);
+            }
+            if (current.status() == RunStatus.COMPLETED) {
+                throw failure("run-completed", "Ship run is already complete: " + runId);
+            }
+
+            ShipContext refreshed = refreshContext(current.context());
+            List<StageRecord> stages = new ArrayList<>(current.stages());
+            int restart = stages.size();
+
+            for (int index = 0; index < stages.size(); index++) {
+                StageRecord record = stages.get(index);
+                if (record.status() != StageStatus.COMPLETED) {
+                    continue;
+                }
+                List<ArtifactRef> refreshedArtifacts = new ArrayList<>(record.artifacts().size());
+                boolean missing = false;
+                for (ArtifactRef artifact : record.artifacts()) {
+                    try {
+                        refreshedArtifacts.add(readArtifact(
+                                Path.of(current.projectDirectory()), Path.of(artifact.path())));
+                    } catch (Failure e) {
+                        restart = Math.min(restart, index);
+                        missing = true;
+                        break;
+                    }
+                }
+                if (!missing && !refreshedArtifacts.equals(record.artifacts())) {
+                    stages.set(index, record.withArtifacts(refreshedArtifacts));
+                }
+            }
+
+            for (int index = 0; index < stages.size(); index++) {
+                StageRecord record = stages.get(index);
+                if (record.status() != StageStatus.COMPLETED) {
+                    restart = Math.min(restart, index);
+                    break;
+                }
+                if (index < restart) {
+                    String expected = ShipRun.inputDigest(refreshed, stages, record.stage());
+                    if (!expected.equals(record.inputDigest())) {
+                        restart = index;
+                        break;
+                    }
+                }
+            }
+
+            String now = now();
+            ShipRun resumed;
+            if (restart == stages.size()) {
+                resumed = copy(
+                        current,
+                        RunStatus.COMPLETED,
+                        Stage.VALIDATE,
+                        refreshed,
+                        stages,
+                        now,
+                        null);
+            } else {
+                for (int index = restart; index < stages.size(); index++) {
+                    stages.set(index, stages.get(index).reset());
+                }
+                Stage stage = Stage.values()[restart];
+                stages.set(
+                        restart,
+                        stages.get(restart)
+                                .start(ShipRun.inputDigest(refreshed, stages, stage)));
+                resumed = copy(
+                        current,
+                        RunStatus.RUNNING,
+                        stage,
+                        refreshed,
+                        stages,
+                        now,
+                        null);
+            }
+            locked.write(resumed);
+            return resumed;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure("state-write-failed", "Could not resume Ship run " + runId, e);
+        }
+    }
+
+    public ShipRun abort(String runId) {
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            if (current.status() == RunStatus.ABORTED) {
+                throw failure("run-aborted", "Ship run is already aborted: " + runId);
+            }
+            if (current.status() == RunStatus.COMPLETED) {
+                throw failure("run-completed", "Completed Ship run cannot be aborted: " + runId);
+            }
+
+            List<StageRecord> stages = new ArrayList<>(current.stages());
+            boolean allCompleted = stages.stream()
+                    .allMatch(stage -> stage.status() == StageStatus.COMPLETED);
+            if (!allCompleted) {
+                int active = current.currentStage().ordinal();
+                stages.set(active, stages.get(active).abort());
+            }
+            ShipRun aborted = copy(
+                    current,
+                    RunStatus.ABORTED,
+                    current.currentStage(),
+                    current.context(),
+                    stages,
+                    now(),
+                    ABORT_MESSAGE);
+            locked.write(aborted);
+            return aborted;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure("state-write-failed", "Could not abort Ship run " + runId, e);
+        }
+    }
+
+    /**
+     * Records a worker result only when it matches the currently running stage attempt.
+     */
+    public ShipRun completeStage(
+            String runId,
+            Stage stage,
+            int attempt,
+            String inputDigest,
+            String outputDigest,
+            List<Path> artifacts,
+            boolean materialAmbiguity) {
+        Objects.requireNonNull(stage, "stage");
+        Objects.requireNonNull(artifacts, "artifacts");
+        if (!ShipDigest.isSha256(outputDigest)) {
+            throw failure("stage-result-invalid", "Ship stage output digest is invalid");
+        }
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            StageRecord active = requireActiveAttempt(current, stage, attempt, inputDigest);
+            requireCurrentInputs(current, active);
+            Path project = Path.of(current.projectDirectory());
+            List<ArtifactRef> references = artifacts.stream()
+                    .map(path -> readArtifact(project, path))
+                    .toList();
+            List<StageRecord> stages = new ArrayList<>(current.stages());
+            stages.set(stage.ordinal(), active.complete(outputDigest, references));
+
+            Stage next = stage.next();
+            RunStatus status;
+            Stage currentStage;
+            if (next == null) {
+                status = current.oversight().pausesAfter(stage, materialAmbiguity)
+                        ? RunStatus.PAUSED
+                        : RunStatus.COMPLETED;
+                currentStage = Stage.VALIDATE;
+            } else if (current.oversight().pausesAfter(stage, materialAmbiguity)) {
+                status = RunStatus.PAUSED;
+                currentStage = next;
+            } else {
+                stages.set(
+                        next.ordinal(),
+                        stages.get(next.ordinal())
+                                .start(ShipRun.inputDigest(current.context(), stages, next)));
+                status = RunStatus.RUNNING;
+                currentStage = next;
+            }
+
+            ShipRun completed = copy(
+                    current,
+                    status,
+                    currentStage,
+                    current.context(),
+                    stages,
+                    now(),
+                    null);
+            locked.write(completed);
+            return completed;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure("state-write-failed", "Could not complete Ship stage for " + runId, e);
+        }
+    }
+
+    /** Records a retryable worker failure for the current stage attempt. */
+    public ShipRun failStage(
+            String runId, Stage stage, int attempt, String inputDigest, String message) {
+        Objects.requireNonNull(stage, "stage");
+        if (message == null || message.isBlank() || message.length() > 1024
+                || message.indexOf('\0') >= 0) {
+            throw failure("stage-result-invalid", "Ship stage failure message is invalid");
+        }
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            StageRecord active = requireActiveAttempt(current, stage, attempt, inputDigest);
+            requireCurrentInputs(current, active);
+            List<StageRecord> stages = new ArrayList<>(current.stages());
+            stages.set(stage.ordinal(), active.fail());
+            ShipRun failed = copy(
+                    current,
+                    RunStatus.FAILED,
+                    stage,
+                    current.context(),
+                    stages,
+                    now(),
+                    message);
+            locked.write(failed);
+            return failed;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure("state-write-failed", "Could not fail Ship stage for " + runId, e);
+        }
+    }
+
+    private ShipRun newRun(
+            String runId,
+            Path project,
+            String pipelineId,
+            Oversight oversight,
+            Stage stage,
+            ShipContext context,
+            List<StageRecord> stages) {
+        String timestamp = now();
+        return new ShipRun(
+                ShipRun.SCHEMA_VERSION,
+                runId,
+                project.toString(),
+                pipelineId,
+                Objects.requireNonNull(oversight, "oversight"),
+                RunStatus.RUNNING,
+                stage,
+                context,
+                stages,
+                timestamp,
+                timestamp,
+                null);
+    }
+
+    private void create(ShipRun run) {
+        try {
+            store.create(run);
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure("state-write-failed", "Could not create Ship run " + run.id(), e);
+        }
+    }
+
+    private static ShipRun copy(
+            ShipRun run,
+            RunStatus status,
+            Stage currentStage,
+            ShipContext context,
+            List<StageRecord> stages,
+            String updatedAt,
+            String message) {
+        return new ShipRun(
+                run.schemaVersion(),
+                run.id(),
+                run.projectDirectory(),
+                run.pipelineId(),
+                run.oversight(),
+                status,
+                currentStage,
+                context,
+                stages,
+                run.createdAt(),
+                updatedAt,
+                message);
+    }
+
+    private static StageRecord requireActiveAttempt(
+            ShipRun run, Stage stage, int attempt, String inputDigest) {
+        StageRecord record = run.stage(stage);
+        if (run.status() != RunStatus.RUNNING
+                || run.currentStage() != stage
+                || record.status() != StageStatus.RUNNING
+                || record.attempts() != attempt
+                || !record.inputDigest().equals(inputDigest)) {
+            throw failure(
+                    "stale-stage-attempt",
+                    "Ship stage result does not match the active attempt");
+        }
+        return record;
+    }
+
+    private static void requireCurrentInputs(ShipRun run, StageRecord active) {
+        ShipContext refreshed;
+        try {
+            refreshed = run.context().refresh();
+        } catch (ShipContext.Failure e) {
+            throw failure(
+                    "stale-stage-input",
+                    "Ship stage input changed or became unavailable; resume the run",
+                    e);
+        }
+        if (!refreshed.equals(run.context())) {
+            throw failure(
+                    "stale-stage-input",
+                    "Ship stage context changed; resume the run");
+        }
+
+        Path project = Path.of(run.projectDirectory());
+        for (int index = 0; index < active.stage().ordinal(); index++) {
+            StageRecord predecessor = run.stages().get(index);
+            for (ArtifactRef artifact : predecessor.artifacts()) {
+                try {
+                    if (!readArtifact(project, Path.of(artifact.path())).equals(artifact)) {
+                        throw failure(
+                                "stale-stage-input",
+                                "A Ship stage artifact changed; resume the run");
+                    }
+                } catch (Failure e) {
+                    if ("stale-stage-input".equals(e.code())) {
+                        throw e;
+                    }
+                    throw failure(
+                            "stale-stage-input",
+                            "A Ship stage artifact changed or became unavailable; resume the run",
+                            e);
+                }
+            }
+        }
+        String expected = ShipRun.inputDigest(refreshed, run.stages(), active.stage());
+        if (!expected.equals(active.inputDigest())) {
+            throw failure(
+                    "stale-stage-input",
+                    "Ship stage input digest is stale; resume the run");
+        }
+    }
+
+    private static Path requireProject(Path supplied) {
+        if (supplied == null) {
+            throw failure("project-invalid", "Ship project directory is required");
+        }
+        final Path project;
+        try {
+            project = supplied.toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            throw failure("project-invalid", "Ship project directory is invalid", e);
+        }
+        if (!Files.exists(project)) {
+            throw failure("project-missing", "Ship project directory does not exist: " + project);
+        }
+        if (!Files.isDirectory(project)) {
+            throw failure("project-invalid", "Ship project path is not a directory: " + project);
+        }
+        if (!Files.isReadable(project)) {
+            throw failure("project-unreadable", "Ship project directory is not readable: " + project);
+        }
+        return project;
+    }
+
+    private static ShipContext resolveContext(Path project, List<? extends Input> inputs) {
+        try {
+            return ShipContext.resolve(project, Objects.requireNonNull(inputs, "context inputs"));
+        } catch (ShipContext.Failure e) {
+            throw failure(contextCode(e), e.getMessage(), e);
+        }
+    }
+
+    private static ShipContext refreshContext(ShipContext context) {
+        try {
+            return context.refresh();
+        } catch (ShipContext.Failure e) {
+            throw failure(contextCode(e), e.getMessage(), e);
+        }
+    }
+
+    private static String contextCode(ShipContext.Failure failure) {
+        return "context-" + failure.code().name().toLowerCase(Locale.ROOT).replace('_', '-');
+    }
+
+    private static String inspectProjectState(Path project) {
+        Path metadata = project.resolve(".camel-kit");
+        Path oldState = metadata.resolve("ship-state.json");
+        if (Files.exists(oldState)) {
+            throw incompatibleState(oldState);
+        }
+
+        Path pipelineFile = metadata.resolve("pipeline.json");
+        if (!Files.exists(pipelineFile)) {
+            return null;
+        }
+        if (!Files.isRegularFile(pipelineFile) || !Files.isReadable(pipelineFile)) {
+            throw incompatibleState(pipelineFile);
+        }
+
+        byte[] encoded;
+        try {
+            if (Files.size(pipelineFile) > MAX_PROJECT_STATE_BYTES) {
+                throw incompatibleState(pipelineFile);
+            }
+            try (InputStream input = Files.newInputStream(pipelineFile)) {
+                encoded = input.readNBytes(MAX_PROJECT_STATE_BYTES + 1);
+            }
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "pre-release-ship-state",
+                    "Existing Ship project state cannot be read and was left unchanged: "
+                                              + pipelineFile,
+                    e);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_PROJECT_STATE_BYTES) {
+            throw incompatibleState(pipelineFile);
+        }
+
+        final JsonNode root;
+        try {
+            root = PROJECT_JSON.readTree(encoded);
+        } catch (IOException e) {
+            throw failure(
+                    "pre-release-ship-state",
+                    "Existing Ship project state is incompatible and was left unchanged: "
+                                              + pipelineFile,
+                    e);
+        }
+        if (root == null || !root.isObject()) {
+            throw incompatibleState(pipelineFile);
+        }
+        JsonNode mode = root.get("mode");
+        if (mode == null || !mode.isTextual() || !"manual".equals(mode.textValue())) {
+            throw incompatibleState(pipelineFile);
+        }
+        JsonNode active = root.get("activePipeline");
+        if (active == null || active.isNull()) {
+            return null;
+        }
+        if (!active.isTextual() || !ShipRun.isPipelineId(active.textValue())) {
+            throw incompatibleState(pipelineFile);
+        }
+        return active.textValue();
+    }
+
+    private static Failure incompatibleState(Path path) {
+        return failure(
+                "pre-release-ship-state",
+                "Existing pre-release Ship state is incompatible and was left unchanged: " + path);
+    }
+
+    private static List<ArtifactRef> importedArtifacts(
+            Path project, String pipelineId, Stage stage) {
+        if (stage == Stage.DISCOVERY) {
+            return List.of();
+        }
+        if (pipelineId == null) {
+            throw failure(
+                    "start-from-artifact-missing",
+                    "Starting from " + stage.next()
+                                                   + " requires a manual activePipeline in .camel-kit/pipeline.json");
+        }
+        String filename = switch (stage) {
+            case DESIGN -> "design-spec.md";
+            case PLAN -> "implementation-plan.md";
+            case EXECUTE -> "execution-report.md";
+            case DISCOVERY, VALIDATE -> throw new IllegalStateException(
+                    "No imported artifact for stage " + stage);
+        };
+        ArtifactRef report = readArtifact(
+                project, project.resolve("docs/camel-kit").resolve(pipelineId).resolve(filename));
+        return stage == Stage.EXECUTE
+                ? List.of(report, readArtifact(project, project))
+                : List.of(report);
+    }
+
+    private static ArtifactRef readArtifact(Path project, Path supplied) {
+        Objects.requireNonNull(supplied, "artifact path");
+        Path normalized;
+        try {
+            normalized = (supplied.isAbsolute() ? supplied : project.resolve(supplied))
+                    .toAbsolutePath()
+                    .normalize();
+        } catch (RuntimeException e) {
+            throw failure("artifact-invalid", "Ship artifact path is invalid", e);
+        }
+        if (!normalized.startsWith(project)) {
+            throw failure(
+                    "artifact-invalid", "Ship artifact is outside the project: " + normalized);
+        }
+
+        try {
+            Path realProject = project.toRealPath();
+            Path realArtifact = normalized.toRealPath();
+            if (!realArtifact.startsWith(realProject)) {
+                throw failure(
+                        "artifact-invalid",
+                        "Ship artifact resolves outside the project: " + normalized);
+            }
+            if (normalized.equals(project)) {
+                return new ArtifactRef(
+                        normalized.toString(), ProjectEvidenceFiles.capture(project).digest());
+            }
+            BasicFileAttributes attributes = Files.readAttributes(normalized, BasicFileAttributes.class);
+            if (!attributes.isRegularFile()) {
+                throw failure(
+                        "artifact-invalid",
+                        "Ship artifact is not a regular file: " + normalized);
+            }
+            if (!Files.isReadable(normalized)) {
+                throw failure(
+                        "artifact-unreadable", "Ship artifact is not readable: " + normalized);
+            }
+            if (attributes.size() > MAX_ARTIFACT_BYTES) {
+                throw failure(
+                        "artifact-too-large", "Ship artifact exceeds the read limit: " + normalized);
+            }
+            byte[] bytes;
+            try (InputStream input = Files.newInputStream(normalized)) {
+                bytes = input.readNBytes(MAX_ARTIFACT_BYTES + 1);
+            }
+            if (bytes.length == 0) {
+                throw failure("artifact-invalid", "Ship artifact is empty: " + normalized);
+            }
+            if (bytes.length > MAX_ARTIFACT_BYTES) {
+                throw failure(
+                        "artifact-too-large", "Ship artifact exceeds the read limit: " + normalized);
+            }
+            return new ArtifactRef(normalized.toString(), ShipDigest.sha256(bytes));
+        } catch (NoSuchFileException e) {
+            throw failure("artifact-missing", "Ship artifact does not exist: " + normalized, e);
+        } catch (AccessDeniedException e) {
+            throw failure(
+                    "artifact-unreadable", "Ship artifact is not readable: " + normalized, e);
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "artifact-unreadable", "Ship artifact could not be read: " + normalized, e);
+        }
+    }
+
+    private static String now() {
+        return Instant.now().toString();
+    }
+
+    private static String newRunId() {
+        return "ship-" + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static Failure failure(String code, String message) {
+        return new Failure(code, message);
+    }
+
+    private static Failure failure(String code, String message, Throwable cause) {
+        return new Failure(code, message, cause);
+    }
+
+    public static final class Failure extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String code;
+
+        private Failure(String code, String message) {
+            super(message);
+            this.code = Objects.requireNonNull(code, "failure code");
+        }
+
+        private Failure(String code, String message, Throwable cause) {
+            super(message, cause);
+            this.code = Objects.requireNonNull(code, "failure code");
+        }
+
+        public String code() {
+            return code;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,9 +45,15 @@ public final class ShipController {
             .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
     private final ShipRunStore store;
+    private final Clock clock;
 
     public ShipController(Path stateRoot) {
+        this(stateRoot, Clock.systemUTC());
+    }
+
+    ShipController(Path stateRoot, Clock clock) {
         this.store = new ShipRunStore(Objects.requireNonNull(stateRoot, "state root"));
+        this.clock = Objects.requireNonNull(clock, "clock");
     }
 
     /** Resolves the conventional user-owned Ship state directory. */
@@ -163,6 +170,7 @@ public final class ShipController {
                 throw failure("run-completed", "Ship run is already complete: " + runId);
             }
 
+            Path project = requireProject(Path.of(current.projectDirectory()));
             ShipContext refreshed = refreshContext(current.context());
             List<StageRecord> stages = new ArrayList<>(current.stages());
             int restart = stages.size();
@@ -176,8 +184,7 @@ public final class ShipController {
                 boolean missing = false;
                 for (ArtifactRef artifact : record.artifacts()) {
                     try {
-                        refreshedArtifacts.add(readArtifact(
-                                Path.of(current.projectDirectory()), Path.of(artifact.path())));
+                        refreshedArtifacts.add(readArtifact(project, Path.of(artifact.path())));
                     } catch (Failure e) {
                         restart = Math.min(restart, index);
                         missing = true;
@@ -204,7 +211,6 @@ public final class ShipController {
                 }
             }
 
-            String now = now();
             ShipRun resumed;
             if (restart == stages.size()) {
                 resumed = copy(
@@ -213,7 +219,6 @@ public final class ShipController {
                         Stage.VALIDATE,
                         refreshed,
                         stages,
-                        now,
                         null);
             } else {
                 for (int index = restart; index < stages.size(); index++) {
@@ -230,7 +235,6 @@ public final class ShipController {
                         stage,
                         refreshed,
                         stages,
-                        now,
                         null);
             }
             locked.write(resumed);
@@ -265,7 +269,6 @@ public final class ShipController {
                     current.currentStage(),
                     current.context(),
                     stages,
-                    now(),
                     ABORT_MESSAGE);
             locked.write(aborted);
             return aborted;
@@ -329,7 +332,6 @@ public final class ShipController {
                     currentStage,
                     current.context(),
                     stages,
-                    now(),
                     null);
             locked.write(completed);
             return completed;
@@ -360,7 +362,6 @@ public final class ShipController {
                     stage,
                     current.context(),
                     stages,
-                    now(),
                     message);
             locked.write(failed);
             return failed;
@@ -405,13 +406,12 @@ public final class ShipController {
         }
     }
 
-    private static ShipRun copy(
+    private ShipRun copy(
             ShipRun run,
             RunStatus status,
             Stage currentStage,
             ShipContext context,
             List<StageRecord> stages,
-            String updatedAt,
             String message) {
         return new ShipRun(
                 run.schemaVersion(),
@@ -424,7 +424,7 @@ public final class ShipController {
                 context,
                 stages,
                 run.createdAt(),
-                updatedAt,
+                mutationTime(run),
                 message);
     }
 
@@ -444,6 +444,7 @@ public final class ShipController {
     }
 
     private static void requireCurrentInputs(ShipRun run, StageRecord active) {
+        Path project = requireProject(Path.of(run.projectDirectory()));
         ShipContext refreshed;
         try {
             refreshed = run.context().refresh();
@@ -459,7 +460,6 @@ public final class ShipController {
                     "Ship stage context changed; resume the run");
         }
 
-        Path project = Path.of(run.projectDirectory());
         for (int index = 0; index < active.stage().ordinal(); index++) {
             StageRecord predecessor = run.stages().get(index);
             for (ArtifactRef artifact : predecessor.artifacts()) {
@@ -686,8 +686,14 @@ public final class ShipController {
         }
     }
 
-    private static String now() {
-        return Instant.now().toString();
+    private String now() {
+        return clock.instant().toString();
+    }
+
+    private String mutationTime(ShipRun run) {
+        Instant previous = Instant.parse(run.updatedAt());
+        Instant current = clock.instant();
+        return current.isBefore(previous) ? run.updatedAt() : current.toString();
     }
 
     private static String newRunId() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
@@ -1,0 +1,345 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+
+/** Compact authoritative state for one local Ship run. */
+public record ShipRun(
+        int schemaVersion,
+        String id,
+        String projectDirectory,
+        String pipelineId,
+        Oversight oversight,
+        RunStatus status,
+        Stage currentStage,
+        ShipContext context,
+        List<StageRecord> stages,
+        String createdAt,
+        String updatedAt,
+        String message) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    private static final Pattern RUN_ID = Pattern.compile("ship-[0-9a-f]{32}");
+    private static final Pattern PIPELINE_ID = Pattern.compile("[0-9]{3,}-[a-z0-9]+(?:-[a-z0-9]+)*");
+
+    public ShipRun {
+        if (schemaVersion != SCHEMA_VERSION) {
+            throw new IllegalArgumentException("Unsupported Ship run schema version: " + schemaVersion);
+        }
+        if (!isRunId(id)) {
+            throw new IllegalArgumentException("Ship run ID is invalid");
+        }
+        projectDirectory = normalizedAbsolutePath(projectDirectory, "project directory");
+        if (pipelineId != null && !isPipelineId(pipelineId)) {
+            throw new IllegalArgumentException("Ship pipeline ID is invalid");
+        }
+        Objects.requireNonNull(oversight, "oversight");
+        Objects.requireNonNull(status, "run status");
+        Objects.requireNonNull(currentStage, "current stage");
+        Objects.requireNonNull(context, "context");
+        stages = List.copyOf(Objects.requireNonNull(stages, "stages"));
+        requireCanonicalStages(stages);
+        createdAt = canonicalInstant(createdAt, "created timestamp");
+        updatedAt = canonicalInstant(updatedAt, "updated timestamp");
+        if (Instant.parse(updatedAt).isBefore(Instant.parse(createdAt))) {
+            throw new IllegalArgumentException("Ship run update precedes its creation");
+        }
+        if (message != null && (message.isBlank() || message.length() > 1024 || message.indexOf('\0') >= 0)) {
+            throw new IllegalArgumentException("Ship run message is invalid");
+        }
+        if ((status == RunStatus.FAILED || status == RunStatus.ABORTED) != (message != null)) {
+            throw new IllegalArgumentException("Only failed or aborted runs carry a message");
+        }
+        requireConsistentProgress(status, currentStage, stages);
+    }
+
+    public static boolean isRunId(String value) {
+        return value != null && RUN_ID.matcher(value).matches();
+    }
+
+    static boolean isPipelineId(String value) {
+        return value != null && PIPELINE_ID.matcher(value).matches();
+    }
+
+    public StageRecord stage(Stage stage) {
+        return stages.get(stage.ordinal());
+    }
+
+    static List<StageRecord> pendingStages() {
+        return java.util.Arrays.stream(Stage.values()).map(StageRecord::pending).toList();
+    }
+
+    static String inputDigest(ShipContext context, List<StageRecord> stages, Stage stage) {
+        List<String> fields = new ArrayList<>();
+        fields.add("camel-kit.ship.stage-input.v1");
+        fields.add(stage.name());
+        fields.add(context.digest());
+        for (int index = 0; index < stage.ordinal(); index++) {
+            StageRecord predecessor = stages.get(index);
+            if (predecessor.status() != StageStatus.COMPLETED) {
+                throw new IllegalStateException("Ship stage " + stage + " has an incomplete predecessor");
+            }
+            fields.add(predecessor.stage().name());
+            fields.add(predecessor.outputDigest());
+            for (ArtifactRef artifact : predecessor.artifacts()) {
+                fields.add(artifact.path());
+                fields.add(artifact.digest());
+            }
+        }
+        return digestFields(fields);
+    }
+
+    static String digestFields(List<String> fields) {
+        ByteArrayOutputStream framed = new ByteArrayOutputStream();
+        for (String field : fields) {
+            byte[] bytes = Objects.requireNonNull(field, "digest field").getBytes(StandardCharsets.UTF_8);
+            framed.writeBytes(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+            framed.writeBytes(bytes);
+        }
+        return ShipDigest.sha256(framed.toByteArray());
+    }
+
+    private static void requireCanonicalStages(List<StageRecord> stages) {
+        if (stages.size() != Stage.values().length) {
+            throw new IllegalArgumentException("Ship run must contain one record for every stage");
+        }
+        for (Stage stage : Stage.values()) {
+            if (stages.get(stage.ordinal()).stage() != stage) {
+                throw new IllegalArgumentException("Ship stage records are not in canonical order");
+            }
+        }
+    }
+
+    private static void requireConsistentProgress(
+            RunStatus status, Stage currentStage, List<StageRecord> stages) {
+        int current = currentStage.ordinal();
+        boolean allCompleted = stages.stream().allMatch(stage -> stage.status() == StageStatus.COMPLETED);
+        if (status == RunStatus.COMPLETED) {
+            if (!allCompleted || currentStage != Stage.VALIDATE) {
+                throw new IllegalArgumentException("Completed Ship run has incomplete stages");
+            }
+            return;
+        }
+        if ((status == RunStatus.PAUSED || status == RunStatus.ABORTED)
+                && allCompleted
+                && currentStage == Stage.VALIDATE) {
+            return;
+        }
+        for (int index = 0; index < stages.size(); index++) {
+            StageStatus stageStatus = stages.get(index).status();
+            if (index < current && stageStatus != StageStatus.COMPLETED) {
+                throw new IllegalArgumentException("Ship run has an incomplete predecessor stage");
+            }
+            if (index > current && stageStatus != StageStatus.PENDING) {
+                throw new IllegalArgumentException("Ship run has an active downstream stage");
+            }
+        }
+        StageStatus active = stages.get(current).status();
+        StageStatus expected = switch (status) {
+            case RUNNING -> StageStatus.RUNNING;
+            case PAUSED -> StageStatus.PENDING;
+            case FAILED -> StageStatus.FAILED;
+            case ABORTED -> StageStatus.ABORTED;
+            case COMPLETED -> throw new IllegalStateException("Completed run handled above");
+        };
+        if (active != expected) {
+            throw new IllegalArgumentException("Ship run status does not match its current stage");
+        }
+    }
+
+    private static String normalizedAbsolutePath(String value, String label) {
+        if (value == null || value.isBlank() || value.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("Ship " + label + " is invalid");
+        }
+        Path path;
+        try {
+            path = Path.of(value);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Ship " + label + " is invalid", e);
+        }
+        Path normalized = path.toAbsolutePath().normalize();
+        if (!normalized.toString().equals(value)) {
+            throw new IllegalArgumentException("Ship " + label + " must be a normalized absolute path");
+        }
+        return value;
+    }
+
+    private static String canonicalInstant(String value, String label) {
+        try {
+            Instant parsed = Instant.parse(Objects.requireNonNull(value, label));
+            if (!parsed.toString().equals(value)) {
+                throw new IllegalArgumentException("Ship " + label + " must be canonical");
+            }
+            return value;
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Ship " + label + " is invalid", e);
+        }
+    }
+
+    public enum Oversight {
+        ALWAYS,
+        SMART,
+        NEVER;
+
+        public boolean pausesAfter(Stage completedStage, boolean materialAmbiguity) {
+            if (materialAmbiguity) {
+                return this != NEVER;
+            }
+            return switch (this) {
+                case ALWAYS -> completedStage == Stage.DESIGN
+                        || completedStage == Stage.PLAN
+                        || completedStage == Stage.EXECUTE
+                        || completedStage == Stage.VALIDATE;
+                case SMART -> completedStage == Stage.PLAN || completedStage == Stage.EXECUTE;
+                case NEVER -> false;
+            };
+        }
+    }
+
+    public enum RunStatus {
+        RUNNING,
+        PAUSED,
+        FAILED,
+        ABORTED,
+        COMPLETED
+    }
+
+    public enum Stage {
+        DISCOVERY,
+        DESIGN,
+        PLAN,
+        EXECUTE,
+        VALIDATE;
+
+        public Stage next() {
+            int next = ordinal() + 1;
+            return next == values().length ? null : values()[next];
+        }
+    }
+
+    public enum StageStatus {
+        PENDING,
+        RUNNING,
+        COMPLETED,
+        FAILED,
+        ABORTED
+    }
+
+    public record ArtifactRef(String path, String digest) {
+        public ArtifactRef {
+            path = normalizedAbsolutePath(path, "artifact path");
+            if (!ShipDigest.isSha256(digest)) {
+                throw new IllegalArgumentException("Ship artifact digest is invalid");
+            }
+        }
+    }
+
+    public record StageRecord(
+            Stage stage,
+            StageStatus status,
+            int attempts,
+            String inputDigest,
+            String outputDigest,
+            List<ArtifactRef> artifacts) {
+
+        public StageRecord {
+            Objects.requireNonNull(stage, "stage");
+            Objects.requireNonNull(status, "stage status");
+            if (attempts < 0) {
+                throw new IllegalArgumentException("Ship stage attempts cannot be negative");
+            }
+            artifacts = List.copyOf(Objects.requireNonNull(artifacts, "artifacts"));
+            if (inputDigest != null && !ShipDigest.isSha256(inputDigest)) {
+                throw new IllegalArgumentException("Ship stage input digest is invalid");
+            }
+            if (outputDigest != null && !ShipDigest.isSha256(outputDigest)) {
+                throw new IllegalArgumentException("Ship stage output digest is invalid");
+            }
+            switch (status) {
+                case PENDING -> require(attempts >= 0 && inputDigest == null && outputDigest == null
+                        && artifacts.isEmpty());
+                case RUNNING -> require(attempts > 0 && inputDigest != null && outputDigest == null
+                        && artifacts.isEmpty());
+                case COMPLETED -> require(inputDigest != null && outputDigest != null);
+                case FAILED -> require(attempts > 0 && inputDigest != null && outputDigest == null
+                        && artifacts.isEmpty());
+                case ABORTED -> require(outputDigest == null && artifacts.isEmpty());
+            }
+        }
+
+        static StageRecord pending(Stage stage) {
+            return new StageRecord(stage, StageStatus.PENDING, 0, null, null, List.of());
+        }
+
+        StageRecord start(String digest) {
+            if (status != StageStatus.PENDING) {
+                throw new IllegalStateException("Only a pending Ship stage can start");
+            }
+            return new StageRecord(
+                    stage, StageStatus.RUNNING, Math.incrementExact(attempts),
+                    digest, null, List.of());
+        }
+
+        StageRecord complete(String digest, List<ArtifactRef> references) {
+            if (status != StageStatus.RUNNING) {
+                throw new IllegalStateException("Only a running Ship stage can complete");
+            }
+            return new StageRecord(
+                    stage, StageStatus.COMPLETED, attempts,
+                    inputDigest, digest, references);
+        }
+
+        StageRecord imported(String input, String output, List<ArtifactRef> references) {
+            if (status != StageStatus.PENDING) {
+                throw new IllegalStateException("Only a pending Ship stage can be imported");
+            }
+            return new StageRecord(stage, StageStatus.COMPLETED, attempts, input, output, references);
+        }
+
+        StageRecord fail() {
+            if (status != StageStatus.RUNNING) {
+                throw new IllegalStateException("Only a running Ship stage can fail");
+            }
+            return new StageRecord(
+                    stage, StageStatus.FAILED, attempts,
+                    inputDigest, null, List.of());
+        }
+
+        StageRecord abort() {
+            if (status == StageStatus.COMPLETED) {
+                throw new IllegalStateException("A completed Ship stage cannot be aborted");
+            }
+            return new StageRecord(
+                    stage, StageStatus.ABORTED, attempts,
+                    inputDigest, null, List.of());
+        }
+
+        StageRecord reset() {
+            return new StageRecord(stage, StageStatus.PENDING, attempts, null, null, List.of());
+        }
+
+        StageRecord withArtifacts(List<ArtifactRef> references) {
+            if (status != StageStatus.COMPLETED) {
+                throw new IllegalStateException("Only a completed Ship stage has artifacts");
+            }
+            return new StageRecord(stage, status, attempts, inputDigest, outputDigest, references);
+        }
+
+        private static void require(boolean condition) {
+            if (!condition) {
+                throw new IllegalArgumentException("Ship stage record does not match its status");
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -1,0 +1,356 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Atomic local persistence and exclusive mutation leases for Ship runs. */
+final class ShipRunStore {
+
+    private static final int MAX_STATE_BYTES = 64 * 1024 * 1024;
+    private static final String STATE_FILE = "state.json";
+    private static final String LOCK_FILE = "run.lock";
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
+
+    private final Path stateRoot;
+    private final boolean posix;
+
+    ShipRunStore(Path stateRoot) {
+        this.stateRoot = Objects.requireNonNull(stateRoot, "stateRoot").toAbsolutePath().normalize();
+        this.posix = this.stateRoot.getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+
+    void create(ShipRun initial) throws IOException {
+        requireCurrent(initial);
+        Path runRoot = runRoot(initial.id());
+        Files.createDirectories(stateRoot, directoryAttributes());
+        try {
+            Files.createDirectory(runRoot, directoryAttributes());
+        } catch (FileAlreadyExistsException e) {
+            throw new StoreException(
+                    "run-already-exists", "Ship run already exists: " + initial.id(), e);
+        }
+        try {
+            write(runRoot, initial);
+        } catch (IOException e) {
+            try {
+                Files.delete(runRoot);
+            } catch (IOException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
+            throw e;
+        }
+    }
+
+    ShipRun read(String runId) throws IOException {
+        Path runRoot = existingRunRoot(runId);
+        Path stateFile = runRoot.resolve(STATE_FILE);
+        if (!Files.exists(stateFile)) {
+            throw new StoreException(
+                    "state-missing", "Ship run state is missing: " + stateFile);
+        }
+        if (!Files.isRegularFile(stateFile)) {
+            throw new StoreException(
+                    "state-corrupt", "Ship run state is not a regular file: " + stateFile);
+        }
+
+        if (Files.size(stateFile) > MAX_STATE_BYTES) {
+            throw new StoreException(
+                    "state-corrupt", "Ship run state has an invalid size: " + stateFile);
+        }
+        byte[] encoded;
+        try (InputStream input = Files.newInputStream(stateFile)) {
+            encoded = input.readNBytes(MAX_STATE_BYTES + 1);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_STATE_BYTES) {
+            throw new StoreException(
+                    "state-corrupt", "Ship run state exceeds the read limit: " + stateFile);
+        }
+
+        JsonNode document;
+        try {
+            document = JSON.readValue(encoded, JsonNode.class);
+        } catch (JsonProcessingException e) {
+            throw corrupt(stateFile, e);
+        }
+        if (document == null || !document.isObject()) {
+            throw corrupt(stateFile, null);
+        }
+        JsonNode schema = document.get("schemaVersion");
+        if (schema == null || !schema.isIntegralNumber() || !schema.canConvertToInt()) {
+            throw corrupt(stateFile, null);
+        }
+        int schemaVersion = schema.intValue();
+        if (schemaVersion != ShipRun.SCHEMA_VERSION) {
+            throw new StoreException(
+                    "state-version-unsupported",
+                    "Unsupported Ship run state schema " + schemaVersion
+                                                 + "; expected " + ShipRun.SCHEMA_VERSION);
+        }
+
+        ShipRun run;
+        try {
+            run = JSON.treeToValue(document, ShipRun.class);
+        } catch (JsonProcessingException e) {
+            throw corrupt(stateFile, e);
+        }
+        if (!runId.equals(run.id())) {
+            throw new StoreException(
+                    "state-corrupt",
+                    "Ship run state ID " + run.id() + " does not match its directory " + runId);
+        }
+        return run;
+    }
+
+    LockedRun lock(String runId) throws IOException {
+        Path runRoot = existingRunRoot(runId);
+        Path lockFile = runRoot.resolve(LOCK_FILE);
+        FileChannel channel = FileChannel.open(
+                lockFile,
+                Set.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE),
+                fileAttributes());
+        FileLock fileLock;
+        try {
+            fileLock = channel.tryLock();
+        } catch (OverlappingFileLockException e) {
+            closeAfterFailure(channel, e);
+            throw busy(runId, e);
+        } catch (IOException e) {
+            closeAfterFailure(channel, e);
+            throw e;
+        }
+        if (fileLock == null) {
+            StoreException busy = busy(runId, null);
+            closeAfterFailure(channel, busy);
+            throw busy;
+        }
+        return new LockedRun(runId, runRoot, channel, fileLock);
+    }
+
+    private void write(Path runRoot, ShipRun run) throws IOException {
+        requireCurrent(run);
+        byte[] encoded;
+        try {
+            encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(run);
+        } catch (JsonProcessingException e) {
+            throw new StoreException(
+                    "state-invalid", "Ship run state cannot be encoded: " + run.id(), e);
+        }
+        if (encoded.length > MAX_STATE_BYTES) {
+            throw new StoreException(
+                    "state-too-large", "Ship run state exceeds " + MAX_STATE_BYTES + " bytes");
+        }
+
+        Path temporary = Files.createTempFile(
+                runRoot, ".state-", ".tmp", fileAttributes());
+        boolean moved = false;
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                ByteBuffer content = ByteBuffer.wrap(encoded);
+                while (content.hasRemaining()) {
+                    channel.write(content);
+                }
+                channel.force(true);
+            }
+            try {
+                Files.move(
+                        temporary,
+                        runRoot.resolve(STATE_FILE),
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw new StoreException(
+                        "atomic-write-unsupported",
+                        "Filesystem does not support atomic Ship run state replacement",
+                        e);
+            }
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private void requireCurrent(ShipRun run) throws StoreException {
+        if (run == null) {
+            throw new StoreException("state-invalid", "Ship run state is required");
+        }
+        runRoot(run.id());
+    }
+
+    private Path existingRunRoot(String runId) throws StoreException {
+        Path runRoot = runRoot(runId);
+        if (!Files.exists(runRoot)) {
+            throw new StoreException("run-not-found", "Ship run was not found: " + runId);
+        }
+        if (!Files.isDirectory(runRoot)) {
+            throw new StoreException(
+                    "state-corrupt", "Ship run path is not a directory: " + runRoot);
+        }
+        return runRoot;
+    }
+
+    private Path runRoot(String runId) throws StoreException {
+        if (runId == null || !ShipRun.isRunId(runId)) {
+            throw new StoreException("run-id-invalid", "Invalid Ship run ID: " + runId);
+        }
+        Path runRoot = stateRoot.resolve(runId).normalize();
+        if (!stateRoot.equals(runRoot.getParent())) {
+            throw new StoreException("run-id-invalid", "Invalid Ship run ID: " + runId);
+        }
+        return runRoot;
+    }
+
+    private FileAttribute<?>[] directoryAttributes() {
+        return attributes("rwx------");
+    }
+
+    private FileAttribute<?>[] fileAttributes() {
+        return attributes("rw-------");
+    }
+
+    private FileAttribute<?>[] attributes(String permissions) {
+        return posix
+                ? new FileAttribute<?>[]{
+                        PosixFilePermissions.asFileAttribute(
+                                PosixFilePermissions.fromString(permissions))}
+                : new FileAttribute<?>[0];
+    }
+
+    private static StoreException corrupt(Path stateFile, Throwable cause) {
+        String message = "Ship run state is corrupt: " + stateFile;
+        return cause == null
+                ? new StoreException("state-corrupt", message)
+                : new StoreException("state-corrupt", message, cause);
+    }
+
+    private static StoreException busy(String runId, Throwable cause) {
+        String message = "Ship run already has an in-progress operation: " + runId;
+        return cause == null
+                ? new StoreException("operation-in-progress", message)
+                : new StoreException("operation-in-progress", message, cause);
+    }
+
+    private static void closeAfterFailure(FileChannel channel, Throwable failure) {
+        try {
+            channel.close();
+        } catch (IOException closeFailure) {
+            failure.addSuppressed(closeFailure);
+        }
+    }
+
+    final class LockedRun implements AutoCloseable {
+
+        private final String runId;
+        private final Path runRoot;
+        private FileChannel channel;
+        private FileLock fileLock;
+
+        private LockedRun(
+                          String runId, Path runRoot, FileChannel channel, FileLock fileLock) {
+            this.runId = runId;
+            this.runRoot = runRoot;
+            this.channel = channel;
+            this.fileLock = fileLock;
+        }
+
+        ShipRun read() throws IOException {
+            requireOpen();
+            return ShipRunStore.this.read(runId);
+        }
+
+        void write(ShipRun next) throws IOException {
+            requireOpen();
+            requireCurrent(next);
+            if (!runId.equals(next.id())) {
+                throw new StoreException(
+                        "state-id-mismatch",
+                        "Cannot write Ship run " + next.id() + " while " + runId + " is locked");
+            }
+            ShipRunStore.this.write(runRoot, next);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (fileLock == null) {
+                return;
+            }
+            IOException failure = null;
+            try {
+                fileLock.release();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                channel.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            } finally {
+                fileLock = null;
+                channel = null;
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        private void requireOpen() throws StoreException {
+            if (fileLock == null) {
+                throw new StoreException("lock-closed", "Ship run lock is already closed: " + runId);
+            }
+        }
+    }
+
+    static final class StoreException extends IOException {
+
+        private final String code;
+
+        StoreException(String code, String message) {
+            super(message);
+            this.code = code;
+        }
+
+        StoreException(String code, String message, Throwable cause) {
+            super(message, cause);
+            this.code = code;
+        }
+
+        String code() {
+            return code;
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -1,0 +1,224 @@
+package io.github.luigidemasi.camelkit.command.ship;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.Kind;
+import io.github.luigidemasi.camelkit.ship.controller.ShipController;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void bareStartUsesSmartOversightAndPrintsStableSummary() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+
+        RunResult result = run(controller, "--project-dir", project.toString());
+        String id = runId(result.output());
+
+        assertEquals(0, result.exitCode(), result.error());
+        assertEquals("", result.error());
+        assertEquals(summary(id, "RUNNING", "DISCOVERY", "SMART"), result.output());
+
+        ShipRun run = controller.status(id);
+        assertEquals(project.toAbsolutePath().normalize().toString(), run.projectDirectory());
+        assertTrue(run.context().sources().isEmpty());
+    }
+
+    @Test
+    void acceptsEveryOversightValue() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+
+        for (String policy : List.of("always", "smart", "never")) {
+            RunResult result = run(
+                    controller,
+                    "--project-dir", project.toString(),
+                    "--ask", policy);
+
+            assertEquals(0, result.exitCode(), result.error());
+            assertTrue(result.output().endsWith(
+                    "Oversight: " + policy.toUpperCase(Locale.ROOT) + System.lineSeparator()));
+        }
+    }
+
+    @Test
+    void preservesMixedRepeatedContextOrder() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path document = Files.writeString(project.resolve("requirements.md"), "from document");
+        ShipController controller = controller("state");
+
+        RunResult result = run(
+                controller,
+                "--project-dir", project.toString(),
+                "--text", "first",
+                "--document", "requirements.md",
+                "--text", "last");
+
+        assertEquals(0, result.exitCode(), result.error());
+        ShipRun run = controller.status(runId(result.output()));
+        assertEquals(List.of(Kind.TEXT, Kind.DOCUMENT, Kind.TEXT),
+                run.context().sources().stream().map(source -> source.kind()).toList());
+        assertEquals("first", run.context().sources().get(0).value());
+        assertEquals(document.toAbsolutePath().normalize().toString(),
+                run.context().sources().get(1).value());
+        assertEquals("last", run.context().sources().get(2).value());
+    }
+
+    @Test
+    void supportsStartFromResumeStatusAndAbort() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+
+        RunResult started = run(
+                controller,
+                "--project-dir", project.toString(),
+                "--start-from", "design",
+                "--text", "Build an integration");
+        String id = runId(started.output());
+        assertEquals(0, started.exitCode(), started.error());
+        assertEquals(summary(id, "RUNNING", "DESIGN", "SMART"), started.output());
+
+        RunResult resumed = run(controller, "--resume", id);
+        assertEquals(0, resumed.exitCode(), resumed.error());
+        assertEquals(started.output(), resumed.output());
+        assertEquals(2, controller.status(id).stage(ShipRun.Stage.DESIGN).attempts());
+
+        RunResult status = run(controller, "--status", id);
+        assertEquals(0, status.exitCode(), status.error());
+        assertEquals(started.output(), status.output());
+
+        RunResult aborted = run(controller, "--abort", id);
+        assertEquals(0, aborted.exitCode(), aborted.error());
+        assertEquals(summary(id, "ABORTED", "DESIGN", "SMART"), aborted.output());
+
+        RunResult rejected = run(controller, "--resume", id);
+        assertEquals(1, rejected.exitCode());
+        assertEquals("", rejected.output());
+        assertTrue(rejected.error().matches("(?is)Error \\[[^]]+]: .*aborted.*\\R"),
+                rejected.error());
+    }
+
+    @Test
+    void rejectsExclusiveOperationsAndContextOnNonStartingOperations() throws Exception {
+        ShipController controller = controller("state");
+        String id = "ship-0123456789abcdef0123456789abcdef";
+
+        RunResult exclusive = run(controller, "--resume", id, "--status", id);
+        assertEquals(CommandLine.ExitCode.USAGE, exclusive.exitCode());
+        assertTrue(exclusive.error().contains("mutually exclusive"), exclusive.error());
+
+        RunResult context = run(controller, "--status", id, "--text", "not allowed");
+        assertEquals(CommandLine.ExitCode.USAGE, context.exitCode());
+        assertTrue(context.error().contains(
+                "--ask, --text, and --document are only valid when starting a run"),
+                context.error());
+
+        RunResult oversight = run(controller, "--abort", id, "--ask", "never");
+        assertEquals(CommandLine.ExitCode.USAGE, oversight.exitCode());
+        assertTrue(oversight.error().contains(
+                "--ask, --text, and --document are only valid when starting a run"),
+                oversight.error());
+    }
+
+    @Test
+    void keepsAtFileExpansionDisabled() throws Exception {
+        Path arguments = Files.writeString(tempDir.resolve("arguments"), "--ask never");
+        ShipController controller = controller("state");
+
+        RunResult result = run(controller, "@" + arguments);
+
+        assertEquals(CommandLine.ExitCode.USAGE, result.exitCode());
+        assertTrue(result.error().contains("Unmatched argument"), result.error());
+    }
+
+    @Test
+    void reportsDistinctDocumentFailuresAsOperationalErrors() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path empty = Files.createFile(project.resolve("empty.txt"));
+        Path malformed = Files.write(project.resolve("malformed.txt"), new byte[]{(byte) 0xc3, 0x28});
+        ShipController controller = controller("state");
+
+        assertDocumentFailure(controller, project, project.resolve("missing.txt"), "missing");
+        assertDocumentFailure(controller, project, empty, "empty");
+        assertDocumentFailure(controller, project, malformed, "malformed");
+    }
+
+    @Test
+    void reportsUnreadableDocumentAsOperationalError() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Assumptions.assumeTrue(Files.getFileStore(project)
+                .supportsFileAttributeView("posix"));
+        Path unreadable = Files.writeString(project.resolve("unreadable.txt"), "secret");
+        Files.setPosixFilePermissions(unreadable, PosixFilePermissions.fromString("---------"));
+        try {
+            assertDocumentFailure(controller("state"), project, unreadable, "unreadable");
+        } finally {
+            Files.setPosixFilePermissions(
+                    unreadable, PosixFilePermissions.fromString("rw-------"));
+        }
+    }
+
+    private void assertDocumentFailure(
+            ShipController controller, Path project, Path document, String expectedCode) {
+        RunResult result = run(
+                controller,
+                "--project-dir", project.toString(),
+                "--document", document.toString());
+
+        assertEquals(1, result.exitCode(), result.error());
+        assertEquals("", result.output());
+        assertTrue(result.error().matches(
+                "(?is)Error \\[[^]]*" + expectedCode + "[^]]*]: .*\\R"),
+                result.error());
+    }
+
+    private ShipController controller(String stateDirectory) {
+        return new ShipController(tempDir.resolve(stateDirectory));
+    }
+
+    private static RunResult run(ShipController controller, String... args) {
+        StringWriter output = new StringWriter();
+        StringWriter error = new StringWriter();
+        CommandLine commandLine = new CommandLine(new ShipCommand(controller));
+        commandLine.setExpandAtFiles(false);
+        commandLine.setOut(new PrintWriter(output, true));
+        commandLine.setErr(new PrintWriter(error, true));
+        int exitCode = commandLine.execute(args);
+        return new RunResult(exitCode, output.toString(), error.toString());
+    }
+
+    private static String runId(String output) {
+        assertTrue(output.startsWith("Run: "), output);
+        return output.lines().findFirst().orElseThrow().substring("Run: ".length());
+    }
+
+    private static String summary(String id, String status, String stage, String oversight) {
+        return String.join(System.lineSeparator(),
+                "Run: " + id,
+                "Status: " + status,
+                "Stage: " + stage,
+                "Oversight: " + oversight,
+                "");
+    }
+
+    private record RunResult(int exitCode, String output, String error) {
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/context/ShipContextTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/context/ShipContextTest.java
@@ -224,6 +224,31 @@ class ShipContextTest {
                         ShipDigest.sha256("x".getBytes(StandardCharsets.UTF_8))));
     }
 
+    @Test
+    void rejectsPersistedContextsOutsideCompactBounds() throws Exception {
+        ShipContext.Source emptyText = ShipContext.resolve(
+                project, List.of(new TextInput(""))).sources().get(0);
+        ShipContext.Source maximumDocument = new ShipContext.Source(
+                Kind.DOCUMENT,
+                project.resolve("claimed-document.md").toAbsolutePath().normalize().toString(),
+                ShipContext.MAX_DOCUMENT_BYTES,
+                ShipDigest.sha256("claimed".getBytes(StandardCharsets.UTF_8)));
+
+        IllegalArgumentException tooMany = assertThrows(
+                IllegalArgumentException.class,
+                () -> new ShipContext(
+                        Collections.nCopies(ShipContext.MAX_SOURCES + 1, emptyText),
+                        ShipContext.none().digest()));
+        IllegalArgumentException tooLarge = assertThrows(
+                IllegalArgumentException.class,
+                () -> new ShipContext(
+                        List.of(maximumDocument, maximumDocument, maximumDocument),
+                        ShipContext.none().digest()));
+
+        assertEquals("Ship context exceeds the source-count limit", tooMany.getMessage());
+        assertEquals("Ship context exceeds the aggregate-byte limit", tooLarge.getMessage());
+    }
+
     private ShipContext resolveDocument(Path path) throws Failure {
         return ShipContext.resolve(project, List.of(new DocumentInput(path)));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/context/ShipContextTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/context/ShipContextTest.java
@@ -1,0 +1,243 @@
+package io.github.luigidemasi.camelkit.ship.context;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.DocumentInput;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.Failure;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.Input;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.Kind;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext.TextInput;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipContextTest {
+
+    @TempDir
+    Path project;
+
+    @Test
+    void preservesAbsentEmptyRepeatedAndOrderedInput() throws Exception {
+        Path firstDocument = Files.writeString(project.resolve("first.md"), "first");
+        Path secondDocument = Files.writeString(project.resolve("second.md"), "second");
+
+        ShipContext none = ShipContext.none();
+        ShipContext emptyText = ShipContext.resolve(
+                project, List.of(new TextInput("")));
+        ShipContext repeated = ShipContext.resolve(
+                project,
+                List.of(
+                        new DocumentInput(firstDocument.getFileName()),
+                        new DocumentInput(firstDocument.getFileName())));
+        ShipContext ordered = ShipContext.resolve(
+                project,
+                List.of(
+                        new DocumentInput(firstDocument.getFileName()),
+                        new TextInput("qualification"),
+                        new DocumentInput(secondDocument.getFileName())));
+        ShipContext reordered = ShipContext.resolve(
+                project,
+                List.of(
+                        new TextInput("qualification"),
+                        new DocumentInput(firstDocument.getFileName()),
+                        new DocumentInput(secondDocument.getFileName())));
+
+        assertTrue(none.sources().isEmpty());
+        assertNotEquals(none.digest(), emptyText.digest());
+        assertEquals("", emptyText.sources().get(0).value());
+        assertEquals(0, emptyText.sources().get(0).byteCount());
+        assertEquals(repeated.sources().get(0), repeated.sources().get(1));
+        assertNotEquals(
+                ShipContext.resolve(
+                        project, List.of(new DocumentInput(firstDocument.getFileName())))
+                        .digest(),
+                repeated.digest());
+        assertEquals(
+                List.of(Kind.DOCUMENT, Kind.TEXT, Kind.DOCUMENT),
+                ordered.sources().stream().map(ShipContext.Source::kind).toList());
+        assertEquals(
+                firstDocument.toAbsolutePath().normalize().toString(),
+                ordered.sources().get(0).value());
+        assertEquals("qualification", ordered.sources().get(1).value());
+        assertEquals(
+                secondDocument.toAbsolutePath().normalize().toString(),
+                ordered.sources().get(2).value());
+        assertNotEquals(ordered.digest(), reordered.digest());
+        assertTrue(ordered.sources().stream()
+                .allMatch(source -> ShipDigest.isSha256(source.digest())));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> ordered.sources().add(ordered.sources().get(0)));
+        assertFalse(ordered.toString().contains("qualification"));
+    }
+
+    @Test
+    void refreshesDocumentsWithoutChangingTextOrOrder() throws Exception {
+        Path document = Files.writeString(project.resolve("requirements.md"), "before");
+        ShipContext context = ShipContext.resolve(
+                project,
+                List.of(
+                        new TextInput("qualification"),
+                        new DocumentInput(document),
+                        new DocumentInput(document)));
+        ShipContext.Source text = context.sources().get(0);
+        String oldDocumentDigest = context.sources().get(1).digest();
+
+        Files.writeString(document, "after");
+        ShipContext refreshed = context.refresh();
+
+        assertEquals(text, refreshed.sources().get(0));
+        assertEquals(
+                List.of(Kind.TEXT, Kind.DOCUMENT, Kind.DOCUMENT),
+                refreshed.sources().stream().map(ShipContext.Source::kind).toList());
+        assertNotEquals(oldDocumentDigest, refreshed.sources().get(1).digest());
+        assertEquals(refreshed.sources().get(1), refreshed.sources().get(2));
+        assertNotEquals(context.digest(), refreshed.digest());
+
+        Files.delete(document);
+        assertFailure(Failure.Code.MISSING, context::refresh);
+    }
+
+    @Test
+    void distinguishesDocumentAndContextFailures() throws Exception {
+        Path empty = Files.createFile(project.resolve("empty.md"));
+        Path malformed = Files.write(
+                project.resolve("malformed.md"), new byte[]{(byte) 0xc3, 0x28});
+        Path nul = Files.write(
+                project.resolve("nul.md"), new byte[]{'a', 0, 'b'});
+        Path directory = Files.createDirectory(project.resolve("directory"));
+        Path oversized = project.resolve("oversized.md");
+        byte[] oversizedBytes = new byte[ShipContext.MAX_DOCUMENT_BYTES + 1];
+        Arrays.fill(oversizedBytes, (byte) 'x');
+        Files.write(oversized, oversizedBytes);
+
+        assertFailure(
+                Failure.Code.MISSING,
+                () -> resolveDocument(project.resolve("missing.md")));
+        assertFailure(Failure.Code.EMPTY, () -> resolveDocument(empty));
+        assertFailure(Failure.Code.MALFORMED, () -> resolveDocument(malformed));
+        assertFailure(Failure.Code.MALFORMED, () -> resolveDocument(nul));
+        assertFailure(Failure.Code.MALFORMED, () -> resolveDocument(directory));
+        assertFailure(Failure.Code.DOCUMENT_TOO_LARGE, () -> resolveDocument(oversized));
+        assertFailure(
+                Failure.Code.MALFORMED,
+                () -> ShipContext.resolve(project, List.of(new TextInput("a\0b"))));
+        assertFailure(
+                Failure.Code.MALFORMED,
+                () -> ShipContext.resolve(project, List.of(new TextInput("\ud800"))));
+        assertFailure(
+                Failure.Code.CONTEXT_TOO_LARGE,
+                () -> ShipContext.resolve(
+                        project,
+                        List.of(new TextInput("x".repeat(ShipContext.MAX_TOTAL_BYTES + 1)))));
+    }
+
+    @Test
+    void enforcesExactSourceDocumentAndAggregateBounds() throws Exception {
+        TextInput empty = new TextInput("");
+        List<Input> exactSourceCount = Collections.nCopies(ShipContext.MAX_SOURCES, empty);
+        List<Input> tooManySources = Collections.nCopies(ShipContext.MAX_SOURCES + 1, empty);
+        Path exactDocument = project.resolve("exact-document.md");
+        byte[] exactDocumentBytes = new byte[ShipContext.MAX_DOCUMENT_BYTES];
+        Arrays.fill(exactDocumentBytes, (byte) 'x');
+        Files.write(exactDocument, exactDocumentBytes);
+
+        assertEquals(
+                ShipContext.MAX_SOURCES,
+                ShipContext.resolve(project, exactSourceCount).sources().size());
+        assertFailure(
+                Failure.Code.CONTEXT_TOO_LARGE,
+                () -> ShipContext.resolve(project, tooManySources));
+        assertEquals(
+                ShipContext.MAX_DOCUMENT_BYTES,
+                resolveDocument(exactDocument).sources().get(0).byteCount());
+        assertEquals(
+                ShipContext.MAX_TOTAL_BYTES,
+                ShipContext.resolve(
+                        project,
+                        List.of(new TextInput("x".repeat(ShipContext.MAX_TOTAL_BYTES))))
+                        .sources()
+                        .get(0)
+                        .byteCount());
+        assertFailure(
+                Failure.Code.CONTEXT_TOO_LARGE,
+                () -> ShipContext.resolve(
+                        project,
+                        List.of(
+                                new DocumentInput(exactDocument),
+                                new DocumentInput(exactDocument),
+                                new TextInput("x"))));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void reportsUnreadableDocuments() throws Exception {
+        Path unreadable = Files.writeString(project.resolve("unreadable.md"), "content");
+        Set<PosixFilePermission> original = Files.getPosixFilePermissions(unreadable);
+        try {
+            Files.setPosixFilePermissions(unreadable, Set.of());
+            assertFalse(Files.isReadable(unreadable));
+            assertFailure(Failure.Code.UNREADABLE, () -> resolveDocument(unreadable));
+        } finally {
+            Files.setPosixFilePermissions(unreadable, original);
+        }
+    }
+
+    @Test
+    void rejectsForgedPersistedIdentities() throws Exception {
+        ShipContext context = ShipContext.resolve(
+                project, List.of(new TextInput("qualification")));
+        ShipContext.Source source = context.sources().get(0);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ShipContext(context.sources(), "sha256:" + "0".repeat(64)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ShipContext.Source(
+                        Kind.TEXT,
+                        source.value() + " changed",
+                        source.byteCount(),
+                        source.digest()));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ShipContext.Source(
+                        Kind.DOCUMENT,
+                        "relative.md",
+                        1,
+                        ShipDigest.sha256("x".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    private ShipContext resolveDocument(Path path) throws Failure {
+        return ShipContext.resolve(project, List.of(new DocumentInput(path)));
+    }
+
+    private static Failure assertFailure(
+            Failure.Code expected, ThrowingOperation operation) {
+        Failure failure = assertThrows(Failure.class, operation::run);
+        assertEquals(expected, failure.code());
+        assertFalse(failure.input().isBlank());
+        return failure;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingOperation {
+        void run() throws Exception;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -85,7 +85,7 @@ class ShipControllerTest {
         Path unreadableProject = Files.createDirectory(directory.resolve("unreadable-project"));
         Files.setPosixFilePermissions(unreadableProject, PosixFilePermissions.fromString("---------"));
         try {
-            Assumptions.assumeFalse(Files.isReadable(unreadableProject));
+            assertFalse(Files.isReadable(unreadableProject));
             assertFailure("project-unreadable",
                     () -> controller("project-state").start(
                             unreadableProject, Oversight.NEVER, List.of()));
@@ -100,7 +100,7 @@ class ShipControllerTest {
         ShipRun run = controller.start(project, Oversight.NEVER, List.of());
         Files.setPosixFilePermissions(artifact, PosixFilePermissions.fromString("---------"));
         try {
-            Assumptions.assumeFalse(Files.isReadable(artifact));
+            assertFalse(Files.isReadable(artifact));
             assertFailure("artifact-unreadable",
                     () -> complete(controller, run, "result", artifact));
         } finally {
@@ -288,7 +288,7 @@ class ShipControllerTest {
     @Test
     void rejectsInvalidMissingOversizedAndEmptyArtifacts() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
-        Path outside = Files.writeString(directory.resolve("outside"), "outside");
+        Path outside = directory.resolve("outside");
         Path empty = Files.createFile(project.resolve("empty"));
         Path oversized = project.resolve("oversized");
         try (RandomAccessFile file = new RandomAccessFile(oversized.toFile(), "rw")) {
@@ -305,7 +305,6 @@ class ShipControllerTest {
                         "outside",
                         project.resolve("..").resolve(outside.getFileName())));
         assertEquals("artifact-invalid", escaped.code());
-        assertTrue(escaped.getMessage().contains("outside the project"));
         assertFailure("artifact-missing",
                 () -> complete(controller, run, "missing", project.resolve("missing")));
         assertFailure("artifact-too-large",
@@ -315,7 +314,7 @@ class ShipControllerTest {
     }
 
     @Test
-    void rejectsMutationsAfterTheProjectIsDeletedWithoutChangingState() throws Exception {
+    void rejectsProjectDependentMutationsButAllowsAbortAfterDeletion() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         ShipController controller = controller("state");
         ShipRun run = controller.start(project, Oversight.NEVER, List.of());
@@ -331,6 +330,7 @@ class ShipControllerTest {
                         run.stage(Stage.DISCOVERY).inputDigest(),
                         "worker failed"));
         assertEquals(run, controller.status(run.id()));
+        assertEquals(RunStatus.ABORTED, controller.abort(run.id()).status());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -1,0 +1,395 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShipControllerTest {
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void startsWithNoInputTextOrDocumentContext() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+
+        ShipRun none = controller.start(project, Oversight.SMART, List.of());
+        assertTrue(none.context().sources().isEmpty());
+        assertEquals(RunStatus.RUNNING, none.status());
+        assertEquals(Stage.DISCOVERY, none.currentStage());
+
+        ShipRun text = controller.start(
+                project, Oversight.SMART, List.of(new ShipContext.TextInput("orders")));
+        assertEquals(1, text.context().sources().size());
+        assertEquals(ShipContext.Kind.TEXT, text.context().sources().get(0).kind());
+        assertEquals("orders", text.context().sources().get(0).value());
+
+        Path document = Files.writeString(project.resolve("requirements.md"), "route requirements");
+        ShipRun documented = controller.start(
+                project, Oversight.SMART, List.of(new ShipContext.DocumentInput(document)));
+        assertEquals(1, documented.context().sources().size());
+        ShipContext.Source source = documented.context().sources().get(0);
+        assertEquals(ShipContext.Kind.DOCUMENT, source.kind());
+        assertEquals(document.toAbsolutePath().normalize().toString(), source.value());
+        assertEquals(ShipDigest.sha256(Files.readAllBytes(document)), source.digest());
+    }
+
+    @Test
+    void advancesLegallyAndAppliesEveryOversightPolicy() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+
+        ShipRun always = controller.start(project, Oversight.ALWAYS, List.of());
+        always = complete(controller, always, "always-discovery");
+        assertEquals(Stage.DESIGN, always.currentStage());
+        assertEquals(RunStatus.RUNNING, always.status());
+        always = complete(controller, always, "always-design");
+        assertEquals(Stage.PLAN, always.currentStage());
+        assertEquals(RunStatus.PAUSED, always.status());
+        assertEquals(StageStatus.PENDING, always.stage(Stage.PLAN).status());
+
+        ShipRun smart = controller.start(project, Oversight.SMART, List.of());
+        smart = complete(controller, smart, "smart-discovery");
+        smart = complete(controller, smart, "smart-design");
+        assertEquals(RunStatus.RUNNING, smart.status());
+        smart = complete(controller, smart, "smart-plan");
+        assertEquals(Stage.EXECUTE, smart.currentStage());
+        assertEquals(RunStatus.PAUSED, smart.status());
+
+        ShipRun never = controller.start(project, Oversight.NEVER, List.of());
+        for (Stage stage : Stage.values()) {
+            assertEquals(stage, never.currentStage());
+            never = complete(controller, never, "never-" + stage);
+        }
+        assertEquals(RunStatus.COMPLETED, never.status());
+        assertEquals(Stage.VALIDATE, never.currentStage());
+        assertTrue(never.stages().stream().allMatch(record -> record.status() == StageStatus.COMPLETED));
+    }
+
+    @Test
+    void resumeRestartsTheEarliestStaleOrIncompleteStage() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path discovery = Files.writeString(project.resolve("discovery.md"), "discovery-v1");
+        Path design = Files.writeString(project.resolve("design.md"), "design-v1");
+        Path plan = Files.writeString(project.resolve("plan.md"), "plan-v1");
+        ShipController controller = controller("state");
+
+        ShipRun run = controller.start(project, Oversight.SMART, List.of());
+        run = complete(controller, run, "discovery", discovery);
+        run = complete(controller, run, "design", design);
+        run = complete(controller, run, "plan", plan);
+        assertEquals(RunStatus.PAUSED, run.status());
+
+        Files.writeString(design, "design-v2");
+        ShipRun resumed = controller.resume(run.id());
+        assertEquals(Stage.PLAN, resumed.currentStage());
+        assertEquals(StageStatus.RUNNING, resumed.stage(Stage.PLAN).status());
+        assertEquals(2, resumed.stage(Stage.PLAN).attempts());
+        assertEquals(StageStatus.COMPLETED, resumed.stage(Stage.DESIGN).status());
+        assertEquals(ShipDigest.sha256(Files.readAllBytes(design)),
+                resumed.stage(Stage.DESIGN).artifacts().get(0).digest());
+
+        Files.delete(discovery);
+        ShipRun missingProducer = controller.resume(run.id());
+        assertEquals(Stage.DISCOVERY, missingProducer.currentStage());
+        assertEquals(StageStatus.RUNNING, missingProducer.stage(Stage.DISCOVERY).status());
+        assertEquals(2, missingProducer.stage(Stage.DISCOVERY).attempts());
+        assertEquals(StageStatus.PENDING, missingProducer.stage(Stage.DESIGN).status());
+    }
+
+    @Test
+    void resumeRejectsTheInterruptedAttemptResult() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun started = controller.start(project, Oversight.NEVER, List.of());
+
+        ShipRun resumed = controller.resume(started.id());
+        assertEquals(2, resumed.stage(Stage.DISCOVERY).attempts());
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        started.id(),
+                        Stage.DISCOVERY,
+                        1,
+                        started.stage(Stage.DISCOVERY).inputDigest(),
+                        digest("late-result"),
+                        List.of(),
+                        false));
+        assertEquals("stale-stage-attempt", failure.code());
+        assertEquals(2, controller.status(started.id()).stage(Stage.DISCOVERY).attempts());
+    }
+
+    @Test
+    void rejectsAStageResultWithTheWrongInputDigest() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        run.id(),
+                        Stage.DISCOVERY,
+                        1,
+                        digest("wrong-input"),
+                        digest("result"),
+                        List.of(),
+                        false));
+
+        assertEquals("stale-stage-attempt", failure.code());
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void resumesAFailedStageWithANewAttempt() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        ShipRun failed = controller.failStage(
+                run.id(),
+                Stage.DISCOVERY,
+                1,
+                run.stage(Stage.DISCOVERY).inputDigest(),
+                "worker failed");
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(StageStatus.FAILED, failed.stage(Stage.DISCOVERY).status());
+
+        ShipRun resumed = controller.resume(run.id());
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(StageStatus.RUNNING, resumed.stage(Stage.DISCOVERY).status());
+        assertEquals(2, resumed.stage(Stage.DISCOVERY).attempts());
+    }
+
+    @Test
+    void rejectsCompletionWhenDocumentContextChangedMidAttempt() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path document = Files.writeString(project.resolve("requirements.md"), "version one");
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(
+                project, Oversight.NEVER, List.of(new ShipContext.DocumentInput(document)));
+
+        Files.writeString(document, "version two");
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        run.id(),
+                        Stage.DISCOVERY,
+                        1,
+                        run.stage(Stage.DISCOVERY).inputDigest(),
+                        digest("result"),
+                        List.of(),
+                        false));
+
+        assertEquals("stale-stage-input", failure.code());
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void rejectsCompletionWhenAPredecessorArtifactChangedMidAttempt() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path discovery = Files.writeString(project.resolve("discovery.md"), "version one");
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery", discovery);
+
+        Files.writeString(discovery, "version two");
+        ShipRun design = run;
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        design.id(),
+                        Stage.DESIGN,
+                        design.stage(Stage.DESIGN).attempts(),
+                        design.stage(Stage.DESIGN).inputDigest(),
+                        digest("design"),
+                        List.of(),
+                        false));
+
+        assertEquals("stale-stage-input", failure.code());
+        assertEquals(design, controller.status(design.id()));
+    }
+
+    @Test
+    void statusReadsAndAbortTerminatesThePersistedRun() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun started = controller.start(project, Oversight.NEVER, List.of());
+
+        assertEquals(started, controller.status(started.id()));
+        ShipRun aborted = controller.abort(started.id());
+        assertEquals(RunStatus.ABORTED, aborted.status());
+        assertEquals(StageStatus.ABORTED, aborted.stage(Stage.DISCOVERY).status());
+        assertEquals(RunStatus.ABORTED, controller.status(started.id()).status());
+        assertThrows(ShipController.Failure.class, () -> controller.resume(started.id()));
+    }
+
+    @Test
+    void startFromImportsExistingArtifactsAtTheirCurrentDigests() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        byte[] pipeline = """
+                {"mode":"manual","activePipeline":"149-local-controller"}
+                """.getBytes(StandardCharsets.UTF_8);
+        Files.write(metadata.resolve("pipeline.json"), pipeline);
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-local-controller"));
+        Path design = Files.writeString(documents.resolve("design-spec.md"), "design");
+        Path plan = Files.writeString(documents.resolve("implementation-plan.md"), "plan");
+
+        ShipRun run = controller("state").startFrom(
+                project,
+                Stage.EXECUTE,
+                Oversight.NEVER,
+                List.of(new ShipContext.TextInput("build the route")));
+
+        assertEquals("149-local-controller", run.pipelineId());
+        assertEquals(Stage.EXECUTE, run.currentStage());
+        assertEquals(StageStatus.RUNNING, run.stage(Stage.EXECUTE).status());
+        assertEquals(StageStatus.COMPLETED, run.stage(Stage.DISCOVERY).status());
+        assertEquals(StageStatus.COMPLETED, run.stage(Stage.DESIGN).status());
+        assertEquals(StageStatus.COMPLETED, run.stage(Stage.PLAN).status());
+        assertEquals(design.toAbsolutePath().normalize().toString(),
+                run.stage(Stage.DESIGN).artifacts().get(0).path());
+        assertEquals(ShipDigest.sha256(Files.readAllBytes(plan)),
+                run.stage(Stage.PLAN).artifacts().get(0).digest());
+        assertArrayEquals(pipeline, Files.readAllBytes(metadata.resolve("pipeline.json")));
+    }
+
+    @Test
+    void startFromDesignRequiresContext() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller("state").startFrom(
+                        project, Stage.DESIGN, Oversight.NEVER, List.of()));
+
+        assertEquals("start-from-context-missing", failure.code());
+    }
+
+    @Test
+    void startFromValidateRecordsAndRechecksTheProjectSnapshot() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-local-controller\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-local-controller"));
+        Files.writeString(documents.resolve("design-spec.md"), "design");
+        Files.writeString(documents.resolve("implementation-plan.md"), "plan");
+        Files.writeString(documents.resolve("execution-report.md"), "execution");
+        Path route = Files.writeString(project.resolve("route.yaml"), "version one");
+        ShipController controller = controller("state");
+
+        ShipRun validating = controller.startFrom(
+                project,
+                Stage.VALIDATE,
+                Oversight.ALWAYS,
+                List.of(new ShipContext.TextInput("build the route")));
+        assertEquals(2, validating.stage(Stage.EXECUTE).artifacts().size());
+        assertEquals(project.toAbsolutePath().normalize().toString(),
+                validating.stage(Stage.EXECUTE).artifacts().get(1).path());
+        String snapshotDigest = validating.stage(Stage.EXECUTE).artifacts().get(1).digest();
+
+        ShipRun paused = complete(controller, validating, "validated");
+        assertEquals(RunStatus.PAUSED, paused.status());
+        Files.writeString(route, "version two");
+
+        ShipRun resumed = controller.resume(paused.id());
+        assertEquals(Stage.VALIDATE, resumed.currentStage());
+        assertEquals(StageStatus.RUNNING, resumed.stage(Stage.VALIDATE).status());
+        assertEquals(2, resumed.stage(Stage.VALIDATE).attempts());
+        assertNotEquals(
+                snapshotDigest, resumed.stage(Stage.EXECUTE).artifacts().get(1).digest());
+    }
+
+    @Test
+    void rejectsAnArtifactSymlinkThatEscapesTheProject() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path outside = Files.writeString(directory.resolve("outside.md"), "outside");
+        Path link = Files.createSymbolicLink(project.resolve("result.md"), outside);
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        run.id(),
+                        Stage.DISCOVERY,
+                        1,
+                        run.stage(Stage.DISCOVERY).inputDigest(),
+                        digest("result"),
+                        List.of(link),
+                        false));
+
+        assertEquals("artifact-invalid", failure.code());
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void rejectsAndPreservesPreReleaseProjectState() throws Exception {
+        Path incompatiblePipeline = Files.createDirectory(directory.resolve("incompatible-pipeline"));
+        Path incompatibleMetadata = Files.createDirectories(incompatiblePipeline.resolve(".camel-kit"));
+        byte[] pipeline = """
+                {"mode":"autonomous","activePipeline":"149-old"}
+                """.getBytes(StandardCharsets.UTF_8);
+        Path pipelineFile = Files.write(incompatibleMetadata.resolve("pipeline.json"), pipeline);
+
+        ShipController.Failure pipelineFailure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller("pipeline-state").start(
+                        incompatiblePipeline, Oversight.SMART, List.of()));
+        assertEquals("pre-release-ship-state", pipelineFailure.code());
+        assertArrayEquals(pipeline, Files.readAllBytes(pipelineFile));
+
+        Path shipStateProject = Files.createDirectory(directory.resolve("ship-state-project"));
+        Path shipMetadata = Files.createDirectories(shipStateProject.resolve(".camel-kit"));
+        byte[] shipState = "{\"old\":true}\n".getBytes(StandardCharsets.UTF_8);
+        Path shipStateFile = Files.write(shipMetadata.resolve("ship-state.json"), shipState);
+
+        ShipController.Failure shipStateFailure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller("ship-state").start(
+                        shipStateProject, Oversight.SMART, List.of()));
+        assertEquals("pre-release-ship-state", shipStateFailure.code());
+        assertArrayEquals(shipState, Files.readAllBytes(shipStateFile));
+    }
+
+    private ShipController controller(String stateDirectory) {
+        return new ShipController(directory.resolve(stateDirectory));
+    }
+
+    private static ShipRun complete(
+            ShipController controller, ShipRun run, String result, Path... artifacts) {
+        Stage stage = run.currentStage();
+        return controller.completeStage(
+                run.id(),
+                stage,
+                run.stage(stage).attempts(),
+                run.stage(stage).inputDigest(),
+                digest(result),
+                List.of(artifacts),
+                false);
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -1,8 +1,14 @@
 package io.github.luigidemasi.camelkit.ship.controller;
 
+import java.io.RandomAccessFile;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
@@ -12,7 +18,9 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,6 +54,58 @@ class ShipControllerTest {
         assertEquals(ShipContext.Kind.DOCUMENT, source.kind());
         assertEquals(document.toAbsolutePath().normalize().toString(), source.value());
         assertEquals(ShipDigest.sha256(Files.readAllBytes(document)), source.digest());
+    }
+
+    @Test
+    void rejectsInvalidProjectRootsWithExactCodes() throws Exception {
+        ShipController controller = controller("state");
+
+        assertFailure("project-invalid",
+                () -> controller.start(null, Oversight.NEVER, List.of()));
+        assertFailure("project-missing",
+                () -> controller.start(directory.resolve("missing"), Oversight.NEVER, List.of()));
+        Path regularFile = Files.writeString(directory.resolve("file"), "not a project");
+        assertFailure("project-invalid",
+                () -> controller.start(regularFile, Oversight.NEVER, List.of()));
+
+        Path brokenPath = (Path) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{Path.class},
+                (proxy, method, arguments) -> {
+                    throw new IllegalStateException("path conversion failed");
+                });
+        assertFailure("project-invalid",
+                () -> controller.start(brokenPath, Oversight.NEVER, List.of()));
+    }
+
+    @Test
+    void rejectsUnreadableProjectAndArtifact() throws Exception {
+        Assumptions.assumeTrue(
+                Files.getFileStore(directory).supportsFileAttributeView("posix"));
+        Path unreadableProject = Files.createDirectory(directory.resolve("unreadable-project"));
+        Files.setPosixFilePermissions(unreadableProject, PosixFilePermissions.fromString("---------"));
+        try {
+            Assumptions.assumeFalse(Files.isReadable(unreadableProject));
+            assertFailure("project-unreadable",
+                    () -> controller("project-state").start(
+                            unreadableProject, Oversight.NEVER, List.of()));
+        } finally {
+            Files.setPosixFilePermissions(
+                    unreadableProject, PosixFilePermissions.fromString("rwx------"));
+        }
+
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path artifact = Files.writeString(project.resolve("artifact"), "result");
+        ShipController controller = controller("artifact-state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        Files.setPosixFilePermissions(artifact, PosixFilePermissions.fromString("---------"));
+        try {
+            Assumptions.assumeFalse(Files.isReadable(artifact));
+            assertFailure("artifact-unreadable",
+                    () -> complete(controller, run, "result", artifact));
+        } finally {
+            Files.setPosixFilePermissions(artifact, PosixFilePermissions.fromString("rw-------"));
+        }
     }
 
     @Test
@@ -226,6 +286,80 @@ class ShipControllerTest {
     }
 
     @Test
+    void rejectsInvalidMissingOversizedAndEmptyArtifacts() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path outside = Files.writeString(directory.resolve("outside"), "outside");
+        Path empty = Files.createFile(project.resolve("empty"));
+        Path oversized = project.resolve("oversized");
+        try (RandomAccessFile file = new RandomAccessFile(oversized.toFile(), "rw")) {
+            file.setLength(64L * 1024 * 1024 + 1);
+        }
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        ShipController.Failure escaped = assertThrows(
+                ShipController.Failure.class,
+                () -> complete(
+                        controller,
+                        run,
+                        "outside",
+                        project.resolve("..").resolve(outside.getFileName())));
+        assertEquals("artifact-invalid", escaped.code());
+        assertTrue(escaped.getMessage().contains("outside the project"));
+        assertFailure("artifact-missing",
+                () -> complete(controller, run, "missing", project.resolve("missing")));
+        assertFailure("artifact-too-large",
+                () -> complete(controller, run, "oversized", oversized));
+        assertFailure("artifact-invalid", () -> complete(controller, run, "empty", empty));
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void rejectsMutationsAfterTheProjectIsDeletedWithoutChangingState() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        Files.delete(project);
+
+        assertFailure("project-missing", () -> controller.resume(run.id()));
+        assertFailure("project-missing", () -> complete(controller, run, "result"));
+        assertFailure("project-missing",
+                () -> controller.failStage(
+                        run.id(),
+                        Stage.DISCOVERY,
+                        1,
+                        run.stage(Stage.DISCOVERY).inputDigest(),
+                        "worker failed"));
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void mutationTimeNeverMovesBackward() throws Exception {
+        Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        Instant t2 = Instant.parse("2026-01-01T02:00:00Z");
+        Instant tMinusOne = Instant.parse("2025-12-31T23:00:00Z");
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path state = directory.resolve("state");
+
+        ShipRun created = new ShipController(state, Clock.fixed(t0, ZoneOffset.UTC))
+                .start(project, Oversight.NEVER, List.of());
+        ShipRun failed = new ShipController(state, Clock.fixed(t2, ZoneOffset.UTC))
+                .failStage(
+                        created.id(),
+                        Stage.DISCOVERY,
+                        1,
+                        created.stage(Stage.DISCOVERY).inputDigest(),
+                        "worker failed");
+        ShipRun resumed = new ShipController(state, Clock.fixed(tMinusOne, ZoneOffset.UTC))
+                .resume(created.id());
+
+        assertEquals(t0.toString(), created.createdAt());
+        assertEquals(t0.toString(), created.updatedAt());
+        assertEquals(t2.toString(), failed.updatedAt());
+        assertEquals(t2.toString(), resumed.updatedAt());
+    }
+
+    @Test
     void statusReadsAndAbortTerminatesThePersistedRun() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         ShipController controller = controller("state");
@@ -236,7 +370,7 @@ class ShipControllerTest {
         assertEquals(RunStatus.ABORTED, aborted.status());
         assertEquals(StageStatus.ABORTED, aborted.stage(Stage.DISCOVERY).status());
         assertEquals(RunStatus.ABORTED, controller.status(started.id()).status());
-        assertThrows(ShipController.Failure.class, () -> controller.resume(started.id()));
+        assertFailure("run-aborted", () -> controller.resume(started.id()));
     }
 
     @Test
@@ -281,6 +415,17 @@ class ShipControllerTest {
                         project, Stage.DESIGN, Oversight.NEVER, List.of()));
 
         assertEquals("start-from-context-missing", failure.code());
+    }
+
+    @Test
+    void startFromLaterStagesRequiresAnActivePipeline() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+
+        for (Stage stage : List.of(Stage.PLAN, Stage.EXECUTE, Stage.VALIDATE)) {
+            assertFailure("start-from-artifact-missing",
+                    () -> controller.startFrom(project, stage, Oversight.NEVER, List.of()));
+        }
     }
 
     @Test
@@ -391,5 +536,10 @@ class ShipControllerTest {
 
     private static String digest(String value) {
         return ShipDigest.sha256(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void assertFailure(String code, Executable operation) {
+        ShipController.Failure failure = assertThrows(ShipController.Failure.class, operation);
+        assertEquals(code, failure.code());
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -1,0 +1,211 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipRunStoreTest {
+
+    private static final String RUN_ID = "ship-00000000000000000000000000000001";
+    private static final String OTHER_RUN_ID = "ship-00000000000000000000000000000002";
+    private static final String THIRD_RUN_ID = "ship-00000000000000000000000000000003";
+    private static final String CREATED_AT = "2026-07-23T12:00:00Z";
+    private static final String UPDATED_AT = "2026-07-23T12:01:00Z";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void createsReadsAndAtomicallyReplacesRunState() throws Exception {
+        ShipRunStore store = store();
+        ShipRun initial = run(RUN_ID);
+        store.create(initial);
+
+        assertEquals(initial, store.read(RUN_ID));
+        ShipRun updated = updated(initial);
+        try (ShipRunStore.LockedRun locked = store.lock(RUN_ID)) {
+            assertEquals(initial, locked.read());
+            assertCode("state-id-mismatch", () -> locked.write(run(OTHER_RUN_ID)));
+            locked.write(updated);
+        }
+
+        assertEquals(updated, store.read(RUN_ID));
+        Path runRoot = stateRoot().resolve(RUN_ID);
+        assertTrue(Files.isRegularFile(runRoot.resolve("state.json")));
+        assertTrue(Files.isRegularFile(runRoot.resolve("run.lock")));
+        try (var files = Files.list(runRoot)) {
+            assertFalse(files.anyMatch(path -> path.getFileName().toString().endsWith(".tmp")));
+        }
+    }
+
+    @Test
+    void keepsCommittedStateWhenAnInterruptedTemporaryFileRemains() throws Exception {
+        ShipRunStore store = store();
+        ShipRun initial = run(RUN_ID);
+        store.create(initial);
+        Path abandoned = Files.writeString(
+                stateRoot().resolve(RUN_ID).resolve(".state-interrupted.tmp"), "{\"schemaVersion\":");
+
+        assertEquals(initial, store.read(RUN_ID));
+        ShipRun updated = updated(initial);
+        try (ShipRunStore.LockedRun locked = store.lock(RUN_ID)) {
+            locked.read();
+            locked.write(updated);
+        }
+
+        assertEquals(updated, store.read(RUN_ID));
+        assertTrue(Files.exists(abandoned));
+    }
+
+    @Test
+    void excludesConcurrentMutationAndReleasesTheLock() throws Exception {
+        ShipRunStore store = store();
+        store.create(run(RUN_ID));
+
+        try (ShipRunStore.LockedRun ignored = store.lock(RUN_ID)) {
+            assertCode("operation-in-progress", () -> {
+                try (ShipRunStore.LockedRun competing = store.lock(RUN_ID)) {
+                    // A competing operation must not enter.
+                }
+            });
+        }
+
+        try (ShipRunStore.LockedRun reacquired = store.lock(RUN_ID)) {
+            assertEquals(RUN_ID, reacquired.read().id());
+        }
+        assertTrue(Files.exists(stateRoot().resolve(RUN_ID).resolve("run.lock")));
+    }
+
+    @Test
+    void distinguishesMissingInvalidAndCorruptState() throws Exception {
+        ShipRunStore store = store();
+        assertCode("run-not-found", () -> store.read(RUN_ID));
+        assertCode("run-id-invalid", () -> store.read("../../outside"));
+
+        Files.createDirectories(stateRoot().resolve(OTHER_RUN_ID));
+        assertCode("state-missing", () -> store.read(OTHER_RUN_ID));
+
+        ShipRun initial = run(THIRD_RUN_ID);
+        store.create(initial);
+        Path state = stateRoot().resolve(THIRD_RUN_ID).resolve("state.json");
+        String valid = Files.readString(state);
+
+        Files.writeString(state, "{");
+        assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
+
+        Files.writeString(state, "{\"schemaVersion\":1,\"schemaVersion\":1}");
+        assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
+
+        Files.writeString(state, valid + "\ntrue");
+        assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
+
+        int closingBrace = valid.lastIndexOf('}');
+        Files.writeString(
+                state, valid.substring(0, closingBrace) + ",\"unexpected\":true}");
+        assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
+
+        Files.writeString(state, "{\"schemaVersion\":1}");
+        assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
+
+        Files.writeString(state, "{\"schemaVersion\":2}");
+        assertCode("state-version-unsupported", () -> store.read(THIRD_RUN_ID));
+
+        Files.writeString(state, valid.replace(THIRD_RUN_ID, OTHER_RUN_ID));
+        assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
+    }
+
+    @Test
+    void rejectsDuplicateCreationWithoutChangingCommittedState() throws Exception {
+        ShipRunStore store = store();
+        ShipRun initial = run(RUN_ID);
+        store.create(initial);
+
+        assertCode("run-already-exists", () -> store.create(updated(initial)));
+
+        assertEquals(initial, store.read(RUN_ID));
+    }
+
+    @Test
+    void createsPrivateStateFilesOnPosixFilesystems() throws Exception {
+        Assumptions.assumeTrue(
+                FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        ShipRunStore store = store();
+        store.create(run(RUN_ID));
+        try (ShipRunStore.LockedRun ignored = store.lock(RUN_ID)) {
+            // Create and retain the stable lock file.
+        }
+
+        Path runRoot = stateRoot().resolve(RUN_ID);
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(stateRoot()));
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(runRoot));
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(runRoot.resolve("state.json")));
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(runRoot.resolve("run.lock")));
+    }
+
+    private ShipRunStore store() {
+        return new ShipRunStore(stateRoot());
+    }
+
+    private Path stateRoot() {
+        return temporaryDirectory.resolve("state");
+    }
+
+    private ShipRun run(String runId) {
+        return new ShipRun(
+                ShipRun.SCHEMA_VERSION,
+                runId,
+                temporaryDirectory.resolve("project").toAbsolutePath().normalize().toString(),
+                null,
+                ShipRun.Oversight.SMART,
+                ShipRun.RunStatus.PAUSED,
+                ShipRun.Stage.DISCOVERY,
+                ShipContext.none(),
+                ShipRun.pendingStages(),
+                CREATED_AT,
+                CREATED_AT,
+                null);
+    }
+
+    private static ShipRun updated(ShipRun run) {
+        return new ShipRun(
+                run.schemaVersion(),
+                run.id(),
+                run.projectDirectory(),
+                run.pipelineId(),
+                ShipRun.Oversight.NEVER,
+                run.status(),
+                run.currentStage(),
+                run.context(),
+                run.stages(),
+                run.createdAt(),
+                UPDATED_AT,
+                run.message());
+    }
+
+    private static void assertCode(String code, Executable action) {
+        ShipRunStore.StoreException failure
+                = assertThrows(ShipRunStore.StoreException.class, action);
+        assertEquals(code, failure.code());
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
@@ -8,6 +8,7 @@ import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.context.ShipContext;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight.ALWAYS;
 import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight.NEVER;
@@ -191,6 +192,34 @@ class ShipRunTest {
                         () -> run(RUNNING, DISCOVERY, wrongOrder, null)));
     }
 
+    @Test
+    void rejectsUnsafePipelineMessagesAndTimestamps() {
+        assertRejected(
+                "Ship pipeline ID is invalid",
+                () -> abortedRun(
+                        "149-safe/../../escape", CREATED_AT, UPDATED_AT, "cancelled"));
+        assertRejected(
+                "Ship run message is invalid",
+                () -> abortedRun(null, CREATED_AT, UPDATED_AT, " "));
+        assertRejected(
+                "Ship run message is invalid",
+                () -> abortedRun(null, CREATED_AT, UPDATED_AT, "x".repeat(1025)));
+        assertRejected(
+                "Ship run message is invalid",
+                () -> abortedRun(null, CREATED_AT, UPDATED_AT, "bad\0message"));
+        assertRejected(
+                "Ship run update precedes its creation",
+                () -> abortedRun(null, UPDATED_AT, CREATED_AT, "cancelled"));
+        assertRejected(
+                "Ship created timestamp is invalid",
+                () -> abortedRun(
+                        null, "2026-07-23T08:00:00.000Z", UPDATED_AT, "cancelled"));
+        assertRejected(
+                "Ship updated timestamp is invalid",
+                () -> abortedRun(
+                        null, CREATED_AT, "2026-07-23T08:00:01.000Z", "cancelled"));
+    }
+
     private static ShipRun run(
             ShipRun.RunStatus status,
             ShipRun.Stage currentStage,
@@ -218,6 +247,31 @@ class ShipRunTest {
                 CREATED_AT,
                 UPDATED_AT,
                 message);
+    }
+
+    private static ShipRun abortedRun(
+            String pipelineId, String createdAt, String updatedAt, String message) {
+        List<ShipRun.StageRecord> stages = ShipRun.pendingStages();
+        stages = replace(stages, DISCOVERY, stages.get(0).abort());
+        return new ShipRun(
+                ShipRun.SCHEMA_VERSION,
+                RUN_ID,
+                "/tmp/camel-kit-project",
+                pipelineId,
+                SMART,
+                ABORTED,
+                DISCOVERY,
+                ShipContext.none(),
+                stages,
+                createdAt,
+                updatedAt,
+                message);
+    }
+
+    private static void assertRejected(String message, Executable construction) {
+        assertEquals(
+                message,
+                assertThrows(IllegalArgumentException.class, construction).getMessage());
     }
 
     private static List<ShipRun.StageRecord> completedThrough(ShipRun.Stage last) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
@@ -1,0 +1,247 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+
+import org.junit.jupiter.api.Test;
+
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight.ALWAYS;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight.NEVER;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight.SMART;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus.ABORTED;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus.COMPLETED;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus.FAILED;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus.PAUSED;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus.RUNNING;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage.DESIGN;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage.DISCOVERY;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage.EXECUTE;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage.PLAN;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage.VALIDATE;
+import static io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus.PENDING;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipRunTest {
+
+    private static final String RUN_ID = "ship-0123456789abcdef0123456789abcdef";
+    private static final String CREATED_AT = "2026-07-23T08:00:00Z";
+    private static final String UPDATED_AT = "2026-07-23T08:00:01Z";
+    private static final String INPUT = digest("input");
+    private static final String OUTPUT = digest("output");
+
+    @Test
+    void parsesCanonicalEnumsAndAdvancesStages() {
+        assertAll(
+                () -> assertSame(ALWAYS, ShipRun.Oversight.valueOf("ALWAYS")),
+                () -> assertSame(SMART, ShipRun.Oversight.valueOf("SMART")),
+                () -> assertSame(NEVER, ShipRun.Oversight.valueOf("NEVER")),
+                () -> assertSame(RUNNING, ShipRun.RunStatus.valueOf("RUNNING")),
+                () -> assertSame(DISCOVERY, ShipRun.Stage.valueOf("DISCOVERY")),
+                () -> assertSame(PENDING, ShipRun.StageStatus.valueOf("PENDING")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> ShipRun.Oversight.valueOf("smart")),
+                () -> assertSame(DESIGN, DISCOVERY.next()),
+                () -> assertSame(PLAN, DESIGN.next()),
+                () -> assertSame(EXECUTE, PLAN.next()),
+                () -> assertSame(VALIDATE, EXECUTE.next()),
+                () -> assertNull(VALIDATE.next()));
+    }
+
+    @Test
+    void appliesOversightPauseSemantics() {
+        assertAll(
+                () -> assertFalse(ALWAYS.pausesAfter(DISCOVERY, false)),
+                () -> assertTrue(ALWAYS.pausesAfter(DESIGN, false)),
+                () -> assertTrue(ALWAYS.pausesAfter(PLAN, false)),
+                () -> assertTrue(ALWAYS.pausesAfter(EXECUTE, false)),
+                () -> assertTrue(ALWAYS.pausesAfter(VALIDATE, false)),
+                () -> assertFalse(SMART.pausesAfter(DESIGN, false)),
+                () -> assertTrue(SMART.pausesAfter(PLAN, false)),
+                () -> assertTrue(SMART.pausesAfter(EXECUTE, false)),
+                () -> assertFalse(SMART.pausesAfter(VALIDATE, false)),
+                () -> assertFalse(NEVER.pausesAfter(PLAN, false)),
+                () -> assertTrue(ALWAYS.pausesAfter(DISCOVERY, true)),
+                () -> assertTrue(SMART.pausesAfter(DISCOVERY, true)),
+                () -> assertFalse(NEVER.pausesAfter(DISCOVERY, true)));
+    }
+
+    @Test
+    void acceptsCanonicalProgressForEveryRunStatus() {
+        List<ShipRun.StageRecord> running = ShipRun.pendingStages();
+        List<ShipRun.StageRecord> runningStages = replace(
+                running, DISCOVERY, running.get(0).start(INPUT));
+
+        List<ShipRun.StageRecord> pausedStages = replace(
+                completedThrough(DISCOVERY), DESIGN, ShipRun.StageRecord.pending(DESIGN));
+
+        List<ShipRun.StageRecord> failed = ShipRun.pendingStages();
+        List<ShipRun.StageRecord> failedStages = replace(
+                failed, DISCOVERY, failed.get(0).start(INPUT).fail());
+
+        List<ShipRun.StageRecord> aborted = ShipRun.pendingStages();
+        List<ShipRun.StageRecord> abortedStages = replace(
+                aborted, DISCOVERY, aborted.get(0).abort());
+
+        assertAll(
+                () -> assertDoesNotThrow(() -> run(RUNNING, DISCOVERY, runningStages, null)),
+                () -> assertDoesNotThrow(() -> run(PAUSED, DESIGN, pausedStages, null)),
+                () -> assertDoesNotThrow(() -> run(FAILED, DISCOVERY, failedStages, "stage failed")),
+                () -> assertDoesNotThrow(() -> run(ABORTED, DISCOVERY, abortedStages, "cancelled")),
+                () -> assertDoesNotThrow(() -> run(COMPLETED, VALIDATE,
+                        completedThrough(VALIDATE), null)),
+                () -> assertDoesNotThrow(() -> run(PAUSED, VALIDATE,
+                        completedThrough(VALIDATE), null)),
+                () -> assertDoesNotThrow(() -> run(ABORTED, VALIDATE,
+                        completedThrough(VALIDATE), "cancelled after final approval")));
+    }
+
+    @Test
+    void incrementsAttemptsAcrossResetAndAllowsOnlyLegalTransitions() {
+        ShipRun.StageRecord pending = ShipRun.StageRecord.pending(DISCOVERY);
+        ShipRun.StageRecord first = pending.start(INPUT);
+        ShipRun.StageRecord failed = first.fail();
+        ShipRun.StageRecord reset = failed.reset();
+        ShipRun.StageRecord second = reset.start(digest("changed input"));
+        ShipRun.StageRecord completed = second.complete(OUTPUT, List.of());
+
+        assertAll(
+                () -> assertEquals(0, pending.attempts()),
+                () -> assertEquals(1, first.attempts()),
+                () -> assertEquals(1, reset.attempts()),
+                () -> assertEquals(2, second.attempts()),
+                () -> assertEquals(2, completed.attempts()),
+                () -> assertEquals(PENDING, reset.status()),
+                () -> assertThrows(IllegalStateException.class, () -> pending.complete(OUTPUT, List.of())),
+                () -> assertThrows(IllegalStateException.class, () -> first.start(INPUT)),
+                () -> assertThrows(IllegalStateException.class,
+                        completed::fail),
+                () -> assertThrows(IllegalStateException.class,
+                        completed::abort));
+    }
+
+    @Test
+    void computesDeterministicFramedInputDigests() {
+        List<ShipRun.StageRecord> completed = completedThrough(DESIGN);
+        ShipRun.ArtifactRef firstArtifact = new ShipRun.ArtifactRef(
+                "/tmp/camel-kit-design.md", digest("design"));
+        List<ShipRun.StageRecord> stages = replace(
+                completed, DESIGN, completed.get(DESIGN.ordinal()).withArtifacts(List.of(firstArtifact)));
+
+        String first = ShipRun.inputDigest(ShipContext.none(), stages, PLAN);
+        String repeated = ShipRun.inputDigest(ShipContext.none(), List.copyOf(stages), PLAN);
+        ShipRun.ArtifactRef changedArtifact = new ShipRun.ArtifactRef(
+                firstArtifact.path(), digest("changed design"));
+        List<ShipRun.StageRecord> changed = replace(stages, DESIGN,
+                stages.get(DESIGN.ordinal()).withArtifacts(List.of(changedArtifact)));
+
+        assertAll(
+                () -> assertTrue(ShipDigest.isSha256(first)),
+                () -> assertEquals(first, repeated),
+                () -> assertNotEquals(first,
+                        ShipRun.inputDigest(ShipContext.none(), changed, PLAN)),
+                () -> assertNotEquals(
+                        ShipRun.digestFields(List.of("ab", "c")),
+                        ShipRun.digestFields(List.of("a", "bc"))),
+                () -> assertThrows(IllegalStateException.class,
+                        () -> ShipRun.inputDigest(ShipContext.none(), ShipRun.pendingStages(), DESIGN)));
+    }
+
+    @Test
+    void rejectsInvalidIdentifiersDigestsAndProgress() {
+        List<ShipRun.StageRecord> stages = ShipRun.pendingStages();
+        List<ShipRun.StageRecord> wrongOrder = new ArrayList<>(stages);
+        wrongOrder.set(DISCOVERY.ordinal(), ShipRun.StageRecord.pending(DESIGN));
+        wrongOrder.set(DESIGN.ordinal(), ShipRun.StageRecord.pending(DISCOVERY));
+
+        assertAll(
+                () -> assertTrue(ShipRun.isRunId(RUN_ID)),
+                () -> assertFalse(ShipRun.isRunId("ship-ABC")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new ShipRun.ArtifactRef("/tmp/artifact", "sha256:bad")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new ShipRun.StageRecord(
+                                DISCOVERY, ShipRun.StageStatus.RUNNING, 0,
+                                INPUT, null, List.of())),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new ShipRun.StageRecord(
+                                DISCOVERY, ShipRun.StageStatus.RUNNING, 1,
+                                "not-a-digest", null, List.of())),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> run(RUNNING, DISCOVERY, stages, null, "ship-ABC")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> run(RUNNING, DESIGN, stages, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> run(COMPLETED, VALIDATE, stages, null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> run(PAUSED, DISCOVERY,
+                                replace(stages, DISCOVERY, stages.get(0).start(INPUT)), null)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> run(RUNNING, DISCOVERY, wrongOrder, null)));
+    }
+
+    private static ShipRun run(
+            ShipRun.RunStatus status,
+            ShipRun.Stage currentStage,
+            List<ShipRun.StageRecord> stages,
+            String message) {
+        return run(status, currentStage, stages, message, RUN_ID);
+    }
+
+    private static ShipRun run(
+            ShipRun.RunStatus status,
+            ShipRun.Stage currentStage,
+            List<ShipRun.StageRecord> stages,
+            String message,
+            String id) {
+        return new ShipRun(
+                ShipRun.SCHEMA_VERSION,
+                id,
+                "/tmp/camel-kit-project",
+                null,
+                SMART,
+                status,
+                currentStage,
+                ShipContext.none(),
+                stages,
+                CREATED_AT,
+                UPDATED_AT,
+                message);
+    }
+
+    private static List<ShipRun.StageRecord> completedThrough(ShipRun.Stage last) {
+        List<ShipRun.StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
+        for (ShipRun.Stage stage : ShipRun.Stage.values()) {
+            if (stage.ordinal() > last.ordinal()) {
+                break;
+            }
+            ShipRun.StageRecord completed = stages.get(stage.ordinal())
+                    .start(digest(stage + " input"))
+                    .complete(digest(stage + " output"), List.of());
+            stages.set(stage.ordinal(), completed);
+        }
+        return List.copyOf(stages);
+    }
+
+    private static List<ShipRun.StageRecord> replace(
+            List<ShipRun.StageRecord> stages, ShipRun.Stage stage, ShipRun.StageRecord record) {
+        List<ShipRun.StageRecord> changed = new ArrayList<>(stages);
+        changed.set(stage.ordinal(), record);
+        return List.copyOf(changed);
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

- add compact versioned run and stage records with `always`, `smart`, and `never` oversight
- persist user-owned run state through bounded atomic JSON replacement and a fail-fast per-run file lock
- resolve ordered no-input, text, and document context with bounded reads and content digests
- implement start, resume, start-from, status, abort, exact attempt binding, and dependency-based stale-stage invalidation
- add a directly tested standalone Picocli command while deliberately leaving it unregistered

## Why

PR #164 reset Ship to the retained local-MVP primitives. This change adds the smallest controller boundary needed before connecting the Pi/Linux worker: state is authoritative outside the project, mutable context and artifacts are rechecked before results advance, and resume restarts only the earliest affected stage.

Start-from imports manual design, plan, execution-report, and generated-project identities without rewriting existing project state. Incompatible pre-release state is reported and preserved.

The command is intentionally not registered in `CamelKitMain`; public cutover remains gated on the real worker and live end-to-end checks.

## Verification

- `./mvnw -B -pl camel-kit-core -am -Dtest=ShipContextTest,ShipRunTest,ShipRunStoreTest,ShipControllerTest,ShipCommandTest -Dsurefire.failIfNoSpecifiedTests=false test` (40 tests)
- `./mvnw -B -pl camel-kit-core -am test` (830 tests across the selected reactor)
- `./mvnw -B -Psourcecheck -pl camel-kit-core -am validate`
- `./mvnw -B clean install`
- `git diff --check`

Website impact: not required for this internal, unregistered slice; the user-facing documentation tracked by #149 remains required before public cutover.

Part of #149.

## Summary by Sourcery

Introduce a compact local Ship run controller with durable state, context handling, and a CLI entrypoint for starting and managing runs.

New Features:
- Add ShipController service to manage local Ship runs with start, start-from, resume, status, abort, and stage completion APIs.
- Introduce ShipContext to resolve, validate, and refresh ordered text and document inputs with content-addressed digests and size limits.
- Provide a Picocli-based ShipCommand for invoking the local controller from the CLI, supporting oversight selection, context arguments, and run operations.

Enhancements:
- Define ShipRun as the authoritative, schema-versioned state model for local runs, including stages, attempts, artifacts, and oversight policies.
- Add ShipRunStore for atomic JSON persistence of run state and exclusive mutation locks in a user-owned state directory.

Tests:
- Add comprehensive unit tests for ShipController behavior, including oversight policies, resume semantics, artifact validation, and start-from flows.
- Add unit tests for ShipContext to cover input ordering, limits, validation, and refresh behavior under various file conditions.
- Add unit tests for ShipRun and ShipRunStore to verify state invariants, ID and schema validation, and locking and persistence semantics.
- Add unit tests for ShipCommand to validate CLI argument handling, operations, error reporting, and integration with the controller.