### PR TITLE
Add bounded Pi worker and local evidence substrate

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -25,7 +25,7 @@ public class DistributionConfig {
 
     private static final String DEFAULT_CITRUS_VERSION = "5.0.0-M2";
     private static final String DEFAULT_CITRUS_MCP_VERSION = "5.0.0-M1";
-    private static final String DEFAULT_PI_VERSION = "0.80.3";
+    private static final String DEFAULT_PI_VERSION = "0.80.6";
     private static final String DEFAULT_PI_MCP_ADAPTER_VERSION = "2.11.0";
 
     private static final Path DEFAULT_USER_CONFIG = Path.of(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogArtifactReader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogArtifactReader.java
@@ -39,18 +39,23 @@ final class CatalogArtifactReader {
         if (maximumBytes < 1 || maximumBytes > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Catalog artifact byte limit is invalid");
         }
-        Path root = Objects.requireNonNull(requestedRoot, "requestedRoot must not be null")
+        Path requested = Objects.requireNonNull(requestedRoot, "requestedRoot must not be null")
                 .toAbsolutePath().normalize();
         Path file = Objects.requireNonNull(requestedFile, "requestedFile must not be null")
                 .toAbsolutePath().normalize();
-        if (!file.startsWith(root) || file.equals(root)) {
+        if (!file.startsWith(requested) || file.equals(requested)) {
             throw new IOException("Catalog artifact is outside its repository root");
         }
-        Path relative = root.relativize(file);
+        Path relative = requested.relativize(file);
         int count = relative.getNameCount();
         if (count < 2) {
             throw new IOException("Catalog artifact path lacks a parent directory");
         }
+        if (Files.isSymbolicLink(requested)
+                || !Files.isDirectory(requested, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Catalog repository root is not a real directory");
+        }
+        Path root = requested.toRealPath();
         try (BoundRoot boundRoot = openRoot(root)) {
             byte[] result = readFrom(
                     boundRoot.stream(), root, relative, 0, boundRoot.identity().device(), maximumBytes);
@@ -78,10 +83,6 @@ final class CatalogArtifactReader {
     }
 
     private static BoundRoot openRoot(Path root) throws IOException {
-        rejectSymbolicComponents(root);
-        if (!root.equals(root.toRealPath())) {
-            throw new IOException("Catalog repository root is not a canonical real directory");
-        }
         DirectoryStream<Path> opened = Files.newDirectoryStream(root);
         if (!(opened instanceof SecureDirectoryStream<?>)) {
             opened.close();
@@ -312,16 +313,6 @@ final class CatalogArtifactReader {
             throw new IOException("Catalog artifact path contains an unsafe segment");
         }
         return name;
-    }
-
-    private static void rejectSymbolicComponents(Path path) throws IOException {
-        Path current = path.getRoot();
-        for (Path component : path) {
-            current = current == null ? component : current.resolve(component);
-            if (Files.isSymbolicLink(current)) {
-                throw new IOException("Catalog repository path contains a symbolic link");
-            }
-        }
     }
 
     private record UnixIdentity(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
@@ -93,7 +93,7 @@ public final class ShipCatalogService {
                     .build())
             .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
-    private final Path localRepository;
+    private Path localRepository;
     private final ResolutionMode resolutionMode;
     private final ArtifactResolver artifactResolver;
 
@@ -114,9 +114,10 @@ public final class ShipCatalogService {
     }
 
     /** Acquires one exact artifact generation and freezes its bytes for every subsequent catalog query. */
-    public Snapshot snapshot(CatalogTarget target) throws IOException {
+    public synchronized Snapshot snapshot(CatalogTarget target) throws IOException {
         Objects.requireNonNull(target, "target must not be null");
         prepareLocalRepository();
+        localRepository = localRepository.toRealPath();
         return new Snapshot(resolve(target));
     }
 
@@ -427,8 +428,8 @@ public final class ShipCatalogService {
 
     private void prepareLocalRepository() throws IOException {
         Path parent = localRepository.getParent();
-        if (parent == null || Files.isSymbolicLink(parent)
-                || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+        if (parent == null
+                || !Files.isDirectory(parent.toRealPath(), LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Catalog repository parent must be a real directory");
         }
         if (!Files.exists(localRepository, LinkOption.NOFOLLOW_LINKS)) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -903,27 +903,24 @@ public final class ShipController {
         if (supplied == null) {
             throw failure("project-invalid", "Ship project directory is required");
         }
-        final Path project;
+        final Path normalized;
         try {
-            project = supplied.toAbsolutePath().normalize();
+            normalized = supplied.toAbsolutePath().normalize();
         } catch (RuntimeException e) {
             throw failure("project-invalid", "Ship project directory is invalid", e);
         }
-        if (!Files.exists(project, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
-            throw failure("project-missing", "Ship project directory does not exist: " + project);
+        if (!Files.exists(normalized, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+            throw failure("project-missing", "Ship project directory does not exist: " + normalized);
         }
-        if (Files.isSymbolicLink(project)
-                || !Files.isDirectory(project, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
-            throw failure("project-invalid", "Ship project path is not a directory: " + project);
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+            throw failure("project-invalid", "Ship project path is not a directory: " + normalized);
         }
+        final Path project;
         try {
-            if (!project.toRealPath().equals(project)) {
-                throw failure(
-                        "project-invalid",
-                        "Ship project path must not cross a symbolic link: " + project);
-            }
+            project = normalized.toRealPath();
         } catch (IOException | SecurityException e) {
-            throw failure("project-invalid", "Ship project path cannot be resolved: " + project, e);
+            throw failure("project-invalid", "Ship project path cannot be resolved: " + normalized, e);
         }
         if (!Files.isReadable(project)) {
             throw failure("project-unreadable", "Ship project directory is not readable: " + project);
@@ -1116,9 +1113,7 @@ public final class ShipController {
             requireNoSymbolicComponents(project, normalized);
             BasicFileAttributes attributes = Files.readAttributes(
                     normalized, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            long linkCount = unixLinkCount(normalized);
-            if (!attributes.isRegularFile() || attributes.isSymbolicLink()
-                    || attributes.fileKey() == null || linkCount != 1) {
+            if (!attributes.isRegularFile() || attributes.isSymbolicLink()) {
                 throw failure(
                         "artifact-invalid",
                         "Ship artifact is not a stable regular file: " + normalized);
@@ -1150,22 +1145,6 @@ public final class ShipController {
             } else {
                 bytes = ProjectEvidenceFiles.readVolatile(project, relative, readLimit);
             }
-            requireNoSymbolicComponents(project, normalized);
-            BasicFileAttributes after = Files.readAttributes(
-                    normalized, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            long afterLinkCount = unixLinkCount(normalized);
-            if (!after.isRegularFile() || after.isSymbolicLink()
-                    || after.fileKey() == null
-                    || afterLinkCount != 1
-                    || linkCount != afterLinkCount
-                    || !attributes.fileKey().equals(after.fileKey())
-                    || attributes.size() != after.size()
-                    || !attributes.lastModifiedTime().equals(after.lastModifiedTime())
-                    || bytes.length != attributes.size()) {
-                throw failure(
-                        "artifact-unreadable",
-                        "Ship artifact changed while it was read: " + normalized);
-            }
             if (bytes.length == 0) {
                 throw failure("artifact-invalid", "Ship artifact is empty: " + normalized);
             }
@@ -1189,19 +1168,6 @@ public final class ShipController {
             throw failure(
                     "artifact-unreadable", "Ship artifact could not be read: " + normalized, e);
         }
-    }
-
-    private static long unixLinkCount(Path path) throws IOException {
-        final Object value;
-        try {
-            value = Files.getAttribute(path, "unix:nlink", LinkOption.NOFOLLOW_LINKS);
-        } catch (IllegalArgumentException | UnsupportedOperationException e) {
-            throw new IOException("Ship artifact link count is unavailable", e);
-        }
-        if (!(value instanceof Number number) || number.longValue() < 1) {
-            throw new IOException("Ship artifact link count is invalid");
-        }
-        return number.longValue();
     }
 
     private static void requireNoSymbolicComponents(Path root, Path path)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -4,12 +4,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -25,6 +27,11 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageRecord;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace;
+import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.StaleBaselineException;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -37,6 +44,8 @@ public final class ShipController {
 
     private static final int MAX_PROJECT_STATE_BYTES = 1024 * 1024;
     private static final int MAX_ARTIFACT_BYTES = 64 * 1024 * 1024;
+    private static final long MAX_STAGE_ARTIFACT_BYTES
+            = ShipTreePolicy.DEFAULT_MAX_AGGREGATE_BYTES;
     private static final String ABORT_MESSAGE = "Run aborted by user";
     private static final ObjectMapper PROJECT_JSON = new ObjectMapper(
             JsonFactory.builder()
@@ -85,8 +94,9 @@ public final class ShipController {
         List<StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
         stages.set(
                 Stage.DISCOVERY.ordinal(),
-                stages.get(Stage.DISCOVERY.ordinal())
-                        .start(ShipRun.inputDigest(context, stages, Stage.DISCOVERY)));
+                startStage(
+                        stages.get(Stage.DISCOVERY.ordinal()),
+                        ShipRun.inputDigest(context, stages, Stage.DISCOVERY)));
         ShipRun run = newRun(
                 runId,
                 project,
@@ -132,8 +142,9 @@ public final class ShipController {
 
         stages.set(
                 startStage.ordinal(),
-                stages.get(startStage.ordinal())
-                        .start(ShipRun.inputDigest(context, stages, startStage)));
+                startStage(
+                        stages.get(startStage.ordinal()),
+                        ShipRun.inputDigest(context, stages, startStage)));
         ShipRun run = newRun(
                 runId,
                 project,
@@ -180,19 +191,41 @@ public final class ShipController {
                 if (record.status() != StageStatus.COMPLETED) {
                     continue;
                 }
-                List<ArtifactRef> refreshedArtifacts = new ArrayList<>(record.artifacts().size());
-                boolean missing = false;
-                for (ArtifactRef artifact : record.artifacts()) {
-                    try {
-                        refreshedArtifacts.add(readArtifact(project, Path.of(artifact.path())));
-                    } catch (Failure e) {
-                        restart = Math.min(restart, index);
-                        missing = true;
-                        break;
+                boolean stagedExecute = record.stage() == Stage.EXECUTE
+                        && record.attempts() > 0;
+                List<ArtifactRef> refreshedArtifacts;
+                try {
+                    if (stagedExecute) {
+                        requireExecuteRoot(
+                                record.artifacts(), expectedWorkspace(locked.directory()));
                     }
+                    refreshedArtifacts = readRecordedArtifacts(
+                            project,
+                            current.id(),
+                            record.stage(),
+                            record.attempts(),
+                            record.inputDigest(),
+                            locked.directory(),
+                            record.artifacts(),
+                            stagedExecute);
+                } catch (Failure e) {
+                    restart = Math.min(restart, index);
+                    break;
                 }
-                if (!missing && !refreshedArtifacts.equals(record.artifacts())) {
-                    stages.set(index, record.withArtifacts(refreshedArtifacts));
+                if (!refreshedArtifacts.equals(record.artifacts())) {
+                    String refreshedOutput = record.outputDigest();
+                    if (record.attempts() == 0 && record.stage() != Stage.DISCOVERY) {
+                        refreshedOutput = refreshedArtifacts.get(0).digest();
+                    } else if (stagedExecute) {
+                        refreshedOutput = ShipRun.executeOutputDigest(requireExecuteRoot(
+                                refreshedArtifacts, expectedWorkspace(locked.directory())));
+                    }
+                    stages.set(
+                            index,
+                            record.withArtifacts(refreshedOutput, refreshedArtifacts));
+                    if (record.stage().next() == null) {
+                        restart = Math.min(restart, index);
+                    }
                 }
             }
 
@@ -227,8 +260,9 @@ public final class ShipController {
                 Stage stage = Stage.values()[restart];
                 stages.set(
                         restart,
-                        stages.get(restart)
-                                .start(ShipRun.inputDigest(refreshed, stages, stage)));
+                        startStage(
+                                stages.get(restart),
+                                ShipRun.inputDigest(refreshed, stages, stage)));
                 resumed = copy(
                         current,
                         RunStatus.RUNNING,
@@ -290,21 +324,132 @@ public final class ShipController {
             String outputDigest,
             List<Path> artifacts,
             boolean materialAmbiguity) {
+        if (stage == Stage.EXECUTE) {
+            throw failure(
+                    "workspace-required",
+                    "Ship EXECUTE results require a workspace bound to the active stage");
+        }
+        return completeStage(
+                runId,
+                stage,
+                attempt,
+                inputDigest,
+                outputDigest,
+                artifacts,
+                false,
+                materialAmbiguity);
+    }
+
+    /**
+     * Records an EXECUTE result from the controller-owned workspace. The workspace root is always retained;
+     * {@code artifacts} contains only additional material files.
+     */
+    public ShipRun completeExecuteStage(
+            String runId,
+            int attempt,
+            String inputDigest,
+            List<Path> artifacts,
+            boolean materialAmbiguity) {
+        return completeStage(
+                runId,
+                Stage.EXECUTE,
+                attempt,
+                inputDigest,
+                null,
+                artifacts,
+                true,
+                materialAmbiguity);
+    }
+
+    /** Prepares the controller-owned workspace for the active EXECUTE attempt. */
+    public Path prepareWorkspace(String runId, int attempt, String inputDigest) {
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            StageRecord active = requireActiveAttempt(current, Stage.EXECUTE, attempt, inputDigest);
+            requireCurrentInputs(current, active, locked.directory());
+            return ShipWorkspace.prepare(
+                    Path.of(current.projectDirectory()),
+                    locked.directory(),
+                    current.id(),
+                    active.attempts(),
+                    active.inputDigest());
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (StaleBaselineException e) {
+            throw failure(
+                    "stale-stage-input",
+                    "Ship workspace baseline changed; resume the run",
+                    e);
+        } catch (IOException e) {
+            throw failure(
+                    "workspace-failed",
+                    "Could not prepare the Ship EXECUTE workspace for " + runId,
+                    e);
+        }
+    }
+
+    private ShipRun completeStage(
+            String runId,
+            Stage stage,
+            int attempt,
+            String inputDigest,
+            String outputDigest,
+            List<Path> artifacts,
+            boolean execute,
+            boolean materialAmbiguity) {
         Objects.requireNonNull(stage, "stage");
         Objects.requireNonNull(artifacts, "artifacts");
-        if (!ShipDigest.isSha256(outputDigest)) {
+        if (execute != (stage == Stage.EXECUTE)) {
+            throw new IllegalStateException("Ship EXECUTE completion mode does not match its stage");
+        }
+        if (!execute && !ShipDigest.isSha256(outputDigest)) {
             throw failure("stage-result-invalid", "Ship stage output digest is invalid");
         }
         try (ShipRunStore.LockedRun locked = store.lock(runId)) {
             ShipRun current = locked.read();
             StageRecord active = requireActiveAttempt(current, stage, attempt, inputDigest);
-            requireCurrentInputs(current, active);
+            requireCurrentInputs(current, active, locked.directory());
             Path project = Path.of(current.projectDirectory());
-            List<ArtifactRef> references = artifacts.stream()
-                    .map(path -> readArtifact(project, path))
-                    .toList();
+            Path artifactRoot;
+            List<Path> normalizedArtifacts;
+            WorkspaceEvidence workspaceEvidence = null;
+            if (execute) {
+                Path expected = expectedWorkspace(locked.directory());
+                normalizedArtifacts = normalizeArtifactPaths(expected, artifacts);
+                requireExecuteArtifactPaths(normalizedArtifacts, expected);
+                workspaceEvidence = verifyWorkspace(
+                        project,
+                        expected,
+                        current.id(),
+                        active.attempts(),
+                        active.inputDigest(),
+                        locked.directory());
+                artifactRoot = workspaceEvidence.candidate();
+            } else {
+                normalizedArtifacts = normalizeArtifactPaths(project, artifacts);
+                artifactRoot = project;
+            }
+            String acceptedOutputDigest = outputDigest;
+            List<ArtifactRef> references;
+            if (execute) {
+                ArtifactRef root = workspaceArtifact(workspaceEvidence, artifactRoot);
+                references = java.util.stream.Stream
+                        .concat(
+                                java.util.stream.Stream.of(root),
+                                workspaceArtifacts(workspaceEvidence, normalizedArtifacts).stream())
+                        .sorted(Comparator.comparing(ArtifactRef::path))
+                        .toList();
+                acceptedOutputDigest = ShipRun.executeOutputDigest(root);
+            } else {
+                requireAggregateArtifactSize(normalizedArtifacts);
+                ArtifactReadBudget budget = new ArtifactReadBudget();
+                references = new ArrayList<>(normalizedArtifacts.size());
+                for (Path path : normalizedArtifacts) {
+                    references.add(readArtifact(artifactRoot, path, budget));
+                }
+            }
             List<StageRecord> stages = new ArrayList<>(current.stages());
-            stages.set(stage.ordinal(), active.complete(outputDigest, references));
+            stages.set(stage.ordinal(), active.complete(acceptedOutputDigest, references));
 
             Stage next = stage.next();
             RunStatus status;
@@ -320,8 +465,9 @@ public final class ShipController {
             } else {
                 stages.set(
                         next.ordinal(),
-                        stages.get(next.ordinal())
-                                .start(ShipRun.inputDigest(current.context(), stages, next)));
+                        startStage(
+                                stages.get(next.ordinal()),
+                                ShipRun.inputDigest(current.context(), stages, next)));
                 status = RunStatus.RUNNING;
                 currentStage = next;
             }
@@ -353,7 +499,7 @@ public final class ShipController {
         try (ShipRunStore.LockedRun locked = store.lock(runId)) {
             ShipRun current = locked.read();
             StageRecord active = requireActiveAttempt(current, stage, attempt, inputDigest);
-            requireCurrentInputs(current, active);
+            requireCurrentInputs(current, active, locked.directory());
             List<StageRecord> stages = new ArrayList<>(current.stages());
             stages.set(stage.ordinal(), active.fail());
             ShipRun failed = copy(
@@ -443,7 +589,17 @@ public final class ShipController {
         return record;
     }
 
-    private static void requireCurrentInputs(ShipRun run, StageRecord active) {
+    private static StageRecord startStage(StageRecord stage, String inputDigest) {
+        if (stage.attempts() == Integer.MAX_VALUE - 1) {
+            throw failure(
+                    "state-corrupt",
+                    "Ship stage attempt count cannot be advanced");
+        }
+        return stage.start(inputDigest);
+    }
+
+    private static void requireCurrentInputs(
+            ShipRun run, StageRecord active, Path runDirectory) {
         Path project = requireProject(Path.of(run.projectDirectory()));
         ShipContext refreshed;
         try {
@@ -462,22 +618,35 @@ public final class ShipController {
 
         for (int index = 0; index < active.stage().ordinal(); index++) {
             StageRecord predecessor = run.stages().get(index);
-            for (ArtifactRef artifact : predecessor.artifacts()) {
-                try {
-                    if (!readArtifact(project, Path.of(artifact.path())).equals(artifact)) {
-                        throw failure(
-                                "stale-stage-input",
-                                "A Ship stage artifact changed; resume the run");
-                    }
-                } catch (Failure e) {
-                    if ("stale-stage-input".equals(e.code())) {
-                        throw e;
-                    }
+            try {
+                boolean stagedExecute = predecessor.stage() == Stage.EXECUTE
+                        && predecessor.attempts() > 0;
+                if (stagedExecute) {
+                    requireExecuteRoot(
+                            predecessor.artifacts(), expectedWorkspace(runDirectory));
+                }
+                if (!readRecordedArtifacts(
+                        project,
+                        run.id(),
+                        predecessor.stage(),
+                        predecessor.attempts(),
+                        predecessor.inputDigest(),
+                        runDirectory,
+                        predecessor.artifacts(),
+                        stagedExecute)
+                        .equals(predecessor.artifacts())) {
                     throw failure(
                             "stale-stage-input",
-                            "A Ship stage artifact changed or became unavailable; resume the run",
-                            e);
+                            "A Ship stage artifact changed; resume the run");
                 }
+            } catch (Failure e) {
+                if ("stale-stage-input".equals(e.code())) {
+                    throw e;
+                }
+                throw failure(
+                        "stale-stage-input",
+                        "A Ship stage artifact changed or became unavailable; resume the run",
+                        e);
             }
         }
         String expected = ShipRun.inputDigest(refreshed, run.stages(), active.stage());
@@ -485,6 +654,248 @@ public final class ShipController {
             throw failure(
                     "stale-stage-input",
                     "Ship stage input digest is stale; resume the run");
+        }
+    }
+
+    private static List<ArtifactRef> readRecordedArtifacts(
+            Path project,
+            String runId,
+            Stage stage,
+            int attempt,
+            String inputDigest,
+            Path runDirectory,
+            List<ArtifactRef> artifacts,
+            boolean stagedExecute) {
+        Path expected = expectedWorkspace(runDirectory);
+        List<Path> paths = new ArrayList<>(artifacts.size());
+        boolean workspaceRequired = stagedExecute;
+        for (ArtifactRef artifact : artifacts) {
+            Path normalized;
+            try {
+                normalized = Path.of(artifact.path()).toAbsolutePath().normalize();
+            } catch (RuntimeException e) {
+                throw failure("artifact-invalid", "Ship artifact path is invalid", e);
+            }
+            if (stagedExecute && !normalized.startsWith(expected)) {
+                throw failure(
+                        "artifact-invalid",
+                        "Ship EXECUTE artifact is outside its workspace: " + normalized);
+            }
+            if (!stagedExecute && !normalized.startsWith(project)) {
+                if (!normalized.startsWith(expected)) {
+                    throw failure(
+                            "artifact-invalid",
+                            "Ship artifact is outside its project and workspace: " + normalized);
+                }
+                workspaceRequired = true;
+            }
+            paths.add(normalized);
+        }
+        if (stage == Stage.EXECUTE && attempt == 0) {
+            return importedExecuteArtifacts(project, paths);
+        }
+        WorkspaceEvidence workspace = workspaceRequired
+                ? verifyWorkspace(project, expected, runId, attempt, inputDigest, runDirectory)
+                : null;
+        if (workspace != null) {
+            return workspaceArtifacts(workspace, paths);
+        }
+        requireAggregateArtifactSize(paths);
+        ArtifactReadBudget budget = new ArtifactReadBudget();
+        List<ArtifactRef> refreshed = new ArrayList<>(paths.size());
+        for (Path path : paths) {
+            refreshed.add(readArtifact(project, path, budget));
+        }
+        return List.copyOf(refreshed);
+    }
+
+    private static List<ArtifactRef> importedExecuteArtifacts(
+            Path project, List<Path> paths) {
+        try {
+            ProjectSnapshot snapshot = ProjectEvidenceFiles.capture(project);
+            List<ArtifactRef> refreshed = new ArrayList<>(paths.size());
+            for (Path path : paths) {
+                if (path.equals(project)) {
+                    refreshed.add(new ArtifactRef(path.toString(), snapshot.digest()));
+                    continue;
+                }
+                String relative = project.relativize(path)
+                        .toString()
+                        .replace(java.io.File.separatorChar, '/');
+                ProjectSnapshot.FileEntry entry = snapshot.files().get(relative);
+                if (entry == null || entry.size() == 0
+                        || entry.classification() != Classification.MATERIAL) {
+                    throw failure(
+                            "artifact-invalid",
+                            "Imported Ship EXECUTE evidence is not material: " + path);
+                }
+                refreshed.add(new ArtifactRef(path.toString(), entry.digest()));
+            }
+            return List.copyOf(refreshed);
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "artifact-unreadable",
+                    "Imported Ship EXECUTE evidence could not be captured",
+                    e);
+        }
+    }
+
+    private static WorkspaceEvidence verifyWorkspace(
+            Path project,
+            Path candidate,
+            String runId,
+            int attempt,
+            String inputDigest,
+            Path runDirectory) {
+        try {
+            Path expected = expectedWorkspace(runDirectory);
+            ProjectSnapshot snapshot = ShipWorkspace.verify(
+                    project, candidate, runId, attempt, inputDigest);
+            Path verified = Path.of(snapshot.root());
+            if (!verified.equals(expected)) {
+                throw new IOException(
+                        "Ship workspace is outside the controller-owned run directory");
+            }
+            return new WorkspaceEvidence(verified, snapshot);
+        } catch (StaleBaselineException e) {
+            throw failure(
+                    "stale-stage-input",
+                    "Ship workspace baseline changed; resume the run",
+                    e);
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship workspace does not match the active stage",
+                    e);
+        }
+    }
+
+    private static List<ArtifactRef> workspaceArtifacts(
+            WorkspaceEvidence evidence, List<Path> paths) {
+        return paths.stream()
+                .map(path -> workspaceArtifact(evidence, path))
+                .toList();
+    }
+
+    private static ArtifactRef workspaceArtifact(
+            WorkspaceEvidence evidence, Path path) {
+        Path candidate = evidence.candidate();
+        if (path.equals(candidate)) {
+            return new ArtifactRef(path.toString(), evidence.snapshot().digest());
+        }
+        String relative = candidate.relativize(path)
+                .toString()
+                .replace(java.io.File.separatorChar, '/');
+        ProjectSnapshot.FileEntry entry = evidence.snapshot().files().get(relative);
+        if (entry == null || entry.size() == 0
+                || entry.classification() != Classification.MATERIAL) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship workspace artifact is not in its accepted staged snapshot: " + path);
+        }
+        return new ArtifactRef(path.toString(), entry.digest());
+    }
+
+    private static Path expectedWorkspace(Path runDirectory) {
+        return runDirectory.resolve("workspace/candidate").toAbsolutePath().normalize();
+    }
+
+    private static ArtifactRef requireExecuteRoot(
+            List<ArtifactRef> artifacts, Path expectedRoot) {
+        List<ArtifactRef> roots = artifacts.stream()
+                .filter(artifact -> artifact.path().equals(expectedRoot.toString()))
+                .toList();
+        if (roots.size() != 1) {
+            throw failure(
+                    "state-invalid",
+                    "Completed Ship EXECUTE evidence has no unique workspace root");
+        }
+        return roots.get(0);
+    }
+
+    private static List<Path> normalizeArtifactPaths(
+            Path root, List<Path> artifacts) {
+        if (artifacts.size() > ShipTreePolicy.DEFAULT_MAX_FILE_COUNT) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship stage has too many artifacts");
+        }
+        List<Path> normalized = new ArrayList<>(artifacts.size());
+        for (Path artifact : artifacts) {
+            if (artifact == null) {
+                throw failure("artifact-invalid", "Ship artifact path is required");
+            }
+            try {
+                normalized.add((artifact.isAbsolute() ? artifact : root.resolve(artifact))
+                        .toAbsolutePath()
+                        .normalize());
+            } catch (RuntimeException e) {
+                throw failure("artifact-invalid", "Ship artifact path is invalid", e);
+            }
+        }
+        if (normalized.stream().anyMatch(path -> !path.startsWith(root))) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship artifact is outside its project or workspace");
+        }
+        if (normalized.stream().distinct().count() != normalized.size()) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship stage artifacts must have distinct paths");
+        }
+        return List.copyOf(normalized);
+    }
+
+    private static void requireAggregateArtifactSize(List<Path> artifacts) {
+        long total = 0;
+        for (Path artifact : artifacts) {
+            try {
+                BasicFileAttributes attributes = Files.readAttributes(
+                        artifact, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                if (attributes.isRegularFile()) {
+                    total = Math.addExact(total, attributes.size());
+                    if (total > MAX_STAGE_ARTIFACT_BYTES) {
+                        throw failure(
+                                "artifact-too-large",
+                                "Ship stage artifacts exceed the aggregate read limit");
+                    }
+                }
+            } catch (NoSuchFileException e) {
+                throw failure(
+                        "artifact-missing", "Ship artifact does not exist: " + artifact, e);
+            } catch (AccessDeniedException e) {
+                throw failure(
+                        "artifact-unreadable", "Ship artifact is not readable: " + artifact, e);
+            } catch (ArithmeticException e) {
+                throw failure(
+                        "artifact-too-large",
+                        "Ship stage artifacts exceed the aggregate read limit",
+                        e);
+            } catch (IOException | SecurityException e) {
+                throw failure(
+                        "artifact-unreadable", "Ship artifact could not be read: " + artifact, e);
+            }
+        }
+    }
+
+    private static void requireExecuteArtifactPaths(
+            List<Path> artifacts, Path expectedRoot) {
+        if (artifacts.size() >= ShipTreePolicy.DEFAULT_MAX_FILE_COUNT) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship EXECUTE stage has too many additional artifacts");
+        }
+        if (artifacts.stream().distinct().count() != artifacts.size()) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship EXECUTE artifacts must have distinct paths");
+        }
+        if (artifacts.stream().anyMatch(
+                artifact -> artifact.equals(expectedRoot)
+                        || !artifact.startsWith(expectedRoot))) {
+            throw failure(
+                    "artifact-invalid",
+                    "Ship EXECUTE artifacts must be additional files in its workspace");
         }
     }
 
@@ -498,11 +909,21 @@ public final class ShipController {
         } catch (RuntimeException e) {
             throw failure("project-invalid", "Ship project directory is invalid", e);
         }
-        if (!Files.exists(project)) {
+        if (!Files.exists(project, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
             throw failure("project-missing", "Ship project directory does not exist: " + project);
         }
-        if (!Files.isDirectory(project)) {
+        if (Files.isSymbolicLink(project)
+                || !Files.isDirectory(project, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
             throw failure("project-invalid", "Ship project path is not a directory: " + project);
+        }
+        try {
+            if (!project.toRealPath().equals(project)) {
+                throw failure(
+                        "project-invalid",
+                        "Ship project path must not cross a symbolic link: " + project);
+            }
+        } catch (IOException | SecurityException e) {
+            throw failure("project-invalid", "Ship project path cannot be resolved: " + project, e);
         }
         if (!Files.isReadable(project)) {
             throw failure("project-unreadable", "Ship project directory is not readable: " + project);
@@ -615,14 +1036,41 @@ public final class ShipController {
             case DISCOVERY, VALIDATE -> throw new IllegalStateException(
                     "No imported artifact for stage " + stage);
         };
-        ArtifactRef report = readArtifact(
-                project, project.resolve("docs/camel-kit").resolve(pipelineId).resolve(filename));
-        return stage == Stage.EXECUTE
-                ? List.of(report, readArtifact(project, project))
-                : List.of(report);
+        Path reportPath = project.resolve("docs/camel-kit").resolve(pipelineId).resolve(filename);
+        if (stage != Stage.EXECUTE) {
+            return List.of(readArtifact(project, reportPath));
+        }
+        try {
+            ProjectSnapshot snapshot = ProjectEvidenceFiles.capture(project);
+            String relative = project.relativize(reportPath)
+                    .toString()
+                    .replace(java.io.File.separatorChar, '/');
+            ProjectSnapshot.FileEntry report = snapshot.files().get(relative);
+            if (report == null || report.size() == 0
+                    || report.classification() != Classification.MATERIAL) {
+                throw failure(
+                        "artifact-missing",
+                        "Ship artifact does not exist or is not material: " + reportPath);
+            }
+            return List.of(
+                    new ArtifactRef(reportPath.toString(), report.digest()),
+                    new ArtifactRef(project.toString(), snapshot.digest()));
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "artifact-unreadable",
+                    "Ship artifact could not be captured: " + reportPath,
+                    e);
+        }
     }
 
     private static ArtifactRef readArtifact(Path project, Path supplied) {
+        return readArtifact(project, supplied, null);
+    }
+
+    private static ArtifactRef readArtifact(
+            Path project,
+            Path supplied,
+            ArtifactReadBudget budget) {
         Objects.requireNonNull(supplied, "artifact path");
         Path normalized;
         try {
@@ -647,32 +1095,89 @@ public final class ShipController {
             }
             if (normalized.equals(project)) {
                 return new ArtifactRef(
-                        normalized.toString(), ProjectEvidenceFiles.capture(project).digest());
+                        normalized.toString(),
+                        ProjectEvidenceFiles.capture(project).digest());
             }
-            BasicFileAttributes attributes = Files.readAttributes(normalized, BasicFileAttributes.class);
-            if (!attributes.isRegularFile()) {
+            String relative = project.relativize(normalized)
+                    .toString()
+                    .replace(java.io.File.separatorChar, '/');
+            Classification classification;
+            try {
+                classification = ShipTreePolicy.current().classify(relative);
+            } catch (IllegalArgumentException e) {
+                throw failure("artifact-invalid", "Ship artifact path is unsafe", e);
+            }
+            if (classification == Classification.DENIED
+                    || classification == Classification.PROTECTED) {
                 throw failure(
                         "artifact-invalid",
-                        "Ship artifact is not a regular file: " + normalized);
+                        "Ship artifact is not publishable under the project-tree policy: " + normalized);
+            }
+            requireNoSymbolicComponents(project, normalized);
+            BasicFileAttributes attributes = Files.readAttributes(
+                    normalized, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            long linkCount = unixLinkCount(normalized);
+            if (!attributes.isRegularFile() || attributes.isSymbolicLink()
+                    || attributes.fileKey() == null || linkCount != 1) {
+                throw failure(
+                        "artifact-invalid",
+                        "Ship artifact is not a stable regular file: " + normalized);
             }
             if (!Files.isReadable(normalized)) {
                 throw failure(
                         "artifact-unreadable", "Ship artifact is not readable: " + normalized);
             }
+            if (attributes.size() == 0) {
+                throw failure("artifact-invalid", "Ship artifact is empty: " + normalized);
+            }
             if (attributes.size() > MAX_ARTIFACT_BYTES) {
                 throw failure(
                         "artifact-too-large", "Ship artifact exceeds the read limit: " + normalized);
             }
+            int readLimit = MAX_ARTIFACT_BYTES;
+            if (budget != null) {
+                if (attributes.size() > budget.remaining()) {
+                    throw failure(
+                            "artifact-too-large",
+                            "Ship stage artifacts exceed the aggregate read limit");
+                }
+                readLimit = Math.toIntExact(
+                        Math.min((long) MAX_ARTIFACT_BYTES, budget.remaining()));
+            }
             byte[] bytes;
-            try (InputStream input = Files.newInputStream(normalized)) {
-                bytes = input.readNBytes(MAX_ARTIFACT_BYTES + 1);
+            if (classification == Classification.MATERIAL) {
+                bytes = ProjectEvidenceFiles.readMaterial(project, relative, readLimit);
+            } else {
+                bytes = ProjectEvidenceFiles.readVolatile(project, relative, readLimit);
+            }
+            requireNoSymbolicComponents(project, normalized);
+            BasicFileAttributes after = Files.readAttributes(
+                    normalized, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            long afterLinkCount = unixLinkCount(normalized);
+            if (!after.isRegularFile() || after.isSymbolicLink()
+                    || after.fileKey() == null
+                    || afterLinkCount != 1
+                    || linkCount != afterLinkCount
+                    || !attributes.fileKey().equals(after.fileKey())
+                    || attributes.size() != after.size()
+                    || !attributes.lastModifiedTime().equals(after.lastModifiedTime())
+                    || bytes.length != attributes.size()) {
+                throw failure(
+                        "artifact-unreadable",
+                        "Ship artifact changed while it was read: " + normalized);
             }
             if (bytes.length == 0) {
                 throw failure("artifact-invalid", "Ship artifact is empty: " + normalized);
             }
-            if (bytes.length > MAX_ARTIFACT_BYTES) {
+            if (bytes.length > readLimit) {
                 throw failure(
-                        "artifact-too-large", "Ship artifact exceeds the read limit: " + normalized);
+                        "artifact-too-large",
+                        readLimit < MAX_ARTIFACT_BYTES
+                                ? "Ship stage artifacts exceed the aggregate read limit"
+                                : "Ship artifact exceeds the read limit: " + normalized);
+            }
+            if (budget != null) {
+                budget.consume(bytes.length);
             }
             return new ArtifactRef(normalized.toString(), ShipDigest.sha256(bytes));
         } catch (NoSuchFileException e) {
@@ -683,6 +1188,38 @@ public final class ShipController {
         } catch (IOException | SecurityException e) {
             throw failure(
                     "artifact-unreadable", "Ship artifact could not be read: " + normalized, e);
+        }
+    }
+
+    private static long unixLinkCount(Path path) throws IOException {
+        final Object value;
+        try {
+            value = Files.getAttribute(path, "unix:nlink", LinkOption.NOFOLLOW_LINKS);
+        } catch (IllegalArgumentException | UnsupportedOperationException e) {
+            throw new IOException("Ship artifact link count is unavailable", e);
+        }
+        if (!(value instanceof Number number) || number.longValue() < 1) {
+            throw new IOException("Ship artifact link count is invalid");
+        }
+        return number.longValue();
+    }
+
+    private static void requireNoSymbolicComponents(Path root, Path path)
+            throws IOException {
+        Path relative = root.relativize(path);
+        Path current = root;
+        int index = 0;
+        for (Path component : relative) {
+            current = current.resolve(component);
+            BasicFileAttributes attributes = Files.readAttributes(
+                    current, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            index++;
+            if (attributes.isSymbolicLink()
+                    || (index < relative.getNameCount() && !attributes.isDirectory())) {
+                throw failure(
+                        "artifact-invalid",
+                        "Ship artifact path crosses a symbolic link or non-directory");
+            }
         }
     }
 
@@ -706,6 +1243,22 @@ public final class ShipController {
 
     private static Failure failure(String code, String message, Throwable cause) {
         return new Failure(code, message, cause);
+    }
+
+    private static final class ArtifactReadBudget {
+
+        private long remaining = MAX_STAGE_ARTIFACT_BYTES;
+
+        private long remaining() {
+            return remaining;
+        }
+
+        private void consume(long bytes) {
+            remaining = Math.subtractExact(remaining, bytes);
+        }
+    }
+
+    private record WorkspaceEvidence(Path candidate, ProjectSnapshot snapshot) {
     }
 
     public static final class Failure extends RuntimeException {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 
 /** Compact authoritative state for one local Ship run. */
 public record ShipRun(
@@ -28,7 +29,7 @@ public record ShipRun(
         String updatedAt,
         String message) {
 
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
 
     private static final Pattern RUN_ID = Pattern.compile("ship-[0-9a-f]{32}");
     private static final Pattern PIPELINE_ID = Pattern.compile("[0-9]{3,}-[a-z0-9]+(?:-[a-z0-9]+)*");
@@ -108,6 +109,13 @@ public record ShipRun(
             framed.writeBytes(bytes);
         }
         return ShipDigest.sha256(framed.toByteArray());
+    }
+
+    static String executeOutputDigest(ArtifactRef root) {
+        return digestFields(List.of(
+                "camel-kit.ship.execute-output.v1",
+                root.path(),
+                root.digest()));
     }
 
     private static void requireCanonicalStages(List<StageRecord> stages) {
@@ -256,10 +264,16 @@ public record ShipRun(
         public StageRecord {
             Objects.requireNonNull(stage, "stage");
             Objects.requireNonNull(status, "stage status");
-            if (attempts < 0) {
-                throw new IllegalArgumentException("Ship stage attempts cannot be negative");
+            if (attempts < 0 || attempts == Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("Ship stage attempts are out of range");
             }
             artifacts = List.copyOf(Objects.requireNonNull(artifacts, "artifacts"));
+            if (artifacts.size() > ShipTreePolicy.DEFAULT_MAX_FILE_COUNT
+                    || artifacts.stream().map(ArtifactRef::path).distinct().count()
+                       != artifacts.size()) {
+                throw new IllegalArgumentException(
+                        "Ship stage artifacts must be bounded and have distinct paths");
+            }
             if (inputDigest != null && !ShipDigest.isSha256(inputDigest)) {
                 throw new IllegalArgumentException("Ship stage input digest is invalid");
             }
@@ -330,10 +344,14 @@ public record ShipRun(
         }
 
         StageRecord withArtifacts(List<ArtifactRef> references) {
+            return withArtifacts(outputDigest, references);
+        }
+
+        StageRecord withArtifacts(String digest, List<ArtifactRef> references) {
             if (status != StageStatus.COMPLETED) {
                 throw new IllegalStateException("Only a completed Ship stage has artifacts");
             }
-            return new StageRecord(stage, status, attempts, inputDigest, outputDigest, references);
+            return new StageRecord(stage, status, attempts, inputDigest, digest, references);
         }
 
         private static void require(boolean condition) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -59,11 +59,13 @@ final class ShipRunStore {
 
     void create(ShipRun initial) throws IOException {
         requireCurrent(initial);
-        Path runRoot = runRoot(initial.id());
+        Path root = resolvedStateRoot("state-root-invalid");
+        Path runRoot = runRoot(root, initial.id());
         requireDisjoint(runRoot, initial, "state-project-overlap");
-        requireLinkFreeStateRoot("state-root-invalid");
-        Files.createDirectories(stateRoot, directoryAttributes());
-        requireLinkFreeStateRoot("state-root-invalid");
+        Files.createDirectories(root, directoryAttributes());
+        root = resolvedStateRoot("state-root-invalid");
+        runRoot = runRoot(root, initial.id());
+        requireDisjoint(runRoot, initial, "state-project-overlap");
         try {
             Files.createDirectory(runRoot, directoryAttributes());
         } catch (FileAlreadyExistsException e) {
@@ -171,7 +173,6 @@ final class ShipRunStore {
 
     private void write(Path runRoot, ShipRun run) throws IOException {
         requireCurrent(run);
-        requireLinkFreeStateRoot("state-invalid");
         if (Files.isSymbolicLink(runRoot)
                 || !Files.isDirectory(runRoot, LinkOption.NOFOLLOW_LINKS)) {
             throw new StoreException(
@@ -229,7 +230,7 @@ final class ShipRunStore {
         if (run == null) {
             throw new StoreException("state-invalid", "Ship run state is required");
         }
-        runRoot(run.id());
+        runRoot(stateRoot, run.id());
     }
 
     private static void requireWorkspaceEvidence(
@@ -332,8 +333,7 @@ final class ShipRunStore {
     }
 
     private Path existingRunRoot(String runId) throws StoreException {
-        requireLinkFreeStateRoot("state-corrupt");
-        Path runRoot = runRoot(runId);
+        Path runRoot = runRoot(resolvedStateRoot("state-corrupt"), runId);
         if (!Files.exists(runRoot, LinkOption.NOFOLLOW_LINKS)) {
             throw new StoreException("run-not-found", "Ship run was not found: " + runId);
         }
@@ -348,32 +348,56 @@ final class ShipRunStore {
     private static void requireDisjoint(
             Path runRoot, ShipRun run, String code)
             throws StoreException {
-        Path project = Path.of(run.projectDirectory());
-        if (runRoot.startsWith(project) || project.startsWith(runRoot)) {
+        final Path canonicalRunRoot;
+        final Path project;
+        try {
+            canonicalRunRoot = canonicalize(runRoot);
+            project = canonicalize(Path.of(run.projectDirectory()));
+        } catch (IOException | RuntimeException e) {
+            throw new StoreException(
+                    code,
+                    "Ship run state and project directories could not be resolved",
+                    e);
+        }
+        if (canonicalRunRoot.startsWith(project) || project.startsWith(canonicalRunRoot)) {
             throw new StoreException(
                     code,
                     "Ship run state and project directories must be disjoint");
         }
     }
 
-    private void requireLinkFreeStateRoot(String code) throws StoreException {
-        Path current = stateRoot.getRoot();
-        for (Path component : stateRoot) {
-            current = current == null ? component : current.resolve(component);
-            if (Files.isSymbolicLink(current)) {
-                throw new StoreException(
-                        code,
-                        "Ship state root must not cross a symbolic link");
-            }
+    private Path resolvedStateRoot(String code) throws StoreException {
+        final Path resolved;
+        try {
+            resolved = canonicalize(stateRoot);
+        } catch (IOException | SecurityException e) {
+            throw new StoreException(code, "Ship state root could not be resolved", e);
         }
+        if (Files.exists(resolved, LinkOption.NOFOLLOW_LINKS)
+                && !Files.isDirectory(resolved, LinkOption.NOFOLLOW_LINKS)) {
+            throw new StoreException(
+                    code,
+                    "Ship state root must be a real directory");
+        }
+        return resolved;
     }
 
-    private Path runRoot(String runId) throws StoreException {
+    private static Path canonicalize(Path path) throws IOException {
+        if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            return path.toRealPath();
+        }
+        Path parent = path.getParent();
+        return parent == null
+                ? path.toRealPath()
+                : canonicalize(parent).resolve(path.getFileName()).normalize();
+    }
+
+    private static Path runRoot(Path root, String runId) throws StoreException {
         if (runId == null || !ShipRun.isRunId(runId)) {
             throw new StoreException("run-id-invalid", "Invalid Ship run ID: " + runId);
         }
-        Path runRoot = stateRoot.resolve(runId).normalize();
-        if (!stateRoot.equals(runRoot.getParent())) {
+        Path runRoot = root.resolve(runId).normalize();
+        if (!root.equals(runRoot.getParent())) {
             throw new StoreException("run-id-invalid", "Invalid Ship run ID: " + runId);
         }
         return runRoot;

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -9,6 +9,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -17,11 +18,17 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Objects;
 import java.util.Set;
 
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.ArtifactRef;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageRecord;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Atomic local persistence and exclusive mutation leases for Ship runs. */
@@ -36,7 +43,11 @@ final class ShipRunStore {
                     .build())
             .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
             .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
 
     private final Path stateRoot;
     private final boolean posix;
@@ -49,7 +60,10 @@ final class ShipRunStore {
     void create(ShipRun initial) throws IOException {
         requireCurrent(initial);
         Path runRoot = runRoot(initial.id());
+        requireDisjoint(runRoot, initial, "state-project-overlap");
+        requireLinkFreeStateRoot("state-root-invalid");
         Files.createDirectories(stateRoot, directoryAttributes());
+        requireLinkFreeStateRoot("state-root-invalid");
         try {
             Files.createDirectory(runRoot, directoryAttributes());
         } catch (FileAlreadyExistsException e) {
@@ -125,6 +139,8 @@ final class ShipRunStore {
                     "state-corrupt",
                     "Ship run state ID " + run.id() + " does not match its directory " + runId);
         }
+        requireDisjoint(runRoot, run, "state-corrupt");
+        requireWorkspaceEvidence(runRoot, run, "state-corrupt");
         return run;
     }
 
@@ -155,6 +171,14 @@ final class ShipRunStore {
 
     private void write(Path runRoot, ShipRun run) throws IOException {
         requireCurrent(run);
+        requireLinkFreeStateRoot("state-invalid");
+        if (Files.isSymbolicLink(runRoot)
+                || !Files.isDirectory(runRoot, LinkOption.NOFOLLOW_LINKS)) {
+            throw new StoreException(
+                    "state-invalid", "Ship run path is not a real directory: " + runRoot);
+        }
+        requireDisjoint(runRoot, run, "state-invalid");
+        requireWorkspaceEvidence(runRoot, run, "state-invalid");
         byte[] encoded;
         try {
             encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(run);
@@ -208,16 +232,140 @@ final class ShipRunStore {
         runRoot(run.id());
     }
 
+    private static void requireWorkspaceEvidence(
+            Path runRoot, ShipRun run, String code)
+            throws StoreException {
+        requireImportedEvidence(run, code);
+        StageRecord execute = run.stage(Stage.EXECUTE);
+        if (execute.status() != StageStatus.COMPLETED) {
+            return;
+        }
+        if (execute.attempts() == 0) {
+            return;
+        }
+        Path expected = runRoot.resolve("workspace/candidate").toAbsolutePath().normalize();
+        ArtifactRef root = null;
+        for (ArtifactRef artifact : execute.artifacts()) {
+            Path path = Path.of(artifact.path());
+            if (!path.startsWith(expected)) {
+                throw invalidWorkspaceEvidence(run, code);
+            }
+            if (path.equals(expected)) {
+                if (root != null) {
+                    throw invalidWorkspaceEvidence(run, code);
+                }
+                root = artifact;
+            }
+        }
+        if (root == null
+                || !ShipRun.executeOutputDigest(root).equals(execute.outputDigest())) {
+            throw invalidWorkspaceEvidence(run, code);
+        }
+    }
+
+    private static void requireImportedEvidence(ShipRun run, String code)
+            throws StoreException {
+        boolean attemptedStageCompleted = false;
+        Path project = Path.of(run.projectDirectory());
+        Path documents = run.pipelineId() == null
+                ? null
+                : project.resolve("docs/camel-kit").resolve(run.pipelineId());
+        for (StageRecord record : run.stages()) {
+            if (record.status() != StageStatus.COMPLETED) {
+                continue;
+            }
+            if (record.attempts() > 0) {
+                attemptedStageCompleted = true;
+                continue;
+            }
+            if (attemptedStageCompleted
+                    || !record.inputDigest().equals(
+                            ShipRun.inputDigest(run.context(), run.stages(), record.stage()))) {
+                throw invalidImportedEvidence(run, code);
+            }
+            boolean canonical = switch (record.stage()) {
+                case DISCOVERY -> record.artifacts().isEmpty()
+                        && record.outputDigest().equals(run.context().digest());
+                case DESIGN -> documents != null
+                        && isImportedFile(record, documents.resolve("design-spec.md"));
+                case PLAN -> documents != null
+                        && isImportedFile(record, documents.resolve("implementation-plan.md"));
+                case EXECUTE -> documents != null
+                        && isImportedExecute(run, record, documents);
+                case VALIDATE -> false;
+            };
+            if (!canonical) {
+                throw invalidImportedEvidence(run, code);
+            }
+        }
+    }
+
+    private static boolean isImportedExecute(
+            ShipRun run, StageRecord execute, Path documents) {
+        if (execute.artifacts().size() != 2) {
+            return false;
+        }
+        ArtifactRef report = execute.artifacts().get(0);
+        ArtifactRef snapshot = execute.artifacts().get(1);
+        Path expectedReport = documents.resolve("execution-report.md");
+        return report.path().equals(expectedReport.toString())
+                && snapshot.path().equals(run.projectDirectory())
+                && execute.outputDigest().equals(report.digest());
+    }
+
+    private static boolean isImportedFile(StageRecord stage, Path expected) {
+        return stage.artifacts().size() == 1
+                && stage.artifacts().get(0).path().equals(expected.toString())
+                && stage.outputDigest().equals(stage.artifacts().get(0).digest());
+    }
+
+    private static StoreException invalidWorkspaceEvidence(ShipRun run, String code) {
+        return new StoreException(
+                code,
+                "Completed Ship EXECUTE evidence is invalid for run " + run.id());
+    }
+
+    private static StoreException invalidImportedEvidence(ShipRun run, String code) {
+        return new StoreException(
+                code,
+                "Imported Ship stage evidence is invalid for run " + run.id());
+    }
+
     private Path existingRunRoot(String runId) throws StoreException {
+        requireLinkFreeStateRoot("state-corrupt");
         Path runRoot = runRoot(runId);
-        if (!Files.exists(runRoot)) {
+        if (!Files.exists(runRoot, LinkOption.NOFOLLOW_LINKS)) {
             throw new StoreException("run-not-found", "Ship run was not found: " + runId);
         }
-        if (!Files.isDirectory(runRoot)) {
+        if (Files.isSymbolicLink(runRoot)
+                || !Files.isDirectory(runRoot, LinkOption.NOFOLLOW_LINKS)) {
             throw new StoreException(
-                    "state-corrupt", "Ship run path is not a directory: " + runRoot);
+                    "state-corrupt", "Ship run path is not a real directory: " + runRoot);
         }
         return runRoot;
+    }
+
+    private static void requireDisjoint(
+            Path runRoot, ShipRun run, String code)
+            throws StoreException {
+        Path project = Path.of(run.projectDirectory());
+        if (runRoot.startsWith(project) || project.startsWith(runRoot)) {
+            throw new StoreException(
+                    code,
+                    "Ship run state and project directories must be disjoint");
+        }
+    }
+
+    private void requireLinkFreeStateRoot(String code) throws StoreException {
+        Path current = stateRoot.getRoot();
+        for (Path component : stateRoot) {
+            current = current == null ? component : current.resolve(component);
+            if (Files.isSymbolicLink(current)) {
+                throw new StoreException(
+                        code,
+                        "Ship state root must not cross a symbolic link");
+            }
+        }
     }
 
     private Path runRoot(String runId) throws StoreException {
@@ -298,6 +446,11 @@ final class ShipRunStore {
                         "Cannot write Ship run " + next.id() + " while " + runId + " is locked");
             }
             ShipRunStore.this.write(runRoot, next);
+        }
+
+        Path directory() throws StoreException {
+            requireOpen();
+            return runRoot;
         }
 
         @Override

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunner.java
@@ -665,11 +665,12 @@ public final class EvidenceRunner {
         if (path == null) {
             throw new IOException(label + " is required");
         }
-        Path real = path.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        if (!Files.isDirectory(real, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(real)) {
+        Path normalized = path.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException(label + " must be a non-symbolic-link directory: " + path);
         }
-        return real;
+        return normalized.toRealPath();
     }
 
     private static Path createEvidenceDirectory(Path path) throws IOException {
@@ -677,23 +678,32 @@ public final class EvidenceRunner {
             throw new IOException("Evidence directory is required");
         }
         Path absolute = path.toAbsolutePath().normalize();
-        Path current = absolute.getRoot();
-        for (int index = 0; index < absolute.getNameCount() - 1; index++) {
-            current = current.resolve(absolute.getName(index));
-            if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
-                Files.createDirectory(current);
-            }
-            if (Files.isSymbolicLink(current) || !Files.isDirectory(current, LinkOption.NOFOLLOW_LINKS)) {
-                throw new IOException("Evidence path contains an unsafe component: " + current);
+        Path parent = absolute.getParent();
+        if (parent == null) {
+            throw new IOException("Evidence directory has no parent");
+        }
+        Path existingParent = parent;
+        while (!Files.exists(existingParent, LinkOption.NOFOLLOW_LINKS)) {
+            existingParent = existingParent.getParent();
+            if (existingParent == null) {
+                throw new IOException("Evidence directory has no existing ancestor: " + absolute);
             }
         }
+        Path realParent = existingParent.toRealPath();
+        if (!Files.isDirectory(realParent, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Evidence directory ancestor must be a directory: " + existingParent);
+        }
+        realParent = realParent.resolve(existingParent.relativize(parent));
+        Files.createDirectories(realParent);
+        realParent = realParent.toRealPath();
+        Path directory = realParent.resolve(absolute.getFileName());
         try {
-            Files.createDirectory(absolute, PosixFilePermissions.asFileAttribute(
+            Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(
                     PosixFilePermissions.fromString("rwx------")));
         } catch (FileAlreadyExistsException e) {
             throw new IOException("Evidence directory must be new and exclusive to one command run: " + absolute, e);
         }
-        return privateDirectory(absolute);
+        return privateDirectory(directory);
     }
 
     private static Path privateTempDirectory(Path parent, String prefix) throws IOException {
@@ -804,13 +814,14 @@ public final class EvidenceRunner {
 
     private static Path resolveWorkingDirectory(Path root, String relative) throws IOException {
         Path directory = relative == null || relative.isBlank() ? root : root.resolve(relative).normalize();
-        if (!directory.startsWith(root)) {
-            throw new IOException("Evidence command working directory escapes the project root");
-        }
-        Path real = directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        if (!real.startsWith(root) || !Files.isDirectory(real, LinkOption.NOFOLLOW_LINKS)
-                || Files.isSymbolicLink(real)) {
+        if (!directory.startsWith(root)
+                || Files.isSymbolicLink(directory)
+                || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Evidence command working directory is not a safe project directory: " + relative);
+        }
+        Path real = directory.toRealPath();
+        if (!real.startsWith(root)) {
+            throw new IOException("Evidence command working directory escapes the project root");
         }
         return real;
     }
@@ -821,7 +832,7 @@ public final class EvidenceRunner {
                 || !Files.isExecutable(path)) {
             throw new IOException(label + " executable is missing, symbolic, non-regular, or not executable: " + path);
         }
-        return path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        return path.toRealPath();
     }
 
     private static JdkIdentity controllerJdk() throws IOException {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStamp.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStamp.java
@@ -1,0 +1,587 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+
+/** Controller-derived result of the required local Ship checks. */
+public record ShipLocalStamp(
+        int schemaVersion,
+        String runId,
+        Status status,
+        List<ToolVersion> toolVersions,
+        List<Check> checks,
+        String generatedAt) {
+
+    public static final int SCHEMA_VERSION = 1;
+    public static final String REDACTED = "<redacted>";
+
+    private static final int MAX_TOOLS = 32;
+    private static final int MAX_CHECKS = 20_000;
+    private static final int MAX_ARGUMENTS = 256;
+    private static final int MAX_PATH_LENGTH = 4_096;
+    private static final int MAX_VERSION_LENGTH = 1_024;
+    private static final int MAX_TEXT_LENGTH = 4_096;
+    private static final int MAX_ARGUMENT_LENGTH = 4_096;
+    private static final Pattern ID = Pattern.compile("[a-z0-9][a-z0-9-]{0,127}");
+    private static final Pattern SENSITIVE_ASSIGNMENT = Pattern.compile(
+            "(?i)(docker[-_]?auth[-_]?config|npm[-_]?config[-_]*auth"
+                                                                        + "|password|passwd|pass|passphrase|pwd"
+                                                                        + "|secret|token|credentials?|auth(?:orization)?|api[-_]?key"
+                                                                        + "|access[-_]?key(?:[-_]?id)?|private[-_]?key|jwt|pat)"
+                                                                        + "([\"']?\\s*[:=]\\s*)"
+                                                                        + "(\"[^\"\\r\\n]*\"|'[^'\\r\\n]*'|[^\"'\\r\\n,}]+)");
+    private static final Pattern AUTHORIZATION_SCHEME = Pattern.compile(
+            "(?i)[\"']?\\b(Bearer|Basic)\\s+[\"']?([^\\s\"',}]+)[\"']?");
+    private static final Pattern URL_USERINFO = Pattern.compile(
+            "[A-Za-z][A-Za-z0-9+.-]*://([^/@\\s]*)@");
+
+    public ShipLocalStamp {
+        if (schemaVersion != SCHEMA_VERSION) {
+            throw new IllegalArgumentException("Unsupported local Stamp schema version");
+        }
+        if (!ShipRun.isRunId(runId)) {
+            throw new IllegalArgumentException("Local Stamp run ID is invalid");
+        }
+        toolVersions = boundedCopy(toolVersions, 1, MAX_TOOLS, "tool versions");
+        checks = boundedCopy(checks, 1, MAX_CHECKS, "checks");
+        requireUnique(toolVersions.stream().map(ToolVersion::tool).toList(), "tool");
+        requireUnique(checks.stream().map(Check::id).toList(), "check");
+        if (checks.stream().noneMatch(Check::required)) {
+            throw new IllegalArgumentException("Local Stamp requires at least one required check");
+        }
+        if (status != deriveStatus(checks)) {
+            throw new IllegalArgumentException("Local Stamp status does not match its evidence");
+        }
+        generatedAt = canonicalInstant(generatedAt, "generated timestamp");
+        Instant generated = Instant.parse(generatedAt);
+        if (checks.stream()
+                .map(Check::command)
+                .filter(Objects::nonNull)
+                .map(CommandRun::endedAt)
+                .map(Instant::parse)
+                .anyMatch(ended -> ended.isAfter(generated))) {
+            throw new IllegalArgumentException(
+                    "Local Stamp generation precedes its command evidence");
+        }
+    }
+
+    public static ShipLocalStamp create(
+            String runId,
+            List<ToolVersion> toolVersions,
+            List<Check> checks,
+            Instant generatedAt) {
+        return new ShipLocalStamp(
+                SCHEMA_VERSION,
+                runId,
+                deriveStatus(checks),
+                toolVersions,
+                checks,
+                Objects.requireNonNull(generatedAt, "generatedAt").toString());
+    }
+
+    /** Derives the result from required checks; diagnostic support labels and worker prose cannot change it. */
+    private static Status deriveStatus(List<Check> checks) {
+        if (checks.stream().anyMatch(check -> check.required() && check.outcome().failed())) {
+            return Status.FAIL;
+        }
+        if (checks.stream().anyMatch(check -> check.required() && check.outcome() == Outcome.WAIVED)) {
+            return Status.COMPLETED_WITH_WAIVER;
+        }
+        return Status.PASS;
+    }
+
+    public enum Status {
+        PASS,
+        COMPLETED_WITH_WAIVER,
+        FAIL
+    }
+
+    public enum Outcome {
+        PASS,
+        FAIL,
+        MISSING,
+        TIMED_OUT,
+        NONZERO,
+        SKIPPED,
+        EMPTY,
+        WAIVED;
+
+        private boolean failed() {
+            return this != PASS && this != WAIVED;
+        }
+    }
+
+    public enum Support {
+        SUPPORTED,
+        EXPERIMENTAL,
+        INCOMPATIBLE,
+        UNTESTED,
+        MISSING;
+
+    }
+
+    /** Detected local tool/runtime diagnostic and its support status. */
+    public record ToolVersion(
+            String tool, String executable, String version, Support support, String message) {
+
+        public ToolVersion {
+            requireId(tool, "tool");
+            Objects.requireNonNull(support, "support");
+            if (support == Support.MISSING) {
+                if (executable != null || version != null) {
+                    throw new IllegalArgumentException(
+                            "A missing tool cannot claim an executable or version");
+                }
+                message = requireText(message, MAX_TEXT_LENGTH, "tool guidance");
+            } else {
+                if (executable != null) {
+                    executable = requireAbsolutePath(executable, "tool executable");
+                }
+                if (version != null || support != Support.UNTESTED) {
+                    version = requireSingleLine(version, MAX_VERSION_LENGTH, "tool version");
+                }
+                if (support == Support.SUPPORTED) {
+                    if (message != null) {
+                        throw new IllegalArgumentException(
+                                "Supported tool diagnostics do not carry a warning");
+                    }
+                } else {
+                    message = requireText(message, MAX_TEXT_LENGTH, "tool warning");
+                }
+            }
+        }
+    }
+
+    /** One controller check. Only required outcomes participate in the Stamp status. */
+    public record Check(
+            String id,
+            boolean required,
+            Outcome outcome,
+            String summary,
+            String waiver,
+            CommandRun command) {
+
+        public Check {
+            requireId(id, "check");
+            Objects.requireNonNull(outcome, "outcome");
+            summary = requireText(summary, MAX_TEXT_LENGTH, "check summary");
+            if (outcome == Outcome.WAIVED) {
+                if (!required) {
+                    throw new IllegalArgumentException("Only a required check can be waived");
+                }
+                waiver = requireText(waiver, MAX_TEXT_LENGTH, "waiver");
+            } else if (waiver != null) {
+                throw new IllegalArgumentException("Only a waived check can carry a waiver");
+            }
+            switch (outcome) {
+                case PASS -> {
+                    if (command != null && !command.succeeded()) {
+                        throw new IllegalArgumentException(
+                                "A passing check cannot contain an unsuccessful command");
+                    }
+                }
+                case MISSING -> {
+                    if (command != null) {
+                        throw new IllegalArgumentException("A missing check cannot contain a command run");
+                    }
+                }
+                case TIMED_OUT -> {
+                    if (command == null || !command.timedOut()) {
+                        throw new IllegalArgumentException(
+                                "A timed-out check requires a timed-out command");
+                    }
+                }
+                case NONZERO -> {
+                    if (command == null || !command.completed() || command.exitCode() == 0) {
+                        throw new IllegalArgumentException(
+                                "A nonzero check requires a completed nonzero command");
+                    }
+                }
+                case SKIPPED, EMPTY -> {
+                    if (command != null && !command.succeeded()) {
+                        throw new IllegalArgumentException(
+                                "A command-backed " + outcome + " check requires a successful command");
+                    }
+                }
+                case WAIVED -> {
+                    if (command != null) {
+                        throw new IllegalArgumentException(
+                                "A waived check cannot contain command evidence");
+                    }
+                }
+                case FAIL -> {
+                    // The outcome may come from deterministic validation of a successful command's result.
+                }
+            }
+        }
+    }
+
+    /** Exact local command facts retained by a controller check. */
+    public record CommandRun(
+            String executable,
+            String version,
+            List<String> redactedArguments,
+            String workingDirectory,
+            List<String> inputDigests,
+            boolean launched,
+            boolean timedOut,
+            boolean outputLimited,
+            Integer exitCode,
+            String startedAt,
+            String endedAt,
+            String stdoutLog,
+            String stdoutDigest,
+            String stderrLog,
+            String stderrDigest) {
+
+        public CommandRun {
+            executable = requireAbsolutePath(executable, "command executable");
+            version = requireSingleLine(version, MAX_VERSION_LENGTH, "command version");
+            redactedArguments = boundedCopy(
+                    redactedArguments, 0, MAX_ARGUMENTS, "redacted arguments");
+            requireRedactedArguments(redactedArguments);
+            workingDirectory = requireAbsolutePath(workingDirectory, "command working directory");
+            inputDigests = boundedCopy(inputDigests, 1, MAX_ARGUMENTS, "command input digests");
+            inputDigests.forEach(digest -> requireDigest(digest, "command input digest"));
+            startedAt = canonicalInstant(startedAt, "command start");
+            endedAt = canonicalInstant(endedAt, "command end");
+            if (Instant.parse(endedAt).isBefore(Instant.parse(startedAt))) {
+                throw new IllegalArgumentException("Command end precedes its start");
+            }
+            stdoutLog = requireAbsolutePath(stdoutLog, "stdout log");
+            stderrLog = requireAbsolutePath(stderrLog, "stderr log");
+            if (stdoutLog.equals(stderrLog)) {
+                throw new IllegalArgumentException("Command stdout and stderr logs must be distinct");
+            }
+            requireDigest(stdoutDigest, "stdout digest");
+            requireDigest(stderrDigest, "stderr digest");
+            if (!launched && (timedOut || outputLimited || exitCode != null)) {
+                throw new IllegalArgumentException(
+                        "An unlaunched command cannot report execution results");
+            }
+            if (launched && timedOut && exitCode != null) {
+                throw new IllegalArgumentException(
+                        "A timed-out command cannot report a completed exit code");
+            }
+            if (launched && !timedOut && exitCode == null) {
+                throw new IllegalArgumentException(
+                        "A completed command must report its exit code");
+            }
+        }
+
+        public boolean completed() {
+            return launched && !timedOut && exitCode != null;
+        }
+
+        public boolean succeeded() {
+            return completed() && !outputLimited && exitCode == 0;
+        }
+    }
+
+    private static <T> List<T> boundedCopy(
+            List<T> values, int minimum, int maximum, String label) {
+        if (values == null || values.size() < minimum || values.size() > maximum
+                || values.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException(
+                    "Local Stamp " + label + " must contain " + minimum + ".." + maximum + " entries");
+        }
+        return List.copyOf(values);
+    }
+
+    private static void requireUnique(List<String> values, String label) {
+        Set<String> unique = new HashSet<>(values);
+        if (unique.size() != values.size()) {
+            throw new IllegalArgumentException("Local Stamp " + label + " IDs must be unique");
+        }
+    }
+
+    private static void requireId(String value, String label) {
+        if (value == null || !ID.matcher(value).matches()) {
+            throw new IllegalArgumentException("Local Stamp " + label + " ID is invalid");
+        }
+    }
+
+    private static String requireAbsolutePath(String value, String label) {
+        String path = requireSingleLine(value, MAX_PATH_LENGTH, label);
+        try {
+            Path parsed = Path.of(path);
+            if (!parsed.isAbsolute() || !parsed.normalize().toString().equals(path)) {
+                throw new IllegalArgumentException(
+                        "Local Stamp " + label + " must be a normalized absolute path");
+            }
+        } catch (InvalidPathException e) {
+            throw new IllegalArgumentException("Local Stamp " + label + " is invalid", e);
+        }
+        return path;
+    }
+
+    private static String canonicalInstant(String value, String label) {
+        try {
+            Instant instant = Instant.parse(Objects.requireNonNull(value, label));
+            if (!instant.toString().equals(value)) {
+                throw new IllegalArgumentException(
+                        "Local Stamp " + label + " must be canonical");
+            }
+            return value;
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Local Stamp " + label + " is invalid", e);
+        }
+    }
+
+    private static String requireText(String value, int maximum, String label) {
+        if (value == null || value.isBlank() || value.length() > maximum
+                || containsUnsafeDisplayCharacter(value)) {
+            throw new IllegalArgumentException(
+                    "Local Stamp " + label + " must contain 1.." + maximum + " safe characters");
+        }
+        return value;
+    }
+
+    private static String requireSingleLine(String value, int maximum, String label) {
+        String text = requireText(value, maximum, label);
+        if (text.indexOf('\r') >= 0 || text.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException("Local Stamp " + label + " must be one line");
+        }
+        return text;
+    }
+
+    private static void requireDigest(String value, String label) {
+        if (!ShipDigest.isSha256(value)) {
+            throw new IllegalArgumentException(
+                    "Local Stamp " + label + " must be a lowercase SHA-256 digest");
+        }
+    }
+
+    private static void requireRedactedArguments(List<String> arguments) {
+        for (int index = 0; index < arguments.size(); index++) {
+            String argument = arguments.get(index);
+            if (argument == null
+                    || argument.length() > MAX_ARGUMENT_LENGTH
+                    || (!argument.isEmpty() && argument.isBlank())
+                    || containsUnsafeDisplayCharacter(argument)
+                    || argument.indexOf('\r') >= 0
+                    || argument.indexOf('\n') >= 0) {
+                throw new IllegalArgumentException(
+                        "Local Stamp command argument must contain 0.."
+                                                   + MAX_ARGUMENT_LENGTH + " safe characters on one line");
+            }
+            requireKnownSecretsRedacted(argument);
+            if (compactCredential(argument)) {
+                if (!isRedactedValue(argument.substring(2))) {
+                    throw new IllegalArgumentException(
+                            "Sensitive command arguments must use " + REDACTED);
+                }
+                continue;
+            }
+            int separator = argument.indexOf('=');
+            String name = separator < 0 ? argument : argument.substring(0, separator);
+            boolean positionalName = separator < 0
+                    && (name.startsWith("-")
+                            || authorizationName(name));
+            if (!isSensitiveOption(name) || (separator < 0 && !positionalName)) {
+                continue;
+            }
+            String value = separator < 0
+                    ? index + 1 < arguments.size() ? arguments.get(index + 1) : null
+                    : argument.substring(separator + 1).trim();
+            int credentialIndex = separator < 0 ? index + 2 : index + 1;
+            if (authorizationName(name) && authorizationScheme(value)) {
+                if (credentialIndex >= arguments.size()
+                        || !isRedactedValue(arguments.get(credentialIndex))) {
+                    throw new IllegalArgumentException(
+                            "Authorization arguments must redact the complete credential");
+                }
+                continue;
+            }
+            if (!isRedactedValue(value)) {
+                throw new IllegalArgumentException(
+                        "Sensitive command arguments must use " + REDACTED);
+            }
+            if (authorizationName(name)
+                    && credentialIndex < arguments.size()
+                    && !arguments.get(credentialIndex).startsWith("-")
+                    && !isRedactedValue(arguments.get(credentialIndex))) {
+                throw new IllegalArgumentException(
+                        "Authorization arguments must redact the complete credential");
+            }
+        }
+    }
+
+    private static void requireKnownSecretsRedacted(String argument) {
+        Matcher assignment = SENSITIVE_ASSIGNMENT.matcher(argument);
+        while (assignment.find()) {
+            if (!isRedactedValue(assignment.group(3).trim())
+                    && !(authorizationName(assignment.group(1))
+                            && authorizationScheme(assignment.group(3)))) {
+                throw new IllegalArgumentException(
+                        "Sensitive command arguments must use " + REDACTED);
+            }
+        }
+        Matcher authorization = AUTHORIZATION_SCHEME.matcher(argument);
+        while (authorization.find()) {
+            if (!REDACTED.equals(authorization.group(2))) {
+                throw new IllegalArgumentException(
+                        "Authorization command arguments must use " + REDACTED);
+            }
+        }
+        Matcher userInfo = URL_USERINFO.matcher(argument);
+        while (userInfo.find()) {
+            if (!REDACTED.equals(userInfo.group(1))) {
+                throw new IllegalArgumentException(
+                        "URL credentials in command arguments must use " + REDACTED);
+            }
+        }
+    }
+
+    private static boolean isRedactedValue(String value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim();
+        if (normalized.length() >= 2
+                && (normalized.charAt(0) == '"' || normalized.charAt(0) == '\'')
+                && normalized.charAt(normalized.length() - 1) == normalized.charAt(0)) {
+            normalized = normalized.substring(1, normalized.length() - 1).trim();
+        }
+        return REDACTED.equals(normalized)
+                || ("Bearer " + REDACTED).equalsIgnoreCase(normalized)
+                || ("Basic " + REDACTED).equalsIgnoreCase(normalized);
+    }
+
+    private static boolean containsUnsafeDisplayCharacter(String value) {
+        for (int offset = 0; offset < value.length();) {
+            char current = value.charAt(offset);
+            if (Character.isHighSurrogate(current)) {
+                if (offset + 1 >= value.length()
+                        || !Character.isLowSurrogate(value.charAt(offset + 1))) {
+                    return true;
+                }
+            } else if (Character.isLowSurrogate(current)) {
+                return true;
+            }
+            int codePoint = value.codePointAt(offset);
+            int type = Character.getType(codePoint);
+            if (Character.isISOControl(codePoint)
+                    || type == Character.FORMAT
+                    || type == Character.LINE_SEPARATOR
+                    || type == Character.PARAGRAPH_SEPARATOR) {
+                return true;
+            }
+            offset += Character.charCount(codePoint);
+        }
+        return false;
+    }
+
+    public static boolean isSensitiveName(String value) {
+        String normalized = normalizedSensitiveName(value);
+        List<String> words = List.of(normalized.split("[^a-z0-9]+"));
+        if (words.size() > 1
+                && Set.of("file", "path", "dir", "directory")
+                        .contains(words.get(words.size() - 1))) {
+            return false;
+        }
+        String joined = String.join("", words);
+        return words.stream().anyMatch(Set.of(
+                "pass",
+                "passphrase",
+                "password",
+                "passwd",
+                "pwd",
+                "secret",
+                "token",
+                "credential",
+                "credentials",
+                "auth",
+                "authorization",
+                "bearer",
+                "cookie",
+                "jwt",
+                "pat")::contains)
+                || Set.of(
+                        "password",
+                        "passwd",
+                        "passphrase",
+                        "pwd",
+                        "secret",
+                        "token",
+                        "credential",
+                        "credentials",
+                        "auth",
+                        "authorization",
+                        "bearer",
+                        "cookie",
+                        "jwt",
+                        "pat")
+                        .stream()
+                        .anyMatch(joined::endsWith)
+                || joined.contains("apikey")
+                || joined.contains("accesskey")
+                || joined.contains("privatekey");
+    }
+
+    public static boolean isSensitiveEnvironmentName(String value) {
+        return !"PWD".equals(value)
+                && !"OLDPWD".equals(value)
+                && isSensitiveName(value);
+    }
+
+    private static boolean isSensitiveOption(String value) {
+        return isSensitiveName(value)
+                || "-u".equals(value)
+                || "-b".equals(value)
+                || "--user".equals(value)
+                || "--userpwd".equals(value)
+                || "--proxy-user".equals(value)
+                || "--oauth2-bearer".equals(value)
+                || "--cookie".equals(value);
+    }
+
+    private static boolean compactCredential(String value) {
+        return value.length() > 2
+                && !value.startsWith("--")
+                && (value.startsWith("-u")
+                        || (value.startsWith("-b")
+                                && (value.indexOf('=', 2) >= 0
+                                        || isRedactedValue(value.substring(2)))));
+    }
+
+    private static boolean authorizationName(String name) {
+        String normalized = normalizedSensitiveName(name);
+        return normalized.equals("authorization")
+                || normalized.equals("auth")
+                || normalized.endsWith("-authorization")
+                || normalized.endsWith("-auth");
+    }
+
+    private static boolean authorizationScheme(String value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim();
+        if (normalized.length() >= 2
+                && (normalized.charAt(0) == '"' || normalized.charAt(0) == '\'')
+                && normalized.charAt(normalized.length() - 1) == normalized.charAt(0)) {
+            normalized = normalized.substring(1, normalized.length() - 1).trim();
+        }
+        return "basic".equalsIgnoreCase(normalized)
+                || "bearer".equalsIgnoreCase(normalized);
+    }
+
+    private static String normalizedSensitiveName(String value) {
+        return value.replaceAll("([a-z0-9])([A-Z])", "$1-$2")
+                .toLowerCase(Locale.ROOT)
+                .replace('_', '-')
+                .replaceFirst("^-+", "");
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampStore.java
@@ -174,11 +174,7 @@ public final class ShipLocalStampStore {
                 || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Local Stamp directory must be a real directory");
         }
-        Path real = normalized.toRealPath();
-        if (!real.equals(normalized)) {
-            throw new IOException("Local Stamp directory must not cross a symbolic link");
-        }
-        return real;
+        return normalized.toRealPath();
     }
 
     private static UserPrincipal requirePrivateDirectory(Path directory)
@@ -259,15 +255,14 @@ public final class ShipLocalStampStore {
             throws IOException {
         Path log = Path.of(supplied).toAbsolutePath().normalize();
         String name = String.valueOf(log.getFileName());
-        if (!log.startsWith(evidenceDirectory)
-                || STAMP_FILE.equals(name)
+        if (STAMP_FILE.equals(name)
                 || name.startsWith(".stamp-")
                 || Files.isSymbolicLink(log)
                 || !Files.isRegularFile(log, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Local Stamp command log is outside its evidence directory: " + log);
         }
         Path real = log.toRealPath();
-        if (!real.startsWith(evidenceDirectory) || !real.equals(log)) {
+        if (!real.startsWith(evidenceDirectory)) {
             throw new IOException("Local Stamp command log escaped its evidence directory: " + log);
         }
         BasicFileAttributes attributes = requirePrivateFile(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampStore.java
@@ -1,0 +1,366 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Atomic persistence for one controller-derived local Stamp.
+ *
+ * <p>
+ * Callers serialize access and keep referenced logs quiescent during reads and writes.
+ */
+public final class ShipLocalStampStore {
+
+    private static final String STAMP_FILE = "stamp.json";
+    private static final int MAX_STAMP_BYTES = 64 * 1024 * 1024;
+    private static final int MAX_LOG_BYTES = 64 * 1024 * 1024;
+    private static final long MAX_TOTAL_LOG_BYTES = 64L * 1024 * 1024;
+    private static final Set<PosixFilePermission> PRIVATE_DIRECTORY
+            = PosixFilePermissions.fromString("rwx------");
+    private static final Set<PosixFilePermission> PRIVATE_FILE
+            = PosixFilePermissions.fromString("rw-------");
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+
+    private ShipLocalStampStore() {
+    }
+
+    public static Path write(
+            Path evidenceDirectory, String expectedRunId, ShipLocalStamp stamp)
+            throws IOException {
+        Path directory = realDirectory(evidenceDirectory);
+        UserPrincipal owner = requirePrivateDirectory(directory);
+        ShipLocalStamp report = Objects.requireNonNull(stamp, "stamp");
+        requireRun(expectedRunId, report);
+        verifyCommandLogs(directory, owner, report);
+
+        Path temporary = Files.createTempFile(
+                directory, ".stamp-", ".tmp", fileAttributes(directory));
+        boolean moved = false;
+        Throwable primary = null;
+        try {
+            requirePrivateFile(temporary, owner, "Temporary local Stamp");
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    LinkOption.NOFOLLOW_LINKS)) {
+                try {
+                    JSON.writerWithDefaultPrettyPrinter().writeValue(
+                            new CappedOutputStream(
+                                    Channels.newOutputStream(channel),
+                                    MAX_STAMP_BYTES),
+                            report);
+                } catch (JsonProcessingException e) {
+                    throw new IOException("Local Stamp cannot be encoded", e);
+                }
+                channel.force(true);
+            }
+            try {
+                Files.move(
+                        temporary,
+                        directory.resolve(STAMP_FILE),
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw new IOException("Filesystem does not support atomic local Stamp replacement", e);
+            }
+            moved = true;
+            Path result = directory.resolve(STAMP_FILE);
+            requirePrivateFile(result, owner, "Local Stamp");
+            return result;
+        } catch (IOException | RuntimeException | Error e) {
+            primary = e;
+            throw e;
+        } finally {
+            if (!moved) {
+                try {
+                    Files.deleteIfExists(temporary);
+                } catch (IOException cleanup) {
+                    if (primary == null) {
+                        throw cleanup;
+                    }
+                    primary.addSuppressed(cleanup);
+                }
+            }
+        }
+    }
+
+    public static ShipLocalStamp read(Path evidenceDirectory, String expectedRunId)
+            throws IOException {
+        if (!ShipRun.isRunId(expectedRunId)) {
+            throw new IOException("Expected local Stamp run ID is invalid");
+        }
+        Path directory = realDirectory(evidenceDirectory);
+        UserPrincipal owner = requirePrivateDirectory(directory);
+        Path file = directory.resolve(STAMP_FILE);
+        if (Files.isSymbolicLink(file)
+                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Local Stamp is missing or invalid: " + file);
+        }
+        requirePrivateFile(file, owner, "Local Stamp");
+        byte[] encoded;
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            encoded = input.readNBytes(MAX_STAMP_BYTES + 1);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_STAMP_BYTES) {
+            throw new IOException("Local Stamp has an invalid size: " + file);
+        }
+        try {
+            ShipLocalStamp stamp = JSON.readValue(encoded, ShipLocalStamp.class);
+            if (stamp == null) {
+                throw new IllegalArgumentException("Local Stamp root cannot be null");
+            }
+            requireRun(expectedRunId, stamp);
+            verifyCommandLogs(directory, owner, stamp);
+            return stamp;
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            throw new IOException("Local Stamp is invalid: " + file, e);
+        }
+    }
+
+    private static void requireRun(String expectedRunId, ShipLocalStamp stamp)
+            throws IOException {
+        if (!ShipRun.isRunId(expectedRunId)
+                || !expectedRunId.equals(stamp.runId())) {
+            throw new IOException("Local Stamp does not match its expected Ship run");
+        }
+    }
+
+    private static Path realDirectory(Path supplied) throws IOException {
+        if (supplied == null) {
+            throw new IOException("Local Stamp directory is required");
+        }
+        Path normalized = supplied.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Local Stamp directory must be a real directory");
+        }
+        Path real = normalized.toRealPath();
+        if (!real.equals(normalized)) {
+            throw new IOException("Local Stamp directory must not cross a symbolic link");
+        }
+        return real;
+    }
+
+    private static UserPrincipal requirePrivateDirectory(Path directory)
+            throws IOException {
+        if (!directory.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            throw new IOException("Local Stamp directory must support POSIX permissions");
+        }
+        String userName = System.getProperty("user.name");
+        if (userName == null || userName.isBlank()) {
+            throw new IOException("Could not determine the current user for the local Stamp directory");
+        }
+        UserPrincipal currentUser = directory.getFileSystem()
+                .getUserPrincipalLookupService()
+                .lookupPrincipalByName(userName);
+        PosixFileAttributes attributes = Files.readAttributes(
+                directory, PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!currentUser.equals(attributes.owner())) {
+            throw new IOException("Local Stamp directory must be owned by the current user");
+        }
+        if (!PRIVATE_DIRECTORY.equals(attributes.permissions())) {
+            throw new IOException("Local Stamp directory permissions must be 0700");
+        }
+        return currentUser;
+    }
+
+    private static PosixFileAttributes requirePrivateFile(
+            Path file, UserPrincipal owner, String label)
+            throws IOException {
+        PosixFileAttributes attributes = Files.readAttributes(
+                file, PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (!attributes.isRegularFile() || attributes.isSymbolicLink()) {
+            throw new IOException(label + " must be a real regular file: " + file);
+        }
+        if (!owner.equals(attributes.owner())) {
+            throw new IOException(label + " must be owned by the current user: " + file);
+        }
+        if (!PRIVATE_FILE.equals(attributes.permissions())) {
+            throw new IOException(label + " permissions must be 0600: " + file);
+        }
+        return attributes;
+    }
+
+    private static void verifyCommandLogs(
+            Path evidenceDirectory, UserPrincipal owner, ShipLocalStamp stamp)
+            throws IOException {
+        Map<Object, ExpectedLog> logs = new LinkedHashMap<>();
+        long totalBytes = 0;
+        for (ShipLocalStamp.Check check : stamp.checks()) {
+            ShipLocalStamp.CommandRun command = check.command();
+            if (command == null) {
+                continue;
+            }
+            ExpectedLog stdout = resolveLog(
+                    evidenceDirectory, owner, command.stdoutLog(), command.stdoutDigest());
+            ExpectedLog stderr = resolveLog(
+                    evidenceDirectory, owner, command.stderrLog(), command.stderrDigest());
+            if (stdout.identity().equals(stderr.identity())
+                    || Files.isSameFile(stdout.path(), stderr.path())) {
+                throw new IOException(
+                        "Local Stamp command stdout and stderr must be distinct files");
+            }
+            totalBytes = addLog(logs, stdout, totalBytes);
+            totalBytes = addLog(logs, stderr, totalBytes);
+        }
+        if (totalBytes > MAX_TOTAL_LOG_BYTES) {
+            throw new IOException("Local Stamp retained logs exceed their total size limit");
+        }
+        for (ExpectedLog log : logs.values()) {
+            verifyLog(log);
+        }
+    }
+
+    private static ExpectedLog resolveLog(
+            Path evidenceDirectory,
+            UserPrincipal owner,
+            String supplied,
+            String expectedDigest)
+            throws IOException {
+        Path log = Path.of(supplied).toAbsolutePath().normalize();
+        String name = String.valueOf(log.getFileName());
+        if (!log.startsWith(evidenceDirectory)
+                || STAMP_FILE.equals(name)
+                || name.startsWith(".stamp-")
+                || Files.isSymbolicLink(log)
+                || !Files.isRegularFile(log, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Local Stamp command log is outside its evidence directory: " + log);
+        }
+        Path real = log.toRealPath();
+        if (!real.startsWith(evidenceDirectory) || !real.equals(log)) {
+            throw new IOException("Local Stamp command log escaped its evidence directory: " + log);
+        }
+        BasicFileAttributes attributes = requirePrivateFile(
+                real, owner, "Local Stamp command log");
+        if (attributes.size() > MAX_LOG_BYTES) {
+            throw new IOException("Local Stamp command log has an invalid size: " + real);
+        }
+        Object identity = attributes.fileKey() == null ? real : attributes.fileKey();
+        return new ExpectedLog(identity, real, attributes.size(), expectedDigest);
+    }
+
+    private static long addLog(
+            Map<Object, ExpectedLog> logs, ExpectedLog candidate, long totalBytes)
+            throws IOException {
+        ExpectedLog existing = logs.putIfAbsent(candidate.identity(), candidate);
+        if (existing != null) {
+            if (!existing.digest().equals(candidate.digest())) {
+                throw new IOException(
+                        "Local Stamp records conflicting digests for one command log");
+            }
+            return totalBytes;
+        }
+        try {
+            return Math.addExact(totalBytes, candidate.size());
+        } catch (ArithmeticException e) {
+            throw new IOException("Local Stamp retained logs exceed their total size limit", e);
+        }
+    }
+
+    private static void verifyLog(ExpectedLog log) throws IOException {
+        byte[] content;
+        try (InputStream input = Files.newInputStream(log.path(), LinkOption.NOFOLLOW_LINKS)) {
+            content = input.readNBytes(MAX_LOG_BYTES + 1);
+        }
+        if (content.length > MAX_LOG_BYTES
+                || content.length != log.size()
+                || !ShipDigest.sha256(content).equals(log.digest())) {
+            throw new IOException(
+                    "Local Stamp command log does not match its recorded digest: " + log.path());
+        }
+    }
+
+    private record ExpectedLog(
+            Object identity, Path path, long size, String digest) {
+    }
+
+    private static final class CappedOutputStream extends OutputStream {
+
+        private final OutputStream delegate;
+        private final long maximum;
+        private long written;
+
+        private CappedOutputStream(OutputStream delegate, long maximum) {
+            this.delegate = delegate;
+            this.maximum = maximum;
+        }
+
+        @Override
+        public void write(int value) throws IOException {
+            requireCapacity(1);
+            delegate.write(value);
+            written++;
+        }
+
+        @Override
+        public void write(byte[] bytes, int offset, int length) throws IOException {
+            requireCapacity(length);
+            delegate.write(bytes, offset, length);
+            written += length;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            flush();
+        }
+
+        private void requireCapacity(int additional) throws IOException {
+            if (additional < 0 || written > maximum - additional) {
+                throw new IOException("Local Stamp exceeds its size limit");
+            }
+        }
+    }
+
+    private static FileAttribute<?>[] fileAttributes(Path path) {
+        return path.getFileSystem().supportedFileAttributeViews().contains("posix")
+                ? new FileAttribute<?>[]{
+                        PosixFilePermissions.asFileAttribute(
+                                PosixFilePermissions.fromString("rw-------"))}
+                : new FileAttribute<?>[0];
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
@@ -17,6 +17,11 @@ public final class ProjectEvidenceFiles {
         return new ProjectSnapshotService().captureSealed(sealedRoot);
     }
 
+    /** Captures material workspace content while rejecting denied and protected additions. */
+    public static ProjectSnapshot captureStaged(Path stagedRoot) throws IOException {
+        return new ProjectSnapshotService().captureStaged(stagedRoot);
+    }
+
     public static boolean unchanged(ProjectSnapshot before, ProjectSnapshot after) {
         return new ProjectSnapshotService().unchanged(before, after);
     }
@@ -31,5 +36,10 @@ public final class ProjectEvidenceFiles {
 
     public static byte[] readMaterial(Path root, String relativePath, int maximumBytes) throws IOException {
         return new ProjectSnapshotService().readMaterial(root, relativePath, maximumBytes);
+    }
+
+    /** Reads one bounded volatile file through the descriptor-relative project boundary. */
+    public static byte[] readVolatile(Path root, String relativePath, int maximumBytes) throws IOException {
+        return new ProjectSnapshotService().readVolatile(root, relativePath, maximumBytes);
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
@@ -154,11 +154,12 @@ final class ProjectSnapshotService {
     }
 
     private static Path requireEmptyTarget(Path targetRoot) throws IOException {
-        Path target = targetRoot.toAbsolutePath().normalize();
-        if (Files.isSymbolicLink(target) || !Files.isDirectory(target, LinkOption.NOFOLLOW_LINKS)
-                || !target.toRealPath(LinkOption.NOFOLLOW_LINKS).equals(target)) {
+        Path supplied = targetRoot.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(supplied)
+                || !Files.isDirectory(supplied, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Ship materialized workspace must be a real directory");
         }
+        Path target = supplied.toRealPath();
         try (var entries = Files.newDirectoryStream(target)) {
             if (entries.iterator().hasNext()) {
                 throw new IOException("Ship materialized workspace must be empty");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
@@ -40,6 +40,12 @@ final class ProjectSnapshotService {
         }
     }
 
+    ProjectSnapshot captureStaged(Path stagedRoot) throws IOException {
+        try (SecureRoot root = ShipSecureFilesystem.open(stagedRoot, "Staged Ship tree", policy)) {
+            return root.snapshotStaged();
+        }
+    }
+
     /** Captures a sealed tree containing material entries only. */
     ProjectSnapshot captureSealed(Path sealedRoot) throws IOException {
         try (SecureRoot root = ShipSecureFilesystem.open(sealedRoot, "Sealed Ship tree", policy)) {
@@ -67,10 +73,12 @@ final class ProjectSnapshotService {
     Comparison compareMaterialTree(ProjectSnapshot before, ProjectSnapshot after) {
         requireCompatible(before, after);
         return combine(
-                compareMaps(material(before.files()), material(after.files())),
                 compareMaps(
-                        materialDirectories(before.directories()),
-                        materialDirectories(after.directories())));
+                        portableMaterial(before.files()),
+                        portableMaterial(after.files())),
+                compareMaps(
+                        portableMaterialDirectories(before.directories()),
+                        portableMaterialDirectories(after.directories())));
     }
 
     boolean unchanged(ProjectSnapshot before, ProjectSnapshot after) {
@@ -138,6 +146,13 @@ final class ProjectSnapshotService {
         }
     }
 
+    /** Reads one bounded volatile file through the descriptor-relative project boundary. */
+    byte[] readVolatile(Path root, String relativePath, int maximumBytes) throws IOException {
+        try (SecureRoot secure = ShipSecureFilesystem.open(root, "Ship volatile read", policy)) {
+            return secure.readVolatileBytes(relativePath, maximumBytes);
+        }
+    }
+
     private static Path requireEmptyTarget(Path targetRoot) throws IOException {
         Path target = targetRoot.toAbsolutePath().normalize();
         if (Files.isSymbolicLink(target) || !Files.isDirectory(target, LinkOption.NOFOLLOW_LINKS)
@@ -193,12 +208,24 @@ final class ProjectSnapshotService {
         return result;
     }
 
-    private static Map<String, DirectoryEntry> materialDirectories(
+    private static Map<String, PortableFile> portableMaterial(
+            Map<String, FileEntry> files) {
+        TreeMap<String, PortableFile> result = new TreeMap<>();
+        files.forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                result.put(path, new PortableFile(
+                        entry.size(), entry.digest(), entry.unixMode() & 0777));
+            }
+        });
+        return result;
+    }
+
+    private static Map<String, PortableDirectory> portableMaterialDirectories(
             Map<String, DirectoryEntry> directories) {
-        TreeMap<String, DirectoryEntry> result = new TreeMap<>();
+        TreeMap<String, PortableDirectory> result = new TreeMap<>();
         directories.forEach((path, entry) -> {
             if (entry.classification() == Classification.MATERIAL) {
-                result.put(path, entry);
+                result.put(path, new PortableDirectory(entry.unixMode() & 0777));
             }
         });
         return result;
@@ -228,5 +255,11 @@ final class ProjectSnapshotService {
             }
         }
         return new Comparison(differences);
+    }
+
+    private record PortableFile(long size, String digest, int permissions) {
+    }
+
+    private record PortableDirectory(int permissions) {
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
@@ -351,20 +351,29 @@ final class ShipSecureFilesystem {
         }
 
         ProjectSnapshot snapshot() throws IOException {
-            return snapshot(false);
+            return snapshot(false, false);
         }
 
         /** Captures a sealed tree containing material entries only. */
         ProjectSnapshot snapshotMaterialOnly() throws IOException {
-            return snapshot(true);
+            return snapshot(true, false);
         }
 
-        private ProjectSnapshot snapshot(boolean materialOnly) throws IOException {
+        /** Captures material staging content while allowing volatile build output. */
+        ProjectSnapshot snapshotStaged() throws IOException {
+            return snapshot(false, true);
+        }
+
+        private ProjectSnapshot snapshot(boolean materialOnly, boolean staged) throws IOException {
             assertRootBinding();
             ScanState state = new ScanState(policy, rootMetadata.fileKey());
             try (BoundDirectory scanRoot = openBoundDirectory(
                     root, Path.of("."), "", rootMetadata)) {
-                scan(scanRoot.stream(), "", rootMetadata, 0, state, materialOnly);
+                try {
+                    scan(scanRoot.stream(), "", rootMetadata, 0, state, materialOnly, staged);
+                } catch (IllegalArgumentException ignored) {
+                    throw unsafe("Ship tree contains an unsafe entry");
+                }
             }
             assertRootBinding();
             return ProjectSnapshot.create(
@@ -373,12 +382,25 @@ final class ShipSecureFilesystem {
 
         /** Reads one bounded material file without following links or exposing protected project metadata. */
         byte[] readMaterialBytes(String relativePath, int maximumBytes) throws IOException {
+            return readBytes(relativePath, maximumBytes, Classification.MATERIAL);
+        }
+
+        /** Reads one bounded volatile file without following links or exposing other project content. */
+        byte[] readVolatileBytes(String relativePath, int maximumBytes) throws IOException {
+            return readBytes(relativePath, maximumBytes, Classification.VOLATILE);
+        }
+
+        private byte[] readBytes(
+                String relativePath,
+                int maximumBytes,
+                Classification requiredClassification)
+                throws IOException {
             if (maximumBytes < 1) {
                 throw new IllegalArgumentException("Maximum Ship read size must be positive");
             }
             String relative = canonicalPath(relativePath);
-            if (classify(relative) != Classification.MATERIAL) {
-                throw unsafe("Only material project files may be read as Ship context: " + relative);
+            if (classify(relative) != requiredClassification) {
+                throw unsafe("Ship file does not have the required classification: " + relative);
             }
             assertRootBinding();
             byte[] result = withParent(relative, (parent, name) -> {
@@ -387,7 +409,7 @@ final class ShipSecureFilesystem {
                 requireRegularFile(basicBefore, before, rootMetadata.device(), relative);
                 long limit = Math.min((long) maximumBytes, policy.maxFileBytes());
                 if (before.size() > limit) {
-                    throw quota("Ship context file exceeds its read limit: " + relative);
+                    throw quota("Ship file exceeds its read limit: " + relative);
                 }
                 ByteArrayOutputStream output = new ByteArrayOutputStream(Math.toIntExact(before.size()));
                 // Java 17 exposes no fstat-style identity from SeekableByteChannel. These
@@ -404,10 +426,10 @@ final class ShipSecureFilesystem {
                         total = Math.addExact(total, read);
                         if (total > before.size()) {
                             throw concurrentMutation(
-                                    "Ship context file grew while it was read: " + relative);
+                                    "Ship file grew while it was read: " + relative);
                         }
                         if (total > limit) {
-                            throw quota("Ship context file exceeds its read limit: " + relative);
+                            throw quota("Ship file exceeds its read limit: " + relative);
                         }
                         output.write(buffer.array(), 0, read);
                         buffer.clear();
@@ -417,7 +439,7 @@ final class ShipSecureFilesystem {
                 UnixIdentity after = relativeIdentity(relative, before.fileKey());
                 requireRegularFile(basicAfter, after, rootMetadata.device(), relative);
                 if (!before.equals(after) || output.size() != before.size()) {
-                    throw concurrentMutation("Ship context file changed while it was read: " + relative);
+                    throw concurrentMutation("Ship file changed while it was read: " + relative);
                 }
                 return output.toByteArray();
             });
@@ -431,7 +453,8 @@ final class ShipSecureFilesystem {
                 UnixIdentity expectedDirectory,
                 int depth,
                 ScanState state,
-                boolean materialOnly)
+                boolean materialOnly,
+                boolean staged)
                 throws IOException {
             validateOpenedDirectory(directory, expectedDirectory, display(prefix));
             UnixIdentity directoryBefore = relativeIdentity(prefix, expectedDirectory.fileKey());
@@ -452,25 +475,38 @@ final class ShipSecureFilesystem {
                     UnixIdentity entryIdentity = relativeIdentity(relative, basic.fileKey());
                     requireDirectory(basic, entryIdentity, rootMetadata.device(), relative);
                     state.visitDirectory(relative, entryIdentity);
+                    if (staged && (classification == Classification.DENIED
+                            || classification == Classification.PROTECTED)) {
+                        throw unsafe("Staged Ship tree contains a non-publishable entry: " + relative);
+                    }
                     if (materialOnly && classification != Classification.MATERIAL) {
                         throw unsafe("Sealed Ship tree contains a non-material entry: " + relative);
                     }
                     if (classification == Classification.DENIED
-                            || classification == Classification.VOLATILE) {
+                            || (classification == Classification.VOLATILE && !staged)) {
                         continue;
                     }
                     int childDepth = Math.addExact(depth, 1);
                     if (childDepth > policy.maxDepth()) {
                         throw quota("Ship tree exceeds the depth quota at " + relative);
                     }
-                    state.addDirectory(relative, entryIdentity, new DirectoryEntry(
-                            classification,
-                            entryIdentity.mode(),
-                            entryIdentity.userId(),
-                            entryIdentity.groupId()));
+                    if (classification != Classification.VOLATILE) {
+                        state.addDirectory(relative, entryIdentity, new DirectoryEntry(
+                                classification,
+                                entryIdentity.mode(),
+                                entryIdentity.userId(),
+                                entryIdentity.groupId()));
+                    }
                     try (BoundDirectory child = openBoundDirectory(
                             directory, name, relative, entryIdentity)) {
-                        scan(child.stream(), relative, entryIdentity, childDepth, state, materialOnly);
+                        scan(
+                                child.stream(),
+                                relative,
+                                entryIdentity,
+                                childDepth,
+                                state,
+                                materialOnly,
+                                staged);
                     }
                     continue;
                 }
@@ -480,11 +516,20 @@ final class ShipSecureFilesystem {
                 UnixIdentity entryIdentity = relativeIdentity(relative, basic.fileKey());
                 requireRegularFile(basic, entryIdentity, rootMetadata.device(), relative);
                 state.visitFile(relative, entryIdentity);
+                if (staged && (classification == Classification.DENIED
+                        || classification == Classification.PROTECTED)) {
+                    throw unsafe("Staged Ship tree contains a non-publishable entry: " + relative);
+                }
                 if (materialOnly && classification != Classification.MATERIAL) {
                     throw unsafe("Sealed Ship tree contains a non-material entry: " + relative);
                 }
-                if (classification == Classification.DENIED
-                        || classification == Classification.VOLATILE) {
+                if (classification == Classification.DENIED) {
+                    continue;
+                }
+                if (classification == Classification.VOLATILE) {
+                    if (staged) {
+                        state.reserve(relative, entryIdentity);
+                    }
                     continue;
                 }
                 state.add(relative, readRegular(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
@@ -65,13 +65,13 @@ final class ShipSecureFilesystem {
         if (!policy.isAllowedAbsolutePath(absolute)) {
             throw unsafe(label + " is outside the allowed project-root lineage");
         }
-        rejectSymbolicComponents(absolute, label);
+        if (Files.isSymbolicLink(absolute)
+                || !Files.isDirectory(absolute, LinkOption.NOFOLLOW_LINKS)) {
+            throw unsafe(label + " must be a real directory: " + absolute);
+        }
         Path root = absolute.toRealPath();
-        if (!root.equals(absolute)
-                || !policy.isAllowedAbsolutePath(root)
-                || Files.isSymbolicLink(root)
-                || !Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)) {
-            throw unsafe(label + " must be an allowed, link-free real directory: " + absolute);
+        if (!policy.isAllowedAbsolutePath(root)) {
+            throw unsafe(label + " is outside the allowed project-root lineage");
         }
         return root;
     }
@@ -100,16 +100,6 @@ final class ShipSecureFilesystem {
                 e.addSuppressed(closeFailure);
             }
             throw e;
-        }
-    }
-
-    private static void rejectSymbolicComponents(Path path, String label) throws IOException {
-        Path current = path.getRoot();
-        for (Path component : path) {
-            current = current == null ? component : current.resolve(component);
-            if (Files.isSymbolicLink(current)) {
-                throw unsafe(label + " path contains a symbolic link: " + current);
-            }
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -192,6 +192,7 @@ final class LocalCommandRunner {
                     timedOut,
                     outputLimited.get(),
                     exitCode,
+                    capturedStdout,
                     stdout.path(),
                     stdout.digest(),
                     stderr.path(),
@@ -829,6 +830,7 @@ final class LocalCommandRunner {
             boolean timedOut,
             boolean outputLimited,
             Integer exitCode,
+            byte[] capturedStdout,
             Path stdoutLog,
             String stdoutDigest,
             Path stderrLog,
@@ -840,6 +842,8 @@ final class LocalCommandRunner {
             Objects.requireNonNull(workingDirectory, "workingDirectory");
             Objects.requireNonNull(startedAt, "startedAt");
             Objects.requireNonNull(endedAt, "endedAt");
+            capturedStdout = Objects.requireNonNull(
+                    capturedStdout, "capturedStdout").clone();
             Objects.requireNonNull(stdoutLog, "stdoutLog");
             Objects.requireNonNull(stdoutDigest, "stdoutDigest");
             Objects.requireNonNull(stderrLog, "stderrLog");
@@ -848,6 +852,11 @@ final class LocalCommandRunner {
                 throw new IllegalArgumentException(
                         "Only a timed-out local command can omit its exit code");
             }
+        }
+
+        @Override
+        public byte[] capturedStdout() {
+            return capturedStdout.clone();
         }
 
         @Override

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -1,0 +1,1151 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Runs one bounded local command without a shell. */
+final class LocalCommandRunner {
+
+    private static final Duration TERMINATION_GRACE = Duration.ofMillis(500);
+    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+    private static final Path SETSID = Path.of("/usr/bin/setsid");
+    private static final Path KILL = Path.of("/bin/kill");
+    private static final byte[] OUTPUT_LIMIT_LOG
+            = "<output-limit-exceeded>\n".getBytes(StandardCharsets.UTF_8);
+    private static final Pattern SENSITIVE_ASSIGNMENT = Pattern.compile(
+            "(?i)(docker[-_]?auth[-_]?config|npm[-_]?config[-_]*auth"
+                                                                        + "|password|passwd|pass|passphrase|pwd"
+                                                                        + "|secret|token|credentials?|auth(?:orization)?"
+                                                                        + "|api[-_]?key"
+                                                                        + "|access[-_]?key(?:[-_]?id)?|private[-_]?key|jwt|pat)"
+                                                                        + "([\"']?\\s*[:=]\\s*)"
+                                                                        + "(\"[^\"\\r\\n]*\"|'[^'\\r\\n]*'|[^\"'\\r\\n,}]+)");
+    private static final Pattern AUTHORIZATION_SCHEME = Pattern.compile(
+            "(?i)[\"']?\\b(Bearer|Basic)\\s+[\"']?([^\\s\"',}]+)[\"']?");
+    private static final Pattern URL_USERINFO = Pattern.compile(
+            "([A-Za-z][A-Za-z0-9+.-]*://)([^/@\\s]*)@");
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final Clock clock;
+
+    LocalCommandRunner() {
+        this(Clock.systemUTC());
+    }
+
+    LocalCommandRunner(Clock clock) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    Result run(Command command) throws IOException, InterruptedException {
+        Objects.requireNonNull(command, "command");
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("Local command invocation was already interrupted");
+        }
+        Path executable = realExecutable(command.executable());
+        Path setsid = trustedHelper(SETSID, "setsid");
+        Path kill = trustedHelper(KILL, "kill");
+        Path workingDirectory = realDirectory(command.workingDirectory(), "working directory");
+        Path evidenceDirectory = realDirectory(command.evidenceDirectory(), "evidence directory");
+        if (workingDirectory.startsWith(evidenceDirectory)
+                || evidenceDirectory.startsWith(workingDirectory)) {
+            throw new IOException(
+                    "Local command working and evidence directories must be disjoint");
+        }
+        List<String> arguments = command.arguments();
+        List<String> vector = new ArrayList<>(arguments.size() + 4);
+        vector.add(setsid.toString());
+        vector.add("--wait");
+        vector.add("--");
+        vector.add(executable.toString());
+        vector.addAll(arguments);
+
+        Process process = null;
+        Thread shutdownHook = null;
+        ExecutorService pumps = Executors.newFixedThreadPool(2, task -> {
+            Thread thread = new Thread(task, "camel-kit-local-command-io");
+            thread.setDaemon(true);
+            return thread;
+        });
+        Future<byte[]> stdoutPump = null;
+        Future<byte[]> stderrPump = null;
+        Instant startedAt = clock.instant();
+        long deadline = deadline(command.timeout());
+        boolean interrupted = false;
+        AtomicBoolean outputLimited = new AtomicBoolean();
+        try {
+            process = new ProcessBuilder(vector)
+                    .directory(workingDirectory.toFile())
+                    .start();
+            Process launched = process;
+            launched.getOutputStream().close();
+            stdoutPump = pumps.submit(() -> readBounded(
+                    launched.getInputStream(),
+                    command.maximumOutputBytesPerStream(),
+                    outputLimited));
+            stderrPump = pumps.submit(() -> readBounded(
+                    launched.getErrorStream(),
+                    command.maximumOutputBytesPerStream(),
+                    outputLimited));
+            shutdownHook = new Thread(
+                    () -> terminateProcessGroup(launched, kill),
+                    "camel-kit-local-command-shutdown");
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+            boolean timedOut = false;
+            while (true) {
+                if (outputLimited.get()) {
+                    if (!terminateProcessGroup(process, kill)) {
+                        throw new IOException(
+                                "Local command exceeded its output limit and its process group could not be reaped");
+                    }
+                    break;
+                }
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    timedOut = true;
+                    if (!terminateProcessGroup(process, kill)) {
+                        throw new IOException(
+                                "Local command timed out and its process group could not be reaped");
+                    }
+                    break;
+                }
+                if (process.waitFor(
+                        Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(100)),
+                        TimeUnit.NANOSECONDS)) {
+                    if (System.nanoTime() >= deadline) {
+                        timedOut = true;
+                    }
+                    break;
+                }
+            }
+
+            if (!terminateProcessGroup(process, kill)) {
+                throw new IOException("Local command process group could not be reaped");
+            }
+            Integer exitCode = timedOut ? null : process.exitValue();
+            Instant endedAt = clock.instant();
+            if (endedAt.isBefore(startedAt)) {
+                endedAt = startedAt;
+            }
+            byte[] capturedStdout = awaitPump(stdoutPump);
+            byte[] capturedStderr = awaitPump(stderrPump);
+            List<String> argumentSecrets = secretValues(arguments);
+            byte[] stdoutEvidence = outputLimited.get()
+                    ? OUTPUT_LIMIT_LOG
+                    : capturedStdout;
+            byte[] stderrEvidence = outputLimited.get()
+                    ? OUTPUT_LIMIT_LOG
+                    : capturedStderr;
+            RetainedLog stdout = retain(
+                    stdoutEvidence,
+                    evidenceDirectory,
+                    ".stdout.log",
+                    command.maximumOutputBytesPerStream(),
+                    argumentSecrets);
+            RetainedLog stderr;
+            try {
+                stderr = retain(
+                        stderrEvidence,
+                        evidenceDirectory,
+                        ".stderr.log",
+                        command.maximumOutputBytesPerStream(),
+                        argumentSecrets);
+            } catch (IOException | RuntimeException e) {
+                Files.deleteIfExists(stdout.path());
+                throw e;
+            }
+            return new Result(
+                    executable,
+                    redactArguments(arguments, argumentSecrets),
+                    workingDirectory,
+                    startedAt,
+                    endedAt,
+                    timedOut,
+                    outputLimited.get(),
+                    exitCode,
+                    stdout.path(),
+                    stdout.digest(),
+                    stderr.path(),
+                    stderr.digest());
+        } catch (InterruptedException e) {
+            interrupted = true;
+            if (process != null && !terminateProcessGroup(process, kill)) {
+                e.addSuppressed(new IOException("Interrupted local command process group could not be reaped"));
+            }
+            throw e;
+        } catch (IOException | RuntimeException e) {
+            if (process != null && !terminateProcessGroup(process, kill)) {
+                e.addSuppressed(new IOException("Failed local command process group could not be reaped"));
+            }
+            throw e;
+        } finally {
+            if (shutdownHook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                } catch (IllegalStateException ignored) {
+                    // JVM shutdown already owns the hook.
+                }
+            }
+            closeProcessStreams(process);
+            if (stdoutPump != null && !stdoutPump.isDone()) {
+                stdoutPump.cancel(true);
+            }
+            if (stderrPump != null && !stderrPump.isDone()) {
+                stderrPump.cancel(true);
+            }
+            shutdownPumps(pumps);
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    static RetainedLog retain(
+            byte[] captured,
+            Path evidenceDirectory,
+            String suffix,
+            int maximumOutputBytes,
+            List<String> secrets)
+            throws IOException {
+        byte[] retained = redactBounded(
+                new String(captured, StandardCharsets.UTF_8),
+                secrets,
+                maximumOutputBytes);
+        Path log = Files.createTempFile(
+                evidenceDirectory, "local-command-", suffix, fileAttributes(evidenceDirectory));
+        try {
+            Files.write(
+                    log,
+                    retained,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE,
+                    LinkOption.NOFOLLOW_LINKS);
+            return new RetainedLog(log, ShipDigest.sha256(retained));
+        } catch (IOException | RuntimeException e) {
+            Files.deleteIfExists(log);
+            throw e;
+        }
+    }
+
+    private static byte[] readBounded(
+            InputStream input, int maximumOutputBytes, AtomicBoolean limited)
+            throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(
+                Math.min(maximumOutputBytes, 8192));
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            int remaining = maximumOutputBytes - output.size();
+            if (remaining > 0) {
+                output.write(buffer, 0, Math.min(remaining, read));
+            }
+            if (read > remaining) {
+                limited.set(true);
+            }
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] awaitPump(Future<byte[]> pump)
+            throws IOException, InterruptedException {
+        try {
+            return pump.get(TERMINATION_TIMEOUT.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException io) {
+                throw io;
+            }
+            throw new IOException("Could not retain local command output", cause);
+        } catch (TimeoutException e) {
+            throw new IOException(
+                    "Local command output stream did not close after process termination",
+                    e);
+        }
+    }
+
+    static List<String> redactArguments(
+            List<String> arguments, List<String> secrets) {
+        return arguments.stream().map(argument -> redact(argument, secrets)).toList();
+    }
+
+    private static String redact(String value, List<String> secrets) {
+        StringBuilder result = new StringBuilder(value.length());
+        redact(value, secrets, (part, start, end, atomic) -> {
+            result.append(part, start, end);
+            return true;
+        });
+        return result.toString();
+    }
+
+    private static byte[] redactBounded(
+            String value, List<String> secrets, int maximumBytes) {
+        BoundedUtf8Output result = new BoundedUtf8Output(maximumBytes);
+        redact(value, secrets, result::append);
+        return result.toByteArray();
+    }
+
+    private static void redact(
+            String value, List<String> secrets, RedactionSink output) {
+        RedactionCursor cursor = new RedactionCursor(
+                value, secretRepresentations(secrets));
+        int offset = 0;
+        while (offset < value.length()) {
+            RedactionMatch match = cursor.next(offset);
+            int unchangedEnd = match == null ? value.length() : match.start();
+            if (!output.append(value, offset, unchangedEnd, false) || match == null) {
+                return;
+            }
+            String replacement = match.replacement();
+            if (!output.append(replacement, 0, replacement.length(), true)) {
+                return;
+            }
+            offset = match.end();
+        }
+    }
+
+    private static RedactionMatch combine(
+            RedactionMatch current, RedactionMatch candidate) {
+        if (current == null) {
+            return candidate;
+        }
+        if (candidate == null) {
+            return current;
+        }
+        if (candidate.start() < current.start()) {
+            return candidate.end() > current.start()
+                    ? new RedactionMatch(
+                            candidate.start(),
+                            Math.max(candidate.end(), current.end()),
+                            candidate.replacement())
+                    : candidate;
+        }
+        return candidate.start() < current.end()
+                ? new RedactionMatch(
+                        current.start(),
+                        Math.max(current.end(), candidate.end()),
+                        current.replacement())
+                : current;
+    }
+
+    private static List<String> secretRepresentations(List<String> secrets) {
+        List<String> literals = new ArrayList<>();
+        for (String secret : secrets) {
+            if (secret == null || secret.isEmpty()) {
+                continue;
+            }
+            literals.add(secret);
+            try {
+                String encoded = JSON.writeValueAsString(secret);
+                literals.add(encoded.substring(1, encoded.length() - 1));
+            } catch (IOException ignored) {
+                // The unescaped representation remains protected.
+            }
+        }
+        return literals.stream()
+                .filter(value -> !value.isEmpty())
+                .distinct()
+                .sorted(Comparator.comparingInt(String::length).reversed())
+                .toList();
+    }
+
+    private static List<String> secretValues(List<String> arguments) {
+        List<String> values = new ArrayList<>();
+        System.getenv().entrySet().stream()
+                .filter(entry -> ShipLocalStamp.isSensitiveEnvironmentName(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .filter(value -> value != null && !value.isEmpty())
+                .forEach(value -> addSecretValue(values, value, true));
+        for (int index = 0; index < arguments.size(); index++) {
+            String argument = arguments.get(index);
+            addMatches(values, SENSITIVE_ASSIGNMENT.matcher(argument), 3);
+            addMatches(values, AUTHORIZATION_SCHEME.matcher(argument), 2);
+            addUrlMatches(values, URL_USERINFO.matcher(argument));
+            int separator = argument.indexOf('=');
+            boolean compactCredential = compactCredential(argument);
+            String name = compactCredential
+                    ? argument.substring(0, 2)
+                    : separator < 0 ? argument : argument.substring(0, separator);
+            boolean authorization = authorizationName(name);
+            if ((separator < 0 && !name.startsWith("-") && !authorization)
+                    || !isSensitiveOption(name)) {
+                continue;
+            }
+            String value = compactCredential
+                    ? argument.substring(2)
+                    : separator < 0
+                            ? index + 1 < arguments.size() ? arguments.get(index + 1) : null
+                    : argument.substring(separator + 1);
+            boolean schemeAuthorization = authorization && authorizationScheme(value);
+            if (value != null && !value.isEmpty() && !ShipLocalStamp.REDACTED.equals(value)) {
+                boolean splitAuthorization = separator < 0 && schemeAuthorization;
+                if (!splitAuthorization) {
+                    addSecretValue(values, value, false);
+                }
+                if (userCredentialName(name)) {
+                    String credential = unquote(value.trim());
+                    int colon = credential.indexOf(':');
+                    if (colon >= 0) {
+                        addSecretValue(values, credential.substring(colon + 1), false);
+                    }
+                } else if (cookieCredentialName(name)) {
+                    for (String cookie : unquote(value.trim()).split(";")) {
+                        int equals = cookie.indexOf('=');
+                        if (equals >= 0) {
+                            addSecretValue(values, cookie.substring(equals + 1).trim(), false);
+                        }
+                    }
+                }
+            }
+            int credentialIndex = separator < 0 ? index + 2 : index + 1;
+            if (authorization
+                    && credentialIndex < arguments.size()
+                    && (schemeAuthorization
+                            || !arguments.get(credentialIndex).startsWith("-"))) {
+                addSecretValue(values, arguments.get(credentialIndex), false);
+            }
+        }
+        return values.stream()
+                .distinct()
+                .sorted(Comparator.comparingInt(String::length).reversed())
+                .toList();
+    }
+
+    private static void addMatches(List<String> values, Matcher matcher, int group) {
+        while (matcher.find()) {
+            String value = matcher.group(group);
+            if (!value.isEmpty() && !ShipLocalStamp.REDACTED.equals(value)) {
+                addSecretValue(values, value, false);
+            }
+        }
+    }
+
+    private static void addUrlMatches(List<String> values, Matcher matcher) {
+        while (matcher.find()) {
+            String userInfo = matcher.group(2);
+            addSecretValue(values, userInfo, false);
+            int colon = userInfo.indexOf(':');
+            if (colon >= 0) {
+                addSecretValue(values, userInfo.substring(colon + 1), false);
+            }
+        }
+    }
+
+    private static void addSecretValue(
+            List<String> values, String supplied, boolean structured) {
+        if (supplied == null || supplied.isEmpty() || ShipLocalStamp.REDACTED.equals(supplied)) {
+            return;
+        }
+        values.add(supplied);
+        String value = unquote(supplied.trim());
+        if (!value.equals(supplied.trim())) {
+            if (!value.isEmpty()) {
+                values.add(value);
+            }
+        }
+        addMatches(values, SENSITIVE_ASSIGNMENT.matcher(value), 3);
+        addMatches(values, AUTHORIZATION_SCHEME.matcher(value), 2);
+        addUrlMatches(values, URL_USERINFO.matcher(value));
+        if (structured) {
+            try {
+                collectJsonValues(JSON.readTree(value), values);
+            } catch (IOException ignored) {
+                // Non-JSON credentials remain protected by their exact representation.
+            }
+        }
+    }
+
+    private static void collectJsonValues(
+            com.fasterxml.jackson.databind.JsonNode node, List<String> values) {
+        if (node == null) {
+            return;
+        }
+        if (node.isTextual()) {
+            addSecretValue(values, node.textValue(), false);
+        } else if (node.isContainerNode()) {
+            node.elements().forEachRemaining(child -> collectJsonValues(child, values));
+        }
+    }
+
+    private static boolean isSensitiveOption(String name) {
+        return ShipLocalStamp.isSensitiveName(name)
+                || userCredentialName(name)
+                || cookieCredentialName(name)
+                || "--oauth2-bearer".equals(name);
+    }
+
+    private static boolean userCredentialName(String name) {
+        return "-u".equals(name)
+                || "--user".equals(name)
+                || "--userpwd".equals(name)
+                || "--proxy-user".equals(name);
+    }
+
+    private static boolean cookieCredentialName(String name) {
+        return "-b".equals(name) || "--cookie".equals(name);
+    }
+
+    private static boolean compactCredential(String value) {
+        return value.length() > 2
+                && !value.startsWith("--")
+                && (value.startsWith("-u")
+                        || (value.startsWith("-b")
+                                && (value.indexOf('=', 2) >= 0
+                                        || ShipLocalStamp.REDACTED.equals(value.substring(2)))));
+    }
+
+    private static boolean authorizationName(String name) {
+        String normalized = name.replaceAll("([a-z0-9])([A-Z])", "$1-$2")
+                .toLowerCase(Locale.ROOT)
+                .replace('_', '-')
+                .replaceFirst("^-+", "");
+        return normalized.equals("authorization")
+                || normalized.equals("auth")
+                || normalized.endsWith("-authorization")
+                || normalized.endsWith("-auth");
+    }
+
+    private static boolean authorizationScheme(String value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = unquote(value.trim()).trim();
+        return "basic".equalsIgnoreCase(normalized)
+                || "bearer".equalsIgnoreCase(normalized);
+    }
+
+    private static String unquote(String value) {
+        return value.length() >= 2
+                && (value.charAt(0) == '"' || value.charAt(0) == '\'')
+                && value.charAt(value.length() - 1) == value.charAt(0)
+                        ? value.substring(1, value.length() - 1)
+                        : value;
+    }
+
+    private static Path realExecutable(Path supplied) throws IOException {
+        Path executable = Objects.requireNonNull(supplied, "executable").toRealPath();
+        if (!Files.isRegularFile(executable, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isExecutable(executable)) {
+            throw new IOException("Local command executable is missing or not executable");
+        }
+        return executable;
+    }
+
+    static Path trustedHelper(Path path, String name) throws IOException {
+        try {
+            return realExecutable(path);
+        } catch (IOException | RuntimeException e) {
+            throw new IOException(
+                    "Required Linux process-group helper `" + name + "` is unavailable",
+                    e);
+        }
+    }
+
+    private static Path realDirectory(Path supplied, String label) throws IOException {
+        if (supplied == null) {
+            throw new IOException("Local command " + label + " is required");
+        }
+        Path normalized = supplied.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Local command " + label + " must be a real directory");
+        }
+        Path real = normalized.toRealPath();
+        if (!real.equals(normalized)) {
+            throw new IOException("Local command " + label + " must not cross a symbolic link");
+        }
+        return real;
+    }
+
+    private static long deadline(Duration duration) {
+        try {
+            return Math.addExact(System.nanoTime(), duration.toNanos());
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    static boolean terminateProcessGroup(Process process, Path kill) {
+        long groupId = process.pid();
+        process.toHandle().destroy();
+        signalProcessGroup(kill, "TERM", groupId);
+        if (awaitProcessGroup(process, kill, groupId, TERMINATION_GRACE)) {
+            return true;
+        }
+        if (process.isAlive()) {
+            process.toHandle().destroyForcibly();
+        }
+        signalProcessGroup(kill, "KILL", groupId);
+        return awaitProcessGroup(process, kill, groupId, TERMINATION_TIMEOUT);
+    }
+
+    private static boolean awaitProcessGroup(
+            Process process, Path kill, long groupId, Duration timeout) {
+        long deadline = deadline(timeout);
+        boolean interrupted = false;
+        try {
+            while (process.isAlive() || processGroupExists(kill, groupId)) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    if (process.isAlive()) {
+                        process.waitFor(
+                                Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(25)),
+                                TimeUnit.NANOSECONDS);
+                    } else {
+                        TimeUnit.NANOSECONDS.sleep(
+                                Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(25)));
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    Thread.interrupted();
+                }
+            }
+            return true;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static boolean processGroupExists(Path kill, long groupId) {
+        Integer result = signalProcessGroup(kill, "0", groupId);
+        if (result != null && result == 0) {
+            return true;
+        }
+        Boolean procResult = processGroupExistsInProc(groupId);
+        return procResult == null || procResult;
+    }
+
+    private static Boolean processGroupExistsInProc(long groupId) {
+        boolean unreadable = false;
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(Path.of("/proc"))) {
+            for (Path entry : entries) {
+                String name = entry.getFileName().toString();
+                if (name.isEmpty() || name.chars().anyMatch(character -> !Character.isDigit(character))) {
+                    continue;
+                }
+                try {
+                    String stat = Files.readString(entry.resolve("stat"));
+                    int commandEnd = stat.lastIndexOf(')');
+                    String[] fields = commandEnd < 0
+                            ? new String[0]
+                            : stat.substring(commandEnd + 1).trim().split("\\s+", 4);
+                    if (fields.length < 3) {
+                        unreadable = true;
+                    } else if (Long.parseLong(fields[2]) == groupId) {
+                        return true;
+                    }
+                } catch (java.nio.file.NoSuchFileException ignored) {
+                    // The process exited while /proc was being scanned.
+                } catch (IOException | NumberFormatException e) {
+                    unreadable = true;
+                }
+            }
+            return unreadable ? null : false;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static Integer signalProcessGroup(Path kill, String signal, long groupId) {
+        Process helper = null;
+        boolean interrupted = false;
+        try {
+            helper = new ProcessBuilder(
+                    kill.toString(),
+                    "--signal",
+                    signal,
+                    "--",
+                    "-" + groupId)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+            helper.getOutputStream().close();
+            long deadline = deadline(TERMINATION_GRACE);
+            while (helper.isAlive()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return null;
+                }
+                try {
+                    helper.waitFor(remaining, TimeUnit.NANOSECONDS);
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    Thread.interrupted();
+                }
+            }
+            return helper.exitValue();
+        } catch (IOException | RuntimeException e) {
+            return null;
+        } finally {
+            if (helper != null && helper.isAlive()) {
+                helper.destroyForcibly();
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    static boolean terminateAll(
+            Process process, List<ProcessHandle> observedChildren) {
+        boolean processReaped = terminateAndWait(process);
+        boolean childrenReaped = terminateHandlesAndWait(observedChildren);
+        return processReaped && childrenReaped;
+    }
+
+    private static boolean terminateAndWait(Process process) {
+        List<ProcessHandle> children = descendants(process);
+        children.forEach(ProcessHandle::destroy);
+        process.toHandle().destroy();
+        if (awaitTermination(process, children, TERMINATION_GRACE)) {
+            return true;
+        }
+        children.forEach(handle -> {
+            if (handle.isAlive()) {
+                handle.destroyForcibly();
+            }
+        });
+        if (process.isAlive()) {
+            process.toHandle().destroyForcibly();
+        }
+        return awaitTermination(process, children, TERMINATION_TIMEOUT);
+    }
+
+    private static boolean awaitTermination(
+            Process process, List<ProcessHandle> children, Duration timeout) {
+        long deadline = deadline(timeout);
+        boolean interrupted = false;
+        try {
+            while (process.isAlive()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    if (!process.waitFor(remaining, TimeUnit.NANOSECONDS)) {
+                        return false;
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    Thread.interrupted();
+                }
+            }
+            return awaitHandles(
+                    children,
+                    Duration.ofNanos(Math.max(0, deadline - System.nanoTime())));
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static boolean awaitHandles(List<ProcessHandle> handles, Duration timeout) {
+        long deadline = deadline(timeout);
+        boolean interrupted = false;
+        try {
+            for (ProcessHandle handle : handles) {
+                while (handle.isAlive()) {
+                    long remaining = deadline - System.nanoTime();
+                    if (remaining <= 0) {
+                        return false;
+                    }
+                    try {
+                        handle.onExit().get(remaining, TimeUnit.NANOSECONDS);
+                    } catch (InterruptedException e) {
+                        interrupted = true;
+                        Thread.interrupted();
+                    } catch (ExecutionException | TimeoutException e) {
+                        return false;
+                    }
+                }
+            }
+            return handles.stream().noneMatch(ProcessHandle::isAlive);
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static List<ProcessHandle> descendants(Process process) {
+        try {
+            return process.toHandle().descendants()
+                    .sorted(Comparator.comparingLong(ProcessHandle::pid).reversed())
+                    .toList();
+        } catch (UnsupportedOperationException e) {
+            return List.of();
+        }
+    }
+
+    static void rememberDescendants(
+            Process process, List<ProcessHandle> observedChildren) {
+        for (ProcessHandle handle : descendants(process)) {
+            if (observedChildren.stream().noneMatch(existing -> existing.pid() == handle.pid())) {
+                observedChildren.add(handle);
+            }
+        }
+    }
+
+    private static boolean terminateHandlesAndWait(List<ProcessHandle> handles) {
+        List<ProcessHandle> live = handles.stream().filter(ProcessHandle::isAlive).toList();
+        live.forEach(ProcessHandle::destroy);
+        if (awaitHandles(live, TERMINATION_GRACE)) {
+            return true;
+        }
+        live.stream()
+                .filter(ProcessHandle::isAlive)
+                .forEach(ProcessHandle::destroyForcibly);
+        return awaitHandles(live, TERMINATION_TIMEOUT);
+    }
+
+    private static void closeProcessStreams(Process process) {
+        if (process == null) {
+            return;
+        }
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+            // Best-effort cleanup after command completion or termination.
+        }
+        try {
+            process.getInputStream().close();
+        } catch (IOException ignored) {
+            // Best-effort cleanup after command completion or termination.
+        }
+        try {
+            process.getErrorStream().close();
+        } catch (IOException ignored) {
+            // Best-effort cleanup after command completion or termination.
+        }
+    }
+
+    private static void shutdownPumps(ExecutorService pumps) {
+        pumps.shutdownNow();
+        boolean interrupted = false;
+        long deadline = deadline(TERMINATION_GRACE);
+        try {
+            while (!pumps.isTerminated()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return;
+                }
+                try {
+                    if (!pumps.awaitTermination(remaining, TimeUnit.NANOSECONDS)) {
+                        return;
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    Thread.interrupted();
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static FileAttribute<?>[] fileAttributes(Path path) {
+        return path.getFileSystem().supportedFileAttributeViews().contains("posix")
+                ? new FileAttribute<?>[]{
+                        PosixFilePermissions.asFileAttribute(
+                                PosixFilePermissions.fromString("rw-------"))}
+                : new FileAttribute<?>[0];
+    }
+
+    record Command(
+            Path executable,
+            List<String> arguments,
+            Path workingDirectory,
+            Path evidenceDirectory,
+            Duration timeout,
+            int maximumOutputBytesPerStream) {
+
+        Command {
+            Objects.requireNonNull(executable, "executable");
+            arguments = arguments == null ? List.of() : List.copyOf(arguments);
+            if (arguments.stream().anyMatch(
+                    argument -> argument == null || argument.indexOf('\0') >= 0)) {
+                throw new IllegalArgumentException("Local command arguments are invalid");
+            }
+            Objects.requireNonNull(workingDirectory, "workingDirectory");
+            Objects.requireNonNull(evidenceDirectory, "evidenceDirectory");
+            if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+                throw new IllegalArgumentException("Local command timeout must be positive");
+            }
+            if (maximumOutputBytesPerStream <= 0) {
+                throw new IllegalArgumentException("Local command output limit must be positive");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Command[executable=" + executable
+                   + ", arguments=<redacted>"
+                   + ", workingDirectory=" + workingDirectory
+                   + ", evidenceDirectory=" + evidenceDirectory
+                   + ", timeout=" + timeout
+                   + ", maximumOutputBytesPerStream=" + maximumOutputBytesPerStream + "]";
+        }
+    }
+
+    record Result(
+            Path executable,
+            List<String> redactedArguments,
+            Path workingDirectory,
+            Instant startedAt,
+            Instant endedAt,
+            boolean timedOut,
+            boolean outputLimited,
+            Integer exitCode,
+            Path stdoutLog,
+            String stdoutDigest,
+            Path stderrLog,
+            String stderrDigest) {
+
+        Result {
+            Objects.requireNonNull(executable, "executable");
+            redactedArguments = List.copyOf(redactedArguments);
+            Objects.requireNonNull(workingDirectory, "workingDirectory");
+            Objects.requireNonNull(startedAt, "startedAt");
+            Objects.requireNonNull(endedAt, "endedAt");
+            Objects.requireNonNull(stdoutLog, "stdoutLog");
+            Objects.requireNonNull(stdoutDigest, "stdoutDigest");
+            Objects.requireNonNull(stderrLog, "stderrLog");
+            Objects.requireNonNull(stderrDigest, "stderrDigest");
+            if (timedOut != (exitCode == null)) {
+                throw new IllegalArgumentException(
+                        "Only a timed-out local command can omit its exit code");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Result[executable=" + executable
+                   + ", redactedArguments=" + redactedArguments
+                   + ", workingDirectory=" + workingDirectory
+                   + ", startedAt=" + startedAt
+                   + ", endedAt=" + endedAt
+                   + ", timedOut=" + timedOut
+                   + ", outputLimited=" + outputLimited
+                   + ", exitCode=" + exitCode
+                   + ", stdoutLog=" + stdoutLog
+                   + ", stdoutDigest=" + stdoutDigest
+                   + ", stderrLog=" + stderrLog
+                   + ", stderrDigest=" + stderrDigest + "]";
+        }
+
+        void deleteLogs() throws IOException {
+            IOException failure = null;
+            try {
+                Files.deleteIfExists(stdoutLog);
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                Files.deleteIfExists(stderrLog);
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    record RetainedLog(Path path, String digest) {
+    }
+
+    private record RedactionMatch(int start, int end, String replacement) {
+    }
+
+    private static final class RedactionCursor {
+
+        private final String value;
+        private final List<String> literals;
+        private final int[] literalStarts;
+        private final Matcher assignment;
+        private final Matcher authorization;
+        private final Matcher url;
+        private boolean assignmentAvailable;
+        private boolean authorizationAvailable;
+        private boolean urlAvailable;
+
+        private RedactionCursor(String value, List<String> literals) {
+            this.value = value;
+            this.literals = literals;
+            literalStarts = new int[literals.size()];
+            for (int index = 0; index < literals.size(); index++) {
+                literalStarts[index] = value.indexOf(literals.get(index));
+            }
+            assignment = SENSITIVE_ASSIGNMENT.matcher(value);
+            authorization = AUTHORIZATION_SCHEME.matcher(value);
+            url = URL_USERINFO.matcher(value);
+            assignmentAvailable = assignment.find();
+            authorizationAvailable = authorization.find();
+            urlAvailable = url.find();
+        }
+
+        private RedactionMatch next(int offset) {
+            while (assignmentAvailable && assignment.start() < offset) {
+                assignmentAvailable = assignment.find();
+            }
+            while (authorizationAvailable && authorization.start() < offset) {
+                authorizationAvailable = authorization.find();
+            }
+            while (urlAvailable && url.start() < offset) {
+                urlAvailable = url.find();
+            }
+            RedactionMatch result = assignmentAvailable
+                    ? new RedactionMatch(
+                            assignment.start(),
+                            assignment.end(),
+                            redactedAssignment(assignment))
+                    : null;
+            result = combine(result, authorizationAvailable
+                    ? new RedactionMatch(
+                            authorization.start(),
+                            authorization.end(),
+                            authorization.group(1) + " " + ShipLocalStamp.REDACTED)
+                    : null);
+            result = combine(result, urlAvailable
+                    ? new RedactionMatch(
+                            url.start(),
+                            url.end(),
+                            url.group(1) + ShipLocalStamp.REDACTED + "@")
+                    : null);
+            for (int index = 0; index < literals.size(); index++) {
+                String literal = literals.get(index);
+                if (literalStarts[index] >= 0 && literalStarts[index] < offset) {
+                    literalStarts[index] = value.indexOf(literal, offset);
+                }
+                int start = literalStarts[index];
+                if (start >= 0) {
+                    result = combine(
+                            result,
+                            new RedactionMatch(
+                                    start,
+                                    start + literal.length(),
+                                    ShipLocalStamp.REDACTED));
+                }
+            }
+            return result;
+        }
+
+        private static String redactedAssignment(Matcher matcher) {
+            String supplied = matcher.group(3);
+            String value = unquote(supplied);
+            String quote = value.equals(supplied) ? "" : supplied.substring(0, 1);
+            return matcher.group(1) + matcher.group(2)
+                   + quote + ShipLocalStamp.REDACTED + quote;
+        }
+    }
+
+    @FunctionalInterface
+    private interface RedactionSink {
+
+        boolean append(String value, int start, int end, boolean atomic);
+    }
+
+    private static final class BoundedUtf8Output {
+
+        private final ByteArrayOutputStream output;
+        private final int maximumBytes;
+
+        private BoundedUtf8Output(int maximumBytes) {
+            this.maximumBytes = maximumBytes;
+            output = new ByteArrayOutputStream(Math.min(maximumBytes, 8192));
+        }
+
+        private boolean append(
+                String value, int start, int end, boolean atomic) {
+            if (atomic && encodedLength(value, start, end)
+                          > maximumBytes - output.size()) {
+                return false;
+            }
+            for (int index = start; index < end;) {
+                int codePoint = value.codePointAt(index);
+                int encodedBytes = codePoint <= 0x7f
+                        ? 1
+                        : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+                if (output.size() + encodedBytes > maximumBytes) {
+                    return false;
+                }
+                if (encodedBytes == 1) {
+                    output.write(codePoint);
+                } else if (encodedBytes == 2) {
+                    output.write(0xc0 | codePoint >> 6);
+                    output.write(0x80 | codePoint & 0x3f);
+                } else if (encodedBytes == 3) {
+                    output.write(0xe0 | codePoint >> 12);
+                    output.write(0x80 | codePoint >> 6 & 0x3f);
+                    output.write(0x80 | codePoint & 0x3f);
+                } else {
+                    output.write(0xf0 | codePoint >> 18);
+                    output.write(0x80 | codePoint >> 12 & 0x3f);
+                    output.write(0x80 | codePoint >> 6 & 0x3f);
+                    output.write(0x80 | codePoint & 0x3f);
+                }
+                index += Character.charCount(codePoint);
+            }
+            return true;
+        }
+
+        private static int encodedLength(String value, int start, int end) {
+            int length = 0;
+            for (int index = start; index < end;) {
+                int codePoint = value.codePointAt(index);
+                length += codePoint <= 0x7f
+                        ? 1
+                        : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+                index += Character.charCount(codePoint);
+            }
+            return length;
+        }
+
+        private byte[] toByteArray() {
+            return output.toByteArray();
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -144,9 +143,6 @@ final class LocalCommandRunner {
                 if (process.waitFor(
                         Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(100)),
                         TimeUnit.NANOSECONDS)) {
-                    if (System.nanoTime() >= deadline) {
-                        timedOut = true;
-                    }
                     break;
                 }
             }
@@ -161,7 +157,8 @@ final class LocalCommandRunner {
             }
             byte[] capturedStdout = awaitPump(stdoutPump);
             byte[] capturedStderr = awaitPump(stderrPump);
-            List<String> argumentSecrets = secretValues(arguments);
+            List<String> argumentSecrets = secretValues(
+                    arguments, command.sensitiveValues());
             byte[] stdoutEvidence = outputLimited.get()
                     ? OUTPUT_LIMIT_LOG
                     : capturedStdout;
@@ -380,12 +377,14 @@ final class LocalCommandRunner {
                 .toList();
     }
 
-    private static List<String> secretValues(List<String> arguments) {
+    private static List<String> secretValues(
+            List<String> arguments, List<String> knownValues) {
         List<String> values = new ArrayList<>();
+        knownValues.forEach(value -> addSecretValue(values, value, true));
         System.getenv().entrySet().stream()
-                .filter(entry -> ShipLocalStamp.isSensitiveEnvironmentName(entry.getKey()))
+                .filter(entry -> isSensitiveEnvironmentValue(
+                        entry.getKey(), entry.getValue()))
                 .map(Map.Entry::getValue)
-                .filter(value -> value != null && !value.isEmpty())
                 .forEach(value -> addSecretValue(values, value, true));
         for (int index = 0; index < arguments.size(); index++) {
             String argument = arguments.get(index);
@@ -440,6 +439,27 @@ final class LocalCommandRunner {
                 .distinct()
                 .sorted(Comparator.comparingInt(String::length).reversed())
                 .toList();
+    }
+
+    static boolean isSensitiveEnvironmentValue(String name, String value) {
+        if (!ShipLocalStamp.isSensitiveEnvironmentName(name)
+                || value == null
+                || value.isEmpty()) {
+            return false;
+        }
+        String normalizedName = name.toUpperCase(Locale.ROOT);
+        boolean featureToggle = normalizedName.startsWith("ENABLE_")
+                || normalizedName.startsWith("DISABLE_")
+                || normalizedName.startsWith("USE_")
+                || normalizedName.endsWith("_ENABLED")
+                || normalizedName.endsWith("_DISABLED");
+        if (!featureToggle) {
+            return true;
+        }
+        return switch (value.trim().toLowerCase(Locale.ROOT)) {
+            case "0", "1", "false", "true", "no", "yes", "off", "on" -> false;
+            default -> true;
+        };
     }
 
     private static void addMatches(List<String> values, Matcher matcher, int group) {
@@ -581,11 +601,7 @@ final class LocalCommandRunner {
                 || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Local command " + label + " must be a real directory");
         }
-        Path real = normalized.toRealPath();
-        if (!real.equals(normalized)) {
-            throw new IOException("Local command " + label + " must not cross a symbolic link");
-        }
-        return real;
+        return normalized.toRealPath();
     }
 
     private static long deadline(Duration duration) {
@@ -644,42 +660,7 @@ final class LocalCommandRunner {
 
     private static boolean processGroupExists(Path kill, long groupId) {
         Integer result = signalProcessGroup(kill, "0", groupId);
-        if (result != null && result == 0) {
-            return true;
-        }
-        Boolean procResult = processGroupExistsInProc(groupId);
-        return procResult == null || procResult;
-    }
-
-    private static Boolean processGroupExistsInProc(long groupId) {
-        boolean unreadable = false;
-        try (DirectoryStream<Path> entries = Files.newDirectoryStream(Path.of("/proc"))) {
-            for (Path entry : entries) {
-                String name = entry.getFileName().toString();
-                if (name.isEmpty() || name.chars().anyMatch(character -> !Character.isDigit(character))) {
-                    continue;
-                }
-                try {
-                    String stat = Files.readString(entry.resolve("stat"));
-                    int commandEnd = stat.lastIndexOf(')');
-                    String[] fields = commandEnd < 0
-                            ? new String[0]
-                            : stat.substring(commandEnd + 1).trim().split("\\s+", 4);
-                    if (fields.length < 3) {
-                        unreadable = true;
-                    } else if (Long.parseLong(fields[2]) == groupId) {
-                        return true;
-                    }
-                } catch (java.nio.file.NoSuchFileException ignored) {
-                    // The process exited while /proc was being scanned.
-                } catch (IOException | NumberFormatException e) {
-                    unreadable = true;
-                }
-            }
-            return unreadable ? null : false;
-        } catch (IOException e) {
-            return null;
-        }
+        return result == null || result == 0;
     }
 
     private static Integer signalProcessGroup(Path kill, String signal, long groupId) {
@@ -720,119 +701,6 @@ final class LocalCommandRunner {
                 Thread.currentThread().interrupt();
             }
         }
-    }
-
-    static boolean terminateAll(
-            Process process, List<ProcessHandle> observedChildren) {
-        boolean processReaped = terminateAndWait(process);
-        boolean childrenReaped = terminateHandlesAndWait(observedChildren);
-        return processReaped && childrenReaped;
-    }
-
-    private static boolean terminateAndWait(Process process) {
-        List<ProcessHandle> children = descendants(process);
-        children.forEach(ProcessHandle::destroy);
-        process.toHandle().destroy();
-        if (awaitTermination(process, children, TERMINATION_GRACE)) {
-            return true;
-        }
-        children.forEach(handle -> {
-            if (handle.isAlive()) {
-                handle.destroyForcibly();
-            }
-        });
-        if (process.isAlive()) {
-            process.toHandle().destroyForcibly();
-        }
-        return awaitTermination(process, children, TERMINATION_TIMEOUT);
-    }
-
-    private static boolean awaitTermination(
-            Process process, List<ProcessHandle> children, Duration timeout) {
-        long deadline = deadline(timeout);
-        boolean interrupted = false;
-        try {
-            while (process.isAlive()) {
-                long remaining = deadline - System.nanoTime();
-                if (remaining <= 0) {
-                    return false;
-                }
-                try {
-                    if (!process.waitFor(remaining, TimeUnit.NANOSECONDS)) {
-                        return false;
-                    }
-                } catch (InterruptedException e) {
-                    interrupted = true;
-                    Thread.interrupted();
-                }
-            }
-            return awaitHandles(
-                    children,
-                    Duration.ofNanos(Math.max(0, deadline - System.nanoTime())));
-        } finally {
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-        }
-    }
-
-    private static boolean awaitHandles(List<ProcessHandle> handles, Duration timeout) {
-        long deadline = deadline(timeout);
-        boolean interrupted = false;
-        try {
-            for (ProcessHandle handle : handles) {
-                while (handle.isAlive()) {
-                    long remaining = deadline - System.nanoTime();
-                    if (remaining <= 0) {
-                        return false;
-                    }
-                    try {
-                        handle.onExit().get(remaining, TimeUnit.NANOSECONDS);
-                    } catch (InterruptedException e) {
-                        interrupted = true;
-                        Thread.interrupted();
-                    } catch (ExecutionException | TimeoutException e) {
-                        return false;
-                    }
-                }
-            }
-            return handles.stream().noneMatch(ProcessHandle::isAlive);
-        } finally {
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-        }
-    }
-
-    private static List<ProcessHandle> descendants(Process process) {
-        try {
-            return process.toHandle().descendants()
-                    .sorted(Comparator.comparingLong(ProcessHandle::pid).reversed())
-                    .toList();
-        } catch (UnsupportedOperationException e) {
-            return List.of();
-        }
-    }
-
-    static void rememberDescendants(
-            Process process, List<ProcessHandle> observedChildren) {
-        for (ProcessHandle handle : descendants(process)) {
-            if (observedChildren.stream().noneMatch(existing -> existing.pid() == handle.pid())) {
-                observedChildren.add(handle);
-            }
-        }
-    }
-
-    private static boolean terminateHandlesAndWait(List<ProcessHandle> handles) {
-        List<ProcessHandle> live = handles.stream().filter(ProcessHandle::isAlive).toList();
-        live.forEach(ProcessHandle::destroy);
-        if (awaitHandles(live, TERMINATION_GRACE)) {
-            return true;
-        }
-        live.stream()
-                .filter(ProcessHandle::isAlive)
-                .forEach(ProcessHandle::destroyForcibly);
-        return awaitHandles(live, TERMINATION_TIMEOUT);
     }
 
     private static void closeProcessStreams(Process process) {
@@ -896,7 +764,25 @@ final class LocalCommandRunner {
             Path workingDirectory,
             Path evidenceDirectory,
             Duration timeout,
-            int maximumOutputBytesPerStream) {
+            int maximumOutputBytesPerStream,
+            List<String> sensitiveValues) {
+
+        Command(
+                Path executable,
+                List<String> arguments,
+                Path workingDirectory,
+                Path evidenceDirectory,
+                Duration timeout,
+                int maximumOutputBytesPerStream) {
+            this(
+                 executable,
+                 arguments,
+                 workingDirectory,
+                 evidenceDirectory,
+                 timeout,
+                 maximumOutputBytesPerStream,
+                 List.of());
+        }
 
         Command {
             Objects.requireNonNull(executable, "executable");
@@ -913,6 +799,14 @@ final class LocalCommandRunner {
             if (maximumOutputBytesPerStream <= 0) {
                 throw new IllegalArgumentException("Local command output limit must be positive");
             }
+            if (sensitiveValues != null
+                    && sensitiveValues.stream().anyMatch(value -> value == null)) {
+                throw new IllegalArgumentException(
+                        "Local command sensitive values are invalid");
+            }
+            sensitiveValues = sensitiveValues == null
+                    ? List.of()
+                    : List.copyOf(sensitiveValues);
         }
 
         @Override

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -1,0 +1,2974 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
+import io.github.luigidemasi.camelkit.ship.worker.LocalCommandRunner.Command;
+import io.github.luigidemasi.camelkit.ship.worker.LocalCommandRunner.RetainedLog;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Runs one bounded Pi stage through one RPC process.
+ *
+ * <p>
+ * The request working directory is the child process cwd, not a filesystem sandbox. The controller must select the
+ * stage workspace and validate its outputs before accepting them.
+ */
+public final class PiWorker {
+
+    private static final int MAX_PROMPT_BYTES = 1024 * 1024;
+    private static final int MAX_LOG_BYTES = 16 * 1024 * 1024;
+    private static final int MAX_SESSION_HEADER_BYTES = 64 * 1024;
+    private static final long MAX_SESSION_BYTES = 64L * 1024 * 1024;
+    private static final int MAX_VERSION_LENGTH = 1024;
+    private static final Duration VERSION_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration ABORT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration ABORT_DRAIN_RESERVE = Duration.ofSeconds(1);
+    private static final Duration EXIT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration IO_TIMEOUT = Duration.ofSeconds(5);
+    private static final String PROMPT_ID = "prompt-1";
+    private static final String ABORT_ID = "abort-1";
+    private static final String READ_ONLY_TOOLS = "read,grep,find,ls";
+    private static final String EXECUTE_TOOLS = "read,bash,edit,write,grep,find,ls";
+    private static final String SCRATCH_PREFIX = ".ship-pi-";
+    private static final Path SETSID = Path.of("/usr/bin/setsid");
+    private static final Path KILL = Path.of("/bin/kill");
+    private static final Set<PosixFilePermission> PRIVATE_DIRECTORY = PosixFilePermissions.fromString("rwx------");
+    private static final Set<PosixFilePermission> PRIVATE_FILE = PosixFilePermissions.fromString("rw-------");
+    private static final Pattern VERSION = Pattern.compile("[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][A-Za-z0-9._-]+)?");
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+    private final Path executable;
+    private final String supportedVersion;
+    private final Duration timeout;
+    private final Clock clock;
+    private final LocalCommandRunner commands;
+    private final Map<String, String> environment;
+
+    public PiWorker(Path executable, String supportedVersion, Duration timeout) {
+        this(executable, supportedVersion, timeout, Clock.systemUTC());
+    }
+
+    PiWorker(Path executable, String supportedVersion, Duration timeout, Clock clock) {
+        this(executable, supportedVersion, timeout, clock, System.getenv());
+    }
+
+    PiWorker(
+             Path executable,
+             String supportedVersion,
+             Duration timeout,
+             Clock clock,
+             Map<String, String> environment) {
+        this.executable = requireExecutable(executable);
+        this.supportedVersion = requireVersion(supportedVersion, "supported Pi version");
+        this.timeout = requireDuration(timeout);
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.commands = new LocalCommandRunner(clock);
+        this.environment = Map.copyOf(Objects.requireNonNull(environment, "environment"));
+    }
+
+    /**
+     * Executes one Pi stage. The prompt is sent as an RPC command and never appears in argv.
+     *
+     * <p>
+     * A validated session turn is published atomically, but that publication is not atomic with the controller's
+     * durable {@link ShipRun}. The controller must recover the result for the same run, stage, input, and attempt
+     * before starting a later attempt.
+     */
+    public Result run(Request request) throws IOException, InterruptedException {
+        Objects.requireNonNull(request, "request");
+        requireLinux();
+        Path workingDirectory = realDirectory(request.workingDirectory(), "Pi working directory");
+        Path sessionDirectory = realDirectory(request.sessionDirectory(), "Pi session directory");
+        Path evidenceDirectory = realDirectory(request.evidenceDirectory(), "Pi evidence directory");
+        requireDisjoint(workingDirectory, sessionDirectory, "working and session directories");
+        requireDisjoint(workingDirectory, evidenceDirectory, "working and evidence directories");
+        requireDisjoint(sessionDirectory, evidenceDirectory, "session and evidence directories");
+        UserPrincipal sessionOwner = requirePrivateSessionDirectory(sessionDirectory);
+        String prompt = requirePrompt(request.prompt());
+
+        LocalCommandRunner.Result versionRun = commands.run(new Command(
+                executable,
+                List.of("--version"),
+                workingDirectory,
+                evidenceDirectory,
+                VERSION_TIMEOUT.compareTo(timeout) < 0 ? VERSION_TIMEOUT : timeout,
+                MAX_LOG_BYTES));
+        Throwable primary = null;
+        Path scratchDirectory = null;
+        SessionLock sessionLock = null;
+        boolean versionLogsDeleted = false;
+        boolean published = false;
+        boolean restoreInterrupt = false;
+        try {
+            if (versionRun.timedOut()
+                    || versionRun.outputLimited()
+                    || versionRun.exitCode() != 0) {
+                throw new IOException(
+                        "Pi is installed but `pi --version` failed; reinstall Pi and verify it is on PATH");
+            }
+            String detectedVersion;
+            try {
+                detectedVersion = requireVersion(
+                        firstLine(Files.readAllBytes(versionRun.stdoutLog())),
+                        "detected Pi version");
+            } catch (IllegalArgumentException | IOException e) {
+                throw new IOException(
+                        "Pi reported an invalid version; reinstall Pi and verify `pi --version`",
+                        e);
+            }
+            if ("0.80.3".equals(detectedVersion)) {
+                throw new IOException(
+                        "Pi 0.80.3 lacks the required settled RPC event; install the maintained Pi "
+                                      + supportedVersion);
+            }
+            ShipLocalStamp.Support support = ShipLocalStamp.Support.EXPERIMENTAL;
+            String warning = detectedVersion.equals(supportedVersion)
+                    ? "Pi " + detectedVersion
+                      + " is experimental until the live Pi end-to-end gate passes"
+                    : "Pi " + detectedVersion + " is unverified; the maintained Pi "
+                      + supportedVersion + " is also experimental until the live end-to-end gate passes";
+            if (!request.acceptExperimental()) {
+                throw new IOException(
+                        warning + "; explicitly accept experimental Pi before starting the stage");
+            }
+
+            String sessionId = sessionId(request);
+            sessionLock = lockSession(sessionDirectory, sessionId, sessionOwner);
+            cleanupAbandonedScratch(sessionDirectory, sessionId, sessionOwner);
+            SessionState previousSession = snapshotExistingSession(
+                    sessionDirectory, sessionId, workingDirectory, sessionOwner);
+            refuseCompletedTurnReplay(previousSession.transcript(), prompt);
+            ScratchSession scratch = createScratch(
+                    sessionDirectory, sessionId, sessionOwner, previousSession);
+            scratchDirectory = scratch.directory();
+            List<String> arguments = arguments(request, scratch.directory(), sessionId);
+            List<String> sensitiveValues = List.copyOf(
+                    sensitiveEnvironmentValues(environment));
+            RpcRun turn = runRpc(
+                    arguments,
+                    workingDirectory,
+                    scratch.directory(),
+                    sessionDirectory,
+                    evidenceDirectory,
+                    sessionId,
+                    sessionOwner,
+                    scratch.previous(),
+                    previousSession,
+                    prompt,
+                    sensitiveValues);
+            restoreInterrupt = turn.restoreInterrupt();
+            CommandRun evidence = new CommandRun(
+                    executable.toString(),
+                    detectedVersion,
+                    LocalCommandRunner.redactArguments(
+                            arguments, sensitiveValues),
+                    workingDirectory.toString(),
+                    List.of(request.inputDigest()),
+                    true,
+                    turn.timedOut(),
+                    turn.outputLimited(),
+                    turn.exitCode(),
+                    turn.startedAt().toString(),
+                    turn.endedAt().toString(),
+                    turn.stdoutLog().toString(),
+                    turn.stdoutDigest(),
+                    turn.stderrLog().toString(),
+                    turn.stderrDigest());
+
+            Outcome outcome = Outcome.SUCCEEDED;
+            String assistantText = turn.assistantText();
+            String failure = null;
+            if (turn.timedOut()) {
+                outcome = Outcome.TIMED_OUT;
+                assistantText = null;
+                failure = "Pi stage exceeded its time limit";
+            } else if (turn.outputLimited()) {
+                outcome = Outcome.FAILED;
+                assistantText = null;
+                failure = "Pi stage exceeded its retained-output limit";
+            } else if (turn.exitCode() != 0) {
+                outcome = Outcome.FAILED;
+                assistantText = null;
+                failure = "Pi exited with status " + turn.exitCode();
+            } else if (turn.protocolFailure() != null) {
+                outcome = Outcome.FAILED;
+                assistantText = null;
+                failure = turn.protocolFailure();
+            } else if (!"stop".equals(turn.stopReason())) {
+                outcome = Outcome.FAILED;
+                assistantText = null;
+                failure = "Pi assistant settled with stop reason " + turn.stopReason();
+            }
+            Result result = new Result(
+                    outcome,
+                    support,
+                    detectedVersion,
+                    warning,
+                    assistantText,
+                    failure,
+                    evidence);
+            versionRun.deleteLogs();
+            versionLogsDeleted = true;
+            if (turn.validatedSession() != null) {
+                publishSession(
+                        turn.validatedSession(),
+                        sessionDirectory,
+                        sessionId,
+                        sessionOwner,
+                        previousSession);
+                published = true;
+            }
+            return result;
+        } catch (IOException | InterruptedException | RuntimeException | Error e) {
+            restoreInterrupt |= Thread.interrupted();
+            primary = e;
+            throw e;
+        } finally {
+            IOException cleanupFailure = null;
+            try {
+                deleteTree(scratchDirectory);
+            } catch (IOException cleanup) {
+                cleanupFailure = cleanup;
+                if (primary != null) {
+                    primary.addSuppressed(cleanup);
+                }
+            }
+            try {
+                if (sessionLock != null) {
+                    sessionLock.close();
+                }
+            } catch (IOException cleanup) {
+                if (cleanupFailure == null) {
+                    cleanupFailure = cleanup;
+                } else {
+                    cleanupFailure.addSuppressed(cleanup);
+                }
+                if (primary != null) {
+                    primary.addSuppressed(cleanup);
+                }
+            }
+            if (!versionLogsDeleted) {
+                try {
+                    versionRun.deleteLogs();
+                } catch (IOException cleanup) {
+                    if (cleanupFailure == null) {
+                        cleanupFailure = cleanup;
+                    } else {
+                        cleanupFailure.addSuppressed(cleanup);
+                    }
+                    if (primary != null) {
+                        primary.addSuppressed(cleanup);
+                    }
+                }
+            }
+            if (primary == null && !published && cleanupFailure != null) {
+                if (restoreInterrupt) {
+                    Thread.currentThread().interrupt();
+                }
+                throw cleanupFailure;
+            }
+            // Once the atomic move commits a validated session, cleanup cannot change the returned outcome.
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private RpcRun runRpc(
+            List<String> arguments,
+            Path workingDirectory,
+            Path sessionDirectory,
+            Path canonicalSessionDirectory,
+            Path evidenceDirectory,
+            String sessionId,
+            UserPrincipal sessionOwner,
+            SessionState previousSession,
+            SessionState canonicalPreviousSession,
+            String prompt,
+            List<String> sensitiveValues)
+            throws IOException, InterruptedException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("Interrupted before launching Pi");
+        }
+        Path setsid = LocalCommandRunner.trustedHelper(SETSID, "setsid");
+        Path kill = LocalCommandRunner.trustedHelper(KILL, "kill");
+        List<String> vector = new ArrayList<>(arguments.size() + 4);
+        vector.add(setsid.toString());
+        vector.add("--wait");
+        vector.add("--");
+        vector.add(executable.toString());
+        vector.addAll(arguments);
+        Instant startedAt = clock.instant();
+        Process process = new ProcessBuilder(vector)
+                .directory(workingDirectory.toFile())
+                .start();
+        List<ProcessHandle> observedChildren = new CopyOnWriteArrayList<>();
+        Thread shutdownHook = new Thread(
+                () -> terminateRpc(process, kill, observedChildren),
+                "camel-kit-pi-rpc-shutdown");
+        RpcOutput stdout = new RpcOutput(MAX_LOG_BYTES);
+        BoundedCapture stderr = new BoundedCapture(MAX_LOG_BYTES);
+        ExecutorService io = null;
+        Future<?> stdoutReader = null;
+        Future<?> stderrReader = null;
+        Future<?> promptWriter = null;
+        boolean acquired = false;
+        try {
+            io = Executors.newFixedThreadPool(3, task -> {
+                Thread thread = new Thread(task, "camel-kit-pi-rpc-io");
+                thread.setDaemon(true);
+                return thread;
+            });
+            stdoutReader = io.submit(() -> {
+                stdout.read(process.getInputStream());
+                return null;
+            });
+            stderrReader = io.submit(() -> {
+                stderr.read(process.getErrorStream());
+                return null;
+            });
+            promptWriter = io.submit(() -> {
+                writeCommand(process.getOutputStream(), promptCommand(prompt));
+                return null;
+            });
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+            acquired = true;
+        } finally {
+            if (!acquired) {
+                terminateRpc(process, kill, observedChildren);
+                close(process.getOutputStream());
+                if (promptWriter != null) {
+                    promptWriter.cancel(true);
+                }
+                if (stdoutReader != null) {
+                    stdoutReader.cancel(true);
+                }
+                if (stderrReader != null) {
+                    stderrReader.cancel(true);
+                }
+                if (io != null) {
+                    io.shutdownNow();
+                    awaitExecutorUninterruptibly(io);
+                }
+            }
+        }
+
+        boolean timedOut = false;
+        boolean outputLimited = false;
+        boolean interrupted = false;
+        boolean lateInterrupted = false;
+        boolean completedNormally = false;
+        String protocolFailure = null;
+        Lifecycle lifecycle = new Lifecycle(prompt);
+        ReconciledTurn reconciliation = null;
+        CompletedTurn completedTurn = null;
+        Path validatedSession = null;
+        Path publishableSession = null;
+        try {
+            long deadline = deadline(timeout);
+            while (!lifecycle.complete()) {
+                LocalCommandRunner.rememberDescendants(process, observedChildren);
+                IOException writeFailure = completedFailure(promptWriter, "Could not send the Pi prompt");
+                if (writeFailure != null) {
+                    protocolFailure = writeFailure.getMessage();
+                    break;
+                }
+                if (stdout.limited() || stderr.limited()) {
+                    outputLimited = true;
+                    break;
+                }
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    timedOut = true;
+                    break;
+                }
+                Frame frame;
+                try {
+                    frame = stdout.poll(Math.min(
+                            remaining, TimeUnit.MILLISECONDS.toNanos(100)));
+                } catch (InterruptedException interruptedPoll) {
+                    lateInterrupted = true;
+                    try {
+                        drainQueued(stdout, lifecycle);
+                    } catch (IOException e) {
+                        protocolFailure = e.getMessage();
+                        break;
+                    }
+                    if (lifecycle.complete()) {
+                        break;
+                    }
+                    throw interruptedPoll;
+                }
+                if (frame == null) {
+                    if (!process.isAlive() && stdoutReader.isDone()) {
+                        protocolFailure = "Pi exited before emitting a terminal RPC result";
+                        break;
+                    }
+                    continue;
+                }
+                try {
+                    acceptFrame(frame, lifecycle);
+                } catch (IOException e) {
+                    protocolFailure = e.getMessage();
+                    break;
+                }
+                if (stdout.limited() || stderr.limited()) {
+                    outputLimited = true;
+                    break;
+                }
+            }
+
+            if (lifecycle.complete() && protocolFailure == null && !outputLimited) {
+                await(promptWriter, "Could not send the Pi prompt");
+                close(process.getOutputStream());
+            } else {
+                boolean attemptedAbort = protocolFailure == null;
+                if (attemptedAbort) {
+                    reconciliation = abort(
+                            process,
+                            promptWriter,
+                            stdout,
+                            observedChildren,
+                            lifecycle);
+                }
+                if (reconciliation == null) {
+                    if (timedOut || outputLimited) {
+                        throw new IOException(
+                                "Pi did not acknowledge the RPC abort; the stage session is not resumable");
+                    }
+                    if (protocolFailure == null) {
+                        protocolFailure = "Pi did not acknowledge the RPC abort";
+                    }
+                }
+                if (!attemptedAbort && promptWriter.isDone()) {
+                    close(process.getOutputStream());
+                }
+            }
+
+            if (lifecycle.complete() || reconciliation != null) {
+                lateInterrupted |= Thread.interrupted();
+                if (!awaitExitUninterruptibly(process, EXIT_TIMEOUT)
+                        && !terminateRpc(process, kill, observedChildren)) {
+                    throw new IOException("Pi RPC process and observed descendants could not be reaped");
+                }
+                lateInterrupted |= Thread.interrupted();
+                LocalCommandRunner.rememberDescendants(process, observedChildren);
+                if (!terminateRpc(process, kill, observedChildren)) {
+                    throw new IOException("Pi RPC left an observed descendant process running");
+                }
+                awaitUninterruptibly(stdoutReader, "Pi RPC output did not close");
+                lateInterrupted |= Thread.interrupted();
+                awaitUninterruptibly(stderrReader, "Pi RPC error output did not close");
+                lateInterrupted |= Thread.interrupted();
+                completedTurn = lifecycle.complete()
+                        ? lifecycle.turn()
+                        : reconciliation.turn();
+                validatedSession = validatePersistedSession(
+                        sessionDirectory,
+                        sessionId,
+                        workingDirectory,
+                        sessionOwner,
+                        previousSession,
+                        prompt,
+                        completedTurn);
+            } else {
+                if (!awaitExit(process, EXIT_TIMEOUT)
+                        && !terminateRpc(process, kill, observedChildren)) {
+                    throw new IOException("Pi RPC process and observed descendants could not be reaped");
+                }
+                LocalCommandRunner.rememberDescendants(process, observedChildren);
+                if (!terminateRpc(process, kill, observedChildren)) {
+                    throw new IOException("Pi RPC left an observed descendant process running");
+                }
+                await(stdoutReader, "Pi RPC output did not close");
+                await(stderrReader, "Pi RPC error output did not close");
+            }
+
+            if (lifecycle.complete() && protocolFailure == null && !timedOut && !outputLimited) {
+                try {
+                    drainAfterTerminal(stdout, lifecycle);
+                } catch (IOException e) {
+                    protocolFailure = e.getMessage();
+                }
+                lateInterrupted |= Thread.interrupted();
+            }
+            outputLimited |= stdout.limited() || stderr.limited();
+            int actualExitCode = process.exitValue();
+            boolean naturalCompletion = lifecycle.complete()
+                    || (reconciliation != null
+                            && reconciliation.naturalCompletion());
+            boolean acknowledgedAbort = reconciliation != null
+                    && !reconciliation.naturalCompletion();
+            boolean effectiveTimedOut = timedOut && !naturalCompletion;
+            if (actualExitCode == 0
+                    && validatedSession != null
+                    && !stdout.protocolUnverifiable()
+                    && protocolFailure == null
+                    && ((naturalCompletion && !outputLimited)
+                            || (acknowledgedAbort
+                                    && (timedOut || outputLimited)))) {
+                publishableSession = validatedSession;
+            }
+            Integer exitCode = effectiveTimedOut ? null : actualExitCode;
+            Instant endedAt = clock.instant();
+            if (endedAt.isBefore(startedAt)) {
+                endedAt = startedAt;
+            }
+            List<String> stdoutSecrets = new ArrayList<>(
+                    sensitiveValues.size() + 1);
+            stdoutSecrets.add(prompt);
+            stdoutSecrets.addAll(sensitiveValues);
+            RetainedLog retainedStdout = LocalCommandRunner.retain(
+                    stdout.safeBytes(),
+                    evidenceDirectory,
+                    ".stdout.log",
+                    MAX_LOG_BYTES,
+                    stdoutSecrets);
+            RetainedLog retainedStderr;
+            try {
+                retainedStderr = LocalCommandRunner.retain(
+                        stderr.metadata(),
+                        evidenceDirectory,
+                        ".stderr.log",
+                        MAX_LOG_BYTES,
+                        sensitiveValues);
+            } catch (IOException | RuntimeException e) {
+                Files.deleteIfExists(retainedStdout.path());
+                throw e;
+            }
+            RpcRun result = new RpcRun(
+                    startedAt,
+                    endedAt,
+                    effectiveTimedOut,
+                    outputLimited,
+                    exitCode,
+                    retainedStdout.path(),
+                    retainedStdout.digest(),
+                    retainedStderr.path(),
+                    retainedStderr.digest(),
+                    naturalCompletion
+                            ? completedTurn.terminal().text()
+                            : null,
+                    naturalCompletion
+                            ? completedTurn.terminal().stopReason()
+                            : null,
+                    protocolFailure,
+                    publishableSession,
+                    lateInterrupted);
+            completedNormally = true;
+            return result;
+        } catch (InterruptedException e) {
+            interrupted = true;
+            reconciliation = abort(
+                    process,
+                    promptWriter,
+                    stdout,
+                    observedChildren,
+                    lifecycle);
+            Thread.interrupted();
+            if (reconciliation != null) {
+                close(process.getOutputStream());
+            } else {
+                terminateRpc(process, kill, observedChildren);
+            }
+            if (!awaitExitUninterruptibly(process, EXIT_TIMEOUT)
+                    && !terminateRpc(process, kill, observedChildren)) {
+                e.addSuppressed(new IOException(
+                        "Interrupted Pi RPC process and observed descendants could not be reaped"));
+            }
+            Thread.interrupted();
+            if (reconciliation == null) {
+                e.addSuppressed(new IOException(
+                        "Pi did not persist a reconciled turn before interruption cleanup"));
+            } else {
+                try {
+                    if (process.isAlive()) {
+                        throw new IOException(
+                                "Interrupted Pi RPC process did not exit after its acknowledged abort");
+                    }
+                    LocalCommandRunner.rememberDescendants(
+                            process, observedChildren);
+                    if (!terminateRpc(process, kill, observedChildren)) {
+                        throw new IOException(
+                                "Interrupted Pi RPC left a descendant process running");
+                    }
+                    awaitUninterruptibly(
+                            stdoutReader,
+                            "Interrupted Pi RPC output did not close");
+                    awaitUninterruptibly(
+                            stderrReader,
+                            "Interrupted Pi RPC error output did not close");
+                    Thread.interrupted();
+                    if (stdout.limited() || stderr.limited()) {
+                        throw new IOException(
+                                "Interrupted Pi RPC exceeded its retained-output limit");
+                    }
+                    validatedSession = validatePersistedSession(
+                            sessionDirectory,
+                            sessionId,
+                            workingDirectory,
+                            sessionOwner,
+                            previousSession,
+                            prompt,
+                            reconciliation.turn());
+                    if (process.exitValue() == 0) {
+                        publishSession(
+                                validatedSession,
+                                canonicalSessionDirectory,
+                                sessionId,
+                                sessionOwner,
+                                canonicalPreviousSession);
+                    } else {
+                        e.addSuppressed(new IOException(
+                                "Pi abort session was not published after a nonzero process exit"));
+                    }
+                } catch (IOException invalidSession) {
+                    e.addSuppressed(invalidSession);
+                }
+            }
+            close(process.getOutputStream());
+            throw e;
+        } catch (IOException | RuntimeException e) {
+            if (!terminateRpc(process, kill, observedChildren)) {
+                e.addSuppressed(new IOException(
+                        "Failed Pi RPC process and observed descendants could not be reaped"));
+            }
+            close(process.getOutputStream());
+            throw e;
+        } finally {
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException ignored) {
+                // JVM shutdown already owns the hook.
+            }
+            close(process.getOutputStream());
+            close(process.getInputStream());
+            close(process.getErrorStream());
+            promptWriter.cancel(true);
+            stdoutReader.cancel(true);
+            stderrReader.cancel(true);
+            io.shutdownNow();
+            awaitExecutorUninterruptibly(io);
+            if (interrupted || (lateInterrupted && !completedNormally)) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static ReconciledTurn abort(
+            Process process,
+            Future<?> promptWriter,
+            RpcOutput stdout,
+            List<ProcessHandle> observedChildren,
+            Lifecycle priorLifecycle) {
+        long deadline = deadline(ABORT_TIMEOUT);
+        ExecutorService writer = null;
+        Future<?> abortWriter = null;
+        AbortLifecycle lifecycle = new AbortLifecycle(priorLifecycle);
+        boolean interrupted = Thread.interrupted();
+        boolean inputClosed = false;
+        try {
+            while (true) {
+                LocalCommandRunner.rememberDescendants(process, observedChildren);
+                long abortRemaining = deadline - System.nanoTime();
+                if (abortRemaining <= 0) {
+                    return null;
+                }
+                Frame queued = stdout.pollNow();
+                if (queued != null) {
+                    if (queued.failure() != null) {
+                        return null;
+                    }
+                    if (queued.endOfStream()) {
+                        return reconciledAtEnd(
+                                lifecycle,
+                                promptWriter,
+                                abortWriter,
+                                deadline);
+                    }
+                    if (!lifecycle.accept(queued.event())) {
+                        return null;
+                    }
+                    continue;
+                }
+                if (lifecycle.complete()
+                        && !inputClosed
+                        && promptWriter.isDone()
+                        && (abortWriter == null
+                                || abortWriter.isDone())) {
+                    if (abortWriter != null
+                            && completedFailureUninterruptibly(
+                                    abortWriter,
+                                    "Could not send the Pi abort")
+                               != null) {
+                        return null;
+                    }
+                    close(process.getOutputStream());
+                    inputClosed = true;
+                }
+                if (!inputClosed
+                        && lifecycle.shouldDisposeTerminal()
+                        && abortRemaining
+                           <= ABORT_DRAIN_RESERVE.toNanos()) {
+                    if (promptWriter.isDone()
+                            && (abortWriter == null
+                                    || abortWriter.isDone())) {
+                        if (abortWriter != null
+                                && completedFailureUninterruptibly(
+                                        abortWriter,
+                                        "Could not send the Pi abort")
+                                   != null) {
+                            return null;
+                        }
+                        close(process.getOutputStream());
+                        inputClosed = true;
+                    }
+                }
+                if (abortWriter == null
+                        && abortRemaining
+                           > ABORT_DRAIN_RESERVE.toNanos()
+                        && lifecycle.shouldIssueAbort()
+                        && promptWriter.isDone()
+                        && process.isAlive()) {
+                    IOException promptFailure = completedFailureUninterruptibly(
+                            promptWriter,
+                            "Could not send the Pi prompt");
+                    interrupted |= Thread.interrupted();
+                    if (promptFailure != null) {
+                        return null;
+                    }
+                    writer = Executors.newSingleThreadExecutor(task -> {
+                        Thread thread = new Thread(
+                                task, "camel-kit-pi-rpc-abort");
+                        thread.setDaemon(true);
+                        return thread;
+                    });
+                    lifecycle.markAbortIssued();
+                    abortWriter = writer.submit(() -> {
+                        writeCommand(
+                                process.getOutputStream(), abortCommand());
+                        return null;
+                    });
+                }
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return null;
+                }
+                Frame frame;
+                try {
+                    frame = stdout.poll(Math.min(
+                            remaining, TimeUnit.MILLISECONDS.toNanos(100)));
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    continue;
+                }
+                if (frame == null) {
+                    continue;
+                }
+                if (frame.failure() != null) {
+                    return null;
+                }
+                if (frame.endOfStream()) {
+                    return reconciledAtEnd(
+                            lifecycle,
+                            promptWriter,
+                            abortWriter,
+                            deadline);
+                }
+                if (!lifecycle.accept(frame.event())) {
+                    return null;
+                }
+            }
+        } finally {
+            if (promptWriter.isDone()
+                    && (abortWriter == null || abortWriter.isDone())) {
+                close(process.getOutputStream());
+            }
+            if (abortWriter != null) {
+                abortWriter.cancel(true);
+            }
+            if (writer != null) {
+                writer.shutdownNow();
+                awaitExecutorUntil(writer, deadline);
+            }
+            interrupted |= Thread.interrupted();
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static ReconciledTurn reconciledAtEnd(
+            AbortLifecycle lifecycle,
+            Future<?> promptWriter,
+            Future<?> abortWriter,
+            long deadline) {
+        if (!awaitDoneUntil(promptWriter, deadline)) {
+            return null;
+        }
+        if (completedFailureUninterruptibly(
+                promptWriter, "Could not send the Pi prompt")
+            != null) {
+            return null;
+        }
+        if (abortWriter != null
+                && (!awaitDoneUntil(abortWriter, deadline)
+                        || completedFailureUninterruptibly(
+                                abortWriter,
+                                "Could not send the Pi abort")
+                           != null)) {
+            return null;
+        }
+        try {
+            return lifecycle.reconciledTurn();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static boolean awaitDoneUntil(
+            Future<?> operation, long deadline) {
+        boolean interrupted = Thread.interrupted();
+        try {
+            while (!operation.isDone()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    TimeUnit.NANOSECONDS.sleep(Math.min(
+                            remaining,
+                            TimeUnit.MILLISECONDS.toNanos(10)));
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+            return true;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static void awaitExecutorUntil(
+            ExecutorService executor, long deadline) {
+        boolean interrupted = Thread.interrupted();
+        try {
+            while (!executor.isTerminated()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return;
+                }
+                try {
+                    if (!executor.awaitTermination(
+                            remaining, TimeUnit.NANOSECONDS)) {
+                        return;
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static boolean terminateRpc(
+            Process process, Path kill, List<ProcessHandle> observedChildren) {
+        boolean groupReaped = LocalCommandRunner.terminateProcessGroup(process, kill);
+        boolean observedReaped = LocalCommandRunner.terminateAll(process, observedChildren);
+        return groupReaped && observedReaped;
+    }
+
+    private static IOException completedFailureUninterruptibly(
+            Future<?> operation, String message) {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    return completedFailure(operation, message);
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static void drainQueued(RpcOutput stdout, Lifecycle lifecycle)
+            throws IOException {
+        Frame frame;
+        while (!lifecycle.complete() && (frame = stdout.pollNow()) != null) {
+            acceptFrame(frame, lifecycle);
+        }
+    }
+
+    private static void acceptFrame(Frame frame, Lifecycle lifecycle)
+            throws IOException {
+        if (frame.endOfStream()) {
+            throw new IOException("Pi closed RPC output before emitting a settled result");
+        }
+        if (frame.failure() != null) {
+            throw new IOException(frame.failure());
+        }
+        lifecycle.accept(frame.event());
+    }
+
+    private static void drainAfterTerminal(RpcOutput stdout, Lifecycle lifecycle)
+            throws IOException {
+        boolean interrupted = false;
+        try {
+            long deadline = deadline(IO_TIMEOUT);
+            while (true) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    throw new IOException("Pi RPC output did not close after stdin was closed");
+                }
+                Frame frame;
+                try {
+                    frame = stdout.poll(remaining);
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    continue;
+                }
+                if (frame == null) {
+                    throw new IOException("Pi RPC output did not close after stdin was closed");
+                }
+                if (frame.endOfStream()) {
+                    return;
+                }
+                if (frame.failure() != null) {
+                    throw new IOException(frame.failure());
+                }
+                lifecycle.accept(frame.event());
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static String sessionId(Request request) {
+        return request.runId() + "-"
+               + request.stage().name().toLowerCase(Locale.ROOT) + "-"
+               + request.inputDigest().substring("sha256:".length());
+    }
+
+    private static List<String> arguments(
+            Request request, Path sessionDirectory, String sessionId) {
+        String tools = request.stage() == ShipRun.Stage.EXECUTE
+                ? EXECUTE_TOOLS
+                : READ_ONLY_TOOLS;
+        return List.of(
+                "--mode",
+                "rpc",
+                "--session-id",
+                sessionId,
+                "--session-dir",
+                sessionDirectory.toString(),
+                "--tools",
+                tools,
+                "--no-approve",
+                "--no-extensions",
+                "--no-skills",
+                "--no-prompt-templates",
+                "--no-themes",
+                "--no-context-files",
+                "--system-prompt",
+                "",
+                "--append-system-prompt",
+                "",
+                "--offline");
+    }
+
+    private static ObjectNode promptCommand(String prompt) {
+        ObjectNode command = JSON.createObjectNode();
+        command.put("id", PROMPT_ID);
+        command.put("type", "prompt");
+        command.put("message", prompt);
+        return command;
+    }
+
+    private static ObjectNode abortCommand() {
+        ObjectNode command = JSON.createObjectNode();
+        command.put("id", ABORT_ID);
+        command.put("type", "abort");
+        return command;
+    }
+
+    private static void writeCommand(OutputStream output, JsonNode command) throws IOException {
+        output.write(JSON.writeValueAsBytes(command));
+        output.write('\n');
+        output.flush();
+    }
+
+    private static IOException completedFailure(Future<?> operation, String message)
+            throws InterruptedException {
+        if (!operation.isDone()) {
+            return null;
+        }
+        try {
+            operation.get();
+            return null;
+        } catch (ExecutionException e) {
+            return new IOException(message, e.getCause());
+        } catch (java.util.concurrent.CancellationException e) {
+            return new IOException(message, e);
+        }
+    }
+
+    private static void await(Future<?> operation, String message)
+            throws IOException, InterruptedException {
+        try {
+            operation.get(IO_TIMEOUT.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (ExecutionException e) {
+            throw new IOException(message, e.getCause());
+        } catch (TimeoutException e) {
+            throw new IOException(message, e);
+        } catch (java.util.concurrent.CancellationException e) {
+            throw new IOException(message, e);
+        }
+    }
+
+    private static void awaitUninterruptibly(Future<?> operation, String message)
+            throws IOException {
+        boolean interrupted = false;
+        try {
+            long deadline = deadline(IO_TIMEOUT);
+            while (true) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    throw new IOException(message);
+                }
+                try {
+                    operation.get(remaining, TimeUnit.NANOSECONDS);
+                    return;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                } catch (ExecutionException e) {
+                    throw new IOException(message, e.getCause());
+                } catch (TimeoutException | java.util.concurrent.CancellationException e) {
+                    throw new IOException(message, e);
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static boolean awaitExit(Process process, Duration duration)
+            throws InterruptedException {
+        return process.waitFor(duration.toNanos(), TimeUnit.NANOSECONDS);
+    }
+
+    private static boolean awaitExitUninterruptibly(Process process, Duration duration) {
+        long deadline = deadline(duration);
+        boolean interrupted = false;
+        try {
+            while (process.isAlive()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    if (!process.waitFor(remaining, TimeUnit.NANOSECONDS)) {
+                        return false;
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+            return true;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static void awaitExecutorUninterruptibly(ExecutorService executor) {
+        boolean interrupted = false;
+        try {
+            long deadline = deadline(IO_TIMEOUT);
+            while (!executor.isTerminated()) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return;
+                }
+                try {
+                    if (!executor.awaitTermination(remaining, TimeUnit.NANOSECONDS)) {
+                        return;
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static long deadline(Duration duration) {
+        try {
+            return Math.addExact(System.nanoTime(), duration.toNanos());
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private static String firstLine(byte[] value) throws IOException {
+        String text = decodeStrict(value).trim();
+        int newline = text.indexOf('\n');
+        String first = (newline < 0 ? text : text.substring(0, newline)).trim();
+        if (first.isEmpty()) {
+            throw new IOException("Pi did not report its version");
+        }
+        return first;
+    }
+
+    private static String decodeStrict(byte[] value) throws IOException {
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(value))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            throw new IOException("Pi emitted invalid UTF-8", e);
+        }
+    }
+
+    private static String requirePrompt(String prompt) {
+        if (prompt == null || prompt.isBlank() || prompt.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("Pi prompt is required");
+        }
+        byte[] encoded = prompt.getBytes(StandardCharsets.UTF_8);
+        if (encoded.length > MAX_PROMPT_BYTES) {
+            throw new IllegalArgumentException("Pi prompt exceeds its size limit");
+        }
+        return prompt;
+    }
+
+    private static Path requireExecutable(Path supplied) {
+        Objects.requireNonNull(supplied, "Pi executable");
+        try {
+            Path executable = supplied.toRealPath();
+            if (!Files.isRegularFile(executable, LinkOption.NOFOLLOW_LINKS)
+                    || !Files.isExecutable(executable)) {
+                throw new IllegalArgumentException(
+                        "Pi is missing or not executable; install Pi and configure its executable path");
+            }
+            return executable;
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Pi is missing or not executable; install Pi and configure its executable path",
+                    e);
+        }
+    }
+
+    private static String requireVersion(String value, String label) {
+        if (value == null
+                || value.trim().length() > MAX_VERSION_LENGTH
+                || !VERSION.matcher(value.trim()).matches()) {
+            throw new IllegalArgumentException(label + " is invalid");
+        }
+        return value.trim();
+    }
+
+    private static Duration requireDuration(Duration value) {
+        if (value == null || value.isZero() || value.isNegative()) {
+            throw new IllegalArgumentException("Pi timeout must be positive");
+        }
+        return value;
+    }
+
+    private static Path realDirectory(Path supplied, String label) throws IOException {
+        if (supplied == null) {
+            throw new IOException(label + " is required");
+        }
+        Path normalized = supplied.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(label + " must be a real directory");
+        }
+        Path real = normalized.toRealPath();
+        if (!real.equals(normalized)) {
+            throw new IOException(label + " must not cross a symbolic link");
+        }
+        return real;
+    }
+
+    private static void requireDisjoint(Path first, Path second, String label) throws IOException {
+        if (first.startsWith(second) || second.startsWith(first)) {
+            throw new IOException("Pi " + label + " must be disjoint");
+        }
+    }
+
+    private static UserPrincipal requirePrivateSessionDirectory(Path directory)
+            throws IOException {
+        String userName = System.getProperty("user.name");
+        if (userName == null || userName.isBlank()) {
+            throw new IOException("Could not determine the current user for the Pi session directory");
+        }
+        UserPrincipal currentUser = FileSystems.getDefault()
+                .getUserPrincipalLookupService()
+                .lookupPrincipalByName(userName);
+        if (!currentUser.equals(Files.getOwner(directory, LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException("Pi session directory must be owned by the current user");
+        }
+        if (!PRIVATE_DIRECTORY.equals(
+                Files.getPosixFilePermissions(directory, LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException("Pi session directory permissions must be 0700");
+        }
+        return currentUser;
+    }
+
+    private static SessionLock lockSession(
+            Path directory, String sessionId, UserPrincipal owner)
+            throws IOException {
+        Path path = directory.resolve("." + sessionId + ".lock");
+        if (Files.isSymbolicLink(path)) {
+            throw new IOException("Pi stage session lock must not be a symbolic link");
+        }
+        FileChannel channel = FileChannel.open(
+                path,
+                Set.of(
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        LinkOption.NOFOLLOW_LINKS),
+                PosixFilePermissions.asFileAttribute(PRIVATE_FILE));
+        try {
+            if (!owner.equals(Files.getOwner(path, LinkOption.NOFOLLOW_LINKS))
+                    || !PRIVATE_FILE.equals(
+                            Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS))) {
+                throw new IOException("Pi stage session lock must be owned by the current user and 0600");
+            }
+            FileLock lock;
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException e) {
+                throw new IOException("Pi stage session is already running", e);
+            }
+            if (lock == null) {
+                throw new IOException("Pi stage session is already running");
+            }
+            return new SessionLock(channel, lock);
+        } catch (IOException | RuntimeException e) {
+            channel.close();
+            throw e;
+        }
+    }
+
+    private static void cleanupAbandonedScratch(
+            Path directory, String sessionId, UserPrincipal owner)
+            throws IOException {
+        String prefix = SCRATCH_PREFIX + sessionId + "-";
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(directory)) {
+            for (Path entry : entries) {
+                if (!entry.getFileName().toString().startsWith(prefix)) {
+                    continue;
+                }
+                if (Files.isSymbolicLink(entry)
+                        || !Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS)
+                        || !owner.equals(Files.getOwner(entry, LinkOption.NOFOLLOW_LINKS))
+                        || !PRIVATE_DIRECTORY.equals(
+                                Files.getPosixFilePermissions(
+                                        entry, LinkOption.NOFOLLOW_LINKS))) {
+                    throw new IOException("Pi stage scratch directory is unsafe");
+                }
+                deleteTree(entry);
+            }
+        }
+    }
+
+    private static ScratchSession createScratch(
+            Path directory,
+            String sessionId,
+            UserPrincipal owner,
+            SessionState previous)
+            throws IOException {
+        Path scratch = Files.createTempDirectory(
+                directory,
+                SCRATCH_PREFIX + sessionId + "-",
+                PosixFilePermissions.asFileAttribute(PRIVATE_DIRECTORY));
+        try {
+            if (!owner.equals(Files.getOwner(scratch, LinkOption.NOFOLLOW_LINKS))
+                    || !PRIVATE_DIRECTORY.equals(
+                            Files.getPosixFilePermissions(
+                                    scratch, LinkOption.NOFOLLOW_LINKS))) {
+                throw new IOException("Pi stage scratch directory must be owned by the current user and 0700");
+            }
+            if (previous.file() == null) {
+                return new ScratchSession(
+                        scratch,
+                        new SessionState(
+                                null, 0, null, previous.transcript()));
+            }
+            Path copy = scratch.resolve(previous.file().getFileName());
+            Files.copy(
+                    previous.file(),
+                    copy,
+                    StandardCopyOption.COPY_ATTRIBUTES,
+                    LinkOption.NOFOLLOW_LINKS);
+            if (!previous.digest().equals(fileDigest(copy, previous.size()))) {
+                throw new IOException("Pi stage session changed while it was copied");
+            }
+            return new ScratchSession(
+                    scratch,
+                    new SessionState(
+                            copy,
+                            previous.size(),
+                            previous.digest(),
+                            previous.transcript()));
+        } catch (IOException | RuntimeException e) {
+            try {
+                deleteTree(scratch);
+            } catch (IOException cleanup) {
+                e.addSuppressed(cleanup);
+            }
+            throw e;
+        }
+    }
+
+    private static void publishSession(
+            Path scratchFile,
+            Path directory,
+            String sessionId,
+            UserPrincipal owner,
+            SessionState previous)
+            throws IOException {
+        List<Path> current = sessionFiles(directory, sessionId, owner, true);
+        if (previous.file() == null) {
+            if (!current.isEmpty()) {
+                throw new IOException("Pi stage session appeared while the worker was running");
+            }
+        } else if (current.size() != 1
+                || !previous.file().equals(current.get(0))
+                || Files.size(previous.file()) != previous.size()
+                || !previous.digest().equals(fileDigest(previous.file(), previous.size()))) {
+            throw new IOException("Pi stage session changed while the worker was running");
+        }
+        Files.setPosixFilePermissions(scratchFile, PRIVATE_FILE);
+        if (!owner.equals(Files.getOwner(scratchFile, LinkOption.NOFOLLOW_LINKS))
+                || !PRIVATE_FILE.equals(
+                        Files.getPosixFilePermissions(
+                                scratchFile, LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException(
+                    "Pi stage session candidate must be owned by the current user and 0600");
+        }
+        try (FileChannel channel = FileChannel.open(
+                scratchFile,
+                StandardOpenOption.WRITE,
+                LinkOption.NOFOLLOW_LINKS)) {
+            channel.force(true);
+        }
+        Path target = previous.file() == null
+                ? directory.resolve(scratchFile.getFileName())
+                : previous.file();
+        if (!target.toAbsolutePath().normalize().getParent().equals(directory)
+                || Files.isSymbolicLink(target)) {
+            throw new IOException("Pi stage session publication target is unsafe");
+        }
+        // This atomic rename is the commit point and intentionally the method's last
+        // potentially failing operation.
+        Files.move(
+                scratchFile,
+                target,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private static void deleteTree(Path path) throws IOException {
+        if (path == null || !Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        if (Files.isSymbolicLink(path)) {
+            throw new IOException("Pi scratch cleanup refused a symbolic link");
+        }
+        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
+                for (Path entry : entries) {
+                    deleteTree(entry);
+                }
+            }
+        }
+        Files.delete(path);
+    }
+
+    private static SessionState snapshotExistingSession(
+            Path directory,
+            String sessionId,
+            Path workingDirectory,
+            UserPrincipal owner)
+            throws IOException {
+        List<Path> matches = sessionFiles(directory, sessionId, owner, true);
+        if (matches.size() > 1) {
+            throw new IOException("Pi stage session ID is ambiguous");
+        }
+        if (matches.isEmpty()) {
+            return new SessionState(
+                    null,
+                    0,
+                    null,
+                    new SessionTranscript(null, List.of()));
+        }
+        Path file = matches.get(0);
+        long size = boundedSessionSize(file);
+        SessionTranscript transcript = parseSession(
+                file, size, sessionId, workingDirectory);
+        return new SessionState(
+                file, size, fileDigest(file, size), transcript);
+    }
+
+    private Path validatePersistedSession(
+            Path directory,
+            String sessionId,
+            Path workingDirectory,
+            UserPrincipal owner,
+            SessionState previous,
+            String prompt,
+            CompletedTurn turn)
+            throws IOException {
+        Objects.requireNonNull(turn, "turn");
+        List<Path> matches = sessionFiles(directory, sessionId, owner, false);
+        if (matches.size() != 1) {
+            throw new IOException("Pi did not persist exactly one stage session");
+        }
+        Path file = matches.get(0);
+        if (previous.file() != null && !previous.file().equals(file)) {
+            throw new IOException("Pi replaced the existing stage session");
+        }
+        long size = boundedSessionSize(file);
+        if (previous.file() != null) {
+            if (size <= previous.size()) {
+                throw new IOException("Pi did not append the current stage turn");
+            }
+            if (!previous.digest().equals(fileDigest(file, previous.size()))) {
+                throw new IOException("Pi rewrote the existing stage session");
+            }
+        }
+        SessionTranscript transcript = parseSession(
+                file, size, sessionId, workingDirectory);
+        validatePersistedTurn(previous, transcript, prompt, turn);
+        rejectSensitiveEnvironmentValues(transcript, turn);
+        return file;
+    }
+
+    private static void validatePersistedTurn(
+            SessionState previous,
+            SessionTranscript transcript,
+            String prompt,
+            CompletedTurn turn)
+            throws IOException {
+        List<JsonNode> entries = transcript.entries();
+        int prefix = previous.transcript().entries().size();
+        if (previous.file() == null) {
+            if (transcript.header() == null
+                    || entries.size() < 2
+                    || !"model_change".equals(entries.get(0).path("type").textValue())
+                    || !"thinking_level_change".equals(
+                            entries.get(1).path("type").textValue())) {
+                throw new IOException(
+                        "Pi new stage session has an invalid model/thinking bootstrap");
+            }
+            prefix = 2;
+        } else if (!previous.transcript().header().equals(transcript.header())
+                || entries.size() < prefix
+                || !previous.transcript().entries().equals(
+                        entries.subList(0, prefix))) {
+            throw new IOException("Pi rewrote the existing stage session records");
+        }
+
+        List<ExpectedRecord> expected = turn.records();
+        if (previous.file() == null
+                && (expected.isEmpty()
+                        || !"message".equals(expected.get(0).type())
+                        || !"user".equals(
+                                expected.get(0).value().path("role").textValue()))) {
+            throw new IOException(
+                    "Pi new stage session persisted a record before its prompt");
+        }
+        if (entries.size() - prefix != expected.size()) {
+            throw new IOException(
+                    "Pi persisted records that do not match the ordered RPC results");
+        }
+        for (int index = 0; index < expected.size(); index++) {
+            JsonNode entry = entries.get(prefix + index);
+            ExpectedRecord record = expected.get(index);
+            if (!record.type().equals(entry.path("type").textValue())
+                    || !matchesExpectedRecord(entry, record)) {
+                throw new IOException(
+                        "Pi persisted records that do not match the ordered RPC results");
+            }
+        }
+
+        boolean userSeen = false;
+        for (ExpectedRecord record : expected) {
+            if (!"message".equals(record.type())) {
+                continue;
+            }
+            String role = record.value().path("role").textValue();
+            if ("user".equals(role)) {
+                if (userSeen
+                        || !matchesPrompt(
+                                record.value().path("content"), prompt)) {
+                    throw new IOException(
+                            "Pi persisted an unrelated current stage prompt");
+                }
+                userSeen = true;
+            } else if (!userSeen) {
+                throw new IOException(
+                        "Pi persisted a message before the current stage prompt");
+            }
+        }
+        if (!userSeen) {
+            throw new IOException("Pi did not persist the current stage prompt");
+        }
+        Terminal terminal = turn.terminal();
+        JsonNode lastMessage = null;
+        for (ExpectedRecord record : expected) {
+            if ("message".equals(record.type())) {
+                lastMessage = record.value();
+            }
+        }
+        if (lastMessage == null || !terminal.assistant().equals(lastMessage)) {
+            throw new IOException(
+                    "Pi persisted terminal content that does not match the RPC result");
+        }
+    }
+
+    private static boolean matchesExpectedRecord(
+            JsonNode entry, ExpectedRecord expected) {
+        if ("message".equals(expected.type())) {
+            return expected.value().equals(entry.path("message"));
+        }
+        if (!"compaction".equals(expected.type())) {
+            return false;
+        }
+        JsonNode value = expected.value();
+        return value.path("summary").equals(entry.path("summary"))
+                && value.path("firstKeptEntryId").equals(
+                        entry.path("firstKeptEntryId"))
+                && value.path("tokensBefore").equals(entry.path("tokensBefore"))
+                && value.path("details").equals(entry.path("details"))
+                && entry.path("fromHook").isBoolean()
+                && !entry.path("fromHook").booleanValue();
+    }
+
+    private static boolean matchesPrompt(JsonNode content, String prompt) {
+        if (content.isTextual()) {
+            return prompt.equals(content.textValue());
+        }
+        if (!content.isArray()) {
+            return false;
+        }
+        StringBuilder text = new StringBuilder();
+        for (JsonNode item : content) {
+            if (!item.isObject()
+                    || !"text".equals(item.path("type").textValue())
+                    || !item.path("text").isTextual()) {
+                return false;
+            }
+            text.append(item.path("text").textValue());
+        }
+        return prompt.contentEquals(text);
+    }
+
+    private static List<Path> sessionFiles(
+            Path directory,
+            String sessionId,
+            UserPrincipal owner,
+            boolean canonical)
+            throws IOException {
+        List<Path> matches = new ArrayList<>(2);
+        String suffix = "_" + sessionId + ".jsonl";
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(directory)) {
+            for (Path file : files) {
+                if (Files.isSymbolicLink(file)) {
+                    throw new IOException("Pi session directory contains an unsafe entry");
+                }
+                String name = file.getFileName().toString();
+                if (Files.isDirectory(file, LinkOption.NOFOLLOW_LINKS)) {
+                    if (!name.startsWith(SCRATCH_PREFIX)
+                            || !owner.equals(
+                                    Files.getOwner(
+                                            file, LinkOption.NOFOLLOW_LINKS))
+                            || !PRIVATE_DIRECTORY.equals(
+                                    Files.getPosixFilePermissions(
+                                            file, LinkOption.NOFOLLOW_LINKS))) {
+                        throw new IOException(
+                                "Pi session directory contains an unsafe entry");
+                    }
+                    continue;
+                }
+                if (!Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
+                        || !owner.equals(
+                                Files.getOwner(file, LinkOption.NOFOLLOW_LINKS))) {
+                    throw new IOException(
+                            "Pi session directory contains an unsafe entry");
+                }
+                if (name.startsWith(".") && name.endsWith(".lock")) {
+                    if (!PRIVATE_FILE.equals(
+                            Files.getPosixFilePermissions(
+                                    file, LinkOption.NOFOLLOW_LINKS))) {
+                        throw new IOException(
+                                "Pi session directory contains an unsafe entry");
+                    }
+                    continue;
+                }
+                if (name.endsWith(suffix)) {
+                    if (canonical
+                            && !PRIVATE_FILE.equals(
+                                    Files.getPosixFilePermissions(
+                                            file,
+                                            LinkOption.NOFOLLOW_LINKS))) {
+                        throw new IOException(
+                                "Pi stage session permissions must be 0600");
+                    }
+                    matches.add(file.toAbsolutePath().normalize());
+                    if (matches.size() > 1) {
+                        break;
+                    }
+                }
+            }
+        }
+        return matches;
+    }
+
+    private static SessionTranscript parseSession(
+            Path file,
+            long expectedSize,
+            String sessionId,
+            Path workingDirectory)
+            throws IOException {
+        if (Files.isSymbolicLink(file)
+                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Pi stage session must be a real JSONL file");
+        }
+        byte[] bytes = new byte[Math.toIntExact(expectedSize)];
+        try (InputStream input = Files.newInputStream(
+                file, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+            if (input.readNBytes(bytes, 0, bytes.length) != bytes.length
+                    || input.read() != -1) {
+                throw new IOException(
+                        "Pi stage session changed while it was inspected");
+            }
+        }
+        int headerEnd = 0;
+        while (headerEnd < bytes.length && bytes[headerEnd] != '\n') {
+            headerEnd++;
+        }
+        int headerBytes = headerEnd;
+        if (headerBytes > 0 && bytes[headerBytes - 1] == '\r') {
+            headerBytes--;
+        }
+        if (headerBytes > MAX_SESSION_HEADER_BYTES) {
+            throw new IOException(
+                    "Pi stage session header exceeds its size limit");
+        }
+        String jsonl = decodeStrict(bytes);
+        String[] lines = jsonl.split("\n", -1);
+        List<JsonNode> records = new ArrayList<>(lines.length);
+        for (int index = 0; index < lines.length; index++) {
+            String line = lines[index];
+            if (line.endsWith("\r")) {
+                line = line.substring(0, line.length() - 1);
+            }
+            if (line.isEmpty() && index == lines.length - 1) {
+                continue;
+            }
+            if (line.isBlank()) {
+                throw new IOException("Pi stage session contains a blank JSONL record");
+            }
+            JsonNode record;
+            try {
+                record = JSON.readTree(line);
+            } catch (IOException e) {
+                throw new IOException(
+                        "Pi stage session contains a malformed JSONL record");
+            }
+            if (record == null || !record.isObject()) {
+                throw new IOException(
+                        "Pi stage session contains a malformed JSONL record");
+            }
+            records.add(record);
+        }
+        if (records.isEmpty()) {
+            throw new IOException("Pi stage session has no JSONL header");
+        }
+        JsonNode header = records.remove(0);
+        if (header == null
+                || !header.isObject()
+                || header.size() != 5
+                || !"session".equals(header.path("type").textValue())
+                || !header.path("version").isIntegralNumber()
+                || header.path("version").longValue() != 3
+                || !sessionId.equals(header.path("id").textValue())
+                || !isNonBlankText(header.path("timestamp"))
+                || !workingDirectory.toString().equals(header.path("cwd").textValue())) {
+            throw new IOException("Pi stage session header does not match this stage");
+        }
+        if (records.isEmpty()) {
+            throw new IOException("Pi stage session has no persisted turn records");
+        }
+        validateLinearEntries(records);
+        List<JsonNode> entries = new ArrayList<>(records.size());
+        for (JsonNode record : records) {
+            entries.add(record.deepCopy());
+        }
+        return new SessionTranscript(
+                header.deepCopy(),
+                List.copyOf(entries));
+    }
+
+    private static void validateLinearEntries(List<JsonNode> entries)
+            throws IOException {
+        Set<String> ids = new HashSet<>();
+        String parent = null;
+        for (int index = 0; index < entries.size(); index++) {
+            JsonNode entry = entries.get(index);
+            if (entry == null
+                    || !entry.isObject()
+                    || !isNonBlankText(entry.path("id"))
+                    || !isNonBlankText(entry.path("timestamp"))) {
+                throw new IOException("Pi stage session has an invalid entry");
+            }
+            String id = entry.path("id").textValue();
+            if (ids.contains(id)) {
+                throw new IOException("Pi stage session has a duplicate entry ID");
+            }
+            JsonNode parentId = entry.get("parentId");
+            if ((index == 0 && (parentId == null || !parentId.isNull()))
+                    || (index > 0
+                            && (parentId == null
+                                    || !parentId.isTextual()
+                                    || !parent.equals(parentId.textValue())))) {
+                throw new IOException(
+                        "Pi stage session entries do not form one linear chain");
+            }
+
+            String type = entry.path("type").textValue();
+            switch (type == null ? "" : type) {
+                case "model_change" -> {
+                    if (index != 0
+                            || entry.size() != 6
+                            || !isNonBlankText(entry.path("provider"))
+                            || !isNonBlankText(entry.path("modelId"))) {
+                        throw new IOException(
+                                "Pi stage session has an invalid model bootstrap");
+                    }
+                }
+                case "thinking_level_change" -> {
+                    if (index != 1
+                            || entry.size() != 5
+                            || !"model_change".equals(
+                                    entries.get(0).path("type").textValue())
+                            || !isNonBlankText(entry.path("thinkingLevel"))) {
+                        throw new IOException(
+                                "Pi stage session has an invalid thinking bootstrap");
+                    }
+                }
+                case "message" -> validateMessageEntry(entry, index);
+                case "compaction" -> validateCompactionEntry(entry, ids);
+                default -> throw new IOException(
+                        "Pi stage session contains an unsupported entry type");
+            }
+            ids.add(id);
+            parent = id;
+        }
+        if (entries.size() < 2
+                || !"model_change".equals(entries.get(0).path("type").textValue())
+                || !"thinking_level_change".equals(
+                        entries.get(1).path("type").textValue())) {
+            throw new IOException(
+                    "Pi stage session has an invalid model/thinking bootstrap");
+        }
+    }
+
+    private static void validateMessageEntry(JsonNode entry, int index)
+            throws IOException {
+        JsonNode message = entry.get("message");
+        String role = message == null ? null : message.path("role").textValue();
+        if (index < 2
+                || entry.size() != 5
+                || message == null
+                || !message.isObject()
+                || (!"user".equals(role)
+                        && !"assistant".equals(role)
+                        && !"toolResult".equals(role))
+                || message.get("content") == null) {
+            throw new IOException("Pi stage session has an invalid message entry");
+        }
+        if ("assistant".equals(role)
+                && !isNonBlankText(message.path("stopReason"))) {
+            throw new IOException(
+                    "Pi stage session has an assistant without a stop reason");
+        }
+    }
+
+    private static void validateCompactionEntry(
+            JsonNode entry, Set<String> priorIds)
+            throws IOException {
+        String firstKept = entry.path("firstKeptEntryId").textValue();
+        if (entry.size() != 9
+                || !isNonBlankText(entry.path("summary"))
+                || firstKept == null
+                || !priorIds.contains(firstKept)
+                || !entry.path("tokensBefore").isIntegralNumber()
+                || entry.path("tokensBefore").longValue() < 0
+                || entry.get("details") == null
+                || !entry.path("fromHook").isBoolean()
+                || entry.path("fromHook").booleanValue()) {
+            throw new IOException("Pi stage session has an invalid compaction entry");
+        }
+    }
+
+    private static boolean isNonBlankText(JsonNode value) {
+        return value != null
+                && value.isTextual()
+                && !value.textValue().isBlank();
+    }
+
+    private static void refuseCompletedTurnReplay(
+            SessionTranscript transcript, String prompt)
+            throws IOException {
+        if (transcript == null || transcript.entries().isEmpty()) {
+            return;
+        }
+        JsonNode lastUser = null;
+        JsonNode lastAssistant = null;
+        for (JsonNode entry : transcript.entries()) {
+            if (!"message".equals(entry.path("type").textValue())) {
+                continue;
+            }
+            JsonNode message = entry.path("message");
+            String role = message.path("role").textValue();
+            if ("user".equals(role)) {
+                lastUser = message;
+                lastAssistant = null;
+            } else if (lastUser != null && "assistant".equals(role)) {
+                lastAssistant = message;
+            }
+        }
+        if (lastUser != null
+                && lastAssistant != null
+                && matchesPrompt(lastUser.path("content"), prompt)
+                && "stop".equals(
+                        lastAssistant.path("stopReason").textValue())) {
+            throw new IOException(
+                    "Pi completed turn requires controller recovery before another attempt");
+        }
+    }
+
+    private void rejectSensitiveEnvironmentValues(
+            SessionTranscript transcript, CompletedTurn turn)
+            throws IOException {
+        Set<String> sensitive = sensitiveEnvironmentValues(environment);
+        if (sensitive.isEmpty()) {
+            return;
+        }
+        if (containsSensitiveValue(transcript.header(), sensitive)) {
+            throw sensitiveOutput();
+        }
+        for (JsonNode entry : transcript.entries()) {
+            if (containsSensitiveValue(entry, sensitive)) {
+                throw sensitiveOutput();
+            }
+        }
+        if (containsSensitiveValue(turn.terminal().assistant(), sensitive)
+                || containsSensitiveValue(turn.terminal().text(), sensitive)) {
+            throw sensitiveOutput();
+        }
+    }
+
+    private static Set<String> sensitiveEnvironmentValues(
+            Map<String, String> environment) {
+        Set<String> values = new HashSet<>();
+        environment.forEach((name, value) -> {
+            if (ShipLocalStamp.isSensitiveEnvironmentName(name)
+                    && value != null
+                    && !value.isEmpty()) {
+                values.add(value);
+            }
+        });
+        return values;
+    }
+
+    private static boolean containsSensitiveValue(
+            JsonNode node, Set<String> sensitive) {
+        if (node == null) {
+            return false;
+        }
+        if (node.isObject()) {
+            var fields = node.fields();
+            while (fields.hasNext()) {
+                var field = fields.next();
+                if (containsSensitiveValue(field.getKey(), sensitive)
+                        || containsSensitiveValue(
+                                field.getValue(), sensitive)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (node.isArray()) {
+            for (JsonNode child : node) {
+                if (containsSensitiveValue(child, sensitive)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return node.isValueNode()
+                && containsSensitiveValue(node.asText(), sensitive);
+    }
+
+    private static boolean containsSensitiveValue(
+            String text, Set<String> sensitive) {
+        if (text == null) {
+            return false;
+        }
+        for (String value : sensitive) {
+            if (text.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static IOException sensitiveOutput() {
+        return new IOException(
+                "Pi output contained a sensitive environment value");
+    }
+
+    private static long boundedSessionSize(Path file) throws IOException {
+        long size = Files.size(file);
+        if (size > MAX_SESSION_BYTES) {
+            throw new IOException("Pi stage session exceeds its size limit");
+        }
+        return size;
+    }
+
+    private static String fileDigest(Path file, long length) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+        try (InputStream input = new DigestInputStream(
+                Files.newInputStream(
+                        file, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS),
+                digest)) {
+            byte[] buffer = new byte[8192];
+            long remaining = length;
+            while (remaining > 0) {
+                int read = input.read(buffer, 0, (int) Math.min(buffer.length, remaining));
+                if (read < 0) {
+                    throw new IOException("Pi stage session changed while it was inspected");
+                }
+                remaining -= read;
+            }
+        }
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static void requireLinux() {
+        String os = System.getProperty("os.name", "");
+        if (!os.toLowerCase(Locale.ROOT).contains("linux")) {
+            throw new IllegalStateException("The first Pi Ship worker supports Linux only");
+        }
+    }
+
+    private static void close(OutputStream output) {
+        try {
+            output.close();
+        } catch (IOException ignored) {
+            // Process cleanup remains authoritative.
+        }
+    }
+
+    private static void close(InputStream input) {
+        try {
+            input.close();
+        } catch (IOException ignored) {
+            // Process cleanup remains authoritative.
+        }
+    }
+
+    public enum Outcome {
+        SUCCEEDED,
+        FAILED,
+        TIMED_OUT
+    }
+
+    public record Request(
+            String runId,
+            ShipRun.Stage stage,
+            int attempt,
+            Path workingDirectory,
+            Path sessionDirectory,
+            Path evidenceDirectory,
+            String inputDigest,
+            boolean acceptExperimental,
+            String prompt) {
+
+        public Request {
+            if (!ShipRun.isRunId(runId)) {
+                throw new IllegalArgumentException("Pi request run ID is invalid");
+            }
+            Objects.requireNonNull(stage, "stage");
+            if (attempt <= 0) {
+                throw new IllegalArgumentException("Pi request attempt must be positive");
+            }
+            Objects.requireNonNull(workingDirectory, "workingDirectory");
+            Objects.requireNonNull(sessionDirectory, "sessionDirectory");
+            Objects.requireNonNull(evidenceDirectory, "evidenceDirectory");
+            if (!ShipDigest.isSha256(inputDigest)) {
+                throw new IllegalArgumentException("Pi request input digest is invalid");
+            }
+            Objects.requireNonNull(prompt, "prompt");
+        }
+
+        @Override
+        public String toString() {
+            return "Request[runId=" + runId
+                   + ", stage=" + stage
+                   + ", attempt=" + attempt
+                   + ", workingDirectory=" + workingDirectory
+                   + ", sessionDirectory=" + sessionDirectory
+                   + ", evidenceDirectory=" + evidenceDirectory
+                   + ", inputDigest=" + inputDigest
+                   + ", acceptExperimental=" + acceptExperimental
+                   + ", prompt=<redacted>]";
+        }
+    }
+
+    public record Result(
+            Outcome outcome,
+            ShipLocalStamp.Support support,
+            String version,
+            String warning,
+            String assistantText,
+            String failure,
+            CommandRun evidence) {
+
+        public Result {
+            Objects.requireNonNull(outcome, "outcome");
+            Objects.requireNonNull(support, "support");
+            version = requireVersion(version, "Pi result version");
+            Objects.requireNonNull(evidence, "evidence");
+            if (support != ShipLocalStamp.Support.EXPERIMENTAL) {
+                throw new IllegalArgumentException(
+                        "Pi worker results remain experimental until the live end-to-end gate passes");
+            }
+            if (!version.equals(evidence.version())) {
+                throw new IllegalArgumentException("Pi result version does not match its evidence");
+            }
+            if (warning == null || warning.isBlank()) {
+                throw new IllegalArgumentException("Experimental Pi results require a warning");
+            }
+            if (outcome == Outcome.SUCCEEDED) {
+                if (assistantText == null || failure != null || !evidence.succeeded()) {
+                    throw new IllegalArgumentException("Successful Pi result is inconsistent");
+                }
+            } else if (outcome == Outcome.TIMED_OUT && !evidence.timedOut()) {
+                throw new IllegalArgumentException("Timed-out Pi result requires timed-out evidence");
+            } else if (assistantText != null || failure == null || failure.isBlank()) {
+                throw new IllegalArgumentException("Failed Pi result is inconsistent");
+            }
+            if (outcome != Outcome.TIMED_OUT && evidence.timedOut()) {
+                throw new IllegalArgumentException("Only a timed-out Pi result can carry timed-out evidence");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Result[outcome=" + outcome
+                   + ", support=" + support
+                   + ", version=" + version
+                   + ", warning=<redacted>"
+                   + ", assistantText=<redacted>"
+                   + ", failure=<redacted>"
+                   + ", evidence=" + evidence + "]";
+        }
+    }
+
+    private static final class Lifecycle {
+
+        private final String prompt;
+        private final List<JsonNode> messages = new ArrayList<>();
+        private final List<ExpectedRecord> records = new ArrayList<>();
+        private final List<Terminal> agentResults = new ArrayList<>();
+        private boolean promptResponse;
+        private boolean settled;
+        private Terminal terminal;
+
+        private Lifecycle(String prompt) {
+            this.prompt = prompt;
+        }
+
+        void accept(JsonNode event) throws IOException {
+            String type = eventType(event);
+            if ("response".equals(type)) {
+                requireResponse(event, PROMPT_ID, "prompt");
+                if (promptResponse) {
+                    throw new IOException("Pi emitted a duplicate prompt response");
+                }
+                promptResponse = true;
+                return;
+            }
+            if (settled) {
+                throw new IOException("Pi emitted an event after it settled");
+            }
+            if ("agent_settled".equals(type)) {
+                requireSettled(event);
+                if (terminal == null) {
+                    throw new IOException("Pi settled before emitting an agent result");
+                }
+                settled = true;
+                return;
+            }
+            if ("session".equals(type)) {
+                throw new IOException("Pi emitted an unexpected RPC session event");
+            }
+            if ("message_end".equals(type)) {
+                acceptMessageEnd(event, prompt, messages, records);
+            } else if ("compaction_end".equals(type)) {
+                acceptCompactionEnd(event, records);
+            } else if ("agent_end".equals(type)) {
+                terminal = terminalCandidate(event);
+                agentResults.add(terminal);
+            }
+        }
+
+        boolean complete() {
+            return promptResponse && terminal != null && settled;
+        }
+
+        Terminal terminal() {
+            return terminal;
+        }
+
+        List<JsonNode> messages() {
+            return List.copyOf(messages);
+        }
+
+        List<ExpectedRecord> records() {
+            return List.copyOf(records);
+        }
+
+        List<Terminal> agentResults() {
+            return List.copyOf(agentResults);
+        }
+
+        CompletedTurn turn() throws IOException {
+            requireTerminalMessage(
+                    terminal, messages, records, agentResults);
+            return new CompletedTurn(
+                    terminal,
+                    List.copyOf(messages),
+                    List.copyOf(records));
+        }
+    }
+
+    private static final class AbortLifecycle {
+
+        private final String prompt;
+        private final List<JsonNode> messages;
+        private final List<ExpectedRecord> records;
+        private final List<Terminal> agentResults;
+        private boolean promptResponse;
+        private boolean abortResponse;
+        private boolean abortIssued;
+        private boolean continuationReady;
+        private boolean settled;
+        private Terminal terminal;
+
+        private AbortLifecycle(Lifecycle prior) {
+            this.prompt = prior.prompt;
+            this.messages = new ArrayList<>(prior.messages);
+            this.records = new ArrayList<>(prior.records);
+            this.agentResults = new ArrayList<>(prior.agentResults);
+            this.promptResponse = prior.promptResponse;
+            this.settled = prior.settled;
+            this.terminal = prior.terminal;
+            this.continuationReady = !records.isEmpty()
+                    && records.get(records.size() - 1).continuesTurn();
+        }
+
+        boolean accept(JsonNode event) {
+            try {
+                String type = eventType(event);
+                if ("response".equals(type)) {
+                    if (PROMPT_ID.equals(event.path("id").textValue())) {
+                        requireResponse(event, PROMPT_ID, "prompt");
+                        if (promptResponse) {
+                            return false;
+                        }
+                        promptResponse = true;
+                    } else {
+                        requireResponse(event, ABORT_ID, "abort");
+                        if (!abortIssued || abortResponse) {
+                            return false;
+                        }
+                        abortResponse = true;
+                    }
+                } else if (settled) {
+                    return false;
+                } else if ("agent_settled".equals(type)) {
+                    requireSettled(event);
+                    if (terminal == null
+                            || !(isAbortedTerminal(terminal)
+                                    || isCancelledRetryTerminal(terminal)
+                                    || isNaturalTerminal(terminal))) {
+                        return false;
+                    }
+                    settled = true;
+                } else if ("session".equals(type)) {
+                    return false;
+                } else if ("message_end".equals(type)) {
+                    acceptMessageEnd(event, prompt, messages, records);
+                    continuationReady = false;
+                } else if ("compaction_end".equals(type)) {
+                    acceptCompactionEnd(event, records);
+                    continuationReady = !records.isEmpty()
+                            && records.get(records.size() - 1)
+                                    .continuesTurn();
+                } else if ("agent_end".equals(type)) {
+                    terminal = terminalCandidate(event);
+                    agentResults.add(terminal);
+                    continuationReady = false;
+                }
+                return true;
+            } catch (IOException e) {
+                return false;
+            }
+        }
+
+        boolean shouldIssueAbort() {
+            return promptResponse
+                    && !settled
+                    && !abortIssued
+                    && (terminal == null
+                            || terminal.willRetry()
+                            || continuationReady
+                            || !terminalMatchesLastMessage());
+        }
+
+        boolean shouldDisposeTerminal() {
+            return !settled && authoritativeTerminal();
+        }
+
+        void markAbortIssued() {
+            abortIssued = true;
+        }
+
+        boolean complete() {
+            return naturalCompletion()
+                    || (promptResponse
+                            && abortIssued
+                            && abortResponse
+                            && settled
+                            && terminal != null
+                            && (isAbortedTerminal(terminal)
+                                    || isCancelledRetryTerminal(terminal)));
+        }
+
+        boolean naturalCompletion() {
+            return settled && authoritativeTerminal();
+        }
+
+        ReconciledTurn reconciledTurn() throws IOException {
+            boolean natural = naturalCompletion()
+                    || authoritativeTerminal();
+            if (!complete() && !natural) {
+                throw new IOException(
+                        "Pi did not emit a complete reconciled turn");
+            }
+            requireTerminalMessage(
+                    terminal, messages, records, agentResults);
+            return new ReconciledTurn(
+                    new CompletedTurn(
+                            terminal,
+                            List.copyOf(messages),
+                            List.copyOf(records)),
+                    natural);
+        }
+
+        private static boolean isAbortedTerminal(Terminal value) {
+            return !value.willRetry()
+                    && "aborted".equals(value.stopReason());
+        }
+
+        private static boolean isCancelledRetryTerminal(Terminal value) {
+            return value.willRetry()
+                    && "error".equals(value.stopReason());
+        }
+
+        private static boolean isNaturalTerminal(Terminal value) {
+            return !value.willRetry()
+                    && !"aborted".equals(value.stopReason());
+        }
+
+        private boolean authoritativeTerminal() {
+            return promptResponse
+                    && terminal != null
+                    && isNaturalTerminal(terminal)
+                    && !continuationReady
+                    && terminalMatchesLastMessage();
+        }
+
+        private boolean terminalMatchesLastMessage() {
+            return !messages.isEmpty()
+                    && terminal != null
+                    && terminal.assistant().equals(
+                            messages.get(messages.size() - 1));
+        }
+    }
+
+    private static String eventType(JsonNode event) throws IOException {
+        if (event == null || !event.isObject() || !event.path("type").isTextual()) {
+            throw new IOException("Pi emitted an invalid JSON event");
+        }
+        return event.path("type").textValue();
+    }
+
+    private static void requireResponse(JsonNode event, String id, String command)
+            throws IOException {
+        if (event.size() != 4
+                || !id.equals(event.path("id").textValue())
+                || !command.equals(event.path("command").textValue())
+                || !event.path("success").isBoolean()
+                || !event.path("success").booleanValue()) {
+            throw new IOException("Pi emitted an invalid " + command + " response");
+        }
+    }
+
+    private static void requireSettled(JsonNode event) throws IOException {
+        if (event.size() != 1) {
+            throw new IOException("Pi emitted an invalid settled event");
+        }
+    }
+
+    private static void acceptMessageEnd(
+            JsonNode event,
+            String prompt,
+            List<JsonNode> messages,
+            List<ExpectedRecord> records)
+            throws IOException {
+        JsonNode message = event.get("message");
+        if (event.size() != 2 || message == null || !message.isObject()) {
+            throw new IOException("Pi emitted an invalid message result");
+        }
+        String role = message.path("role").textValue();
+        if ("user".equals(role)) {
+            if (!messages.isEmpty() || !matchesPrompt(message.path("content"), prompt)) {
+                throw new IOException("Pi emitted an unrelated user message");
+            }
+        } else if (!"assistant".equals(role) && !"toolResult".equals(role)) {
+            throw new IOException("Pi emitted an unsupported message result");
+        } else if (messages.isEmpty()) {
+            throw new IOException("Pi emitted a message before the stage prompt");
+        }
+        JsonNode copy = message.deepCopy();
+        messages.add(copy);
+        records.add(new ExpectedRecord("message", copy, false));
+    }
+
+    private static void acceptCompactionEnd(
+            JsonNode event, List<ExpectedRecord> records)
+            throws IOException {
+        if (!isNonBlankText(event.path("reason"))
+                || !event.path("aborted").isBoolean()
+                || !event.path("willRetry").isBoolean()) {
+            throw new IOException("Pi emitted an invalid compaction result");
+        }
+        JsonNode result = event.get("result");
+        if (result == null) {
+            if (event.path("willRetry").booleanValue()
+                    || (event.path("aborted").booleanValue()
+                            ? event.size() != 4
+                            : event.size() != 5
+                                    || !isNonBlankText(event.path("errorMessage")))) {
+                throw new IOException("Pi emitted an invalid compaction result");
+            }
+            return;
+        }
+        if (event.size() != 5
+                || event.path("aborted").booleanValue()
+                || !result.isObject()
+                || result.size() != 5
+                || !isNonBlankText(result.path("summary"))
+                || !isNonBlankText(result.path("firstKeptEntryId"))
+                || !result.path("tokensBefore").isIntegralNumber()
+                || result.path("tokensBefore").longValue() < 0
+                || !result.path("estimatedTokensAfter").isIntegralNumber()
+                || result.path("estimatedTokensAfter").longValue() < 0
+                || result.get("details") == null) {
+            throw new IOException("Pi emitted an invalid compaction result");
+        }
+        ObjectNode persisted = JSON.createObjectNode();
+        persisted.set("summary", result.path("summary").deepCopy());
+        persisted.set(
+                "firstKeptEntryId",
+                result.path("firstKeptEntryId").deepCopy());
+        persisted.set(
+                "tokensBefore", result.path("tokensBefore").deepCopy());
+        persisted.set("details", result.path("details").deepCopy());
+        records.add(new ExpectedRecord(
+                "compaction",
+                persisted,
+                event.path("willRetry").booleanValue()));
+    }
+
+    private static void requireTerminalMessage(
+            Terminal terminal,
+            List<JsonNode> messages,
+            List<ExpectedRecord> records,
+            List<Terminal> agentResults)
+            throws IOException {
+        if (terminal == null
+                || messages.size() < 2
+                || !"user".equals(messages.get(0).path("role").textValue())
+                || !terminal.assistant().equals(messages.get(messages.size() - 1))) {
+            throw new IOException(
+                    "Pi terminal assistant does not match its ordered message results");
+        }
+        Set<String> outstandingTools = new HashSet<>();
+        for (int index = 1; index < messages.size(); index++) {
+            JsonNode message = messages.get(index);
+            String role = message.path("role").textValue();
+            if ("assistant".equals(role)) {
+                boolean last = index == messages.size() - 1;
+                String stopReason = message.path("stopReason").textValue();
+                if (!outstandingTools.isEmpty()) {
+                    if (!last || !"aborted".equals(stopReason)) {
+                        throw new IOException(
+                                "Pi emitted an assistant before all tool results");
+                    }
+                    outstandingTools.clear();
+                }
+                if ("toolUse".equals(stopReason)) {
+                    collectToolCalls(message.path("content"), outstandingTools);
+                    if (last || outstandingTools.isEmpty()) {
+                        throw new IOException(
+                                "Pi emitted an invalid tool-use assistant");
+                    }
+                } else {
+                    Terminal result = matchingAgentResult(
+                            message, agentResults);
+                    if (result == null
+                            || (!last
+                                    && !result.willRetry()
+                                    && !(("error".equals(stopReason)
+                                            || "length".equals(stopReason))
+                                            && hasCompactionContinuation(
+                                                    index, records)))) {
+                        throw new IOException(
+                                "Pi emitted an unrelated intermediate assistant");
+                    }
+                }
+            } else if ("toolResult".equals(role)) {
+                String callId = message.path("toolCallId").textValue();
+                if (callId == null || !outstandingTools.remove(callId)) {
+                    throw new IOException(
+                            "Pi emitted an unrelated tool result");
+                }
+            }
+        }
+        if (!outstandingTools.isEmpty()) {
+            throw new IOException("Pi omitted a tool result");
+        }
+        for (Terminal result : agentResults) {
+            if (messages.stream().noneMatch(result.assistant()::equals)) {
+                throw new IOException(
+                        "Pi agent result does not match an ordered message result");
+            }
+        }
+    }
+
+    private static boolean hasCompactionContinuation(
+            int messageIndex, List<ExpectedRecord> records) {
+        int currentMessage = -1;
+        boolean afterMessage = false;
+        for (ExpectedRecord record : records) {
+            if ("message".equals(record.type())) {
+                if (afterMessage) {
+                    return false;
+                }
+                currentMessage++;
+                afterMessage = currentMessage == messageIndex;
+            } else if (afterMessage
+                    && "compaction".equals(record.type())
+                    && record.continuesTurn()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Terminal matchingAgentResult(
+            JsonNode assistant, List<Terminal> agentResults) {
+        for (Terminal result : agentResults) {
+            if (result.assistant().equals(assistant)) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private static void collectToolCalls(
+            JsonNode content, Set<String> callIds)
+            throws IOException {
+        if (!content.isArray()) {
+            throw new IOException("Pi tool-use assistant has invalid content");
+        }
+        for (JsonNode item : content) {
+            if ("toolCall".equals(item.path("type").textValue())
+                    && isNonBlankText(item.path("id"))
+                    && !callIds.add(item.path("id").textValue())) {
+                throw new IOException("Pi emitted a duplicate tool call");
+            }
+        }
+    }
+
+    private static Terminal terminalCandidate(JsonNode event)
+            throws IOException {
+        JsonNode willRetry = event.get("willRetry");
+        if (willRetry == null || !willRetry.isBoolean()) {
+            throw new IOException("Pi agent result has an invalid retry state");
+        }
+        JsonNode messages = event.get("messages");
+        if (messages == null || !messages.isArray() || messages.isEmpty()) {
+            throw new IOException("Pi agent result has no assistant message");
+        }
+        JsonNode assistant = messages.get(messages.size() - 1);
+        JsonNode content = assistant.get("content");
+        String stopReason = assistant.path("stopReason").textValue();
+        if (!"assistant".equals(assistant.path("role").textValue())
+                || stopReason == null
+                || stopReason.isBlank()
+                || content == null
+                || !content.isArray()
+                || (willRetry.booleanValue()
+                        && !"error".equals(stopReason))) {
+            throw new IOException("Pi agent result has an invalid assistant message");
+        }
+        StringBuilder text = new StringBuilder();
+        for (JsonNode item : content) {
+            if ("text".equals(item.path("type").textValue()) && item.path("text").isTextual()) {
+                text.append(item.path("text").textValue());
+            }
+        }
+        return new Terminal(
+                assistant.deepCopy(),
+                stopReason,
+                text.toString(),
+                willRetry.booleanValue());
+    }
+
+    private static final class RpcOutput {
+
+        private static final int QUEUE_CAPACITY = 256;
+        private static final byte[] INVALID = "{\"type\":\"invalid-json-redacted\"}\n".getBytes(StandardCharsets.UTF_8);
+        private static final Set<String> TRANSIENT_EVENTS = Set.of(
+                "message_update", "tool_execution_update");
+
+        private final int limit;
+        private final BlockingQueue<Frame> frames = new LinkedBlockingQueue<>();
+        private final ByteArrayOutputStream safe = new ByteArrayOutputStream(8192);
+        private final AtomicBoolean limited = new AtomicBoolean();
+        private final AtomicBoolean protocolUnverifiable = new AtomicBoolean();
+        private long primaryMaterialBytes;
+        private long recoveryMaterialBytes;
+        private long queuedBytes;
+        private int queuedFrames;
+        private boolean settled;
+
+        private RpcOutput(int limit) {
+            this.limit = limit;
+        }
+
+        void read(InputStream input) throws IOException, InterruptedException {
+            ByteArrayOutputStream line = new ByteArrayOutputStream(8192);
+            boolean lineLimited = false;
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                for (int index = 0; index < read; index++) {
+                    int value = buffer[index] & 0xff;
+                    if (value == '\n') {
+                        emit(line.toByteArray(), lineLimited, true);
+                        line.reset();
+                        lineLimited = false;
+                    } else if (line.size() < limit) {
+                        line.write(value);
+                    } else {
+                        lineLimited = true;
+                        limited.set(true);
+                    }
+                }
+            }
+            if (line.size() > 0 || lineLimited) {
+                emit(line.toByteArray(), lineLimited, false);
+            }
+            frames.offer(Frame.end());
+        }
+
+        private void emit(byte[] bytes, boolean truncated, boolean terminated)
+                throws InterruptedException {
+            long rawBytes = bytes.length + (terminated ? 1L : 0L);
+            if (bytes.length > 0 && bytes[bytes.length - 1] == '\r') {
+                bytes = java.util.Arrays.copyOf(bytes, bytes.length - 1);
+            }
+            if (truncated) {
+                markUnverifiableLimit();
+                return;
+            }
+            JsonNode event;
+            try {
+                event = JSON.readTree(decodeStrict(bytes));
+            } catch (IOException e) {
+                append(INVALID);
+                protocolUnverifiable.set(true);
+                offer(Frame.failed("Pi emitted malformed JSON output"));
+                return;
+            }
+            String type = event == null ? null : event.path("type").textValue();
+            if (!settled && TRANSIENT_EVENTS.contains(type)) {
+                return;
+            }
+            if (!admitMaterial(rawBytes)) {
+                return;
+            }
+            byte[] retained;
+            try {
+                retained = JSON.writeValueAsBytes(sanitize(event));
+            } catch (IOException e) {
+                append(INVALID);
+                protocolUnverifiable.set(true);
+                offer(Frame.failed("Pi output could not be retained"));
+                return;
+            }
+            appendRetained(retained);
+            appendRetained(new byte[]{'\n'});
+            offer(Frame.event(event, rawBytes));
+            settled |= "agent_settled".equals(type);
+        }
+
+        private boolean admitMaterial(long rawBytes) {
+            if (!limited.get()
+                    && primaryMaterialBytes <= limit - rawBytes) {
+                primaryMaterialBytes += rawBytes;
+                return true;
+            }
+            limited.set(true);
+            if (recoveryMaterialBytes <= limit - rawBytes) {
+                recoveryMaterialBytes += rawBytes;
+                return true;
+            }
+            markUnverifiableLimit();
+            return false;
+        }
+
+        private void markUnverifiableLimit() {
+            limited.set(true);
+            if (protocolUnverifiable.compareAndSet(false, true)) {
+                append(INVALID);
+            }
+        }
+
+        private synchronized void offer(Frame frame) {
+            long rawBytes = frame.rawBytes();
+            if (queuedFrames >= QUEUE_CAPACITY
+                    || queuedBytes > limit - rawBytes) {
+                markUnverifiableLimit();
+                return;
+            }
+            queuedFrames++;
+            queuedBytes += rawBytes;
+            frames.offer(frame);
+        }
+
+        private synchronized void release(Frame frame) {
+            if (!frame.endOfStream()) {
+                queuedFrames--;
+                queuedBytes -= frame.rawBytes();
+            }
+        }
+
+        private synchronized void append(byte[] bytes) {
+            int remaining = limit - safe.size();
+            if (remaining > 0) {
+                safe.write(bytes, 0, Math.min(remaining, bytes.length));
+            }
+        }
+
+        private synchronized void appendRetained(byte[] bytes) {
+            if (bytes.length > limit - safe.size()) {
+                limited.set(true);
+                append(INVALID);
+                return;
+            }
+            safe.write(bytes, 0, bytes.length);
+        }
+
+        Frame poll(long nanos) throws InterruptedException {
+            Frame frame = frames.poll(nanos, TimeUnit.NANOSECONDS);
+            if (frame != null) {
+                release(frame);
+            }
+            return frame;
+        }
+
+        Frame pollNow() {
+            Frame frame = frames.poll();
+            if (frame != null) {
+                release(frame);
+            }
+            return frame;
+        }
+
+        boolean limited() {
+            return limited.get();
+        }
+
+        boolean protocolUnverifiable() {
+            return protocolUnverifiable.get();
+        }
+
+        synchronized byte[] safeBytes() {
+            return safe.toByteArray();
+        }
+
+        private static JsonNode sanitize(JsonNode event) {
+            ObjectNode safe = JSON.createObjectNode();
+            String type = event == null ? null : event.path("type").textValue();
+            if ("response".equals(type)) {
+                safe.put("type", "response");
+                String id = event.path("id").textValue();
+                safe.put(
+                        "id",
+                        PROMPT_ID.equals(id) || ABORT_ID.equals(id)
+                                ? id
+                                : ShipLocalStamp.REDACTED);
+                String command = event.path("command").textValue();
+                safe.put(
+                        "command",
+                        "prompt".equals(command) || "abort".equals(command)
+                                ? command
+                                : ShipLocalStamp.REDACTED);
+                if (event.path("success").isBoolean()) {
+                    safe.put("success", event.path("success").booleanValue());
+                }
+            } else if ("agent_end".equals(type)) {
+                safe.put("type", "agent_end");
+                if (event.path("willRetry").isBoolean()) {
+                    safe.put("willRetry", event.path("willRetry").booleanValue());
+                }
+                safe.put("content", ShipLocalStamp.REDACTED);
+            } else if ("agent_settled".equals(type)) {
+                safe.put("type", "agent_settled");
+            } else {
+                safe.put("type", "event-redacted");
+            }
+            return safe;
+        }
+    }
+
+    private static final class BoundedCapture {
+
+        private final int limit;
+        private final AtomicBoolean limited = new AtomicBoolean();
+        private final AtomicLong observed = new AtomicLong();
+
+        private BoundedCapture(int limit) {
+            this.limit = limit;
+        }
+
+        void read(InputStream input) throws IOException {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                long current = observed.get();
+                observed.set(current > Long.MAX_VALUE - read
+                        ? Long.MAX_VALUE
+                        : current + read);
+                if (observed.get() > limit) {
+                    limited.set(true);
+                }
+            }
+        }
+
+        boolean limited() {
+            return limited.get();
+        }
+
+        byte[] metadata() {
+            return ("{\"bytes\":" + observed.get()
+                    + ",\"limited\":" + limited()
+                    + ",\"content\":\"" + ShipLocalStamp.REDACTED + "\"}\n")
+                    .getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    private record Frame(
+            JsonNode event, String failure, boolean endOfStream, long rawBytes) {
+
+        private static Frame event(JsonNode event, long rawBytes) {
+            return new Frame(event, null, false, rawBytes);
+        }
+
+        private static Frame failed(String failure) {
+            return new Frame(null, failure, false, 0);
+        }
+
+        private static Frame end() {
+            return new Frame(null, null, true, 0);
+        }
+    }
+
+    private record SessionState(
+            Path file, long size, String digest, SessionTranscript transcript) {
+    }
+
+    private record ScratchSession(Path directory, SessionState previous) {
+    }
+
+    private record SessionTranscript(JsonNode header, List<JsonNode> entries) {
+    }
+
+    private record ExpectedRecord(
+            String type, JsonNode value, boolean continuesTurn) {
+    }
+
+    private record SessionLock(FileChannel channel, FileLock lock)
+            implements
+                AutoCloseable {
+
+        @Override
+        public void close() throws IOException {
+            IOException failure = null;
+            try {
+                lock.release();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                channel.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    private record Terminal(
+            JsonNode assistant, String stopReason, String text, boolean willRetry) {
+    }
+
+    private record CompletedTurn(
+            Terminal terminal,
+            List<JsonNode> messages,
+            List<ExpectedRecord> records) {
+    }
+
+    private record ReconciledTurn(
+            CompletedTurn turn, boolean naturalCompletion) {
+    }
+
+    private record RpcRun(
+            Instant startedAt,
+            Instant endedAt,
+            boolean timedOut,
+            boolean outputLimited,
+            Integer exitCode,
+            Path stdoutLog,
+            String stdoutDigest,
+            Path stderrLog,
+            String stderrDigest,
+            String assistantText,
+            String stopReason,
+            String protocolFailure,
+            Path validatedSession,
+            boolean restoreInterrupt) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -75,6 +75,8 @@ public final class PiWorker {
     private static final int MAX_SESSION_HEADER_BYTES = 64 * 1024;
     private static final long MAX_SESSION_BYTES = 64L * 1024 * 1024;
     private static final int MAX_VERSION_LENGTH = 1024;
+    // Short values cannot be distinguished reliably from ordinary transcript text.
+    private static final int MIN_SENSITIVE_TRANSCRIPT_MATCH_LENGTH = 8;
     private static final Duration VERSION_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration ABORT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration ABORT_DRAIN_RESERVE = Duration.ofSeconds(1);
@@ -1926,7 +1928,8 @@ public final class PiWorker {
             return false;
         }
         for (String value : sensitive) {
-            if (text.contains(value)) {
+            if (value.length() >= MIN_SENSITIVE_TRANSCRIPT_MATCH_LENGTH
+                    && text.contains(value)) {
                 return true;
             }
         }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -173,7 +173,7 @@ public final class PiWorker {
             String detectedVersion;
             try {
                 detectedVersion = requireVersion(
-                        firstLine(Files.readAllBytes(versionRun.stdoutLog())),
+                        firstLine(versionRun.capturedStdout()),
                         "detected Pi version");
             } catch (IllegalArgumentException | IOException e) {
                 throw new IOException(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -145,6 +144,8 @@ public final class PiWorker {
         requireDisjoint(sessionDirectory, evidenceDirectory, "session and evidence directories");
         UserPrincipal sessionOwner = requirePrivateSessionDirectory(sessionDirectory);
         String prompt = requirePrompt(request.prompt());
+        List<String> sensitiveValues = List.copyOf(
+                sensitiveEnvironmentValues(environment));
 
         LocalCommandRunner.Result versionRun = commands.run(new Command(
                 executable,
@@ -152,7 +153,8 @@ public final class PiWorker {
                 workingDirectory,
                 evidenceDirectory,
                 VERSION_TIMEOUT.compareTo(timeout) < 0 ? VERSION_TIMEOUT : timeout,
-                MAX_LOG_BYTES));
+                MAX_LOG_BYTES,
+                sensitiveValues));
         Throwable primary = null;
         Path scratchDirectory = null;
         SessionLock sessionLock = null;
@@ -199,11 +201,9 @@ public final class PiWorker {
                     sessionDirectory, sessionId, workingDirectory, sessionOwner);
             refuseCompletedTurnReplay(previousSession.transcript(), prompt);
             ScratchSession scratch = createScratch(
-                    sessionDirectory, sessionId, sessionOwner, previousSession);
+                    sessionDirectory, sessionId, previousSession);
             scratchDirectory = scratch.directory();
             List<String> arguments = arguments(request, scratch.directory(), sessionId);
-            List<String> sensitiveValues = List.copyOf(
-                    sensitiveEnvironmentValues(environment));
             RpcRun turn = runRpc(
                     arguments,
                     workingDirectory,
@@ -273,8 +273,6 @@ public final class PiWorker {
                 publishSession(
                         turn.validatedSession(),
                         sessionDirectory,
-                        sessionId,
-                        sessionOwner,
                         previousSession);
                 published = true;
             }
@@ -362,9 +360,8 @@ public final class PiWorker {
         Process process = new ProcessBuilder(vector)
                 .directory(workingDirectory.toFile())
                 .start();
-        List<ProcessHandle> observedChildren = new CopyOnWriteArrayList<>();
         Thread shutdownHook = new Thread(
-                () -> terminateRpc(process, kill, observedChildren),
+                () -> terminateRpc(process, kill),
                 "camel-kit-pi-rpc-shutdown");
         RpcOutput stdout = new RpcOutput(MAX_LOG_BYTES);
         BoundedCapture stderr = new BoundedCapture(MAX_LOG_BYTES);
@@ -395,7 +392,7 @@ public final class PiWorker {
             acquired = true;
         } finally {
             if (!acquired) {
-                terminateRpc(process, kill, observedChildren);
+                terminateRpc(process, kill);
                 close(process.getOutputStream());
                 if (promptWriter != null) {
                     promptWriter.cancel(true);
@@ -427,7 +424,6 @@ public final class PiWorker {
         try {
             long deadline = deadline(timeout);
             while (!lifecycle.complete()) {
-                LocalCommandRunner.rememberDescendants(process, observedChildren);
                 IOException writeFailure = completedFailure(promptWriter, "Could not send the Pi prompt");
                 if (writeFailure != null) {
                     protocolFailure = writeFailure.getMessage();
@@ -488,7 +484,6 @@ public final class PiWorker {
                             process,
                             promptWriter,
                             stdout,
-                            observedChildren,
                             lifecycle);
                 }
                 if (reconciliation == null) {
@@ -508,13 +503,12 @@ public final class PiWorker {
             if (lifecycle.complete() || reconciliation != null) {
                 lateInterrupted |= Thread.interrupted();
                 if (!awaitExitUninterruptibly(process, EXIT_TIMEOUT)
-                        && !terminateRpc(process, kill, observedChildren)) {
-                    throw new IOException("Pi RPC process and observed descendants could not be reaped");
+                        && !terminateRpc(process, kill)) {
+                    throw new IOException("Pi RPC process group could not be reaped");
                 }
                 lateInterrupted |= Thread.interrupted();
-                LocalCommandRunner.rememberDescendants(process, observedChildren);
-                if (!terminateRpc(process, kill, observedChildren)) {
-                    throw new IOException("Pi RPC left an observed descendant process running");
+                if (!terminateRpc(process, kill)) {
+                    throw new IOException("Pi RPC process group could not be reaped");
                 }
                 awaitUninterruptibly(stdoutReader, "Pi RPC output did not close");
                 lateInterrupted |= Thread.interrupted();
@@ -533,12 +527,11 @@ public final class PiWorker {
                         completedTurn);
             } else {
                 if (!awaitExit(process, EXIT_TIMEOUT)
-                        && !terminateRpc(process, kill, observedChildren)) {
-                    throw new IOException("Pi RPC process and observed descendants could not be reaped");
+                        && !terminateRpc(process, kill)) {
+                    throw new IOException("Pi RPC process group could not be reaped");
                 }
-                LocalCommandRunner.rememberDescendants(process, observedChildren);
-                if (!terminateRpc(process, kill, observedChildren)) {
-                    throw new IOException("Pi RPC left an observed descendant process running");
+                if (!terminateRpc(process, kill)) {
+                    throw new IOException("Pi RPC process group could not be reaped");
                 }
                 await(stdoutReader, "Pi RPC output did not close");
                 await(stderrReader, "Pi RPC error output did not close");
@@ -623,18 +616,17 @@ public final class PiWorker {
                     process,
                     promptWriter,
                     stdout,
-                    observedChildren,
                     lifecycle);
             Thread.interrupted();
             if (reconciliation != null) {
                 close(process.getOutputStream());
             } else {
-                terminateRpc(process, kill, observedChildren);
+                terminateRpc(process, kill);
             }
             if (!awaitExitUninterruptibly(process, EXIT_TIMEOUT)
-                    && !terminateRpc(process, kill, observedChildren)) {
+                    && !terminateRpc(process, kill)) {
                 e.addSuppressed(new IOException(
-                        "Interrupted Pi RPC process and observed descendants could not be reaped"));
+                        "Interrupted Pi RPC process group could not be reaped"));
             }
             Thread.interrupted();
             if (reconciliation == null) {
@@ -646,11 +638,9 @@ public final class PiWorker {
                         throw new IOException(
                                 "Interrupted Pi RPC process did not exit after its acknowledged abort");
                     }
-                    LocalCommandRunner.rememberDescendants(
-                            process, observedChildren);
-                    if (!terminateRpc(process, kill, observedChildren)) {
+                    if (!terminateRpc(process, kill)) {
                         throw new IOException(
-                                "Interrupted Pi RPC left a descendant process running");
+                                "Interrupted Pi RPC process group could not be reaped");
                     }
                     awaitUninterruptibly(
                             stdoutReader,
@@ -675,8 +665,6 @@ public final class PiWorker {
                         publishSession(
                                 validatedSession,
                                 canonicalSessionDirectory,
-                                sessionId,
-                                sessionOwner,
                                 canonicalPreviousSession);
                     } else {
                         e.addSuppressed(new IOException(
@@ -689,9 +677,9 @@ public final class PiWorker {
             close(process.getOutputStream());
             throw e;
         } catch (IOException | RuntimeException e) {
-            if (!terminateRpc(process, kill, observedChildren)) {
+            if (!terminateRpc(process, kill)) {
                 e.addSuppressed(new IOException(
-                        "Failed Pi RPC process and observed descendants could not be reaped"));
+                        "Failed Pi RPC process group could not be reaped"));
             }
             close(process.getOutputStream());
             throw e;
@@ -719,7 +707,6 @@ public final class PiWorker {
             Process process,
             Future<?> promptWriter,
             RpcOutput stdout,
-            List<ProcessHandle> observedChildren,
             Lifecycle priorLifecycle) {
         long deadline = deadline(ABORT_TIMEOUT);
         ExecutorService writer = null;
@@ -729,7 +716,6 @@ public final class PiWorker {
         boolean inputClosed = false;
         try {
             while (true) {
-                LocalCommandRunner.rememberDescendants(process, observedChildren);
                 long abortRemaining = deadline - System.nanoTime();
                 if (abortRemaining <= 0) {
                     return null;
@@ -936,11 +922,8 @@ public final class PiWorker {
         }
     }
 
-    private static boolean terminateRpc(
-            Process process, Path kill, List<ProcessHandle> observedChildren) {
-        boolean groupReaped = LocalCommandRunner.terminateProcessGroup(process, kill);
-        boolean observedReaped = LocalCommandRunner.terminateAll(process, observedChildren);
-        return groupReaped && observedReaped;
+    private static boolean terminateRpc(Process process, Path kill) {
+        return LocalCommandRunner.terminateProcessGroup(process, kill);
     }
 
     private static IOException completedFailureUninterruptibly(
@@ -1262,11 +1245,7 @@ public final class PiWorker {
                 || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException(label + " must be a real directory");
         }
-        Path real = normalized.toRealPath();
-        if (!real.equals(normalized)) {
-            throw new IOException(label + " must not cross a symbolic link");
-        }
-        return real;
+        return normalized.toRealPath();
     }
 
     private static void requireDisjoint(Path first, Path second, String label) throws IOException {
@@ -1355,7 +1334,6 @@ public final class PiWorker {
     private static ScratchSession createScratch(
             Path directory,
             String sessionId,
-            UserPrincipal owner,
             SessionState previous)
             throws IOException {
         Path scratch = Files.createTempDirectory(
@@ -1363,12 +1341,6 @@ public final class PiWorker {
                 SCRATCH_PREFIX + sessionId + "-",
                 PosixFilePermissions.asFileAttribute(PRIVATE_DIRECTORY));
         try {
-            if (!owner.equals(Files.getOwner(scratch, LinkOption.NOFOLLOW_LINKS))
-                    || !PRIVATE_DIRECTORY.equals(
-                            Files.getPosixFilePermissions(
-                                    scratch, LinkOption.NOFOLLOW_LINKS))) {
-                throw new IOException("Pi stage scratch directory must be owned by the current user and 0700");
-            }
             if (previous.file() == null) {
                 return new ScratchSession(
                         scratch,
@@ -1381,9 +1353,6 @@ public final class PiWorker {
                     copy,
                     StandardCopyOption.COPY_ATTRIBUTES,
                     LinkOption.NOFOLLOW_LINKS);
-            if (!previous.digest().equals(fileDigest(copy, previous.size()))) {
-                throw new IOException("Pi stage session changed while it was copied");
-            }
             return new ScratchSession(
                     scratch,
                     new SessionState(
@@ -1404,29 +1373,9 @@ public final class PiWorker {
     private static void publishSession(
             Path scratchFile,
             Path directory,
-            String sessionId,
-            UserPrincipal owner,
             SessionState previous)
             throws IOException {
-        List<Path> current = sessionFiles(directory, sessionId, owner, true);
-        if (previous.file() == null) {
-            if (!current.isEmpty()) {
-                throw new IOException("Pi stage session appeared while the worker was running");
-            }
-        } else if (current.size() != 1
-                || !previous.file().equals(current.get(0))
-                || Files.size(previous.file()) != previous.size()
-                || !previous.digest().equals(fileDigest(previous.file(), previous.size()))) {
-            throw new IOException("Pi stage session changed while the worker was running");
-        }
         Files.setPosixFilePermissions(scratchFile, PRIVATE_FILE);
-        if (!owner.equals(Files.getOwner(scratchFile, LinkOption.NOFOLLOW_LINKS))
-                || !PRIVATE_FILE.equals(
-                        Files.getPosixFilePermissions(
-                                scratchFile, LinkOption.NOFOLLOW_LINKS))) {
-            throw new IOException(
-                    "Pi stage session candidate must be owned by the current user and 0600");
-        }
         try (FileChannel channel = FileChannel.open(
                 scratchFile,
                 StandardOpenOption.WRITE,
@@ -1655,51 +1604,30 @@ public final class PiWorker {
         String suffix = "_" + sessionId + ".jsonl";
         try (DirectoryStream<Path> files = Files.newDirectoryStream(directory)) {
             for (Path file : files) {
-                if (Files.isSymbolicLink(file)) {
-                    throw new IOException("Pi session directory contains an unsafe entry");
-                }
                 String name = file.getFileName().toString();
-                if (Files.isDirectory(file, LinkOption.NOFOLLOW_LINKS)) {
-                    if (!name.startsWith(SCRATCH_PREFIX)
-                            || !owner.equals(
-                                    Files.getOwner(
-                                            file, LinkOption.NOFOLLOW_LINKS))
-                            || !PRIVATE_DIRECTORY.equals(
-                                    Files.getPosixFilePermissions(
-                                            file, LinkOption.NOFOLLOW_LINKS))) {
-                        throw new IOException(
-                                "Pi session directory contains an unsafe entry");
-                    }
+                if (!name.endsWith(suffix)) {
                     continue;
+                }
+                if (Files.isSymbolicLink(file)) {
+                    throw new IOException("Pi stage session must not be a symbolic link");
                 }
                 if (!Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
                         || !owner.equals(
                                 Files.getOwner(file, LinkOption.NOFOLLOW_LINKS))) {
                     throw new IOException(
-                            "Pi session directory contains an unsafe entry");
+                            "Pi stage session must be a regular file owned by the current user");
                 }
-                if (name.startsWith(".") && name.endsWith(".lock")) {
-                    if (!PRIVATE_FILE.equals(
-                            Files.getPosixFilePermissions(
-                                    file, LinkOption.NOFOLLOW_LINKS))) {
-                        throw new IOException(
-                                "Pi session directory contains an unsafe entry");
-                    }
-                    continue;
+                if (canonical
+                        && !PRIVATE_FILE.equals(
+                                Files.getPosixFilePermissions(
+                                        file,
+                                        LinkOption.NOFOLLOW_LINKS))) {
+                    throw new IOException(
+                            "Pi stage session permissions must be 0600");
                 }
-                if (name.endsWith(suffix)) {
-                    if (canonical
-                            && !PRIVATE_FILE.equals(
-                                    Files.getPosixFilePermissions(
-                                            file,
-                                            LinkOption.NOFOLLOW_LINKS))) {
-                        throw new IOException(
-                                "Pi stage session permissions must be 0600");
-                    }
-                    matches.add(file.toAbsolutePath().normalize());
-                    if (matches.size() > 1) {
-                        break;
-                    }
+                matches.add(file.toAbsolutePath().normalize());
+                if (matches.size() > 1) {
+                    break;
                 }
             }
         }
@@ -1956,9 +1884,7 @@ public final class PiWorker {
             Map<String, String> environment) {
         Set<String> values = new HashSet<>();
         environment.forEach((name, value) -> {
-            if (ShipLocalStamp.isSensitiveEnvironmentName(name)
-                    && value != null
-                    && !value.isEmpty()) {
+            if (LocalCommandRunner.isSensitiveEnvironmentValue(name, value)) {
                 values.add(value);
             }
         });

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
@@ -1,0 +1,542 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Prepares one controller-owned staging directory without changing the live project. */
+public final class ShipWorkspace {
+
+    private static final String WORKSPACE = "workspace";
+    private static final String STALE_WORKSPACE = ".workspace-stale";
+    private static final String CANDIDATE = "candidate";
+    private static final String BINDING = "workspace.json";
+    private static final String BINDING_TEMPORARY = ".workspace.json.tmp";
+    private static final int MAX_BINDING_BYTES = 16 * 1024;
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+
+    private ShipWorkspace() {
+    }
+
+    public static Path prepare(
+            Path liveProject,
+            Path runDirectory,
+            String runId,
+            int attempt,
+            String inputDigest)
+            throws IOException {
+        Path project = realProject(liveProject);
+        Path run = realDirectory(runDirectory, "Ship run directory");
+        requireBindingFields(runId, attempt, inputDigest);
+        if (run.startsWith(project) || project.startsWith(run)) {
+            throw new IOException("Ship run directory and live project must be disjoint");
+        }
+        Path workspace = run.resolve(WORKSPACE);
+        Path staleWorkspace = run.resolve(STALE_WORKSPACE);
+        recoverPublication(project, runId, workspace, staleWorkspace);
+        cleanAbandonedWorkspaces(run);
+        if (exists(workspace)) {
+            repairPublishedWorkspace(workspace);
+            Binding binding = bindingFor(workspace, project, runId);
+            if (attempt < binding.attempt()) {
+                throw new IOException("Ship workspace belongs to a newer Execute attempt");
+            }
+            if (inputDigest.equals(binding.inputDigest())) {
+                boolean wasLaterAttempt = attempt > binding.attempt();
+                if (wasLaterAttempt) {
+                    advanceAttempt(workspace, binding, attempt);
+                }
+                try {
+                    ProjectSnapshot snapshot = verify(
+                            project,
+                            workspace.resolve(CANDIDATE),
+                            runId,
+                            attempt,
+                            inputDigest);
+                    return Path.of(snapshot.root());
+                } catch (StaleBaselineException e) {
+                    if (!wasLaterAttempt) {
+                        throw e;
+                    }
+                }
+            } else {
+                if (attempt <= binding.attempt()) {
+                    throw new IOException("Ship workspace binding does not match the active stage");
+                }
+                try {
+                    verify(
+                            project,
+                            workspace.resolve(CANDIDATE),
+                            runId,
+                            binding.attempt(),
+                            binding.inputDigest());
+                } catch (StaleBaselineException ignored) {
+                    // A later Execute attempt is authorized to rebuild a stale valid workspace.
+                }
+            }
+        }
+
+        Path temporary = Files.createTempDirectory(
+                run, ".workspace-", fileAttributes(run, "rwx------"));
+        try {
+            Path candidate = temporary.resolve(CANDIDATE);
+            createPrivateDirectory(candidate);
+            ProjectSnapshot materialized = ProjectEvidenceFiles.materializeMaterial(project, candidate);
+            String baseline = materialIdentity(materialized);
+            writeBinding(
+                    temporary.resolve(BINDING),
+                    new Binding(1, project.toString(), runId, attempt, inputDigest, baseline));
+            makeBindingReadOnly(temporary);
+            publish(temporary, workspace, staleWorkspace);
+        } catch (IOException | RuntimeException preparationFailure) {
+            try {
+                deleteTree(temporary);
+            } catch (IOException cleanupFailure) {
+                preparationFailure.addSuppressed(cleanupFailure);
+            }
+            throw preparationFailure;
+        }
+        return workspace.resolve(CANDIDATE).toRealPath(LinkOption.NOFOLLOW_LINKS);
+    }
+
+    /**
+     * Verifies one published candidate against the exact controller stage that prepared it.
+     */
+    public static ProjectSnapshot verify(
+            Path liveProject,
+            Path suppliedCandidate,
+            String runId,
+            int attempt,
+            String inputDigest)
+            throws IOException {
+        Path project = realProject(liveProject);
+        requireBindingFields(runId, attempt, inputDigest);
+        Path candidate = realDirectory(suppliedCandidate, "Ship workspace candidate");
+        Path workspace = candidate.getParent();
+        if (workspace == null
+                || !CANDIDATE.equals(String.valueOf(candidate.getFileName()))
+                || !WORKSPACE.equals(String.valueOf(workspace.getFileName()))
+                || Files.isSymbolicLink(workspace)
+                || !workspace.toRealPath(LinkOption.NOFOLLOW_LINKS).equals(workspace)) {
+            throw new IOException("Ship workspace candidate is not in a published workspace");
+        }
+        Binding binding = readBinding(workspace.resolve(BINDING));
+        if (!project.toString().equals(binding.projectDirectory())
+                || !runId.equals(binding.runId())
+                || attempt != binding.attempt()
+                || !inputDigest.equals(binding.inputDigest())) {
+            throw new IOException("Ship workspace binding does not match the active stage");
+        }
+        ProjectSnapshot snapshot = ProjectEvidenceFiles.captureStaged(candidate);
+        String currentBaseline = materialIdentity(ProjectEvidenceFiles.capture(project));
+        if (!currentBaseline.equals(binding.baselineDigest())) {
+            throw new StaleBaselineException(
+                    "Ship workspace baseline no longer matches the live project");
+        }
+        return snapshot;
+    }
+
+    private static Path realProject(Path supplied) throws IOException {
+        if (supplied == null) {
+            throw new IOException("Ship project directory is required");
+        }
+        final Path normalized;
+        try {
+            normalized = supplied.toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            throw new IOException("Ship project directory is invalid", e);
+        }
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Ship project must be a real directory");
+        }
+        Path real = normalized.toRealPath();
+        if (!real.equals(normalized)) {
+            throw new IOException("Ship project must not cross a symbolic link");
+        }
+        return real;
+    }
+
+    private static Path realDirectory(Path supplied, String label) throws IOException {
+        if (supplied == null) {
+            throw new IOException(label + " is required");
+        }
+        Path normalized = supplied.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(label + " must be a real directory");
+        }
+        Path real = normalized.toRealPath();
+        if (!real.equals(normalized)) {
+            throw new IOException(label + " must not cross a symbolic link");
+        }
+        return real;
+    }
+
+    private static void requireBindingFields(
+            String runId, int attempt, String inputDigest)
+            throws IOException {
+        requireBindingFields(runId, inputDigest);
+        if (attempt < 1) {
+            throw new IOException("Ship workspace stage binding is invalid");
+        }
+    }
+
+    private static void requireBindingFields(String runId, String inputDigest)
+            throws IOException {
+        if (!ShipRun.isRunId(runId) || !ShipDigest.isSha256(inputDigest)) {
+            throw new IOException("Ship workspace stage binding is invalid");
+        }
+    }
+
+    private static boolean exists(Path path) {
+        return Files.exists(path, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(path);
+    }
+
+    private static void createPrivateDirectory(Path directory) throws IOException {
+        if (directory.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rwx------")));
+        } else {
+            Files.createDirectory(directory);
+        }
+    }
+
+    private static Binding readBinding(Path path) throws IOException {
+        if (Files.isSymbolicLink(path)
+                || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Ship workspace binding is invalid");
+        }
+        byte[] encoded;
+        try (InputStream input = Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS)) {
+            encoded = input.readNBytes(MAX_BINDING_BYTES + 1);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_BINDING_BYTES) {
+            throw new IOException("Ship workspace binding is invalid");
+        }
+        final Binding binding;
+        try {
+            binding = JSON.readValue(encoded, Binding.class);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Ship workspace binding is invalid", e);
+        }
+        final Path project;
+        try {
+            project = Path.of(binding.projectDirectory());
+        } catch (RuntimeException e) {
+            throw new IOException("Ship workspace binding is invalid", e);
+        }
+        if (binding.schemaVersion() != 1
+                || !ShipRun.isRunId(binding.runId())
+                || binding.attempt() < 1
+                || !ShipDigest.isSha256(binding.inputDigest())
+                || !ShipDigest.isSha256(binding.baselineDigest())
+                || !project.isAbsolute()
+                || !project.normalize().toString().equals(binding.projectDirectory())) {
+            throw new IOException("Ship workspace binding is invalid");
+        }
+        return binding;
+    }
+
+    private static Binding bindingFor(Path workspace, Path project, String runId)
+            throws IOException {
+        Path published = realDirectory(workspace, "Ship workspace");
+        if (!WORKSPACE.equals(String.valueOf(published.getFileName()))) {
+            throw new IOException("Ship workspace is not published at the expected path");
+        }
+        Binding binding = readBinding(published.resolve(BINDING));
+        if (!project.toString().equals(binding.projectDirectory())
+                || !runId.equals(binding.runId())) {
+            throw new IOException("Ship workspace binding does not match its controller run");
+        }
+        return binding;
+    }
+
+    private static void publish(Path temporary, Path workspace, Path staleWorkspace)
+            throws IOException {
+        boolean displaced = false;
+        try {
+            if (exists(workspace)) {
+                Files.move(workspace, staleWorkspace, StandardCopyOption.ATOMIC_MOVE);
+                displaced = true;
+            }
+            Files.move(temporary, workspace, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException | RuntimeException publicationFailure) {
+            if (displaced && !exists(workspace)) {
+                try {
+                    Files.move(staleWorkspace, workspace, StandardCopyOption.ATOMIC_MOVE);
+                } catch (IOException restorationFailure) {
+                    publicationFailure.addSuppressed(restorationFailure);
+                }
+            }
+            try {
+                deleteTree(temporary);
+            } catch (IOException cleanupFailure) {
+                publicationFailure.addSuppressed(cleanupFailure);
+            }
+            throw publicationFailure;
+        }
+        if (displaced) {
+            deleteTree(staleWorkspace);
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!exists(root)) {
+            return;
+        }
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(
+                    Path directory, BasicFileAttributes attributes)
+                    throws IOException {
+                if (directory.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                    Files.setPosixFilePermissions(
+                            directory, PosixFilePermissions.fromString("rwx------"));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+                    throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path directory, IOException failure)
+                    throws IOException {
+                if (failure != null) {
+                    throw failure;
+                }
+                Files.delete(directory);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void recoverPublication(
+            Path project,
+            String runId,
+            Path workspace,
+            Path staleWorkspace)
+            throws IOException {
+        if (!exists(staleWorkspace)) {
+            return;
+        }
+        if (!exists(workspace)) {
+            Files.move(staleWorkspace, workspace, StandardCopyOption.ATOMIC_MOVE);
+            return;
+        }
+        try {
+            repairPublishedWorkspace(workspace);
+            bindingFor(workspace, project, runId);
+            ProjectEvidenceFiles.captureStaged(workspace.resolve(CANDIDATE));
+        } catch (IOException invalidPublication) {
+            try {
+                deleteTree(workspace);
+                Files.move(staleWorkspace, workspace, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException recoveryFailure) {
+                invalidPublication.addSuppressed(recoveryFailure);
+                throw invalidPublication;
+            }
+        }
+        deleteTree(staleWorkspace);
+    }
+
+    private static void cleanAbandonedWorkspaces(Path run)
+            throws IOException {
+        List<Path> abandoned = new ArrayList<>();
+        try (var entries = Files.list(run)) {
+            entries.filter(path -> {
+                String name = String.valueOf(path.getFileName());
+                return name.startsWith(".workspace-")
+                        && !STALE_WORKSPACE.equals(name);
+            }).forEach(abandoned::add);
+        }
+        abandoned.sort(Comparator.comparing(Path::toString));
+        for (Path path : abandoned) {
+            deleteTree(path);
+        }
+    }
+
+    private static void repairPublishedWorkspace(Path workspace) throws IOException {
+        Path published = realDirectory(workspace, "Ship workspace");
+        if (published.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(
+                    published, PosixFilePermissions.fromString("rwx------"));
+        }
+        try {
+            deleteTree(published.resolve(BINDING_TEMPORARY));
+        } finally {
+            sealWorkspaceDirectory(published);
+        }
+    }
+
+    private static void advanceAttempt(Path workspace, Binding binding, int attempt)
+            throws IOException {
+        Path temporary = workspace.resolve(BINDING_TEMPORARY);
+        if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(
+                    workspace, PosixFilePermissions.fromString("rwx------"));
+        }
+        try {
+            deleteTree(temporary);
+            writeBinding(
+                    temporary,
+                    new Binding(
+                            binding.schemaVersion(),
+                            binding.projectDirectory(),
+                            binding.runId(),
+                            attempt,
+                            binding.inputDigest(),
+                            binding.baselineDigest()));
+            if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                makeBindingFileReadOnly(temporary);
+            }
+            Files.move(
+                    temporary,
+                    workspace.resolve(BINDING),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        } finally {
+            try {
+                deleteTree(temporary);
+            } finally {
+                sealWorkspaceDirectory(workspace);
+            }
+        }
+    }
+
+    private static void writeBinding(Path target, Binding binding) throws IOException {
+        byte[] encoded = JSON.writeValueAsBytes(binding);
+        if (encoded.length > MAX_BINDING_BYTES) {
+            throw new IOException("Ship workspace binding exceeds its size limit");
+        }
+        Files.createFile(target, fileAttributes(target.getParent(), "rw-------"));
+        try (FileChannel channel = FileChannel.open(
+                target, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            ByteBuffer content = ByteBuffer.wrap(encoded);
+            while (content.hasRemaining()) {
+                channel.write(content);
+            }
+            channel.force(true);
+        }
+    }
+
+    private static void makeBindingReadOnly(Path workspace) throws IOException {
+        if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            makeBindingFileReadOnly(workspace.resolve(BINDING));
+            sealWorkspaceDirectory(workspace);
+        }
+    }
+
+    private static void makeBindingFileReadOnly(Path binding) throws IOException {
+        Files.setPosixFilePermissions(
+                binding, PosixFilePermissions.fromString("r--------"));
+    }
+
+    private static void sealWorkspaceDirectory(Path workspace) throws IOException {
+        if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(
+                    workspace, PosixFilePermissions.fromString("r-x------"));
+        }
+    }
+
+    private static FileAttribute<?>[] fileAttributes(Path path, String permissions) {
+        return path.getFileSystem().supportedFileAttributeViews().contains("posix")
+                ? new FileAttribute<?>[]{
+                        PosixFilePermissions.asFileAttribute(
+                                PosixFilePermissions.fromString(permissions))}
+                : new FileAttribute<?>[0];
+    }
+
+    private static String materialIdentity(ProjectSnapshot snapshot) {
+        ByteArrayOutputStream framed = new ByteArrayOutputStream();
+        field(framed, "camel-kit.ship.workspace-material.v1");
+        field(framed, snapshot.policyDigest());
+        snapshot.directories().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                field(framed, "directory");
+                field(framed, path);
+                field(framed, Integer.toString(entry.unixMode() & 0777));
+            }
+        });
+        snapshot.files().forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                field(framed, "file");
+                field(framed, path);
+                field(framed, Long.toString(entry.size()));
+                field(framed, entry.digest());
+                field(framed, Integer.toString(entry.unixMode() & 0777));
+            }
+        });
+        return ShipDigest.sha256(framed.toByteArray());
+    }
+
+    private static void field(ByteArrayOutputStream output, String value) {
+        byte[] encoded = Objects.requireNonNull(value, "workspace identity field")
+                .getBytes(StandardCharsets.UTF_8);
+        output.writeBytes(ByteBuffer.allocate(Integer.BYTES).putInt(encoded.length).array());
+        output.writeBytes(encoded);
+    }
+
+    private record Binding(
+            int schemaVersion,
+            String projectDirectory,
+            String runId,
+            int attempt,
+            String inputDigest,
+            String baselineDigest) {
+    }
+
+    public static final class StaleBaselineException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        private StaleBaselineException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
@@ -125,7 +125,6 @@ public final class ShipWorkspace {
             writeBinding(
                     temporary.resolve(BINDING),
                     new Binding(1, project.toString(), runId, attempt, inputDigest, baseline));
-            makeBindingReadOnly(temporary);
             publish(temporary, workspace, staleWorkspace);
         } catch (IOException | RuntimeException preparationFailure) {
             try {
@@ -154,9 +153,7 @@ public final class ShipWorkspace {
         Path workspace = candidate.getParent();
         if (workspace == null
                 || !CANDIDATE.equals(String.valueOf(candidate.getFileName()))
-                || !WORKSPACE.equals(String.valueOf(workspace.getFileName()))
-                || Files.isSymbolicLink(workspace)
-                || !workspace.toRealPath(LinkOption.NOFOLLOW_LINKS).equals(workspace)) {
+                || !WORKSPACE.equals(String.valueOf(workspace.getFileName()))) {
             throw new IOException("Ship workspace candidate is not in a published workspace");
         }
         Binding binding = readBinding(workspace.resolve(BINDING));
@@ -189,11 +186,7 @@ public final class ShipWorkspace {
                 || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException("Ship project must be a real directory");
         }
-        Path real = normalized.toRealPath();
-        if (!real.equals(normalized)) {
-            throw new IOException("Ship project must not cross a symbolic link");
-        }
-        return real;
+        return normalized.toRealPath();
     }
 
     private static Path realDirectory(Path supplied, String label) throws IOException {
@@ -205,11 +198,7 @@ public final class ShipWorkspace {
                 || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
             throw new IOException(label + " must be a real directory");
         }
-        Path real = normalized.toRealPath();
-        if (!real.equals(normalized)) {
-            throw new IOException(label + " must not cross a symbolic link");
-        }
-        return real;
+        return normalized.toRealPath();
     }
 
     private static void requireBindingFields(
@@ -406,20 +395,12 @@ public final class ShipWorkspace {
             Files.setPosixFilePermissions(
                     published, PosixFilePermissions.fromString("rwx------"));
         }
-        try {
-            deleteTree(published.resolve(BINDING_TEMPORARY));
-        } finally {
-            sealWorkspaceDirectory(published);
-        }
+        deleteTree(published.resolve(BINDING_TEMPORARY));
     }
 
     private static void advanceAttempt(Path workspace, Binding binding, int attempt)
             throws IOException {
         Path temporary = workspace.resolve(BINDING_TEMPORARY);
-        if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-            Files.setPosixFilePermissions(
-                    workspace, PosixFilePermissions.fromString("rwx------"));
-        }
         try {
             deleteTree(temporary);
             writeBinding(
@@ -431,20 +412,13 @@ public final class ShipWorkspace {
                             attempt,
                             binding.inputDigest(),
                             binding.baselineDigest()));
-            if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-                makeBindingFileReadOnly(temporary);
-            }
             Files.move(
                     temporary,
                     workspace.resolve(BINDING),
                     StandardCopyOption.ATOMIC_MOVE,
                     StandardCopyOption.REPLACE_EXISTING);
         } finally {
-            try {
-                deleteTree(temporary);
-            } finally {
-                sealWorkspaceDirectory(workspace);
-            }
+            deleteTree(temporary);
         }
     }
 
@@ -461,25 +435,6 @@ public final class ShipWorkspace {
                 channel.write(content);
             }
             channel.force(true);
-        }
-    }
-
-    private static void makeBindingReadOnly(Path workspace) throws IOException {
-        if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-            makeBindingFileReadOnly(workspace.resolve(BINDING));
-            sealWorkspaceDirectory(workspace);
-        }
-    }
-
-    private static void makeBindingFileReadOnly(Path binding) throws IOException {
-        Files.setPosixFilePermissions(
-                binding, PosixFilePermissions.fromString("r--------"));
-    }
-
-    private static void sealWorkspaceDirectory(Path workspace) throws IOException {
-        if (workspace.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-            Files.setPosixFilePermissions(
-                    workspace, PosixFilePermissions.fromString("r-x------"));
         }
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -90,7 +90,7 @@ class DistributionConfigTest {
         assertEquals("central=https://repo1.maven.org/maven2/", config.citrusMcpRepos());
         assertEquals("https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots",
                 config.camelCatalogRepos());
-        assertEquals("0.80.3", config.piVersion());
+        assertEquals("0.80.6", config.piVersion());
         assertEquals("2.11.0", config.piMcpAdapterVersion());
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogServiceTest.java
@@ -66,6 +66,23 @@ class ShipCatalogServiceTest {
         assertTrue(error.getMessage().contains("real directory"));
     }
 
+    @Test
+    void localRepositoryBelowSymbolicAncestorIsAccepted() throws Exception {
+        Path realParent = Files.createDirectory(repository.resolve("real-parent"));
+        Path symbolicParent = repository.resolve("symbolic-parent");
+        Files.createSymbolicLink(symbolicParent, realParent.getFileName());
+        Path localRepository = symbolicParent.resolve("repository");
+        Files.createDirectories(localRepository);
+        writeJar(localRepository, "org.apache.camel", "camel-catalog", CAMEL_VERSION,
+                mainEntries(CAMEL_VERSION, "timer"));
+
+        CatalogEvidenceSet result = offlineService(localRepository).snapshot(
+                new CatalogTarget("main", CAMEL_VERSION, null, null)).evidenceFor(
+                        List.of(subject(Kind.COMPONENT, "timer")));
+
+        assertEquals(1, result.artifacts().size());
+    }
+
     @TempDir
     Path repository;
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -101,12 +101,21 @@ class ShipControllerTest {
         Path linkedState = Files.createSymbolicLink(
                 directory.resolve("linked-state"), embeddedState);
         assertFailure(
-                "state-root-invalid",
+                "state-project-overlap",
                 () -> new ShipController(linkedState).start(
                         project, Oversight.NEVER, List.of()));
         try (var entries = Files.list(embeddedState)) {
             assertTrue(entries.findAny().isEmpty());
         }
+
+        Path linkedProject = Files.createSymbolicLink(
+                directory.resolve("linked-project"), project);
+        Path nestedState = linkedProject.resolve("nested-state");
+        assertFailure(
+                "state-project-overlap",
+                () -> new ShipController(nestedState).start(
+                        project, Oversight.NEVER, List.of()));
+        assertFalse(Files.exists(project.resolve("nested-state")));
 
         Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
         Files.writeString(
@@ -140,12 +149,8 @@ class ShipControllerTest {
         Path realProject = Files.createDirectory(realParent.resolve("project"));
         Path rootLink = directory.resolve("project-link");
         Files.createSymbolicLink(rootLink, realProject);
-        Path parentLink = directory.resolve("parent-link");
-        Files.createSymbolicLink(parentLink, realParent);
         assertFailure("project-invalid",
                 () -> controller.start(rootLink, Oversight.NEVER, List.of()));
-        assertFailure("project-invalid",
-                () -> controller.start(parentLink.resolve("project"), Oversight.NEVER, List.of()));
 
         Path brokenPath = (Path) Proxy.newProxyInstance(
                 getClass().getClassLoader(),
@@ -155,6 +160,52 @@ class ShipControllerTest {
                 });
         assertFailure("project-invalid",
                 () -> controller.start(brokenPath, Oversight.NEVER, List.of()));
+    }
+
+    @Test
+    void startsAProjectBelowASymlinkedAncestorAtItsCanonicalPath() throws Exception {
+        Path realParent = Files.createDirectory(directory.resolve("real-parent"));
+        Path realProject = Files.createDirectory(realParent.resolve("project"));
+        Path parentLink = Files.createSymbolicLink(
+                directory.resolve("parent-link"), realParent);
+
+        ShipRun run = controller("state").start(
+                parentLink.resolve("project"), Oversight.NEVER, List.of());
+
+        assertEquals(realProject.toRealPath().toString(), run.projectDirectory());
+    }
+
+    @Test
+    void completesAndReadsExecuteWithStateBelowASymlinkedAncestor() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path realStateParent = Files.createDirectory(directory.resolve("real-state-parent"));
+        Path linkedStateParent = Files.createSymbolicLink(
+                directory.resolve("linked-state-parent"), realStateParent);
+        Path stateRoot = linkedStateParent.resolve("state");
+        ShipController controller = new ShipController(stateRoot);
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Path route = Files.writeString(
+                workspace.resolve("route.yaml"), "from:\n  uri: direct:start\n");
+        ShipRun validating = controller.completeExecuteStage(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest(),
+                List.of(route),
+                false);
+
+        assertEquals(validating, new ShipController(stateRoot).status(run.id()));
+        assertEquals(
+                realStateParent.resolve("state").toRealPath()
+                        .resolve(run.id()).resolve("workspace/candidate").toString(),
+                validating.stage(Stage.EXECUTE).artifacts().get(0).path());
     }
 
     @Test
@@ -786,7 +837,7 @@ class ShipControllerTest {
         ShipRun run = controller.start(project, Oversight.NEVER, List.of());
 
         assertFailure(
-                "artifact-invalid",
+                "artifact-unreadable",
                 () -> complete(controller, run, "validation", alias));
         assertEquals(run, controller.status(run.id()));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -4,12 +4,19 @@ import java.io.RandomAccessFile;
 import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.context.ShipContext;
@@ -17,7 +24,13 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipFilesystemException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -29,6 +42,24 @@ class ShipControllerTest {
 
     @TempDir
     Path directory;
+
+    @AfterEach
+    void makePublishedWorkspacesRemovable() throws Exception {
+        if (!directory.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
+        try (var paths = Files.walk(directory)) {
+            for (Path path : paths.filter(item -> {
+                String name = String.valueOf(item.getFileName());
+                return "workspace".equals(name) || ".workspace-stale".equals(name);
+            })
+                    .toList()) {
+                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                    Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"));
+                }
+            }
+        }
+    }
 
     @Test
     void startsWithNoInputTextOrDocumentContext() throws Exception {
@@ -57,6 +88,44 @@ class ShipControllerTest {
     }
 
     @Test
+    void rejectsControllerStateInsideTheProjectBeforeCreatingIt() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path state = project.resolve("ship-state");
+
+        assertFailure(
+                "state-project-overlap",
+                () -> new ShipController(state).start(project, Oversight.NEVER, List.of()));
+        assertFalse(Files.exists(state));
+
+        Path embeddedState = Files.createDirectory(project.resolve("embedded-state"));
+        Path linkedState = Files.createSymbolicLink(
+                directory.resolve("linked-state"), embeddedState);
+        assertFailure(
+                "state-root-invalid",
+                () -> new ShipController(linkedState).start(
+                        project, Oversight.NEVER, List.of()));
+        try (var entries = Files.list(embeddedState)) {
+            assertTrue(entries.findAny().isEmpty());
+        }
+
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-import\"}\n");
+        Path documents = Files.createDirectories(project.resolve("docs/camel-kit/149-import"));
+        Files.writeString(documents.resolve("design-spec.md"), "design");
+        Files.writeString(documents.resolve("implementation-plan.md"), "plan");
+        Files.writeString(documents.resolve("execution-report.md"), "execution");
+        Path importedState = project.resolve("imported-ship-state");
+
+        assertFailure(
+                "state-project-overlap",
+                () -> new ShipController(importedState).startFrom(
+                        project, Stage.VALIDATE, Oversight.NEVER, List.of()));
+        assertFalse(Files.exists(importedState));
+    }
+
+    @Test
     void rejectsInvalidProjectRootsWithExactCodes() throws Exception {
         ShipController controller = controller("state");
 
@@ -67,6 +136,16 @@ class ShipControllerTest {
         Path regularFile = Files.writeString(directory.resolve("file"), "not a project");
         assertFailure("project-invalid",
                 () -> controller.start(regularFile, Oversight.NEVER, List.of()));
+        Path realParent = Files.createDirectory(directory.resolve("real-parent"));
+        Path realProject = Files.createDirectory(realParent.resolve("project"));
+        Path rootLink = directory.resolve("project-link");
+        Files.createSymbolicLink(rootLink, realProject);
+        Path parentLink = directory.resolve("parent-link");
+        Files.createSymbolicLink(parentLink, realParent);
+        assertFailure("project-invalid",
+                () -> controller.start(rootLink, Oversight.NEVER, List.of()));
+        assertFailure("project-invalid",
+                () -> controller.start(parentLink.resolve("project"), Oversight.NEVER, List.of()));
 
         Path brokenPath = (Path) Proxy.newProxyInstance(
                 getClass().getClassLoader(),
@@ -237,6 +316,32 @@ class ShipControllerTest {
     }
 
     @Test
+    void resumeRestartsCompletedValidateWhenItsArtifactChanges() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.ALWAYS, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = controller.resume(run.id());
+        run = complete(controller, run, "plan");
+        run = controller.resume(run.id());
+        run = complete(controller, run, "execute");
+        run = controller.resume(run.id());
+        Path artifact = Files.writeString(
+                Files.createDirectories(project.resolve("target")).resolve("validation.txt"),
+                "validated");
+        ShipRun paused = complete(controller, run, "validate", artifact);
+        assertEquals(RunStatus.PAUSED, paused.status());
+
+        Files.writeString(artifact, "changed after validation");
+        ShipRun resumed = controller.resume(paused.id());
+
+        assertEquals(Stage.VALIDATE, resumed.currentStage());
+        assertEquals(StageStatus.RUNNING, resumed.stage(Stage.VALIDATE).status());
+        assertEquals(2, resumed.stage(Stage.VALIDATE).attempts());
+    }
+
+    @Test
     void rejectsCompletionWhenDocumentContextChangedMidAttempt() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         Path document = Files.writeString(project.resolve("requirements.md"), "version one");
@@ -286,10 +391,347 @@ class ShipControllerTest {
     }
 
     @Test
+    void acceptsOnlyBoundWorkspaceArtifactsAndRevalidatesTheirMutation() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path liveArtifact = Files.writeString(project.resolve("unbound.md"), "unbound");
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        assertEquals(Stage.EXECUTE, run.currentStage());
+
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Path report = Files.writeString(
+                workspace.resolve("execution-report.md"), "executed");
+        Path route = Files.writeString(workspace.resolve("orders.camel.yaml"), "version one");
+        ShipRun executing = run;
+
+        assertFailure(
+                "workspace-required",
+                () -> controller.completeStage(
+                        executing.id(),
+                        Stage.EXECUTE,
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        digest("execute"),
+                        List.of(),
+                        false));
+        assertFailure(
+                "artifact-invalid",
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(liveArtifact),
+                        false));
+        assertFailure(
+                "artifact-invalid",
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(workspace),
+                        false));
+        Path credential = Files.writeString(workspace.resolve(".env"), "TOKEN=secret");
+        assertFailure(
+                "artifact-invalid",
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(report),
+                        false));
+        Files.delete(credential);
+        Files.createDirectories(workspace.resolve("target"));
+        Files.writeString(workspace.resolve("target/build.log"), "volatile output");
+
+        ShipRun validating = controller.completeExecuteStage(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest(),
+                List.of(report),
+                false);
+        ProjectSnapshot acceptedSnapshot = ProjectEvidenceFiles.captureStaged(workspace);
+        assertEquals(Stage.VALIDATE, validating.currentStage());
+        assertTrue(ShipDigest.isSha256(validating.stage(Stage.EXECUTE).outputDigest()));
+        String executeOutputDigest = validating.stage(Stage.EXECUTE).outputDigest();
+        String candidateDigest = validating.stage(Stage.EXECUTE).artifacts().stream()
+                .filter(artifact -> artifact.path().equals(workspace.toString()))
+                .findFirst()
+                .orElseThrow()
+                .digest();
+        String reportDigest = validating.stage(Stage.EXECUTE).artifacts().stream()
+                .filter(artifact -> artifact.path().equals(report.toString()))
+                .findFirst()
+                .orElseThrow()
+                .digest();
+        assertEquals(acceptedSnapshot.digest(), candidateDigest);
+        assertEquals(
+                acceptedSnapshot.files().get("execution-report.md").digest(),
+                reportDigest);
+        assertTrue(validating.stage(Stage.EXECUTE).artifacts().stream()
+                .anyMatch(artifact -> artifact.path().equals(report.toString())));
+
+        Files.writeString(route, "version two");
+        ShipRun resumed = controller.resume(validating.id());
+
+        assertEquals(Stage.VALIDATE, resumed.currentStage());
+        assertEquals(StageStatus.COMPLETED, resumed.stage(Stage.EXECUTE).status());
+        assertNotEquals(
+                candidateDigest,
+                resumed.stage(Stage.EXECUTE).artifacts().stream()
+                        .filter(artifact -> artifact.path().equals(workspace.toString()))
+                        .findFirst()
+                        .orElseThrow()
+                        .digest());
+        assertNotEquals(
+                executeOutputDigest,
+                resumed.stage(Stage.EXECUTE).outputDigest());
+        assertEquals(StageStatus.RUNNING, resumed.stage(Stage.VALIDATE).status());
+        assertEquals(2, resumed.stage(Stage.VALIDATE).attempts());
+    }
+
+    @Test
+    void rejectsPersistedProjectOverlapWithTheRunDirectory() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        run = controller.completeExecuteStage(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest(),
+                List.of(),
+                false);
+
+        String runId = run.id();
+        Path state = directory.resolve("state").resolve(runId).resolve("state.json");
+        ObjectMapper json = new ObjectMapper();
+        ObjectNode document = (ObjectNode) json.readTree(state.toFile());
+        document.put("projectDirectory", workspace.toString());
+        byte[] tampered = json.writeValueAsBytes(document);
+        Files.write(state, tampered);
+
+        assertFailure("state-corrupt", () -> controller.resume(runId));
+        assertArrayEquals(tampered, Files.readAllBytes(state));
+    }
+
+    @Test
+    void reportsAnExhaustedPersistedAttemptAsCorruptState() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        Path state = directory.resolve("state").resolve(run.id()).resolve("state.json");
+        ObjectMapper json = new ObjectMapper();
+        ObjectNode document = (ObjectNode) json.readTree(state.toFile());
+        ((ObjectNode) document.withArray("stages").get(Stage.DISCOVERY.ordinal()))
+                .put("attempts", Integer.MAX_VALUE - 1);
+        Files.write(state, json.writeValueAsBytes(document));
+
+        assertFailure("state-corrupt", () -> controller.resume(run.id()));
+
+        Path nextProject = Files.createDirectory(directory.resolve("next-project"));
+        ShipController advancing = controller("next-state");
+        ShipRun active = advancing.start(nextProject, Oversight.NEVER, List.of());
+        Path nextState = directory.resolve("next-state")
+                .resolve(active.id())
+                .resolve("state.json");
+        document = (ObjectNode) json.readTree(nextState.toFile());
+        ((ObjectNode) document.withArray("stages").get(Stage.DESIGN.ordinal()))
+                .put("attempts", Integer.MAX_VALUE - 1);
+        Files.write(nextState, json.writeValueAsBytes(document));
+
+        assertFailure(
+                "state-corrupt",
+                () -> advancing.completeStage(
+                        active.id(),
+                        Stage.DISCOVERY,
+                        active.stage(Stage.DISCOVERY).attempts(),
+                        active.stage(Stage.DISCOVERY).inputDigest(),
+                        digest("discovery"),
+                        List.of(),
+                        false));
+    }
+
+    @Test
+    void reportsAChangedWorkspaceBaselineAsStaleInput() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Files.writeString(project.resolve("README.md"), "baseline");
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Files.writeString(project.resolve("README.md"), "changed");
+        ShipRun executing = run;
+
+        assertFailure(
+                "stale-stage-input",
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(),
+                        false));
+        assertEquals(executing, controller.status(executing.id()));
+
+        ShipRun resumed = controller.resume(executing.id());
+        assertEquals(2, resumed.stage(Stage.EXECUTE).attempts());
+        Path refreshed = controller.prepareWorkspace(
+                resumed.id(),
+                resumed.stage(Stage.EXECUTE).attempts(),
+                resumed.stage(Stage.EXECUTE).inputDigest());
+        assertEquals(workspace, refreshed);
+        assertEquals("changed", Files.readString(refreshed.resolve("README.md")));
+    }
+
+    @Test
+    void rebindsTheWorkspaceWhenUpstreamInputRestartsExecute() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path plan = Files.writeString(project.resolve("plan.md"), "plan one");
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan one", plan);
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Files.writeString(workspace.resolve("partial.txt"), "interrupted edit");
+
+        Files.writeString(plan, "plan two");
+        ShipRun executing = controller.resume(run.id());
+        assertEquals(Stage.EXECUTE, executing.currentStage());
+        assertEquals(2, executing.stage(Stage.EXECUTE).attempts());
+
+        Path rebound = controller.prepareWorkspace(
+                executing.id(),
+                executing.stage(Stage.EXECUTE).attempts(),
+                executing.stage(Stage.EXECUTE).inputDigest());
+        assertEquals(workspace, rebound);
+        assertFalse(Files.exists(rebound.resolve("partial.txt")));
+        assertEquals("plan two", Files.readString(rebound.resolve("plan.md")));
+    }
+
+    @Test
+    void requiresTheWorkspaceBindingToMatchTheActiveExecuteAttempt() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Files.writeString(workspace.resolve("partial.txt"), "preserve me");
+
+        ShipRun resumed = controller.resume(run.id());
+        assertEquals(2, resumed.stage(Stage.EXECUTE).attempts());
+        assertFailure(
+                "artifact-invalid",
+                () -> controller.completeExecuteStage(
+                        resumed.id(),
+                        resumed.stage(Stage.EXECUTE).attempts(),
+                        resumed.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(),
+                        false));
+        assertEquals(resumed, controller.status(resumed.id()));
+
+        Path rebound = controller.prepareWorkspace(
+                resumed.id(),
+                resumed.stage(Stage.EXECUTE).attempts(),
+                resumed.stage(Stage.EXECUTE).inputDigest());
+        assertEquals(workspace, rebound);
+        assertEquals("preserve me", Files.readString(rebound.resolve("partial.txt")));
+        ShipRun validating = controller.completeExecuteStage(
+                resumed.id(),
+                resumed.stage(Stage.EXECUTE).attempts(),
+                resumed.stage(Stage.EXECUTE).inputDigest(),
+                List.of(),
+                false);
+        assertEquals(Stage.VALIDATE, validating.currentStage());
+    }
+
+    @Test
+    void rejectsAnEmptyExecuteArtifactWithoutChangingTheRun() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Path empty = Files.createFile(workspace.resolve("execution-report.md"));
+        ShipRun executing = run;
+
+        assertFailure(
+                "artifact-invalid",
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(empty),
+                        false));
+        assertEquals(executing, controller.status(executing.id()));
+    }
+
+    @Test
+    void mapsAnUnsafeWorkspaceFilenameToATypedControllerFailure() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Files.writeString(workspace.resolve("line\nbreak"), "content");
+        ShipRun executing = run;
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(),
+                        false));
+
+        assertEquals("artifact-invalid", failure.code());
+        ShipFilesystemException cause = assertInstanceOf(
+                ShipFilesystemException.class, failure.getCause());
+        assertEquals(ShipFilesystemException.UNSAFE_ENTRY, cause.code());
+        assertEquals(executing, controller.status(executing.id()));
+    }
+
+    @Test
     void rejectsInvalidMissingOversizedAndEmptyArtifacts() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         Path outside = directory.resolve("outside");
         Path empty = Files.createFile(project.resolve("empty"));
+        Path duplicate = Files.writeString(project.resolve("duplicate"), "duplicate");
         Path oversized = project.resolve("oversized");
         try (RandomAccessFile file = new RandomAccessFile(oversized.toFile(), "rw")) {
             file.setLength(64L * 1024 * 1024 + 1);
@@ -310,7 +752,49 @@ class ShipControllerTest {
         assertFailure("artifact-too-large",
                 () -> complete(controller, run, "oversized", oversized));
         assertFailure("artifact-invalid", () -> complete(controller, run, "empty", empty));
+        assertFailure("artifact-invalid",
+                () -> complete(controller, run, "duplicate", duplicate, duplicate));
+
+        List<Path> aggregate = new ArrayList<>();
+        for (int index = 0; index < 17; index++) {
+            Path artifact = project.resolve("aggregate-" + index);
+            try (RandomAccessFile file = new RandomAccessFile(artifact.toFile(), "rw")) {
+                file.setLength(64L * 1024 * 1024);
+            }
+            aggregate.add(artifact);
+        }
+        assertFailure(
+                "artifact-too-large",
+                () -> controller.completeStage(
+                        run.id(),
+                        run.currentStage(),
+                        run.stage(run.currentStage()).attempts(),
+                        run.stage(run.currentStage()).inputDigest(),
+                        digest("aggregate"),
+                        aggregate,
+                        false));
         assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void rejectsAVolatileArtifactHardlinkedToDeniedContent() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path credential = Files.writeString(project.resolve(".env"), "TOKEN=secret");
+        Path target = Files.createDirectory(project.resolve("target"));
+        Path alias = Files.createLink(target.resolve("validation.txt"), credential);
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        assertFailure(
+                "artifact-invalid",
+                () -> complete(controller, run, "validation", alias));
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void rejectsConcurrentArtifactSizeChangesAndReplacement() throws Exception {
+        assertConcurrentArtifactMutationRejected("size-change", false);
+        assertConcurrentArtifactMutationRejected("replacement", true);
     }
 
     @Test
@@ -385,8 +869,9 @@ class ShipControllerTest {
                 project.resolve("docs/camel-kit/149-local-controller"));
         Path design = Files.writeString(documents.resolve("design-spec.md"), "design");
         Path plan = Files.writeString(documents.resolve("implementation-plan.md"), "plan");
+        ShipController controller = controller("state");
 
-        ShipRun run = controller("state").startFrom(
+        ShipRun run = controller.startFrom(
                 project,
                 Stage.EXECUTE,
                 Oversight.NEVER,
@@ -403,6 +888,41 @@ class ShipControllerTest {
         assertEquals(ShipDigest.sha256(Files.readAllBytes(plan)),
                 run.stage(Stage.PLAN).artifacts().get(0).digest());
         assertArrayEquals(pipeline, Files.readAllBytes(metadata.resolve("pipeline.json")));
+
+        Files.writeString(plan, "plan two");
+        ShipRun resumed = controller.resume(run.id());
+
+        assertEquals(Stage.EXECUTE, resumed.currentStage());
+        assertEquals(2, resumed.stage(Stage.EXECUTE).attempts());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(plan)),
+                resumed.stage(Stage.PLAN).outputDigest());
+    }
+
+    @Test
+    void startFromPlanRefreshesImportedDesignOutputBeforeRetry() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-import\"}");
+        Path documents = Files.createDirectories(project.resolve("docs/camel-kit/149-import"));
+        Path design = Files.writeString(documents.resolve("design-spec.md"), "design");
+        ShipController controller = controller("state");
+        ShipRun run = controller.startFrom(
+                project,
+                Stage.PLAN,
+                Oversight.NEVER,
+                List.of(new ShipContext.TextInput("build the route")));
+
+        Files.writeString(design, "design two");
+        ShipRun resumed = controller.resume(run.id());
+
+        assertEquals(Stage.PLAN, resumed.currentStage());
+        assertEquals(2, resumed.stage(Stage.PLAN).attempts());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(design)),
+                resumed.stage(Stage.DESIGN).outputDigest());
     }
 
     @Test
@@ -439,8 +959,10 @@ class ShipControllerTest {
                 project.resolve("docs/camel-kit/149-local-controller"));
         Files.writeString(documents.resolve("design-spec.md"), "design");
         Files.writeString(documents.resolve("implementation-plan.md"), "plan");
-        Files.writeString(documents.resolve("execution-report.md"), "execution");
+        Path executionReport = Files.writeString(
+                documents.resolve("execution-report.md"), "execution");
         Path route = Files.writeString(project.resolve("route.yaml"), "version one");
+        ProjectSnapshot importedSnapshot = ProjectEvidenceFiles.capture(project);
         ShipController controller = controller("state");
 
         ShipRun validating = controller.startFrom(
@@ -451,11 +973,22 @@ class ShipControllerTest {
         assertEquals(2, validating.stage(Stage.EXECUTE).artifacts().size());
         assertEquals(project.toAbsolutePath().normalize().toString(),
                 validating.stage(Stage.EXECUTE).artifacts().get(1).path());
+        assertEquals(
+                importedSnapshot.files()
+                        .get("docs/camel-kit/149-local-controller/execution-report.md")
+                        .digest(),
+                validating.stage(Stage.EXECUTE).artifacts().get(0).digest());
+        assertEquals(
+                importedSnapshot.digest(),
+                validating.stage(Stage.EXECUTE).artifacts().get(1).digest());
         String snapshotDigest = validating.stage(Stage.EXECUTE).artifacts().get(1).digest();
+        String executeOutputDigest = validating.stage(Stage.EXECUTE).outputDigest();
 
         ShipRun paused = complete(controller, validating, "validated");
         assertEquals(RunStatus.PAUSED, paused.status());
         Files.writeString(route, "version two");
+        Files.writeString(executionReport, "execution two");
+        ProjectSnapshot changedSnapshot = ProjectEvidenceFiles.capture(project);
 
         ShipRun resumed = controller.resume(paused.id());
         assertEquals(Stage.VALIDATE, resumed.currentStage());
@@ -463,6 +996,16 @@ class ShipControllerTest {
         assertEquals(2, resumed.stage(Stage.VALIDATE).attempts());
         assertNotEquals(
                 snapshotDigest, resumed.stage(Stage.EXECUTE).artifacts().get(1).digest());
+        assertNotEquals(
+                executeOutputDigest, resumed.stage(Stage.EXECUTE).outputDigest());
+        assertEquals(
+                changedSnapshot.files()
+                        .get("docs/camel-kit/149-local-controller/execution-report.md")
+                        .digest(),
+                resumed.stage(Stage.EXECUTE).artifacts().get(0).digest());
+        assertEquals(
+                changedSnapshot.digest(),
+                resumed.stage(Stage.EXECUTE).artifacts().get(1).digest());
     }
 
     @Test
@@ -485,6 +1028,29 @@ class ShipControllerTest {
                         false));
 
         assertEquals("artifact-invalid", failure.code());
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    @Test
+    void rejectsFinalAndIntermediateArtifactSymlinksInsideTheProject() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path realDirectory = Files.createDirectory(project.resolve("real"));
+        Path target = Files.writeString(realDirectory.resolve("result.md"), "result");
+        Path finalLink = Files.createSymbolicLink(project.resolve("result-link.md"), target);
+        Path directoryLink = Files.createSymbolicLink(project.resolve("directory-link"), realDirectory);
+        ShipController controller = controller("state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        assertFailure(
+                "artifact-invalid",
+                () -> complete(controller, run, "final-link", finalLink));
+        assertFailure(
+                "artifact-invalid",
+                () -> complete(
+                        controller,
+                        run,
+                        "directory-link",
+                        directoryLink.resolve("result.md")));
         assertEquals(run, controller.status(run.id()));
     }
 
@@ -521,9 +1087,97 @@ class ShipControllerTest {
         return new ShipController(directory.resolve(stateDirectory));
     }
 
-    private static ShipRun complete(
+    private void assertConcurrentArtifactMutationRejected(String name, boolean replace)
+            throws Exception {
+        Path project = Files.createDirectory(directory.resolve(name + "-project"));
+        Path target = Files.createDirectory(project.resolve("target"));
+        Path artifact = target.resolve("validation.txt");
+        try (RandomAccessFile file = new RandomAccessFile(artifact.toFile(), "rw")) {
+            file.setLength(32L * 1024 * 1024);
+        }
+        Path replacement = directory.resolve(name + "-replacement");
+        ShipController controller = controller(name + "-state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        AtomicBoolean stop = new AtomicBoolean();
+        AtomicReference<Throwable> mutationFailure = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread mutator = new Thread(() -> {
+            try {
+                if (replace) {
+                    long size = 48L * 1024 * 1024;
+                    while (!stop.get()) {
+                        try (RandomAccessFile file = new RandomAccessFile(replacement.toFile(), "rw")) {
+                            file.setLength(size);
+                        }
+                        Files.move(
+                                replacement,
+                                artifact,
+                                StandardCopyOption.ATOMIC_MOVE,
+                                StandardCopyOption.REPLACE_EXISTING);
+                        started.countDown();
+                        size = size == 48L * 1024 * 1024
+                                ? 32L * 1024 * 1024
+                                : 48L * 1024 * 1024;
+                    }
+                } else {
+                    try (RandomAccessFile file = new RandomAccessFile(artifact.toFile(), "rw")) {
+                        file.setLength(48L * 1024 * 1024);
+                        started.countDown();
+                        long size = 32L * 1024 * 1024;
+                        while (!stop.get()) {
+                            file.setLength(size);
+                            size = size == 32L * 1024 * 1024
+                                    ? 48L * 1024 * 1024
+                                    : 32L * 1024 * 1024;
+                        }
+                    }
+                }
+            } catch (Throwable failure) {
+                mutationFailure.set(failure);
+                started.countDown();
+            } finally {
+                try {
+                    Files.deleteIfExists(replacement);
+                } catch (Throwable cleanupFailure) {
+                    mutationFailure.compareAndSet(null, cleanupFailure);
+                }
+            }
+        }, "ship-artifact-mutator");
+        mutator.setDaemon(true);
+        mutator.start();
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+
+        ShipController.Failure failure;
+        try {
+            failure = assertThrows(
+                    ShipController.Failure.class,
+                    () -> complete(controller, run, "validation", artifact));
+        } finally {
+            stop.set(true);
+            mutator.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        assertFalse(mutator.isAlive());
+        assertNull(mutationFailure.get());
+        assertEquals("artifact-unreadable", failure.code());
+        assertEquals(run, controller.status(run.id()));
+    }
+
+    private ShipRun complete(
             ShipController controller, ShipRun run, String result, Path... artifacts) {
         Stage stage = run.currentStage();
+        if (stage == Stage.EXECUTE) {
+            controller.prepareWorkspace(
+                    run.id(),
+                    run.stage(stage).attempts(),
+                    run.stage(stage).inputDigest());
+            return controller.completeExecuteStage(
+                    run.id(),
+                    run.stage(stage).attempts(),
+                    run.stage(stage).inputDigest(),
+                    List.of(artifacts),
+                    false);
+        }
         return controller.completeStage(
                 run.id(),
                 stage,

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -57,6 +57,51 @@ class ShipRunStoreTest {
     }
 
     @Test
+    void createsAMissingStateRootBelowASymlinkedAncestor() throws Exception {
+        Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-state-parent"));
+        Path linkedParent = Files.createSymbolicLink(
+                temporaryDirectory.resolve("linked-state-parent"), realParent);
+        Path state = linkedParent.resolve("nested/state");
+        ShipRunStore store = new ShipRunStore(state);
+        ShipRun initial = run(RUN_ID);
+
+        store.create(initial);
+
+        assertEquals(initial, store.read(RUN_ID));
+        assertTrue(Files.isRegularFile(
+                realParent.resolve("nested/state").resolve(RUN_ID).resolve("state.json")));
+    }
+
+    @Test
+    void acceptsADirectorySymlinkAsTheConfiguredStateRoot() throws Exception {
+        Path realState = Files.createDirectory(temporaryDirectory.resolve("real-state"));
+        Path linkedState = Files.createSymbolicLink(
+                temporaryDirectory.resolve("linked-state"), realState);
+        ShipRunStore store = new ShipRunStore(linkedState);
+        ShipRun initial = run(RUN_ID);
+
+        store.create(initial);
+
+        assertEquals(initial, store.read(RUN_ID));
+        assertTrue(Files.isRegularFile(realState.resolve(RUN_ID).resolve("state.json")));
+    }
+
+    @Test
+    void rejectsBrokenAndNonDirectoryStateRoots() throws Exception {
+        Path regularFile = Files.writeString(temporaryDirectory.resolve("state-file"), "state");
+        assertCode(
+                "state-root-invalid",
+                () -> new ShipRunStore(regularFile).create(run(RUN_ID)));
+
+        Path brokenLink = Files.createSymbolicLink(
+                temporaryDirectory.resolve("broken-state"),
+                temporaryDirectory.resolve("missing-target"));
+        assertCode(
+                "state-root-invalid",
+                () -> new ShipRunStore(brokenLink).create(run(OTHER_RUN_ID)));
+    }
+
+    @Test
     void keepsCommittedStateWhenAnInterruptedTemporaryFileRemains() throws Exception {
         ShipRunStore store = store();
         ShipRun initial = run(RUN_ID);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -4,9 +4,14 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.List;
 
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.context.ShipContext;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -117,10 +122,10 @@ class ShipRunStoreTest {
                 state, valid.substring(0, closingBrace) + ",\"unexpected\":true}");
         assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
 
-        Files.writeString(state, "{\"schemaVersion\":1}");
+        Files.writeString(state, "{\"schemaVersion\":2}");
         assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
 
-        Files.writeString(state, "{\"schemaVersion\":2}");
+        Files.writeString(state, "{\"schemaVersion\":1}");
         assertCode("state-version-unsupported", () -> store.read(THIRD_RUN_ID));
 
         Files.writeString(state, valid.replace(THIRD_RUN_ID, OTHER_RUN_ID));
@@ -136,6 +141,156 @@ class ShipRunStoreTest {
         assertCode("run-already-exists", () -> store.create(updated(initial)));
 
         assertEquals(initial, store.read(RUN_ID));
+    }
+
+    @Test
+    void rejectsProjectOverlapOnWriteAndRead() throws Exception {
+        ShipRunStore store = store();
+        ShipRun initial = run(RUN_ID);
+        store.create(initial);
+        Path runRoot = stateRoot().resolve(RUN_ID).toAbsolutePath().normalize();
+        ShipRun overlapping = withProject(initial, runRoot);
+
+        try (ShipRunStore.LockedRun locked = store.lock(RUN_ID)) {
+            assertCode("state-invalid", () -> locked.write(overlapping));
+        }
+        assertEquals(initial, store.read(RUN_ID));
+
+        Path state = runRoot.resolve("state.json");
+        ObjectMapper json = new ObjectMapper();
+        ObjectNode document = (ObjectNode) json.readTree(state.toFile());
+        document.put("projectDirectory", runRoot.toString());
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+    }
+
+    @Test
+    void rejectsAttemptedExecuteDowngradedToAnImportWithoutProvenance() throws Exception {
+        ShipRunStore store = store();
+        ShipRun completed = completedRun(RUN_ID);
+        store.create(completed);
+        Path state = stateRoot().resolve(RUN_ID).resolve("state.json");
+        ObjectMapper json = new ObjectMapper();
+        ObjectNode document = (ObjectNode) json.readTree(state.toFile());
+        ObjectNode execute = (ObjectNode) document.withArray("stages")
+                .get(ShipRun.Stage.EXECUTE.ordinal());
+        String reportDigest = ShipDigest.sha256(
+                "import-shaped-report".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        document.put("pipelineId", "149-import");
+        execute.put("attempts", 0);
+        execute.put("outputDigest", reportDigest);
+        execute.putArray("artifacts")
+                .addObject()
+                .put(
+                        "path",
+                        Path.of(completed.projectDirectory())
+                                .resolve("docs/camel-kit/149-import/execution-report.md")
+                                .toString())
+                .put("digest", reportDigest);
+        execute.withArray("artifacts")
+                .addObject()
+                .put("path", completed.projectDirectory())
+                .put(
+                        "digest",
+                        ShipDigest.sha256(
+                                "import-shaped-project"
+                                        .getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        Files.write(state, json.writeValueAsBytes(document));
+
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+    }
+
+    @Test
+    void preservesCanonicalImportedExecuteEvidence() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
+        Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                project.resolve(".camel-kit/pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-import\"}");
+        Path documents = Files.createDirectories(project.resolve("docs/camel-kit/149-import"));
+        Files.writeString(documents.resolve("design-spec.md"), "design");
+        Files.writeString(documents.resolve("implementation-plan.md"), "plan");
+        Files.writeString(documents.resolve("execution-report.md"), "execution");
+
+        ShipRun imported = new ShipController(stateRoot()).startFrom(
+                project,
+                ShipRun.Stage.VALIDATE,
+                ShipRun.Oversight.NEVER,
+                List.of());
+
+        assertEquals(0, imported.stage(ShipRun.Stage.EXECUTE).attempts());
+        assertEquals(imported, store().read(imported.id()));
+    }
+
+    @Test
+    void rejectsNonCanonicalPartialImportEvidence() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
+        Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                project.resolve(".camel-kit/pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-import\"}");
+        Path documents = Files.createDirectories(project.resolve("docs/camel-kit/149-import"));
+        Files.writeString(documents.resolve("design-spec.md"), "design");
+        Files.writeString(documents.resolve("implementation-plan.md"), "plan");
+        ShipRun imported = new ShipController(stateRoot()).startFrom(
+                project,
+                ShipRun.Stage.EXECUTE,
+                ShipRun.Oversight.NEVER,
+                List.of());
+        assertEquals(imported, store().read(imported.id()));
+
+        Path state = stateRoot().resolve(imported.id()).resolve("state.json");
+        byte[] valid = Files.readAllBytes(state);
+        ObjectMapper json = new ObjectMapper();
+        ObjectNode document = (ObjectNode) json.readTree(valid);
+        ObjectNode design = stage(document, ShipRun.Stage.DESIGN);
+        String forged = ShipDigest.sha256(
+                "forged".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        design.put("outputDigest", forged);
+        ObjectNode artifact = (ObjectNode) design.withArray("artifacts").get(0);
+        artifact.put("path", project.resolve("forged.md").toString());
+        artifact.put("digest", forged);
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store().read(imported.id()));
+
+        document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.DISCOVERY).put("attempts", 1);
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store().read(imported.id()));
+    }
+
+    @Test
+    void rejectsNullCoercedNumericEnumAndUnboundedAttempts() throws Exception {
+        ShipRunStore store = store();
+        store.create(run(RUN_ID));
+        Path state = stateRoot().resolve(RUN_ID).resolve("state.json");
+        byte[] valid = Files.readAllBytes(state);
+        ObjectMapper json = new ObjectMapper();
+
+        ObjectNode document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.DISCOVERY).putNull("attempts");
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+
+        document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.DISCOVERY).put("attempts", "0");
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+
+        document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.DISCOVERY).put("attempts", 0.0);
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+
+        document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.DISCOVERY).put("status", 0);
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+
+        document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.DISCOVERY).put("attempts", Integer.MAX_VALUE);
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
     }
 
     @Test
@@ -187,6 +342,46 @@ class ShipRunStoreTest {
                 null);
     }
 
+    private ShipRun completedRun(String runId) {
+        List<ShipRun.StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
+        ShipContext context = ShipContext.none();
+        for (ShipRun.Stage stage : ShipRun.Stage.values()) {
+            String input = ShipRun.inputDigest(context, stages, stage);
+            List<ShipRun.ArtifactRef> artifacts = List.of();
+            String output = ShipDigest.sha256(stage.name().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            if (stage == ShipRun.Stage.EXECUTE) {
+                ShipRun.ArtifactRef root = new ShipRun.ArtifactRef(
+                        stateRoot().resolve(runId).resolve("workspace/candidate")
+                                .toAbsolutePath().normalize().toString(),
+                        ShipDigest.sha256("workspace".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                artifacts = List.of(root);
+                output = ShipRun.executeOutputDigest(root);
+            }
+            stages.set(
+                    stage.ordinal(),
+                    new ShipRun.StageRecord(
+                            stage,
+                            ShipRun.StageStatus.COMPLETED,
+                            1,
+                            input,
+                            output,
+                            artifacts));
+        }
+        return new ShipRun(
+                ShipRun.SCHEMA_VERSION,
+                runId,
+                temporaryDirectory.resolve("project").toAbsolutePath().normalize().toString(),
+                null,
+                ShipRun.Oversight.NEVER,
+                ShipRun.RunStatus.COMPLETED,
+                ShipRun.Stage.VALIDATE,
+                context,
+                stages,
+                CREATED_AT,
+                UPDATED_AT,
+                null);
+    }
+
     private static ShipRun updated(ShipRun run) {
         return new ShipRun(
                 run.schemaVersion(),
@@ -201,6 +396,26 @@ class ShipRunStoreTest {
                 run.createdAt(),
                 UPDATED_AT,
                 run.message());
+    }
+
+    private static ShipRun withProject(ShipRun run, Path project) {
+        return new ShipRun(
+                run.schemaVersion(),
+                run.id(),
+                project.toString(),
+                run.pipelineId(),
+                run.oversight(),
+                run.status(),
+                run.currentStage(),
+                run.context(),
+                run.stages(),
+                run.createdAt(),
+                run.updatedAt(),
+                run.message());
+    }
+
+    private static ObjectNode stage(ObjectNode document, ShipRun.Stage stage) {
+        return (ObjectNode) document.withArray("stages").get(stage.ordinal());
     }
 
     private static void assertCode(String code, Executable action) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -214,6 +214,100 @@ class EvidenceRunnerTest {
     }
 
     @Test
+    void acceptsSymlinkedEvidenceParentButRejectsSymlinkLeaf() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path realParent = Files.createDirectory(tempDir.resolve("real-evidence-parent"));
+        Path parentAlias = Files.createSymbolicLink(tempDir.resolve("evidence-parent-alias"), realParent);
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        Path evidenceDirectory = parentAlias.resolve("evidence");
+        EvidenceCommand aliasCommand = command(project, "alias-check", Duration.ofSeconds(2));
+
+        CommandEvidence result = runner(new RecordingLauncher(fakeBubblewrap, null, null)).run(
+                project, evidenceDirectory, aliasCommand);
+
+        Path realEvidenceDirectory = realParent.resolve("evidence").toRealPath();
+        assertTrue(result.passed(), result::toString);
+        assertEquals(realEvidenceDirectory, Path.of(result.stdoutLog()).getParent());
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(realEvidenceDirectory));
+        EvidenceRunner.cleanupEphemeral(evidenceDirectory, aliasCommand, result);
+        assertFalse(Files.exists(realEvidenceDirectory));
+
+        Path target = Files.createDirectory(realParent.resolve("existing-target"));
+        Path symlinkLeaf = parentAlias.resolve("symlink-evidence");
+        Files.createSymbolicLink(symlinkLeaf, target);
+        RecordingLauncher rejectedLauncher = new RecordingLauncher(fakeBubblewrap, null, null);
+
+        IOException rejected = assertThrows(IOException.class, () -> runner(rejectedLauncher).run(
+                project, symlinkLeaf, command(project, "symlink-check", Duration.ofSeconds(2))));
+
+        assertTrue(rejected.getMessage().contains("new and exclusive"));
+        assertTrue(Files.isSymbolicLink(symlinkLeaf));
+        assertTrue(Files.isDirectory(target));
+        assertTrue(rejectedLauncher.invocations.isEmpty());
+    }
+
+    @Test
+    void createsMissingEvidenceParentDirectories() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("candidate"));
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        Path evidenceDirectory = tempDir.resolve("missing/nested/evidence");
+        EvidenceCommand command = command(project, "nested-parent-check", Duration.ofSeconds(2));
+
+        CommandEvidence result = runner(new RecordingLauncher(fakeBubblewrap, null, null)).run(
+                project, evidenceDirectory, command);
+
+        assertTrue(result.passed(), result::toString);
+        assertEquals(evidenceDirectory.toRealPath(), Path.of(result.stdoutLog()).getParent());
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(evidenceDirectory));
+        EvidenceRunner.cleanupEphemeral(evidenceDirectory, command, result);
+        assertFalse(Files.exists(evidenceDirectory));
+        assertTrue(Files.isDirectory(tempDir.resolve("missing/nested")));
+    }
+
+    @Test
+    void canonicalizesProjectPathsBelowASymlinkedAncestor() throws Exception {
+        Path realParent = Files.createDirectory(tempDir.resolve("real-project-parent"));
+        Path project = Files.createDirectory(realParent.resolve("candidate"));
+        Path parentAlias = Files.createSymbolicLink(tempDir.resolve("project-parent-alias"), realParent);
+        Path projectAlias = parentAlias.resolve("candidate");
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+
+        CommandEvidence result = runner(launcher).run(
+                projectAlias,
+                tempDir.resolve("evidence"),
+                command(projectAlias, "project-alias-check", Duration.ofSeconds(2)));
+
+        assertTrue(result.passed(), result::toString);
+        for (Invocation invocation : launcher.invocations) {
+            assertEquals(project.toRealPath(), invocation.candidate());
+            assertEquals(project.toRealPath(), invocation.workingDirectory());
+        }
+    }
+
+    @Test
+    void rejectsEvidenceNestedInTheProjectThroughAnAlternateAlias() throws Exception {
+        Path realParent = Files.createDirectory(tempDir.resolve("real-project-parent"));
+        Path project = Files.createDirectory(realParent.resolve("candidate"));
+        Path parentAlias = Files.createSymbolicLink(tempDir.resolve("project-parent-alias"), realParent);
+        Path nestedEvidenceAlias = parentAlias.resolve("candidate/evidence");
+        Path fakeBubblewrap = executable(tempDir.resolve("fake-bwrap"), "fixture");
+        RecordingLauncher launcher = new RecordingLauncher(fakeBubblewrap, null, null);
+
+        assertThrows(IOException.class, () -> runner(launcher).run(
+                project,
+                nestedEvidenceAlias,
+                command(project, "nested-evidence-check", Duration.ofSeconds(2))));
+
+        assertFalse(Files.exists(project.resolve("evidence")));
+        assertTrue(launcher.invocations.isEmpty());
+    }
+
+    @Test
     void midRunAuthorityTamperAlwaysFailsClosed() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("candidate"));
         for (AuthorityTamper tamper : AuthorityTamper.values()) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampTest.java
@@ -492,8 +492,31 @@ class ShipLocalStampTest {
     }
 
     @Test
-    void rejectsReservedAliasedAndPhysicallySharedLogs(@TempDir Path directory)
+    void acceptsSymbolicAncestorButRejectsSymbolicDirectory(@TempDir Path directory)
             throws Exception {
+        Path realAncestor = Files.createDirectory(directory.resolve("real-ancestor"));
+        Path evidence = Files.createDirectory(realAncestor.resolve("evidence"));
+        makePrivate(evidence);
+        Path symbolicAncestor = directory.resolve("symbolic-ancestor");
+        Files.createSymbolicLink(symbolicAncestor, realAncestor.getFileName());
+        Path aliasedEvidence = symbolicAncestor.resolve("evidence");
+        ShipLocalStamp stamp = persistableStamp(aliasedEvidence, 0);
+
+        Path report = ShipLocalStampStore.write(aliasedEvidence, RUN_ID, stamp);
+
+        assertEquals(evidence.resolve("stamp.json"), report);
+        assertEquals(stamp, ShipLocalStampStore.read(aliasedEvidence, RUN_ID));
+        Path symbolicEvidence = directory.resolve("symbolic-evidence");
+        Files.createSymbolicLink(symbolicEvidence, evidence);
+        assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.read(symbolicEvidence, RUN_ID));
+    }
+
+    @Test
+    void rejectsReservedAliasedAndPhysicallySharedLogs(@TempDir Path root)
+            throws Exception {
+        Path directory = Files.createDirectory(root.resolve("evidence"));
         makePrivate(directory);
         ShipLocalStamp passed = persistableStamp(directory, 0);
         Path report = ShipLocalStampStore.write(directory, RUN_ID, passed);
@@ -515,10 +538,10 @@ class ShipLocalStampTest {
         assertTrue(reservedFailure.getMessage().contains("outside its evidence directory"));
         assertArrayEquals(unchanged, Files.readAllBytes(report));
 
-        Path nested = Files.createDirectory(directory.resolve("nested"));
+        Path nested = Files.createDirectory(root.resolve("outside"));
         Path nestedLog = writePrivate(nested.resolve("stdout.log"), "nested");
         Path alias = directory.resolve("alias");
-        Files.createSymbolicLink(alias, nested.getFileName());
+        Files.createSymbolicLink(alias, nested);
         ShipLocalStamp.CommandRun aliased = storedCommand(
                 directory,
                 alias.resolve(nestedLog.getFileName()),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampTest.java
@@ -1,0 +1,795 @@
+package io.github.luigidemasi.camelkit.ship.evidence;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.EMPTY;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.MISSING;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.NONZERO;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.PASS;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.SKIPPED;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.TIMED_OUT;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome.WAIVED;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Status.COMPLETED_WITH_WAIVER;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Status.FAIL;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Support.EXPERIMENTAL;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Support.INCOMPATIBLE;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Support.SUPPORTED;
+import static io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Support.UNTESTED;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipLocalStampTest {
+
+    private static final String RUN_ID = "ship-0123456789abcdef0123456789abcdef";
+    private static final Instant STARTED = Instant.parse("2026-07-24T08:00:00Z");
+    private static final Instant ENDED = Instant.parse("2026-07-24T08:00:01Z");
+    private static final Set<PosixFilePermission> PRIVATE_DIRECTORY
+            = PosixFilePermissions.fromString("rwx------");
+    private static final Set<PosixFilePermission> PRIVATE_FILE
+            = PosixFilePermissions.fromString("rw-------");
+
+    @Test
+    void derivesPassFromRequiredChecks() {
+        ShipLocalStamp stamp = stamp(List.of(
+                check("optional-diagnostic", false, NONZERO, "Optional probe failed", null, nonzeroCommand())));
+
+        assertEquals(ShipLocalStamp.Status.PASS, stamp.status());
+    }
+
+    @Test
+    void requiredFailureWinsDespiteWorkerProse() {
+        ShipLocalStamp stamp = stamp(List.of(
+                check("required-check", true, NONZERO, "Everything passed", null, nonzeroCommand()),
+                check("worker-report", false, PASS, "Worker claims success", null, null)));
+
+        assertEquals(FAIL, stamp.status());
+    }
+
+    @Test
+    void requiredNonPassingOutcomesFail() {
+        ShipLocalStamp missing = stamp(List.of(check(
+                "missing-check", true, MISSING,
+                "Required evidence is missing", null, null)));
+        ShipLocalStamp empty = stamp(List.of(check(
+                "empty-check", true, EMPTY,
+                "Required evidence is empty", null, successfulCommand())));
+        ShipLocalStamp skipped = stamp(List.of(check(
+                "skipped-check", true, SKIPPED,
+                "Required check was skipped", null, successfulCommand())));
+
+        assertAll(
+                () -> assertEquals(FAIL, missing.status()),
+                () -> assertEquals(FAIL, empty.status()),
+                () -> assertEquals(FAIL, skipped.status()));
+    }
+
+    @Test
+    void requiresExplicitWaiversAndLetsFailuresWin() {
+        ShipLocalStamp waived = stamp(List.of(
+                check("manual-review", true, WAIVED,
+                        "Manual review waived", "Accepted local exception", null)));
+        ShipLocalStamp failed = stamp(List.of(
+                check("manual-review", true, WAIVED,
+                        "Manual review waived", "Accepted local exception", null),
+                check("required-check", true, NONZERO,
+                        "Required check failed", null, nonzeroCommand())));
+
+        assertAll(
+                () -> assertEquals(COMPLETED_WITH_WAIVER, waived.status()),
+                () -> assertEquals(FAIL, failed.status()),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "manual-review", true, WAIVED, "Waived", null, null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "manual-review", false, WAIVED, "Waived", "Not required", null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "manual-review", true, PASS, "Passed", "Unclaimed waiver", null)),
+                () -> check(
+                        "composer-defined-check", true, WAIVED,
+                        "Waived", "Accepted", null),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "manual-review", true, WAIVED,
+                        "Waived", "Accepted", successfulCommand())));
+    }
+
+    @Test
+    void validatesCommandFactsAndRedactionBoundaries() {
+        ArrayList<String> arguments = new ArrayList<>(
+                List.of("--token", ShipLocalStamp.REDACTED,
+                        "-Drepo.password=" + ShipLocalStamp.REDACTED, "--verbose"));
+        ShipLocalStamp.CommandRun command = command(
+                arguments, true, false, 0, STARTED, ENDED,
+                digest("stdout"), digest("stderr"));
+        arguments.set(3, "--changed");
+
+        assertAll(
+                () -> assertEquals("--verbose", command.redactedArguments().get(3)),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--token=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("-Drepo.password=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("-Daws.secretAccessKey=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("-Drepo.token.value=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--aws-access-key-id=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--service-private-key=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--service-jwt=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--service-pat=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--db-pass", "actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--mysql-pwd=actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--client-credentials", "actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("Bearer actual-secret"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("https://user:pass@example.test"), true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--header=Authorization: Bearer actual-secret"),
+                        true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of("--authorization", ShipLocalStamp.REDACTED, "credential"),
+                        true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> command(
+                        List.of(
+                                "Authorization: " + ShipLocalStamp.REDACTED,
+                                "Bearer " + ShipLocalStamp.REDACTED,
+                                "https://" + ShipLocalStamp.REDACTED + "@example.test",
+                                "--credentials-file=/tmp/credentials.json",
+                                "/tmp/token-project"),
+                        true, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr")),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of(), true, false, 0,
+                        ENDED, STARTED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of(), true, false, 0,
+                        STARTED, ENDED, "sha256:bad", digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.CommandRun(
+                        "relative/camel", "Camel 4", List.of(),
+                        "/tmp/workspace", List.of(digest("input")),
+                        true, false, false, 0, STARTED.toString(), ENDED.toString(),
+                        "/tmp/stdout.log", digest("stdout"),
+                        "/tmp/stderr.log", digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.CommandRun(
+                        "/usr/bin/camel", "Camel 4", List.of(),
+                        "/tmp/workspace", List.of(),
+                        true, false, false, 0, STARTED.toString(), ENDED.toString(),
+                        "/tmp/stdout.log", digest("stdout"),
+                        "/tmp/stderr.log", digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> command(
+                        List.of(), false, false, 0,
+                        STARTED, ENDED, digest("stdout"), digest("stderr"))),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "validation", true, PASS, "Passed", null, nonzeroCommand())));
+    }
+
+    @Test
+    void rejectsCredentialBypassesAndAcceptsRunnerRedactionForms() {
+        List<List<String>> bypasses = List.of(
+                List.of("--auth", "actual-secret"),
+                List.of("--passphrase", "actual-secret"),
+                List.of("--docker-auth-config", "{\"auth\":\"actual-secret\"}"),
+                List.of("DOCKER_AUTH_CONFIG=actual-secret"),
+                List.of("NPM_CONFIG__AUTH=actual-secret"),
+                List.of("Basic \"actual-secret\""),
+                List.of("Bearer 'actual-secret'"),
+                List.of("--authorization=Bearer", "actual-secret"),
+                List.of("--authorization", "Basic", "actual-secret"),
+                List.of("https://actual-secret@example.test"),
+                List.of("https://:actual-secret@example.test"),
+                List.of("https://@example.test"),
+                List.of("-u", "user:actual-secret"),
+                List.of("-uuser:actual-secret"),
+                List.of("--user=user:actual-secret"),
+                List.of("--userpwd", "user:actual-secret"),
+                List.of("--proxy-user=user:actual-secret"),
+                List.of("--oauth2-bearer=actual-secret"),
+                List.of("--cookie=SID=actual-secret"),
+                List.of("-bSID=actual-secret"),
+                List.of("--config={\"password\":\"actual-secret,tail\"}"),
+                List.of("--header=Authorization: \"Basic actual-secret\""));
+        for (List<String> arguments : bypasses) {
+            assertThrows(IllegalArgumentException.class, () -> command(
+                    arguments, true, false, 0,
+                    STARTED, ENDED, digest("stdout"), digest("stderr")));
+        }
+
+        for (List<String> arguments : List.of(
+                List.of("--authorization", ShipLocalStamp.REDACTED, ShipLocalStamp.REDACTED),
+                List.of("--authorization", "Bearer", ShipLocalStamp.REDACTED),
+                List.of("--authorization=" + ShipLocalStamp.REDACTED, ShipLocalStamp.REDACTED),
+                List.of("--authorization=Basic", ShipLocalStamp.REDACTED),
+                List.of("Basic " + ShipLocalStamp.REDACTED),
+                List.of("Bearer \"" + ShipLocalStamp.REDACTED + "\""),
+                List.of("https://" + ShipLocalStamp.REDACTED + "@example.test"),
+                List.of("-u", ShipLocalStamp.REDACTED),
+                List.of("-u" + ShipLocalStamp.REDACTED),
+                List.of("--user=" + ShipLocalStamp.REDACTED),
+                List.of("--proxy-user=" + ShipLocalStamp.REDACTED),
+                List.of("--oauth2-bearer=" + ShipLocalStamp.REDACTED),
+                List.of("--cookie=" + ShipLocalStamp.REDACTED),
+                List.of("-b" + ShipLocalStamp.REDACTED),
+                List.of("--passphrase", ShipLocalStamp.REDACTED),
+                List.of("--docker-auth-config", ShipLocalStamp.REDACTED),
+                List.of("--config={\"password\":\"" + ShipLocalStamp.REDACTED + "\"}"),
+                List.of("--header=Authorization: \"" + ShipLocalStamp.REDACTED + "\""),
+                List.of("", "--system-prompt", ""))) {
+            command(arguments, true, false, 0,
+                    STARTED, ENDED, digest("stdout"), digest("stderr"));
+        }
+
+        assertAll(
+                () -> assertTrue(ShipLocalStamp.isSensitiveName("--pwd")),
+                () -> assertFalse(ShipLocalStamp.isSensitiveEnvironmentName("PWD")),
+                () -> assertFalse(ShipLocalStamp.isSensitiveEnvironmentName("OLDPWD")),
+                () -> assertTrue(ShipLocalStamp.isSensitiveEnvironmentName("DB_PWD")),
+                () -> assertTrue(ShipLocalStamp.isSensitiveEnvironmentName("OAUTH2_BEARER")),
+                () -> assertTrue(ShipLocalStamp.isSensitiveEnvironmentName("COOKIE")),
+                () -> assertFalse(ShipLocalStamp.isSensitiveEnvironmentName("COOKIE_FILE")),
+                () -> assertFalse(ShipLocalStamp.isSensitiveEnvironmentName("COOKIE_PATH")));
+    }
+
+    @Test
+    void validatesCommandBackedOutcomeConsistency() {
+        ShipLocalStamp.CommandRun timedOut = command(
+                List.of("verify"), true, true, null,
+                STARTED, ENDED, digest("stdout"), digest("stderr"));
+        ShipLocalStamp.CommandRun unlaunched = command(
+                List.of("verify"), false, false, null,
+                STARTED, ENDED, digest("stdout"), digest("stderr"));
+        ShipLocalStamp.CommandRun outputLimited = command(
+                List.of("verify"), true, false, true, 0,
+                STARTED, ENDED, digest("stdout"), digest("stderr"));
+        assertAll(
+                () -> check("validation", true, PASS, "Passed", null, null),
+                () -> check("validation", true, TIMED_OUT, "Timed out", null, timedOut),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "validation", true, SKIPPED,
+                        "Skipped", null, nonzeroCommand())),
+                () -> assertFalse(unlaunched.completed()),
+                () -> assertFalse(unlaunched.succeeded()),
+                () -> assertFalse(outputLimited.succeeded()),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "validation", true, PASS, "Passed", null, outputLimited)),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "validation", true, NONZERO, "Failed", null, timedOut)));
+    }
+
+    @Test
+    void requiresOneRequiredCheckButAcceptsComposerDefinedEvidence() {
+        List<ShipLocalStamp.ToolVersion> customTool = List.of(new ShipLocalStamp.ToolVersion(
+                "custom-runner", null, "1.0", SUPPORTED, null));
+        List<ShipLocalStamp.Check> customCheck = List.of(check(
+                "integration-test-extra", true, PASS, "Custom check passed", null, null));
+        List<ShipLocalStamp.Check> optionalOnly = List.of(check(
+                "optional-check", false, PASS, "Optional check passed", null, null));
+
+        assertAll(
+                () -> create(customTool, customCheck),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> create(customTool, optionalOnly)),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> create(List.of(), customCheck)));
+    }
+
+    @Test
+    void rejectsPredatedEvidenceAndUnsafeDisplayText() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () -> ShipLocalStamp.create(
+                        RUN_ID,
+                        tools(),
+                        completeChecks(List.of(check(
+                                "command-check",
+                                true,
+                                PASS,
+                                "Command passed",
+                                null,
+                                successfulCommand()))),
+                        STARTED)),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "worker-report",
+                        false,
+                        PASS,
+                        "unsafe\u001b[31m",
+                        null,
+                        null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "worker-report",
+                        false,
+                        PASS,
+                        "unsafe\u202e",
+                        null,
+                        null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> check(
+                        "worker-report",
+                        false,
+                        PASS,
+                        "unsafe\uD800",
+                        null,
+                        null)));
+    }
+
+    @Test
+    void genericToolDiagnosticsDoNotOverrideRequiredChecks() {
+        ShipLocalStamp experimental = stamp(withTool(new ShipLocalStamp.ToolVersion(
+                "pi", "/usr/bin/pi", "0.80.6", EXPERIMENTAL, "Version is experimental")), List.of());
+        ShipLocalStamp.ToolVersion incompatible = new ShipLocalStamp.ToolVersion(
+                "pi", "/usr/bin/pi", "0.70.0", INCOMPATIBLE, "Required JSON mode is absent");
+        ShipLocalStamp.ToolVersion untested = new ShipLocalStamp.ToolVersion(
+                "pi", "/usr/bin/pi", null, UNTESTED, "Version could not be identified");
+        ShipLocalStamp.ToolVersion missing = new ShipLocalStamp.ToolVersion(
+                "pi", null, null, ShipLocalStamp.Support.MISSING,
+                "Install Pi and configure its executable");
+        ShipLocalStamp missingNode = stamp(withTool(new ShipLocalStamp.ToolVersion(
+                "node", null, null, ShipLocalStamp.Support.MISSING,
+                "Standalone Node was not found")), List.of());
+        ShipLocalStamp supportedWithoutExecutable = stamp(withTool(new ShipLocalStamp.ToolVersion(
+                "pi", null, "0.80.6", SUPPORTED, null)), List.of());
+        ShipLocalStamp osWithExecutable = stamp(withTool(new ShipLocalStamp.ToolVersion(
+                "os", "/usr/bin/uname", "Linux 6.15", SUPPORTED, null)), List.of());
+
+        assertAll(
+                () -> assertEquals(ShipLocalStamp.Status.PASS, experimental.status()),
+                () -> assertEquals(ShipLocalStamp.Status.PASS, missingNode.status()),
+                () -> assertEquals(ShipLocalStamp.Status.PASS, supportedWithoutExecutable.status()),
+                () -> assertEquals(ShipLocalStamp.Status.PASS, osWithExecutable.status()),
+                () -> assertEquals(ShipLocalStamp.Status.PASS, stamp(
+                        withTool(incompatible), List.of()).status()),
+                () -> assertEquals(ShipLocalStamp.Status.PASS, stamp(
+                        withTool(untested), List.of()).status()),
+                () -> assertEquals(ShipLocalStamp.Status.PASS, stamp(
+                        withTool(missing), List.of()).status()),
+                () -> assertEquals(FAIL, stamp(
+                        withTool(missing),
+                        List.of(check(
+                                "required-capability",
+                                true,
+                                MISSING,
+                                "Pi is unavailable",
+                                null,
+                                null)))
+                        .status()),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "missing", "/usr/bin/tool", null,
+                        ShipLocalStamp.Support.MISSING, "Install it")),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "missing", null, "1.0",
+                        ShipLocalStamp.Support.MISSING, "Install it")),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "missing", null, null,
+                        ShipLocalStamp.Support.MISSING, null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "supported", null, null, SUPPORTED, null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "supported", null, "1.0", SUPPORTED, "Unexpected warning")),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "experimental", null, "1.0", EXPERIMENTAL, null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> new ShipLocalStamp.ToolVersion(
+                        "tool", "relative/tool", "1.0", SUPPORTED, null)));
+    }
+
+    @Test
+    void roundTripsJsonWithStatusAndCanonicalTimestamps() throws Exception {
+        ShipLocalStamp original = stamp(List.of());
+        ObjectMapper json = new ObjectMapper();
+
+        String encoded = json.writeValueAsString(original);
+        ShipLocalStamp decoded = json.readValue(encoded, ShipLocalStamp.class);
+
+        assertAll(
+                () -> assertEquals(original, decoded),
+                () -> assertTrue(encoded.contains("\"status\":\"PASS\"")),
+                () -> assertTrue(encoded.contains("\"generatedAt\":\"2026-07-24T08:00:01Z\"")),
+                () -> assertThrows(Exception.class, () -> json.readValue(
+                        encoded.replace("\"status\":\"PASS\"", "\"status\":\"FAIL\""),
+                        ShipLocalStamp.class)));
+    }
+
+    @Test
+    void rejectsDuplicateToolAndCheckIds() {
+        List<ShipLocalStamp.ToolVersion> duplicateTools = new ArrayList<>(tools());
+        duplicateTools.add(tools().get(0));
+        List<ShipLocalStamp.Check> duplicateChecks = new ArrayList<>(completeChecks(List.of()));
+        duplicateChecks.add(duplicateChecks.get(0));
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> create(duplicateTools, completeChecks(List.of()))),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> create(tools(), duplicateChecks)));
+    }
+
+    @Test
+    void atomicallyPersistsAndStrictlyReloadsTheStamp(@TempDir Path directory) throws Exception {
+        makePrivate(directory);
+        ShipLocalStamp passed = persistableStamp(directory, 0);
+        ShipLocalStamp failed = persistableStamp(directory, 1);
+
+        Path report = ShipLocalStampStore.write(directory, RUN_ID, failed);
+        byte[] failedReport = Files.readAllBytes(report);
+        Files.writeString(directory.resolve("stdout.log"), "tampered");
+        assertThrows(IOException.class, () -> ShipLocalStampStore.write(directory, RUN_ID, passed));
+        assertArrayEquals(failedReport, Files.readAllBytes(report));
+        assertThrows(IOException.class, () -> ShipLocalStampStore.read(directory, RUN_ID));
+
+        Files.writeString(directory.resolve("stdout.log"), "stdout");
+        assertEquals(failed, ShipLocalStampStore.read(directory, RUN_ID));
+        ShipLocalStampStore.write(directory, RUN_ID, passed);
+
+        assertAll(
+                () -> assertEquals(directory.resolve("stamp.json"), report),
+                () -> assertEquals(passed, ShipLocalStampStore.read(directory, RUN_ID)));
+
+        String encoded = Files.readString(report);
+        for (String invalid : List.of(
+                "null",
+                "{\"schemaVersion\":1," + encoded.substring(1),
+                encoded + " true",
+                replace(encoded, "\"runId\"", "\"unknown\":true,\"runId\""),
+                replace(encoded, "\"status\" : \"PASS\"", "\"status\" : 0"),
+                replace(encoded, "\"schemaVersion\" : 1", "\"schemaVersion\" : 1.0"),
+                replace(encoded, "\"schemaVersion\" : 1", "\"schemaVersion\" : \"1\""),
+                replace(encoded, "\"launched\" : true", "\"launched\" : null"))) {
+            Files.writeString(report, invalid);
+            assertThrows(IOException.class, () -> ShipLocalStampStore.read(directory, RUN_ID));
+        }
+        Files.writeString(report, encoded);
+        assertEquals(passed, ShipLocalStampStore.read(directory, RUN_ID));
+
+        String anotherRun = "ship-ffffffffffffffffffffffffffffffff";
+        byte[] unchanged = Files.readAllBytes(report);
+        assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.write(directory, anotherRun, passed));
+        assertArrayEquals(unchanged, Files.readAllBytes(report));
+        assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.read(directory, anotherRun));
+    }
+
+    @Test
+    void rejectsReservedAliasedAndPhysicallySharedLogs(@TempDir Path directory)
+            throws Exception {
+        makePrivate(directory);
+        ShipLocalStamp passed = persistableStamp(directory, 0);
+        Path report = ShipLocalStampStore.write(directory, RUN_ID, passed);
+        Path stderr = directory.resolve("stderr.log");
+
+        ShipLocalStamp.CommandRun reserved = storedCommand(
+                directory,
+                report,
+                stderr,
+                0,
+                ShipDigest.sha256(Files.readAllBytes(report)),
+                digest("stderr"));
+        ShipLocalStamp reservedStamp = persistableStamp(directory, 0, List.of(check(
+                "evidence-check", true, PASS, "Evidence check passed", null, reserved)));
+        byte[] unchanged = Files.readAllBytes(report);
+        IOException reservedFailure = assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.write(directory, RUN_ID, reservedStamp));
+        assertTrue(reservedFailure.getMessage().contains("outside its evidence directory"));
+        assertArrayEquals(unchanged, Files.readAllBytes(report));
+
+        Path nested = Files.createDirectory(directory.resolve("nested"));
+        Path nestedLog = writePrivate(nested.resolve("stdout.log"), "nested");
+        Path alias = directory.resolve("alias");
+        Files.createSymbolicLink(alias, nested.getFileName());
+        ShipLocalStamp.CommandRun aliased = storedCommand(
+                directory,
+                alias.resolve(nestedLog.getFileName()),
+                stderr,
+                0,
+                digest("nested"),
+                digest("stderr"));
+        IOException aliasFailure = assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.write(
+                        directory,
+                        RUN_ID,
+                        persistableStamp(directory, 0, List.of(check(
+                                "evidence-check",
+                                true,
+                                PASS,
+                                "Evidence check passed",
+                                null,
+                                aliased)))));
+        assertTrue(aliasFailure.getMessage().contains("escaped its evidence directory"));
+
+        Path shared = writePrivate(directory.resolve("shared.log"), "shared");
+        Path sharedAlias = directory.resolve("shared-alias.log");
+        Files.createLink(sharedAlias, shared);
+        ShipLocalStamp.CommandRun hardLinked = storedCommand(
+                directory,
+                shared,
+                sharedAlias,
+                0,
+                digest("shared"),
+                digest("shared"));
+        IOException hardLinkFailure = assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.write(
+                        directory,
+                        RUN_ID,
+                        persistableStamp(directory, 0, List.of(check(
+                                "evidence-check",
+                                true,
+                                PASS,
+                                "Evidence check passed",
+                                null,
+                                hardLinked)))));
+        assertTrue(hardLinkFailure.getMessage().contains(
+                "stdout and stderr must be distinct files"));
+    }
+
+    @Test
+    void requiresPrivateEvidenceAndPersistsPrivateFiles(@TempDir Path directory)
+            throws Exception {
+        makePrivate(directory);
+        ShipLocalStamp stamp = persistableStamp(directory, 0);
+        Path stdout = directory.resolve("stdout.log");
+        Path stderr = directory.resolve("stderr.log");
+
+        Files.setPosixFilePermissions(
+                directory, PosixFilePermissions.fromString("rwxr-x---"));
+        IOException directoryFailure = assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.write(directory, RUN_ID, stamp));
+        assertTrue(directoryFailure.getMessage().contains("0700"));
+
+        Files.setPosixFilePermissions(directory, PRIVATE_DIRECTORY);
+        Files.setPosixFilePermissions(
+                stdout, PosixFilePermissions.fromString("rw-r-----"));
+        IOException logFailure = assertThrows(
+                IOException.class,
+                () -> ShipLocalStampStore.write(directory, RUN_ID, stamp));
+        assertTrue(logFailure.getMessage().contains("0600"));
+
+        Files.setPosixFilePermissions(stdout, PRIVATE_FILE);
+        Path report = ShipLocalStampStore.write(directory, RUN_ID, stamp);
+        assertAll(
+                () -> assertEquals(
+                        PRIVATE_DIRECTORY, Files.getPosixFilePermissions(directory)),
+                () -> assertEquals(PRIVATE_FILE, Files.getPosixFilePermissions(report)),
+                () -> assertEquals(PRIVATE_FILE, Files.getPosixFilePermissions(stdout)),
+                () -> assertEquals(PRIVATE_FILE, Files.getPosixFilePermissions(stderr)));
+    }
+
+    private static ShipLocalStamp persistableStamp(Path directory, int buildExit)
+            throws IOException {
+        return persistableStamp(directory, buildExit, List.of());
+    }
+
+    private static ShipLocalStamp persistableStamp(
+            Path directory,
+            int buildExit,
+            List<ShipLocalStamp.Check> replacements)
+            throws IOException {
+        Path stdout = writePrivate(directory.resolve("stdout.log"), "stdout");
+        Path stderr = writePrivate(directory.resolve("stderr.log"), "stderr");
+        ShipLocalStamp.CommandRun command = storedCommand(directory, stdout, stderr, buildExit);
+        List<ShipLocalStamp.Check> commands = new ArrayList<>(
+                List.of(check(
+                        "command-check",
+                        true,
+                        buildExit == 0 ? PASS : NONZERO,
+                        buildExit == 0 ? "Command passed" : "Command failed",
+                        null,
+                        command)));
+        for (ShipLocalStamp.Check replacement : replacements) {
+            commands.removeIf(check -> check.id().equals(replacement.id()));
+            commands.add(replacement);
+        }
+        return stamp(commands);
+    }
+
+    private static void makePrivate(Path directory) throws IOException {
+        Assumptions.assumeTrue(
+                directory.getFileSystem().supportedFileAttributeViews().contains("posix"));
+        Files.setPosixFilePermissions(directory, PRIVATE_DIRECTORY);
+    }
+
+    private static Path writePrivate(Path path, String content) throws IOException {
+        Path file = Files.writeString(path, content);
+        Files.setPosixFilePermissions(file, PRIVATE_FILE);
+        return file;
+    }
+
+    private static ShipLocalStamp.CommandRun storedCommand(
+            Path workingDirectory, Path stdout, Path stderr, int exitCode) {
+        return storedCommand(
+                workingDirectory,
+                stdout,
+                stderr,
+                exitCode,
+                digest("stdout"),
+                digest("stderr"));
+    }
+
+    private static ShipLocalStamp.CommandRun storedCommand(
+            Path workingDirectory,
+            Path stdout,
+            Path stderr,
+            int exitCode,
+            String stdoutDigest,
+            String stderrDigest) {
+        return new ShipLocalStamp.CommandRun(
+                "/usr/bin/camel",
+                "Camel 4.15.0",
+                List.of("verify"),
+                workingDirectory.toString(),
+                List.of(digest("input")),
+                true,
+                false,
+                false,
+                exitCode,
+                STARTED.toString(),
+                ENDED.toString(),
+                stdout.toString(),
+                stdoutDigest,
+                stderr.toString(),
+                stderrDigest);
+    }
+
+    private static ShipLocalStamp stamp(List<ShipLocalStamp.Check> checks) {
+        return stamp(tools(), checks);
+    }
+
+    private static ShipLocalStamp stamp(
+            List<ShipLocalStamp.ToolVersion> tools, List<ShipLocalStamp.Check> checks) {
+        return create(tools, completeChecks(checks));
+    }
+
+    private static ShipLocalStamp create(
+            List<ShipLocalStamp.ToolVersion> tools, List<ShipLocalStamp.Check> checks) {
+        return ShipLocalStamp.create(RUN_ID, tools, checks, ENDED);
+    }
+
+    private static List<ShipLocalStamp.ToolVersion> tools() {
+        return List.of(new ShipLocalStamp.ToolVersion(
+                "pi", "/usr/bin/pi", "0.80.6", SUPPORTED, null));
+    }
+
+    private static List<ShipLocalStamp.ToolVersion> withTool(
+            ShipLocalStamp.ToolVersion replacement) {
+        List<ShipLocalStamp.ToolVersion> replaced = new ArrayList<>(tools());
+        replaced.removeIf(tool -> tool.tool().equals(replacement.tool()));
+        replaced.add(replacement);
+        return List.copyOf(replaced);
+    }
+
+    private static List<ShipLocalStamp.Check> completeChecks(List<ShipLocalStamp.Check> replacements) {
+        List<ShipLocalStamp.Check> checks = new ArrayList<>(
+                List.of(
+                        check("baseline-check", true, PASS, "Baseline check passed", null, null)));
+        for (ShipLocalStamp.Check replacement : replacements) {
+            checks.removeIf(check -> check.id().equals(replacement.id()));
+            checks.add(replacement);
+        }
+        return List.copyOf(checks);
+    }
+
+    private static ShipLocalStamp.Check check(
+            String id,
+            boolean required,
+            ShipLocalStamp.Outcome outcome,
+            String summary,
+            String waiver,
+            ShipLocalStamp.CommandRun command) {
+        return new ShipLocalStamp.Check(id, required, outcome, summary, waiver, command);
+    }
+
+    private static ShipLocalStamp.CommandRun successfulCommand() {
+        return command(
+                List.of("verify"), true, false, 0,
+                STARTED, ENDED, digest("stdout"), digest("stderr"));
+    }
+
+    private static ShipLocalStamp.CommandRun nonzeroCommand() {
+        return command(
+                List.of("verify"), true, false, 1,
+                STARTED, ENDED, digest("stdout"), digest("stderr"));
+    }
+
+    private static ShipLocalStamp.CommandRun command(
+            List<String> arguments,
+            boolean launched,
+            boolean timedOut,
+            Integer exitCode,
+            Instant startedAt,
+            Instant endedAt,
+            String stdoutDigest,
+            String stderrDigest) {
+        return command(
+                arguments,
+                launched,
+                timedOut,
+                false,
+                exitCode,
+                startedAt,
+                endedAt,
+                stdoutDigest,
+                stderrDigest);
+    }
+
+    private static ShipLocalStamp.CommandRun command(
+            List<String> arguments,
+            boolean launched,
+            boolean timedOut,
+            boolean outputLimited,
+            Integer exitCode,
+            Instant startedAt,
+            Instant endedAt,
+            String stdoutDigest,
+            String stderrDigest) {
+        return new ShipLocalStamp.CommandRun(
+                "/usr/bin/camel",
+                "Camel 4.15.0",
+                arguments,
+                "/tmp/camel-kit-workspace",
+                List.of(digest("input")),
+                launched,
+                timedOut,
+                outputLimited,
+                exitCode,
+                startedAt.toString(),
+                endedAt.toString(),
+                "/tmp/camel-kit-stdout.log",
+                stdoutDigest,
+                "/tmp/camel-kit-stderr.log",
+                stderrDigest);
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static String replace(String source, String target, String replacement) {
+        assertTrue(source.contains(target), target);
+        return source.replace(target, replacement);
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -1,5 +1,6 @@
 package io.github.luigidemasi.camelkit.ship.security;
 
+import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.StandardProtocolFamily;
 import java.net.URI;
@@ -250,14 +251,52 @@ class ProjectSnapshotServiceTest {
     }
 
     @Test
-    void rejectsSymbolicRootComponents() throws Exception {
+    void acceptsSymbolicAncestorsButRejectsASymbolicRootLeaf() throws Exception {
         Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-parent"));
         Path project = Files.createDirectory(realParent.resolve("project"));
-        Path alias = temporaryDirectory.resolve("parent-alias");
-        Files.createSymbolicLink(alias, realParent);
+        Path parentAlias = temporaryDirectory.resolve("parent-alias");
+        Files.createSymbolicLink(parentAlias, realParent);
+        Path rootAlias = temporaryDirectory.resolve("project-alias");
+        Files.createSymbolicLink(rootAlias, project);
+        Path deniedParent = Files.createDirectory(temporaryDirectory.resolve(".git"));
+        Path deniedAlias = deniedParent.resolve("parent-alias");
+        Files.createSymbolicLink(deniedAlias, realParent);
+        Path canonicalDeniedParent = Files.createDirectories(temporaryDirectory.resolve("canonical-denied/.git"));
+        Files.createDirectory(canonicalDeniedParent.resolve("project"));
+        Path allowedAlias = temporaryDirectory.resolve("allowed-alias");
+        Files.createSymbolicLink(allowedAlias, canonicalDeniedParent);
 
+        assertEquals(
+                project.toRealPath().toString(),
+                new ProjectSnapshotService().capture(parentAlias.resolve("project")).root());
         assertCode(ShipFilesystemException.UNSAFE_ENTRY,
-                () -> new ProjectSnapshotService().capture(alias.resolve("project")));
+                () -> new ProjectSnapshotService().capture(rootAlias));
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> new ProjectSnapshotService().capture(deniedAlias.resolve("project")));
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> new ProjectSnapshotService().capture(allowedAlias.resolve("project")));
+    }
+
+    @Test
+    void materializationAcceptsATargetUnderASymbolicAncestorButRejectsALeafAlias()
+            throws Exception {
+        Path source = project();
+        write(source, "README.md", "material");
+        Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-output-parent"));
+        Path target = Files.createDirectory(realParent.resolve("candidate"));
+        Path parentAlias = temporaryDirectory.resolve("output-parent-alias");
+        Files.createSymbolicLink(parentAlias, realParent);
+        ProjectSnapshotService service = new ProjectSnapshotService();
+
+        ProjectSnapshot materialized = service.materializeMaterial(source, parentAlias.resolve("candidate"));
+
+        assertEquals(target.toRealPath().toString(), materialized.root());
+        assertEquals("material", Files.readString(target.resolve("README.md")));
+
+        Path otherTarget = Files.createDirectory(realParent.resolve("other-candidate"));
+        Path targetAlias = temporaryDirectory.resolve("candidate-alias");
+        Files.createSymbolicLink(targetAlias, otherTarget);
+        assertThrows(IOException.class, () -> service.materializeMaterial(source, targetAlias));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -195,6 +195,45 @@ class ProjectSnapshotServiceTest {
     }
 
     @Test
+    void readsOnlyBoundedVolatileFilesThroughTheHeldProjectDescriptor() throws Exception {
+        Path project = project();
+        Path generated = write(project, "target/generated.txt", "generated");
+        write(project, "requirements.md", "requirements");
+        write(project, ".camel-kit/pipeline.json", "private");
+
+        assertArrayEquals(
+                Files.readAllBytes(generated),
+                ProjectEvidenceFiles.readVolatile(project, "target/generated.txt", 1024));
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> ProjectEvidenceFiles.readVolatile(project, "requirements.md", 1024));
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> ProjectEvidenceFiles.readVolatile(
+                        project, ".camel-kit/pipeline.json", 1024));
+        assertCode(ShipFilesystemException.TREE_QUOTA_EXCEEDED,
+                () -> ProjectEvidenceFiles.readVolatile(project, "target/generated.txt", 4));
+    }
+
+    @Test
+    void volatileReadRejectsSymlinkedParentsFinalLinksAndHardLinks() throws Exception {
+        Path project = project();
+        Path target = Files.createDirectory(project.resolve("target"));
+        Path outside = Files.createDirectory(temporaryDirectory.resolve("outside"));
+        Path secret = write(outside, "secret.txt", "secret");
+        Files.createSymbolicLink(target.resolve("linked-parent"), outside);
+        Files.createSymbolicLink(target.resolve("linked.txt"), secret);
+        Files.createLink(target.resolve("hard-linked.txt"), secret);
+
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> ProjectEvidenceFiles.readVolatile(
+                        project, "target/linked-parent/secret.txt", 1024));
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> ProjectEvidenceFiles.readVolatile(project, "target/linked.txt", 1024));
+        assertCode(ShipFilesystemException.UNSAFE_ENTRY,
+                () -> ProjectEvidenceFiles.readVolatile(
+                        project, "target/hard-linked.txt", 1024));
+    }
+
+    @Test
     void rejectsSymbolicLinksAndHardLinksDuringSnapshot() throws Exception {
         Path symbolicProject = project();
         Path original = write(symbolicProject, "original.txt", "value");
@@ -313,7 +352,7 @@ class ProjectSnapshotServiceTest {
 
     @Test
     void rejectsHostileOnDiskNamesWithTypedDisplaySafeDiagnostics() throws Exception {
-        for (String hostile : List.of("line\nbreak", "back\\slash")) {
+        for (String hostile : List.of("line\nbreak", "control\u0001name", "back\\slash")) {
             Path project = project();
             Files.writeString(project.resolve(hostile), "content");
 
@@ -644,8 +683,9 @@ class ProjectSnapshotServiceTest {
         assertTrue(Modifier.isFinal(ProjectEvidenceFiles.class.getModifiers()));
         assertEquals(0, ProjectEvidenceFiles.class.getConstructors().length);
         assertEquals(
-                Set.of("capture", "captureSealed", "unchanged", "unchangedMaterialTree",
-                        "materializeMaterial", "readMaterial"),
+                Set.of("capture", "captureStaged", "captureSealed", "unchanged",
+                        "unchangedMaterialTree", "materializeMaterial", "readMaterial",
+                        "readVolatile"),
                 Arrays.stream(ProjectEvidenceFiles.class.getDeclaredMethods())
                         .filter(method -> Modifier.isPublic(method.getModifiers()))
                         .map(method -> method.getName())

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -1,0 +1,568 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.worker.LocalCommandRunner.Command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class LocalCommandRunnerTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    private Path executable;
+    private Path fixture;
+    private Path workingDirectory;
+    private Path evidenceDirectory;
+
+    @BeforeEach
+    void prepareFixture() throws Exception {
+        fixture = Files.createDirectory(temporaryDirectory.resolve("fixture"));
+        executable = writeExecutable(fixture.resolve("command"),
+                """
+                        #!/bin/sh
+                        fixture=$(dirname "$0")
+                        mode="$1"
+                        shift
+                        if [ "$mode" = "echo" ]; then
+                          cat > "$fixture/input"
+                          printf '%s\\n' '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"fixture-secret"}]}}'
+                          printf '%s\\n' '{"token":"fixture-secret"}'
+                          printf '%s\\n' 'Authorization=Bearer fixture-secret' >&2
+                          printf '%s\\n' 'Authorization: Basic dXNlcjpwYXNz' >&2
+                          printf '%s\\n' 'Authorization: "Basic quoted-value"' >&2
+                          printf '%s\\n' 'AWS_ACCESS_KEY_ID=log-access-key' >&2
+                          printf '%s\\n' "SERVICE_PRIVATE_KEY='log-private-key'" >&2
+                          printf '%s\\n' 'SERVICE_JWT=log-jwt' >&2
+                          printf '%s\\n' 'SERVICE_PAT=log-pat' >&2
+                          exit 0
+                        fi
+                        if [ "$mode" = "embedded-secrets" ]; then
+                          printf '%s\\n' 'supersecret' 'password-fragment' 'db-secret' \
+                            'quoted-token' 'json-secret,tail' 'url-token' 'empty-user-secret'
+                          exit 0
+                        fi
+                        if [ "$mode" = "credential-carriers" ]; then
+                          printf '%s\\n' 'proxy-secret' 'oauth-secret' \
+                            'cookie-secret' 'compact-cookie-secret' 'carrier-auth-secret'
+                          exit 0
+                        fi
+                        if [ "$mode" = "nonzero" ]; then
+                          printf '%s\\n' 'failed'
+                          exit 7
+                        fi
+                        if [ "$mode" = "oversized" ]; then
+                          dd if=/dev/zero bs=4096 count=2 2>/dev/null
+                          exit 0
+                        fi
+                        if [ "$mode" = "oversized-secret" ]; then
+                          printf 'captured-secret-prefix'
+                          dd if=/dev/zero bs=4096 count=2 2>/dev/null
+                          exit 0
+                        fi
+                        if [ "$mode" = "delayed-exit" ]; then
+                          sleep 0.05
+                          exit 0
+                        fi
+                        if [ "$mode" = "fast-detach" ]; then
+                          (
+                            trap '' TERM HUP INT
+                            sleep 1
+                            touch delayed-mutation
+                          ) &
+                          printf '%s\\n' "$!" > "$fixture/detached-pid"
+                          exit 0
+                        fi
+                        if [ "$mode" = "output-flood" ]; then
+                          sh -c 'trap "" TERM HUP INT; while :; do printf "%04096d" 0; done' &
+                          child=$!
+                          printf '%s\\n' "$$" > "$fixture/parent-pid"
+                          printf '%s\\n' "$child" > "$fixture/child-pid"
+                          touch "$fixture/ready"
+                          trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 143' TERM HUP INT
+                          wait "$child"
+                        fi
+                        if [ "$mode" != "no-read" ]; then
+                          cat > /dev/null
+                        fi
+                        sh -c 'trap "" TERM HUP INT; while :; do sleep 300; done' &
+                        child=$!
+                        printf '%s\\n' "$$" > "$fixture/parent-pid"
+                        printf '%s\\n' "$child" > "$fixture/child-pid"
+                        touch "$fixture/ready"
+                        trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 143' TERM HUP INT
+                        wait "$child"
+                        """);
+        workingDirectory = Files.createDirectory(temporaryDirectory.resolve("workspace"));
+        evidenceDirectory = Files.createDirectory(temporaryDirectory.resolve("evidence"));
+    }
+
+    @Test
+    void closesInputAndRetainsOnlyRedactedBoundedLogs() throws Exception {
+        List<String> arguments = new ArrayList<>(
+                List.of("echo", "--token", "fixture-secret"));
+        Command command = command(arguments, Duration.ofSeconds(5), 4096);
+        arguments.clear();
+
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command);
+
+        assertEquals(0, result.exitCode());
+        assertEquals(0, Files.size(fixture.resolve("input")));
+        String retainedStdout = Files.readString(result.stdoutLog());
+        assertFalse(retainedStdout.contains("fixture-secret"));
+        assertTrue(retainedStdout.contains("\"text\":\"<redacted>\""));
+        assertTrue(retainedStdout.contains("{\"token\":\"<redacted>\"}"));
+        String retainedStderr = Files.readString(result.stderrLog());
+        assertTrue(retainedStderr.contains("Authorization=<redacted>"));
+        assertTrue(retainedStderr.contains("Authorization: <redacted>"));
+        assertTrue(retainedStderr.contains("Authorization: \"<redacted>\""));
+        assertTrue(retainedStderr.contains("AWS_ACCESS_KEY_ID=<redacted>"));
+        assertTrue(retainedStderr.contains("SERVICE_PRIVATE_KEY='<redacted>'"));
+        assertTrue(retainedStderr.contains("SERVICE_JWT=<redacted>"));
+        assertTrue(retainedStderr.contains("SERVICE_PAT=<redacted>"));
+        assertFalse(retainedStderr.contains("dXNlcjpwYXNz"));
+        assertFalse(retainedStderr.contains("quoted-value"));
+        assertFalse(retainedStderr.contains("log-access-key"));
+        assertEquals(
+                List.of("echo", "--token", "<redacted>"),
+                result.redactedArguments());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(result.stdoutLog())),
+                result.stdoutDigest());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(result.stderrLog())),
+                result.stderrDigest());
+        assertFalse(command.toString().contains("fixture-secret"));
+        assertFalse(result.toString().contains("fixture-secret"));
+    }
+
+    @Test
+    void redactsEchoedFragmentsFromEmbeddedArgumentSecrets() throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of(
+                        "embedded-secrets",
+                        "--header=Authorization: Bearer supersecret",
+                        "-u",
+                        "user:password-fragment",
+                        "MYSQL_PWD: db-secret",
+                        "--header=Authorization: Bearer \"quoted-token\"",
+                        "--config={\"password\":\"json-secret,tail\"}",
+                        "https://url-token@host",
+                        "https://:empty-user-secret@host"),
+                Duration.ofSeconds(5),
+                4096));
+
+        assertEquals(
+                "<redacted>\n<redacted>\n<redacted>\n<redacted>\n"
+                     + "<redacted>\n<redacted>\n<redacted>\n",
+                Files.readString(result.stdoutLog()));
+        assertEquals(
+                List.of(
+                        "embedded-secrets",
+                        "--header=Authorization: <redacted>",
+                        "-u",
+                        "<redacted>",
+                        "MYSQL_PWD: <redacted>",
+                        "--header=Authorization: <redacted>",
+                        "--config={\"password\":\"<redacted>\"}",
+                        "https://<redacted>@host",
+                        "https://<redacted>@host"),
+                result.redactedArguments());
+    }
+
+    @Test
+    void redactsMultiwordAuthorizationAndExtendedSensitiveArguments() throws Exception {
+        List<String> arguments = List.of(
+                "echo",
+                "--authorization",
+                "Basic",
+                "abc",
+                "--authorization=Bearer",
+                "split-token",
+                "--auth",
+                "Bearer \"quoted-token\"",
+                "--passphrase",
+                "argument-passphrase",
+                "--docker-auth-config",
+                "{\"auth\":\"docker-token\"}",
+                "--npm-config--auth",
+                "npm-token",
+                "--aws-access-key-id",
+                "AKIAARGUMENT",
+                "--service-private-key",
+                "argument-private",
+                "--service-jwt",
+                "argument-jwt",
+                "--service-pat",
+                "argument-pat");
+
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                arguments, Duration.ofSeconds(5), 4096));
+
+        assertEquals(List.of(
+                "echo",
+                "--authorization",
+                "Basic",
+                "<redacted>",
+                "--authorization=<redacted>",
+                "<redacted>",
+                "--auth",
+                "Bearer <redacted>",
+                "--passphrase",
+                "<redacted>",
+                "--docker-auth-config",
+                "<redacted>",
+                "--npm-config--auth",
+                "<redacted>",
+                "--aws-access-key-id",
+                "<redacted>",
+                "--service-private-key",
+                "<redacted>",
+                "--service-jwt",
+                "<redacted>",
+                "--service-pat",
+                "<redacted>"), result.redactedArguments());
+        assertFalse(result.toString().contains("AKIAARGUMENT"));
+        assertFalse(result.toString().contains("argument-private"));
+        assertFalse(result.toString().contains("argument-jwt"));
+        assertFalse(result.toString().contains("argument-pat"));
+        assertFalse(result.toString().contains("argument-passphrase"));
+        assertFalse(result.toString().contains("docker-token"));
+        assertFalse(result.toString().contains("npm-token"));
+    }
+
+    @Test
+    void redactsKnownCredentialCarriersAndProducesValidStampArguments() throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of(
+                        "credential-carriers",
+                        "--proxy-user=user:proxy-secret",
+                        "--oauth2-bearer=oauth-secret",
+                        "--cookie=SID=cookie-secret",
+                        "-bSID=compact-cookie-secret",
+                        "--authorization",
+                        "Bearer",
+                        "carrier-auth-secret"),
+                Duration.ofSeconds(5),
+                4096));
+
+        assertEquals(
+                List.of(
+                        "credential-carriers",
+                        "--proxy-user=<redacted>",
+                        "--oauth2-bearer=<redacted>",
+                        "--cookie=<redacted>",
+                        "-b<redacted>",
+                        "--authorization",
+                        "Bearer",
+                        "<redacted>"),
+                result.redactedArguments());
+        assertEquals(
+                "<redacted>\n<redacted>\n<redacted>\n<redacted>\n<redacted>\n",
+                Files.readString(result.stdoutLog()));
+
+        ShipLocalStamp.CommandRun evidence = stampCommand(result);
+        assertEquals(result.redactedArguments(), evidence.redactedArguments());
+    }
+
+    @Test
+    void directAuthorizationFormsProduceValidStampArguments() throws Exception {
+        List<List<String>> forms = List.of(
+                List.of("echo", "--authorization=direct-secret", "direct-payload"),
+                List.of("echo", "--authorization", "direct-secret", "direct-payload"),
+                List.of("echo", "--proxyAuthorization=proxy-secret", "proxy-payload"),
+                List.of("echo", "--authorization", "\"Bearer\"", "quoted-token"),
+                List.of("echo", "--authorization=Bearer", "-opaque-token"),
+                List.of("echo", "authorization", "Bearer", "bare-token"));
+        List<List<String>> expected = List.of(
+                List.of("echo", "--authorization=<redacted>", "<redacted>"),
+                List.of("echo", "--authorization", "<redacted>", "<redacted>"),
+                List.of("echo", "--proxyAuthorization=<redacted>", "<redacted>"),
+                List.of("echo", "--authorization", "\"Bearer\"", "<redacted>"),
+                List.of("echo", "--authorization=<redacted>", "<redacted>"),
+                List.of("echo", "authorization", "Bearer", "<redacted>"));
+        for (int index = 0; index < forms.size(); index++) {
+            LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                    forms.get(index), Duration.ofSeconds(5), 4096));
+
+            assertEquals(expected.get(index), result.redactedArguments());
+            assertEquals(
+                    result.redactedArguments(),
+                    stampCommand(result).redactedArguments());
+        }
+    }
+
+    @Test
+    void reapsFastDetachedProcessGroupBeforeReturning() throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of("fast-detach"), Duration.ofSeconds(5), 4096));
+
+        long detached = Long.parseLong(
+                Files.readString(fixture.resolve("detached-pid")).trim());
+        assertEquals(0, result.exitCode());
+        assertFalse(ProcessHandle.of(detached).map(ProcessHandle::isAlive).orElse(false));
+        Thread.sleep(Duration.ofSeconds(1).toMillis());
+        assertFalse(Files.exists(workingDirectory.resolve("delayed-mutation")));
+    }
+
+    @Test
+    void reportsNonzeroAndBoundsExcessiveOutput() throws Exception {
+        LocalCommandRunner runner = new LocalCommandRunner();
+
+        LocalCommandRunner.Result nonzero = runner.run(command(
+                List.of("nonzero"), Duration.ofSeconds(5), 4096));
+        LocalCommandRunner.Result oversized = runner.run(command(
+                List.of("oversized"), Duration.ofSeconds(5), 1024));
+
+        assertEquals(7, nonzero.exitCode());
+        assertFalse(nonzero.timedOut());
+        assertTrue(oversized.outputLimited());
+        assertTrue(Files.size(oversized.stdoutLog()) <= 1024);
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(oversized.stdoutLog())),
+                oversized.stdoutDigest());
+    }
+
+    @Test
+    void outputLimitRetainsOnlyTheLimitMarker() throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of("oversized-secret"), Duration.ofSeconds(5), 128));
+
+        assertTrue(result.outputLimited());
+        assertEquals("<output-limit-exceeded>\n", Files.readString(result.stdoutLog()));
+        assertEquals("<output-limit-exceeded>\n", Files.readString(result.stderrLog()));
+        assertFalse(Files.readString(result.stdoutLog()).contains("captured-secret-prefix"));
+    }
+
+    @Test
+    void outputFloodForciblyReapsProcessGroup() throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of("output-flood"), Duration.ofSeconds(5), 1024));
+
+        assertTrue(result.outputLimited());
+        assertProcessesGone();
+    }
+
+    @Test
+    void boundsShortSecretRedactionWithoutRescanningTheMarker() throws Exception {
+        int maximumBytes = 1024;
+        LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
+                "a".repeat(4096).getBytes(StandardCharsets.UTF_8),
+                evidenceDirectory,
+                ".stdout.log",
+                maximumBytes,
+                List.of("a", "redacted"));
+
+        String content = Files.readString(retained.path());
+        assertTrue(Files.size(retained.path()) <= maximumBytes);
+        assertEquals(
+                ShipLocalStamp.REDACTED.repeat(
+                        maximumBytes / ShipLocalStamp.REDACTED.length()),
+                content);
+    }
+
+    @Test
+    void rejectsPreInterruptedInvocationWithoutLaunching() {
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(
+                    InterruptedException.class,
+                    () -> new LocalCommandRunner().run(command(
+                            List.of("echo"),
+                            Duration.ofSeconds(5),
+                            4096)));
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertFalse(Files.exists(fixture.resolve("input")));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void accountsTinyTimeoutBeforeTheProcessCanExit() throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of("delayed-exit"),
+                Duration.ofMillis(1),
+                4096));
+
+        assertTrue(result.timedOut());
+        assertNull(result.exitCode());
+    }
+
+    @Test
+    void rejectsEqualOrNestedWorkingAndEvidenceDirectories() throws Exception {
+        Path parent = Files.createDirectory(temporaryDirectory.resolve("overlap"));
+        Path child = Files.createDirectory(parent.resolve("child"));
+
+        assertOverlapRejected(parent, parent);
+        assertOverlapRejected(parent, child);
+        assertOverlapRejected(child, parent);
+        assertFalse(Files.exists(fixture.resolve("input")));
+    }
+
+    @Test
+    void timeoutForciblyReapsTermIgnoringChild()
+            throws Exception {
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command(
+                List.of("no-read"), Duration.ofMillis(300), 4096));
+
+        assertTrue(result.timedOut());
+        assertNull(result.exitCode());
+        assertProcessesGone();
+    }
+
+    @Test
+    void interruptionForciblyReapsTreeAndPreservesInterrupt() throws Exception {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                new LocalCommandRunner().run(command(
+                        List.of("block"),
+                        Duration.ofSeconds(30),
+                        4096));
+                failure.set(new AssertionError("Local command unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertProcessesGone();
+    }
+
+    @Test
+    void rejectsWorkingDirectoryThroughAncestorSymlink() throws Exception {
+        Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-parent"));
+        Path realWorking = Files.createDirectory(realParent.resolve("working"));
+        Path alias = temporaryDirectory.resolve("alias-parent");
+        Files.createSymbolicLink(alias, realParent.getFileName());
+        Command command = new Command(
+                executable,
+                List.of("echo"),
+                alias.resolve(realWorking.getFileName()),
+                evidenceDirectory,
+                Duration.ofSeconds(5),
+                4096);
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> new LocalCommandRunner().run(command));
+
+        assertTrue(failure.getMessage().contains("symbolic link"));
+        assertFalse(Files.exists(fixture.resolve("input")));
+    }
+
+    private void assertOverlapRejected(Path working, Path evidence) {
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> new LocalCommandRunner().run(new Command(
+                        executable,
+                        List.of("echo"),
+                        working,
+                        evidence,
+                        Duration.ofSeconds(5),
+                        4096)));
+        assertTrue(failure.getMessage().contains("disjoint"));
+    }
+
+    private Command command(
+            List<String> arguments,
+            Duration timeout,
+            int maximumOutputBytes) {
+        return new Command(
+                executable,
+                arguments,
+                workingDirectory,
+                evidenceDirectory,
+                timeout,
+                maximumOutputBytes);
+    }
+
+    private static ShipLocalStamp.CommandRun stampCommand(
+            LocalCommandRunner.Result result) {
+        return new ShipLocalStamp.CommandRun(
+                result.executable().toString(),
+                "1.0",
+                result.redactedArguments(),
+                result.workingDirectory().toString(),
+                List.of(ShipDigest.sha256("input".getBytes(StandardCharsets.UTF_8))),
+                true,
+                result.timedOut(),
+                result.outputLimited(),
+                result.exitCode(),
+                result.startedAt().toString(),
+                result.endedAt().toString(),
+                result.stdoutLog().toString(),
+                result.stdoutDigest(),
+                result.stderrLog().toString(),
+                result.stderrDigest());
+    }
+
+    private void assertProcessesGone() throws Exception {
+        long parent = Long.parseLong(Files.readString(fixture.resolve("parent-pid")).trim());
+        long child = Long.parseLong(Files.readString(fixture.resolve("child-pid")).trim());
+        awaitGone(parent);
+        awaitGone(child);
+        assertFalse(ProcessHandle.of(parent).map(ProcessHandle::isAlive).orElse(false));
+        assertFalse(ProcessHandle.of(child).map(ProcessHandle::isAlive).orElse(false));
+    }
+
+    private static void awaitFile(Path path) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (!Files.exists(path)) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Timed out waiting for " + path);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static void awaitGone(long pid) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Process is still alive: " + pid);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static Path writeExecutable(Path path, String script) throws IOException {
+        Files.writeString(path, script);
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"));
+        return path;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -70,6 +70,11 @@ class LocalCommandRunnerTest {
                             'cookie-secret' 'compact-cookie-secret' 'carrier-auth-secret'
                           exit 0
                         fi
+                        if [ "$mode" = "known-secret" ]; then
+                          printf '%s\\n' "$@"
+                          printf '%s\\n' "$@" >&2
+                          exit 0
+                        fi
                         if [ "$mode" = "nonzero" ]; then
                           printf '%s\\n' 'failed'
                           exit 7
@@ -146,6 +151,9 @@ class LocalCommandRunnerTest {
         assertFalse(retainedStderr.contains("dXNlcjpwYXNz"));
         assertFalse(retainedStderr.contains("quoted-value"));
         assertFalse(retainedStderr.contains("log-access-key"));
+        assertFalse(retainedStderr.contains("log-private-key"));
+        assertFalse(retainedStderr.contains("log-jwt"));
+        assertFalse(retainedStderr.contains("log-pat"));
         assertEquals(
                 List.of("echo", "--token", "<redacted>"),
                 result.redactedArguments());
@@ -286,6 +294,42 @@ class LocalCommandRunnerTest {
 
         ShipLocalStamp.CommandRun evidence = stampCommand(result);
         assertEquals(result.redactedArguments(), evidence.redactedArguments());
+    }
+
+    @Test
+    void redactsCallerKnownSecretsWithoutGuessingOverloadedFlags() throws Exception {
+        String secret = "hunter2";
+        Command command = new Command(
+                executable,
+                List.of("known-secret", "-p", secret),
+                workingDirectory,
+                evidenceDirectory,
+                Duration.ofSeconds(5),
+                4096,
+                List.of(secret));
+
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command);
+        ShipLocalStamp.CommandRun evidence = stampCommand(result);
+
+        assertEquals(
+                List.of("known-secret", "-p", "<redacted>"),
+                result.redactedArguments());
+        assertFalse(Files.readString(result.stdoutLog()).contains(secret));
+        assertFalse(Files.readString(result.stderrLog()).contains(secret));
+        assertFalse(result.toString().contains(secret));
+        assertFalse(evidence.toString().contains(secret));
+    }
+
+    @Test
+    void filtersOnlyBooleanFeatureToggleEnvironmentValues() {
+        assertFalse(LocalCommandRunner.isSensitiveEnvironmentValue(
+                "AUTH_ENABLED", "true"));
+        assertFalse(LocalCommandRunner.isSensitiveEnvironmentValue(
+                "USE_JWT", "1"));
+        assertFalse(LocalCommandRunner.isSensitiveEnvironmentValue(
+                "ENABLE_COOKIE", "false"));
+        assertTrue(LocalCommandRunner.isSensitiveEnvironmentValue("PASS", "xy"));
+        assertTrue(LocalCommandRunner.isSensitiveEnvironmentValue("TOKEN", "1"));
     }
 
     @Test
@@ -464,25 +508,34 @@ class LocalCommandRunnerTest {
     }
 
     @Test
-    void rejectsWorkingDirectoryThroughAncestorSymlink() throws Exception {
+    void acceptsAncestorSymlinksButRejectsALeafDirectorySymlink() throws Exception {
         Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-parent"));
         Path realWorking = Files.createDirectory(realParent.resolve("working"));
-        Path alias = temporaryDirectory.resolve("alias-parent");
-        Files.createSymbolicLink(alias, realParent.getFileName());
-        Command command = new Command(
+        Path parentAlias = temporaryDirectory.resolve("alias-parent");
+        Files.createSymbolicLink(parentAlias, realParent.getFileName());
+
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(new Command(
                 executable,
                 List.of("echo"),
-                alias.resolve(realWorking.getFileName()),
+                parentAlias.resolve(realWorking.getFileName()),
                 evidenceDirectory,
                 Duration.ofSeconds(5),
-                4096);
+                4096));
 
+        assertEquals(realWorking, result.workingDirectory());
+        Path leafAlias = temporaryDirectory.resolve("working-link");
+        Files.createSymbolicLink(leafAlias, realWorking);
         IOException failure = assertThrows(
                 IOException.class,
-                () -> new LocalCommandRunner().run(command));
+                () -> new LocalCommandRunner().run(new Command(
+                        executable,
+                        List.of("echo"),
+                        leafAlias,
+                        evidenceDirectory,
+                        Duration.ofSeconds(5),
+                        4096)));
 
-        assertTrue(failure.getMessage().contains("symbolic link"));
-        assertFalse(Files.exists(fixture.resolve("input")));
+        assertTrue(failure.getMessage().contains("real directory"));
     }
 
     private void assertOverlapRejected(Path working, Path evidence) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -461,7 +461,7 @@ class PiWorkerTest {
         List<String> names = List.of(
                 "OPENAI_API_KEY", "AUTH", "JWT", "PASS", "TOKEN");
         List<String> values = List.of(
-                "fixture-secret-123", "auth-value", "jwt-value", "xy", "1");
+                "fixture-secret-123", "auth-value", "jwt-value", "password-value", "token-value");
         ShipRun.Stage[] stages = ShipRun.Stage.values();
         for (int index = 0; index < names.size(); index++) {
             String secret = values.get(index);
@@ -514,12 +514,29 @@ class PiWorkerTest {
     }
 
     @Test
+    void shortSensitiveValuesDoNotRejectAnOrdinaryPersistedTurn()
+            throws Exception {
+        ShipRun.Stage stage = ShipRun.Stage.DESIGN;
+
+        PiWorker.Result result = worker(
+                Duration.ofSeconds(5),
+                Map.of(
+                        "DB_PASSWORD", "test",
+                        "COOKIE_NAME", "session",
+                        "TOKEN", "1"))
+                .run(request(stage, "test prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertTrue(hasSession(sessionId(stage)));
+    }
+
+    @Test
     void rejectsSensitiveEnvironmentValuesInObjectKeysAndScalarValues()
             throws Exception {
         List<String> modes = List.of(
                 "leak-assistant-key", "leak-tool-number");
         List<String> values = List.of(
-                "nested-secret-key", "8675309");
+                "nested-secret-key", "86753090");
         ShipRun.Stage[] stages = ShipRun.Stage.values();
         for (int index = 0; index < modes.size(); index++) {
             String secret = values.get(index);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -1,0 +1,1807 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipController;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class PiWorkerTest {
+
+    private static final String RUN_ID = "ship-0123456789abcdef0123456789abcdef";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    private Path executable;
+    private Path fixture;
+    private Path workingDirectory;
+    private Path sessions;
+    private Path evidence;
+
+    @BeforeEach
+    void prepareFixture() throws Exception {
+        fixture = Files.createDirectory(temporaryDirectory.resolve("fake-pi"));
+        try (var script = Objects.requireNonNull(
+                PiWorkerTest.class.getResourceAsStream(
+                        "fake-pi-0.80.6.sh"))) {
+            executable = writeExecutable(
+                    fixture.resolve("pi-rpc"),
+                    new String(script.readAllBytes(), StandardCharsets.UTF_8));
+        }
+        Files.writeString(fixture.resolve("version"), "0.80.6\n");
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        Files.writeString(fixture.resolve("assistant-text"), "done");
+        workingDirectory = Files.createDirectory(temporaryDirectory.resolve("workspace"));
+        sessions = Files.createDirectory(temporaryDirectory.resolve("sessions"));
+        Files.setPosixFilePermissions(
+                sessions, PosixFilePermissions.fromString("rwx------"));
+        evidence = Files.createDirectory(temporaryDirectory.resolve("evidence"));
+    }
+
+    @Test
+    void runsReadOnlyRpcStageWithoutRetainingThePrompt() throws Exception {
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DISCOVERY, "private prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertEquals(ShipLocalStamp.Support.EXPERIMENTAL, result.support());
+        assertEquals("0.80.6", result.version());
+        assertTrue(result.warning().contains("live Pi end-to-end gate"));
+        assertEquals("done", result.assistantText());
+        assertEquals(workingDirectory.toString(), Files.readString(fixture.resolve("cwd")).trim());
+        assertEquals(
+                "{\"id\":\"prompt-1\",\"type\":\"prompt\",\"message\":\"private prompt\"}",
+                Files.readString(fixture.resolve("prompt")).trim());
+        List<String> arguments = Files.readAllLines(fixture.resolve("args"));
+        Path scratch = assertScratchArgument(
+                sessionId(ShipRun.Stage.DISCOVERY), arguments);
+        assertEquals(
+                List.of(
+                        "--mode",
+                        "rpc",
+                        "--session-id",
+                        sessionId(ShipRun.Stage.DISCOVERY),
+                        "--session-dir",
+                        scratch.toString(),
+                        "--tools",
+                        "read,grep,find,ls",
+                        "--no-approve",
+                        "--no-extensions",
+                        "--no-skills",
+                        "--no-prompt-templates",
+                        "--no-themes",
+                        "--no-context-files",
+                        "--system-prompt",
+                        "",
+                        "--append-system-prompt",
+                        "",
+                        "--offline"),
+                arguments);
+        assertFalse(Files.readString(fixture.resolve("args")).contains("private prompt"));
+        assertTrue(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+        List<String> session = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DISCOVERY)));
+        assertEquals(5, session.size());
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(
+                        sessionFile(sessionId(ShipRun.Stage.DISCOVERY))));
+        assertTrue(session.get(3).contains("\"role\":\"user\""));
+        assertTrue(session.get(4).contains("\"stopReason\":\"stop\""));
+
+        String retainedStdout = Files.readString(Path.of(result.evidence().stdoutLog()));
+        String retainedStderr = Files.readString(Path.of(result.evidence().stderrLog()));
+        assertFalse(retainedStdout.contains("private prompt"));
+        assertFalse(retainedStdout.contains("done"));
+        assertTrue(retainedStdout.contains("\"content\":\"<redacted>\""));
+        assertEquals(
+                "{\"bytes\":36,\"limited\":false,\"content\":\"<redacted>\"}",
+                retainedStderr.trim());
+        assertFalse(retainedStderr.contains("private prompt"));
+        assertEquals(workingDirectory.toString(), result.evidence().workingDirectory());
+        assertEquals(List.of(inputDigest()), result.evidence().inputDigests());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(Path.of(result.evidence().stdoutLog()))),
+                result.evidence().stdoutDigest());
+    }
+
+    @Test
+    void executeStageUsesTheExplicitWriteToolAllowlist() throws Exception {
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.EXECUTE, "execute"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        List<String> arguments = Files.readAllLines(fixture.resolve("args"));
+        Path scratch = assertScratchArgument(
+                sessionId(ShipRun.Stage.EXECUTE), arguments);
+        assertEquals(
+                List.of(
+                        "--mode",
+                        "rpc",
+                        "--session-id",
+                        sessionId(ShipRun.Stage.EXECUTE),
+                        "--session-dir",
+                        scratch.toString(),
+                        "--tools",
+                        "read,bash,edit,write,grep,find,ls",
+                        "--no-approve",
+                        "--no-extensions",
+                        "--no-skills",
+                        "--no-prompt-templates",
+                        "--no-themes",
+                        "--no-context-files",
+                        "--system-prompt",
+                        "",
+                        "--append-system-prompt",
+                        "",
+                        "--offline"),
+                arguments);
+        assertTrue(hasSession(sessionId(ShipRun.Stage.EXECUTE)));
+    }
+
+    @Test
+    void changedInputDigestUsesANewStageSession() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        String changedDigest = ShipDigest.sha256(
+                "changed input".getBytes(StandardCharsets.UTF_8));
+
+        worker.run(request(ShipRun.Stage.DESIGN, "first"));
+        worker.run(new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.DESIGN,
+                1,
+                workingDirectory,
+                sessions,
+                evidence,
+                changedDigest,
+                true,
+                "second"));
+
+        String first = sessionId(ShipRun.Stage.DESIGN);
+        String changed = sessionId(RUN_ID, ShipRun.Stage.DESIGN, changedDigest);
+        assertEquals(List.of(first, changed), Files.readAllLines(fixture.resolve("session-ids")));
+        assertTrue(hasSession(first));
+        assertTrue(hasSession(changed));
+        assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void requiresSettledEventAndAcceptsUnicodeJsonSeparators() throws Exception {
+        String assistant = "before\u2028middle\u2029after";
+        Files.writeString(fixture.resolve("mode"), "settled\n");
+        Files.writeString(fixture.resolve("assistant-text"), assistant);
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DESIGN, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertEquals(assistant, result.assistantText());
+        assertFalse(result.toString().contains(assistant));
+        assertFalse(result.toString().contains("live Pi end-to-end gate"));
+
+        Files.writeString(fixture.resolve("mode"), "terminal-before-response\n");
+        assertEquals(
+                PiWorker.Outcome.SUCCEEDED,
+                worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DESIGN, "second"))
+                        .outcome());
+    }
+
+    @Test
+    void requiresExplicitExperimentalAcceptanceBeforeStartingTheStage() throws Exception {
+        PiWorker.Request rejected = request(ShipRun.Stage.DISCOVERY, "private prompt", false);
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5)).run(rejected));
+
+        assertTrue(failure.getMessage().contains("explicitly accept experimental Pi"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+        assertFalse(Files.exists(fixture.resolve("session-dirs")));
+        assertFalse(Files.exists(fixture.resolve("prompt")));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+        assertFalse(rejected.toString().contains("private prompt"));
+    }
+
+    @Test
+    void rejectsStrictRpcProtocolViolations() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+
+        for (String mode : List.of(
+                "malformed",
+                "invalid-utf",
+                "duplicate",
+                "response-wrong-bool",
+                "response-wrong-id",
+                "response-wrong-command",
+                "response-extra-field",
+                "missing-content",
+                "retry-wrong-bool",
+                "missing-settled",
+                "settled-extra",
+                "trailing")) {
+            Files.writeString(fixture.resolve("mode"), mode + "\n");
+
+            PiWorker.Result result = worker.run(request(ShipRun.Stage.PLAN, "prompt"));
+
+            assertEquals(PiWorker.Outcome.FAILED, result.outcome(), mode);
+            assertNull(result.assistantText(), mode);
+            assertFalse(hasSession(sessionId(ShipRun.Stage.PLAN)), mode);
+        }
+
+        Files.writeString(
+                fixture.resolve("mode"), "tool-orphan-stop\n");
+        IOException orphan = assertThrows(
+                IOException.class,
+                () -> worker.run(request(
+                        ShipRun.Stage.PLAN, "orphan")));
+        assertTrue(orphan.getMessage().contains("all tool results"));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.PLAN)));
+    }
+
+    @Test
+    void persistsSemanticErrorAndLengthTurnsForResume() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        for (String mode : List.of("stop-error", "stop-length")) {
+            ShipRun.Stage stage = "stop-error".equals(mode)
+                    ? ShipRun.Stage.DISCOVERY
+                    : ShipRun.Stage.DESIGN;
+            Files.writeString(fixture.resolve("mode"), mode + "\n");
+
+            PiWorker.Result result = worker.run(request(stage, "prompt"));
+
+            assertEquals(PiWorker.Outcome.FAILED, result.outcome());
+            assertTrue(result.failure().contains(mode.substring("stop-".length())));
+            assertTrue(hasSession(sessionId(stage)));
+        }
+    }
+
+    @Test
+    void bindsRetryToolAndCompactionRecordsInRpcOrder() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        List<String> modes = List.of(
+                "retry-then-success",
+                "tool-sequence",
+                "compaction-success",
+                "compaction-failed",
+                "compaction-aborted");
+        ShipRun.Stage[] stages = ShipRun.Stage.values();
+        for (int index = 0; index < modes.size(); index++) {
+            Files.writeString(
+                    fixture.resolve("mode"), modes.get(index) + "\n");
+
+            PiWorker.Result result = worker.run(
+                    request(stages[index], "prompt-" + index));
+
+            assertEquals(
+                    PiWorker.Outcome.SUCCEEDED,
+                    result.outcome(),
+                    modes.get(index));
+            String persisted = Files.readString(
+                    sessionFile(sessionId(stages[index])));
+            assertEquals(
+                    modes.get(index).equals("retry-then-success")
+                            || modes.get(index).equals("compaction-success"),
+                    persisted.contains("\"type\":\"compaction\""),
+                    modes.get(index));
+        }
+    }
+
+    @Test
+    void acceptsProviderAutoRetryWithoutCompaction() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "auto-retry-success\n");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5)).run(
+                request(ShipRun.Stage.DISCOVERY, "auto-retry"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertFalse(Files.readString(
+                sessionFile(sessionId(ShipRun.Stage.DISCOVERY)))
+                .contains("\"type\":\"compaction\""));
+    }
+
+    @Test
+    void acceptsLengthOverflowCompactionContinuation() throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"), "retry-length-then-success\n");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5)).run(
+                request(ShipRun.Stage.PLAN, "length-overflow"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        String persisted = Files.readString(
+                sessionFile(sessionId(ShipRun.Stage.PLAN)));
+        assertTrue(persisted.contains("\"stopReason\":\"length\""));
+        assertTrue(persisted.contains("\"type\":\"compaction\""));
+        assertTrue(persisted.contains("\"stopReason\":\"stop\""));
+    }
+
+    @Test
+    void allowsResumeCompactionBeforeTheNewUserButRejectsUnrelatedAssistants()
+            throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        worker.run(request(ShipRun.Stage.DESIGN, "baseline"));
+        Files.writeString(fixture.resolve("mode"), "pre-user-compaction\n");
+
+        PiWorker.Result resumed = worker.run(new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.DESIGN,
+                2,
+                workingDirectory,
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "current"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, resumed.outcome());
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DESIGN)));
+        assertEquals(8, persisted.size());
+        assertTrue(persisted.get(5).contains("\"type\":\"compaction\""));
+        assertTrue(persisted.get(6).contains("\"role\":\"user\""));
+
+        Files.writeString(fixture.resolve("mode"), "pre-user-compaction\n");
+        IOException newSessionCompaction = assertThrows(
+                IOException.class,
+                () -> worker.run(request(
+                        ShipRun.Stage.DISCOVERY, "new")));
+        assertTrue(newSessionCompaction.getMessage().contains(
+                "before its prompt"));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+
+        Files.writeString(fixture.resolve("mode"), "unrelated-intermediate\n");
+        IOException unrelated = assertThrows(
+                IOException.class,
+                () -> worker.run(request(
+                        ShipRun.Stage.PLAN, "unrelated")));
+        assertTrue(unrelated.getMessage().contains("intermediate assistant"));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.PLAN)));
+    }
+
+    @Test
+    void discardsValidatedScratchAfterTrailingOutputExitFailureOrRetentionFailure()
+            throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(10));
+        for (String mode : List.of("trailing", "settled-nonzero", "settled-hang")) {
+            ShipRun.Stage stage = switch (mode) {
+                case "trailing" -> ShipRun.Stage.DISCOVERY;
+                case "settled-nonzero" -> ShipRun.Stage.DESIGN;
+                default -> ShipRun.Stage.PLAN;
+            };
+            Files.writeString(fixture.resolve("mode"), mode + "\n");
+
+            PiWorker.Result result = worker.run(request(stage, "prompt"));
+
+            assertEquals(PiWorker.Outcome.FAILED, result.outcome(), mode);
+            assertFalse(hasSession(sessionId(stage)), mode);
+            assertNoScratchDirectories();
+        }
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        worker.run(request(ShipRun.Stage.VALIDATE, "baseline"));
+        Path canonical = sessionFile(sessionId(ShipRun.Stage.VALIDATE));
+        byte[] before = Files.readAllBytes(canonical);
+        Files.writeString(fixture.resolve("mode"), "settled-nonzero\n");
+        PiWorker.Result nonzero = worker.run(new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.VALIDATE,
+                2,
+                workingDirectory,
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "current"));
+        assertEquals(PiWorker.Outcome.FAILED, nonzero.outcome());
+        assertArrayEquals(before, Files.readAllBytes(canonical));
+
+        Files.writeString(fixture.resolve("mode"), "retention-failure\n");
+        try {
+            assertThrows(
+                    IOException.class,
+                    () -> worker.run(request(
+                            ShipRun.Stage.EXECUTE, "prompt")));
+        } finally {
+            Files.setPosixFilePermissions(
+                    evidence, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+        assertFalse(hasSession(sessionId(ShipRun.Stage.EXECUTE)));
+        assertNoScratchDirectories();
+    }
+
+    @Test
+    void redactsUntrustedRpcMetadataFromRetainedOutput() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "metadata-secret\n");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.PLAN, "prompt"));
+
+        assertEquals(PiWorker.Outcome.FAILED, result.outcome());
+        String retained = Files.readString(Path.of(result.evidence().stdoutLog()));
+        assertFalse(retained.contains("fixture-secret-fragment"));
+        assertTrue(retained.contains("\"type\":\"event-redacted\""));
+        assertTrue(retained.contains("\"id\":\"<redacted>\""));
+        assertTrue(retained.contains("\"command\":\"<redacted>\""));
+    }
+
+    @Test
+    void rejectsSensitiveEnvironmentValuesInAssistantAndToolResults()
+            throws Exception {
+        List<String> names = List.of(
+                "OPENAI_API_KEY", "AUTH", "JWT", "PASS");
+        List<String> values = List.of(
+                "fixture-secret-123", "auth-value", "jwt-value", "xy");
+        ShipRun.Stage[] stages = ShipRun.Stage.values();
+        for (int index = 0; index < names.size(); index++) {
+            String secret = values.get(index);
+            ShipRun.Stage stage = stages[index];
+            String prompt = "prompt-" + index;
+            Files.writeString(fixture.resolve("secret"), secret);
+            Files.writeString(
+                    fixture.resolve("mode"),
+                    (index % 2 == 0 ? "leak-assistant" : "leak-tool")
+                                             + "\n");
+            PiWorker sensitiveWorker = worker(
+                    Duration.ofSeconds(5),
+                    Map.of(names.get(index), secret));
+
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> sensitiveWorker.run(request(
+                            stage, prompt)));
+
+            assertTrue(failure.getMessage().contains(
+                    "sensitive environment value"));
+            assertFalse(hasSession(sessionId(stage)));
+            assertNoScratchDirectories();
+            assertEvidenceDoesNotContain(secret);
+        }
+
+        String cwd = workingDirectory.toString();
+        Files.writeString(fixture.resolve("secret"), cwd);
+        Files.writeString(fixture.resolve("mode"), "leak-assistant\n");
+        PiWorker.Result allowed = worker(
+                Duration.ofSeconds(5),
+                Map.of("PWD", cwd, "OLDPWD", cwd))
+                .run(request(ShipRun.Stage.VALIDATE, "pwd"));
+        assertEquals(PiWorker.Outcome.SUCCEEDED, allowed.outcome());
+        assertEquals(cwd, allowed.assistantText());
+    }
+
+    @Test
+    void rejectsSensitiveEnvironmentValuesInObjectKeysAndScalarValues()
+            throws Exception {
+        List<String> modes = List.of(
+                "leak-assistant-key", "leak-tool-number");
+        List<String> values = List.of(
+                "nested-secret-key", "8675309");
+        ShipRun.Stage[] stages = ShipRun.Stage.values();
+        for (int index = 0; index < modes.size(); index++) {
+            String secret = values.get(index);
+            ShipRun.Stage stage = stages[index];
+            String prompt = "prompt-" + index;
+            Files.writeString(fixture.resolve("secret"), secret);
+            Files.writeString(
+                    fixture.resolve("mode"), modes.get(index) + "\n");
+
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> worker(
+                            Duration.ofSeconds(5),
+                            Map.of("API_TOKEN", secret))
+                            .run(request(stage, prompt)));
+
+            assertTrue(failure.getMessage().contains(
+                    "sensitive environment value"));
+            assertFalse(hasSession(sessionId(stage)));
+            assertNoScratchDirectories();
+            assertEvidenceDoesNotContain(secret);
+        }
+    }
+
+    @Test
+    void redactsSensitiveEnvironmentCollisionsFromLocalEvidence()
+            throws Exception {
+        List<String> secrets = List.of("rpc", "prompt", "bytes");
+        ShipRun.Stage[] stages = {
+                ShipRun.Stage.DISCOVERY,
+                ShipRun.Stage.DESIGN,
+                ShipRun.Stage.PLAN
+        };
+        for (int index = 0; index < secrets.size(); index++) {
+            String secret = secrets.get(index);
+            Files.writeString(fixture.resolve("mode"), "success\n");
+
+            PiWorker.Result result = worker(
+                    Duration.ofSeconds(5),
+                    Map.of("API_TOKEN", secret))
+                    .run(request(stages[index], "safe-input-" + index));
+
+            assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+            assertTrue(result.evidence().redactedArguments().stream()
+                    .noneMatch(argument -> argument.contains(secret)));
+            assertFalse(Files.readString(
+                    Path.of(result.evidence().stdoutLog()))
+                    .contains(secret));
+            assertFalse(Files.readString(
+                    Path.of(result.evidence().stderrLog()))
+                    .contains(secret));
+        }
+    }
+
+    @Test
+    void ignoresCumulativeStreamingSnapshotsWithoutLosingTheTerminal()
+            throws Exception {
+        String[] modes = {
+                "cumulative-update-burst",
+                "cumulative-tool-update-burst"
+        };
+        ShipRun.Stage[] stages = {
+                ShipRun.Stage.DISCOVERY,
+                ShipRun.Stage.DESIGN
+        };
+        for (int index = 0; index < modes.length; index++) {
+            Files.writeString(
+                    fixture.resolve("mode"), modes[index] + "\n");
+
+            PiWorker.Result result = worker(Duration.ofSeconds(30))
+                    .run(request(stages[index], "streaming-" + index));
+
+            assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+            assertEquals("done", result.assistantText());
+            assertTrue(hasSession(sessionId(stages[index])));
+            assertTrue(Files.size(Path.of(result.evidence().stdoutLog()))
+                       < 1024 * 1024);
+        }
+    }
+
+    @Test
+    void malformedSessionErrorsDoNotRetainSensitiveJson() throws Exception {
+        String secret = "malformed-secret-credential";
+        Files.writeString(fixture.resolve("secret"), secret);
+        Files.writeString(
+                fixture.resolve("mode"), "session-malformed-secret\n");
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker(
+                        Duration.ofSeconds(5),
+                        Map.of("API_TOKEN", secret))
+                        .run(request(ShipRun.Stage.PLAN, "prompt")));
+
+        for (Throwable cause = failure;
+             cause != null;
+             cause = cause.getCause()) {
+            assertFalse(cause.toString().contains(secret));
+        }
+        assertFalse(hasSession(sessionId(ShipRun.Stage.PLAN)));
+        assertNoScratchDirectories();
+        assertEvidenceDoesNotContain(secret);
+    }
+
+    @Test
+    void retainsNonzeroExitAndBoundsExcessiveOutput() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "nonzero\n");
+        PiWorker.Result nonzero = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.VALIDATE, "prompt"));
+
+        Files.writeString(fixture.resolve("mode"), "oversized\n");
+        PiWorker.Result oversized = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.VALIDATE, "prompt"));
+
+        assertEquals(PiWorker.Outcome.FAILED, nonzero.outcome());
+        assertEquals(7, nonzero.evidence().exitCode());
+        assertTrue(nonzero.failure().contains("status 7"));
+        assertEquals(PiWorker.Outcome.FAILED, oversized.outcome());
+        assertTrue(oversized.failure().contains("retained-output limit"));
+        assertTrue(hasSession(sessionId(ShipRun.Stage.VALIDATE)));
+        assertTrue(Files.readString(sessionFile(
+                sessionId(ShipRun.Stage.VALIDATE)))
+                .contains("\"stopReason\":\"aborted\""));
+        assertTrue(Files.size(Path.of(oversized.evidence().stderrLog())) <= 16 * 1024 * 1024);
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(Path.of(oversized.evidence().stderrLog()))),
+                oversized.evidence().stderrDigest());
+    }
+
+    @Test
+    void boundsCumulativeMaterialRpcOutput() throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"), "material-output-burst\n");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(10))
+                .run(request(ShipRun.Stage.VALIDATE, "prompt"));
+
+        assertEquals(PiWorker.Outcome.FAILED, result.outcome());
+        assertTrue(result.evidence().outputLimited());
+        assertTrue(result.failure().contains("retained-output limit"));
+        assertTrue(hasSession(sessionId(ShipRun.Stage.VALIDATE)));
+        assertTrue(Files.readString(sessionFile(
+                sessionId(ShipRun.Stage.VALIDATE)))
+                .contains("\"stopReason\":\"aborted\""));
+        assertNoScratchDirectories();
+    }
+
+    @Test
+    void rejectsUnverifiableOutputAfterAcknowledgedAbort() throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"),
+                "material-output-burst-trailing\n");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(10))
+                .run(request(ShipRun.Stage.EXECUTE, "prompt"));
+
+        assertEquals(PiWorker.Outcome.FAILED, result.outcome());
+        assertTrue(result.evidence().outputLimited());
+        assertFalse(hasSession(sessionId(ShipRun.Stage.EXECUTE)));
+        assertNoScratchDirectories();
+    }
+
+    @Test
+    void reportsVersionCompatibilityAndExecutableGuidance() throws Exception {
+        Files.writeString(fixture.resolve("version"), "0.81.1\n");
+
+        PiWorker.Result experimental = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, experimental.outcome());
+        assertEquals(ShipLocalStamp.Support.EXPERIMENTAL, experimental.support());
+        assertEquals("0.81.1", experimental.version());
+        assertTrue(experimental.warning().contains("0.80.6"));
+        assertTrue(experimental.warning().contains("unverified"));
+
+        Files.deleteIfExists(fixture.resolve("args"));
+        Files.deleteIfExists(fixture.resolve("prompt"));
+        Files.writeString(fixture.resolve("version"), "0.80.3\n");
+        IOException incompatible = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DESIGN, "prompt")));
+        assertTrue(incompatible.getMessage().contains("settled RPC event"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+        assertFalse(Files.exists(fixture.resolve("prompt")));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DESIGN)));
+
+        Files.writeString(fixture.resolve("version"), "0.81.1\n");
+        IOException unaccepted = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DESIGN, "prompt", false)));
+        assertTrue(unaccepted.getMessage().contains("explicitly accept"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+
+        Files.writeString(fixture.resolve("version"), "not-a-version\n");
+        IOException invalid = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
+        IllegalArgumentException missing = assertThrows(
+                IllegalArgumentException.class,
+                () -> new PiWorker(
+                        temporaryDirectory.resolve("missing-pi"),
+                        "0.80.6",
+                        Duration.ofSeconds(5)));
+
+        assertTrue(invalid.getMessage().contains("invalid version"));
+        assertTrue(missing.getMessage().contains("install Pi"));
+    }
+
+    @Test
+    void followsTheConfiguredExecutableSymlink() throws Exception {
+        Path symlink = fixture.resolve("pi-link");
+        Files.createSymbolicLink(symlink, executable.getFileName());
+
+        PiWorker.Result result = new PiWorker(
+                symlink, "0.80.6", Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertEquals(executable.toString(), result.evidence().executable());
+    }
+
+    @Test
+    void rejectsAliasedOrOverlappingRuntimeDirectories() throws Exception {
+        Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-parent"));
+        Path realWorking = Files.createDirectory(realParent.resolve("working"));
+        Path aliasParent = temporaryDirectory.resolve("alias-parent");
+        Files.createSymbolicLink(aliasParent, realParent.getFileName());
+        PiWorker.Request aliased = new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.DISCOVERY,
+                1,
+                aliasParent.resolve(realWorking.getFileName()),
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "prompt");
+        Path nestedEvidence = Files.createDirectory(workingDirectory.resolve("nested-evidence"));
+        PiWorker.Request overlapsWorking = new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.DISCOVERY,
+                1,
+                workingDirectory,
+                sessions,
+                nestedEvidence,
+                inputDigest(),
+                true,
+                "prompt");
+        PiWorker.Request sharedStateDirectory = new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.DISCOVERY,
+                1,
+                workingDirectory,
+                sessions,
+                sessions,
+                inputDigest(),
+                true,
+                "prompt");
+
+        IOException aliasFailure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5)).run(aliased));
+        IOException workingFailure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5)).run(overlapsWorking));
+        IOException stateFailure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5)).run(sharedStateDirectory));
+
+        assertTrue(aliasFailure.getMessage().contains("symbolic link"));
+        assertTrue(workingFailure.getMessage().contains("disjoint"));
+        assertTrue(stateFailure.getMessage().contains("disjoint"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+    }
+
+    @Test
+    void rejectsInsecureSessionDirectoryBeforeLaunchingPi() throws Exception {
+        Files.setPosixFilePermissions(
+                sessions, PosixFilePermissions.fromString("rwxr-x---"));
+
+        IOException permissions = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
+
+        assertTrue(permissions.getMessage().contains("0700"));
+        Files.setPosixFilePermissions(
+                sessions, PosixFilePermissions.fromString("rwx------"));
+        Files.createSymbolicLink(
+                sessions.resolve("unsafe-entry"), fixture.resolve("version"));
+
+        IOException entry = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
+
+        assertTrue(entry.getMessage().contains("unsafe entry"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+    }
+
+    @Test
+    void rejectsMismatchedOrAmbiguousPersistedStageSessions() throws Exception {
+        String[] modes = {"session-mismatch", "session-cwd", "session-duplicate"};
+        ShipRun.Stage[] stages = {
+                ShipRun.Stage.DISCOVERY,
+                ShipRun.Stage.DESIGN,
+                ShipRun.Stage.PLAN
+        };
+
+        for (int index = 0; index < modes.length; index++) {
+            int caseIndex = index;
+            Files.writeString(fixture.resolve("mode"), modes[index] + "\n");
+
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> worker(Duration.ofSeconds(5))
+                            .run(request(stages[caseIndex], "prompt")),
+                    modes[index]);
+
+            assertTrue(
+                    failure.getMessage().contains("session"),
+                    modes[index] + ": " + failure.getMessage());
+        }
+    }
+
+    @Test
+    void requiresPersistedTurnRecordsAndAppendOnlyResume() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "header-only\n");
+
+        IOException headerOnly = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
+
+        assertTrue(headerOnly.getMessage().contains("no persisted turn records"));
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        worker.run(request(ShipRun.Stage.DESIGN, "first"));
+        byte[] before = Files.readAllBytes(sessionFile(sessionId(ShipRun.Stage.DESIGN)));
+        Files.writeString(fixture.resolve("mode"), "unchanged-session\n");
+
+        IOException unchanged = assertThrows(
+                IOException.class,
+                () -> worker.run(request(ShipRun.Stage.DESIGN, "second")));
+
+        assertTrue(unchanged.getMessage().contains("did not append"));
+        assertTrue(java.util.Arrays.equals(
+                before, Files.readAllBytes(sessionFile(sessionId(ShipRun.Stage.DESIGN)))));
+
+        Files.writeString(fixture.resolve("mode"), "rewrite-session\n");
+        IOException rewritten = assertThrows(
+                IOException.class,
+                () -> worker.run(request(ShipRun.Stage.DESIGN, "third")));
+
+        assertTrue(rewritten.getMessage().contains("Pi"));
+        assertArrayEquals(
+                before,
+                Files.readAllBytes(
+                        sessionFile(sessionId(ShipRun.Stage.DESIGN))));
+    }
+
+    @Test
+    void refusesToReplayACompletedPromptBeforeLaunchingRpc() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        PiWorker.Request first = request(
+                ShipRun.Stage.DESIGN, "same prompt", true);
+        worker.run(first);
+        Path canonical = sessionFile(sessionId(ShipRun.Stage.DESIGN));
+        byte[] before = Files.readAllBytes(canonical);
+        Files.delete(fixture.resolve("args"));
+        Files.delete(fixture.resolve("prompt"));
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker.run(new PiWorker.Request(
+                        RUN_ID,
+                        ShipRun.Stage.DESIGN,
+                        2,
+                        workingDirectory,
+                        sessions,
+                        evidence,
+                        inputDigest(),
+                        true,
+                        "same prompt")));
+
+        assertTrue(failure.getMessage().contains("controller recovery"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+        assertFalse(Files.exists(fixture.resolve("prompt")));
+        assertArrayEquals(before, Files.readAllBytes(canonical));
+    }
+
+    @Test
+    void rejectsBrokenLinearSessionChainsWithoutPublishingThem() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        for (ShipRun.Stage stage : List.of(
+                ShipRun.Stage.DISCOVERY, ShipRun.Stage.DESIGN)) {
+            String mode = stage == ShipRun.Stage.DISCOVERY
+                    ? "session-wrong-parent"
+                    : "session-duplicate-id";
+            Files.writeString(fixture.resolve("mode"), mode + "\n");
+
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> worker.run(request(stage, "prompt")));
+
+            assertTrue(failure.getMessage().contains("session"));
+            assertFalse(hasSession(sessionId(stage)));
+            assertNoScratchDirectories();
+        }
+    }
+
+    @Test
+    void serializesSessionsAndCleansAbandonedScratch() throws Exception {
+        String sessionId = sessionId(ShipRun.Stage.DISCOVERY);
+        Path abandoned = Files.createDirectory(
+                sessions.resolve(".ship-pi-" + sessionId + "-abandoned"));
+        Files.setPosixFilePermissions(
+                abandoned, PosixFilePermissions.fromString("rwx------"));
+        Files.writeString(abandoned.resolve("partial"), "partial");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertFalse(Files.exists(abandoned));
+        assertNoScratchDirectories();
+
+        String lockedSession = sessionId(ShipRun.Stage.DESIGN);
+        Path lockPath = sessions.resolve("." + lockedSession + ".lock");
+        try (FileChannel channel = FileChannel.open(
+                lockPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Files.setPosixFilePermissions(
+                    lockPath, PosixFilePermissions.fromString("rw-------"));
+            IOException locked = assertThrows(
+                    IOException.class,
+                    () -> worker(Duration.ofSeconds(5))
+                            .run(request(ShipRun.Stage.DESIGN, "prompt")));
+            assertTrue(locked.getMessage().contains("already running"));
+            assertFalse(hasSession(lockedSession));
+        }
+    }
+
+    @Test
+    void rejectsInvalidAppendedSessionTurns() throws Exception {
+        String[] modes = {
+                "session-whitespace",
+                "session-malformed-turn",
+                "session-unrelated-prompt",
+                "session-wrong-stop",
+                "session-missing-stop"
+        };
+        ShipRun.Stage[] stages = ShipRun.Stage.values();
+        PiWorker worker = worker(Duration.ofSeconds(5));
+
+        for (int index = 0; index < modes.length; index++) {
+            ShipRun.Stage stage = stages[index];
+            Files.writeString(fixture.resolve("mode"), "success\n");
+            worker.run(request(stage, "baseline"));
+            Path canonical = sessionFile(sessionId(stage));
+            byte[] before = Files.readAllBytes(canonical);
+            Files.writeString(fixture.resolve("mode"), modes[index] + "\n");
+
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> worker.run(request(stage, "current")),
+                    modes[index]);
+
+            assertTrue(failure.getMessage().contains("Pi"), modes[index]);
+            assertArrayEquals(
+                    before, Files.readAllBytes(canonical), modes[index]);
+        }
+    }
+
+    @Test
+    void retriesFromTheCleanCanonicalPrefixAfterDiscardingPoisonedScratch()
+            throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        ShipRun.Stage stage = ShipRun.Stage.DESIGN;
+        worker.run(request(stage, "baseline"));
+        Path canonical = sessionFile(sessionId(stage));
+        byte[] baseline = Files.readAllBytes(canonical);
+
+        Files.writeString(
+                fixture.resolve("mode"), "session-unrelated-prompt\n");
+        assertThrows(
+                IOException.class,
+                () -> worker.run(new PiWorker.Request(
+                        RUN_ID,
+                        stage,
+                        2,
+                        workingDirectory,
+                        sessions,
+                        evidence,
+                        inputDigest(),
+                        true,
+                        "current")));
+        assertArrayEquals(baseline, Files.readAllBytes(canonical));
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result retry = worker.run(new PiWorker.Request(
+                RUN_ID,
+                stage,
+                3,
+                workingDirectory,
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "current"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, retry.outcome());
+        List<String> persisted = Files.readAllLines(canonical);
+        assertEquals(7, persisted.size());
+        assertEquals(
+                1,
+                persisted.stream()
+                        .filter(line -> line.contains(
+                                "\"content\":\"current\""))
+                        .count());
+    }
+
+    @Test
+    void timeoutFailsClosedWhenPiDoesNotAcknowledgeAbort() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "unacknowledged-abort\n");
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofMillis(200))
+                        .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
+
+        assertTrue(failure.getMessage().contains("not resumable"));
+        assertEquals(
+                "{\"id\":\"abort-1\",\"type\":\"abort\"}",
+                Files.readString(fixture.resolve("abort")).trim());
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+    }
+
+    @Test
+    void timeoutAcknowledgesAbortBeforePersistingTheStageSession() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "block\n");
+
+        PiWorker.Result result = worker(Duration.ofMillis(300))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.TIMED_OUT, result.outcome());
+        assertFalse(result.evidence().succeeded());
+        assertEquals(
+                "{\"id\":\"abort-1\",\"type\":\"abort\"}",
+                Files.readString(fixture.resolve("abort")).trim());
+        assertTrue(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+        assertTrue(Files.readString(sessionFile(sessionId(ShipRun.Stage.DISCOVERY)))
+                .contains("\"stopReason\":\"aborted\""));
+        assertProcessesGone();
+    }
+
+    @Test
+    void timeoutDuringRetryDelayPublishesOnlyTheBoundErrorTurn()
+            throws Exception {
+        Files.writeString(fixture.resolve("mode"), "retry-delay-block\n");
+
+        PiWorker.Result result = worker(Duration.ofMillis(300))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.TIMED_OUT, result.outcome());
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DISCOVERY)));
+        assertEquals(5, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"error\""));
+        assertFalse(persisted.get(4).contains("\"stopReason\":\"aborted\""));
+    }
+
+    @Test
+    void abortReconciliationUsesOneSharedDeadline() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "preflight-hang\n");
+        long started = System.nanoTime();
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofMillis(100))
+                        .run(request(
+                                ShipRun.Stage.DISCOVERY, "prompt")));
+        Duration elapsed = Duration.ofNanos(
+                System.nanoTime() - started);
+
+        assertTrue(failure.getMessage().contains("did not acknowledge"));
+        assertTrue(elapsed.compareTo(Duration.ofSeconds(4)) >= 0);
+        assertTrue(elapsed.compareTo(Duration.ofSeconds(8)) < 0);
+        assertFalse(Files.exists(fixture.resolve("abort")));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+    }
+
+    @Test
+    void timeoutPreservesANaturalStopThatWinsAfterAbort() throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"), "natural-stop-after-abort\n");
+
+        PiWorker.Result result = worker(Duration.ofMillis(300))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertEquals("done", result.assistantText());
+        assertFalse(result.evidence().timedOut());
+        assertTrue(result.evidence().succeeded());
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DISCOVERY)));
+        assertEquals(6, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"stop\""));
+        assertTrue(persisted.get(5).contains("\"type\":\"compaction\""));
+    }
+
+    @Test
+    void interruptionDrainsAQueuedNaturalTurnAsPiExits()
+            throws Exception {
+        Files.writeString(fixture.resolve("mode"), "queued-natural-exit\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(ShipRun.Stage.DESIGN, "prompt"));
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        Thread.sleep(250);
+        Files.writeString(fixture.resolve("release"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertFalse(Files.exists(fixture.resolve("abort")));
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DESIGN)));
+        assertEquals(5, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"stop\""));
+    }
+
+    @Test
+    void interruptionDisposesAndPublishesAPostAgentTerminalWithoutSettled()
+            throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"), "terminal-no-settled\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(ShipRun.Stage.DESIGN, "prompt"));
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertFalse(Files.exists(fixture.resolve("unexpected-input")));
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DESIGN)));
+        assertEquals(5, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"stop\""));
+    }
+
+    @Test
+    void interruptionWaitsForPreflightCompactionAndPromptResponse()
+            throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        worker.run(request(ShipRun.Stage.PLAN, "baseline"));
+        Files.writeString(
+                fixture.resolve("mode"), "preflight-compaction-block\n");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(new PiWorker.Request(
+                        RUN_ID,
+                        ShipRun.Stage.PLAN,
+                        2,
+                        workingDirectory,
+                        sessions,
+                        evidence,
+                        inputDigest(),
+                        true,
+                        "current"));
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("compaction-ready"));
+        invocation.interrupt();
+        Thread.sleep(250);
+        assertFalse(Files.exists(fixture.resolve("abort")));
+        Files.writeString(
+                fixture.resolve("release-compaction"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.PLAN)));
+        assertEquals(8, persisted.size());
+        assertTrue(persisted.get(5).contains("\"type\":\"compaction\""));
+        assertTrue(persisted.get(6).contains("\"content\":\"current\""));
+        assertTrue(persisted.get(7).contains("\"stopReason\":\"aborted\""));
+    }
+
+    @Test
+    void interruptionAbortsOnlyAfterOverflowCompactionCanContinue()
+            throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"), "overflow-compaction-abort\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(ShipRun.Stage.VALIDATE, "prompt"));
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("compaction-ready"));
+        invocation.interrupt();
+        Thread.sleep(250);
+        assertFalse(Files.exists(fixture.resolve("abort-received")));
+        Files.writeString(
+                fixture.resolve("release-compaction"), "release\n");
+        awaitFile(fixture.resolve("compaction-ended"));
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertFalse(Files.exists(fixture.resolve("premature-abort")));
+        assertEquals(
+                "{\"id\":\"abort-1\",\"type\":\"abort\"}",
+                Files.readString(fixture.resolve("abort")).trim());
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.VALIDATE)));
+        assertEquals(7, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"error\""));
+        assertTrue(persisted.get(5).contains("\"type\":\"compaction\""));
+        assertTrue(persisted.get(6).contains("\"stopReason\":\"aborted\""));
+    }
+
+    @Test
+    void partialMultiToolAbortPublishesAndResumesWithoutRepeatingWork()
+            throws Exception {
+        Files.writeString(fixture.resolve("mode"), "partial-tool-abort\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(ShipRun.Stage.EXECUTE, "prompt"));
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(
+                List.of("call-a"),
+                Files.readAllLines(fixture.resolve("tool-executions")));
+        List<String> interruptedSession = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.EXECUTE)));
+        assertEquals(7, interruptedSession.size());
+        assertTrue(interruptedSession.get(4).contains("\"call-b\""));
+        assertTrue(interruptedSession.get(5).contains("\"call-a\""));
+        assertTrue(interruptedSession.get(6).contains(
+                "\"stopReason\":\"aborted\""));
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result resumed = worker.run(new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.EXECUTE,
+                2,
+                workingDirectory,
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "resume"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, resumed.outcome());
+        assertEquals(
+                List.of("call-a"),
+                Files.readAllLines(fixture.resolve("tool-executions")));
+        assertEquals(
+                9,
+                Files.readAllLines(
+                        sessionFile(sessionId(ShipRun.Stage.EXECUTE)))
+                        .size());
+    }
+
+    @Test
+    void overflowContinuationToolMessagesRemainAbortableBeforeAgentEnd()
+            throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"),
+                "overflow-continuation-tool-abort\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(ShipRun.Stage.EXECUTE, "prompt"));
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(
+                "{\"id\":\"abort-1\",\"type\":\"abort\"}",
+                Files.readString(fixture.resolve("abort")).trim());
+        assertEquals(
+                List.of("call-a"),
+                Files.readAllLines(fixture.resolve("tool-executions")));
+        List<String> interruptedSession = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.EXECUTE)));
+        assertEquals(9, interruptedSession.size());
+        assertTrue(interruptedSession.get(4).contains(
+                "\"stopReason\":\"error\""));
+        assertTrue(interruptedSession.get(5).contains(
+                "\"type\":\"compaction\""));
+        assertTrue(interruptedSession.get(6).contains("\"call-b\""));
+        assertTrue(interruptedSession.get(7).contains("\"call-a\""));
+        assertTrue(interruptedSession.get(8).contains(
+                "\"stopReason\":\"aborted\""));
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result resumed = worker.run(new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.EXECUTE,
+                2,
+                workingDirectory,
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "resume"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, resumed.outcome());
+        assertEquals(
+                List.of("call-a"),
+                Files.readAllLines(fixture.resolve("tool-executions")));
+        assertEquals(
+                11,
+                Files.readAllLines(
+                        sessionFile(sessionId(ShipRun.Stage.EXECUTE)))
+                        .size());
+    }
+
+    @Test
+    void interruptionPersistsAbortAndResumesTheSameStageSession() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "block\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        ShipController controller = new ShipController(temporaryDirectory.resolve("state"));
+        ShipRun run = controller.start(workingDirectory, ShipRun.Oversight.NEVER, List.of());
+        String sessionId = sessionId(
+                run.id(),
+                ShipRun.Stage.DISCOVERY,
+                run.stage(ShipRun.Stage.DISCOVERY).inputDigest());
+        PiWorker.Request request = new PiWorker.Request(
+                run.id(),
+                ShipRun.Stage.DISCOVERY,
+                1,
+                workingDirectory,
+                sessions,
+                evidence,
+                run.stage(ShipRun.Stage.DISCOVERY).inputDigest(),
+                true,
+                "prompt");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request);
+                failure.set(new AssertionError("Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        assertFalse(hasSession(sessionId));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(
+                "{\"id\":\"abort-1\",\"type\":\"abort\"}",
+                Files.readString(fixture.resolve("abort")).trim());
+        assertTrue(hasSession(sessionId));
+        assertTrue(Files.readString(sessionFile(sessionId))
+                .contains("\"stopReason\":\"aborted\""));
+        assertProcessesGone();
+
+        ShipRun resumed = controller.resume(run.id());
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result resumedResult = worker.run(new PiWorker.Request(
+                resumed.id(),
+                ShipRun.Stage.DISCOVERY,
+                2,
+                workingDirectory,
+                sessions,
+                evidence,
+                resumed.stage(ShipRun.Stage.DISCOVERY).inputDigest(),
+                true,
+                "resume"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, resumedResult.outcome());
+        assertEquals(2, resumed.stage(ShipRun.Stage.DISCOVERY).attempts());
+        assertEquals(
+                List.of(sessionId, sessionId),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertEquals(
+                List.of(sessionId),
+                Files.readAllLines(fixture.resolve("resumed-sessions")));
+        List<String> persisted = Files.readAllLines(sessionFile(sessionId));
+        assertEquals(7, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"aborted\""));
+        assertTrue(persisted.get(6).contains("\"stopReason\":\"stop\""));
+    }
+
+    @Test
+    void repeatedInterruptsReuseOneAbortCommandAndDeadline() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "repeated-interrupt-abort\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(ShipRun.Stage.DESIGN, "prompt"));
+                failure.set(new AssertionError("Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        awaitFile(fixture.resolve("abort-received"));
+        invocation.interrupt();
+        invocation.interrupt();
+        Files.writeString(fixture.resolve("release"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+        assertEquals(5, Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.DESIGN))).size());
+    }
+
+    @Test
+    void lateInterruptAfterTerminalResultDoesNotAbortOrRetryTheTurn() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "late-terminal-exit\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                result.set(worker.run(request(ShipRun.Stage.PLAN, "prompt")));
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        Files.writeString(fixture.resolve("release"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
+        assertTrue(interrupted.get());
+        assertFalse(Files.exists(fixture.resolve("abort")));
+        assertEquals(
+                List.of(sessionId(ShipRun.Stage.PLAN)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertEquals(5, Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.PLAN))).size());
+    }
+
+    @Test
+    void lateInterruptAfterAbortAcknowledgementKeepsThePersistedAbort() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "late-abort-exit\n");
+        PiWorker worker = worker(Duration.ofMillis(300));
+        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                result.set(worker.run(request(ShipRun.Stage.VALIDATE, "prompt")));
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        Files.writeString(fixture.resolve("release"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertEquals(PiWorker.Outcome.TIMED_OUT, result.get().outcome());
+        assertTrue(interrupted.get());
+        assertEquals(
+                List.of(sessionId(ShipRun.Stage.VALIDATE)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        List<String> persisted = Files.readAllLines(
+                sessionFile(sessionId(ShipRun.Stage.VALIDATE)));
+        assertEquals(5, persisted.size());
+        assertTrue(persisted.get(4).contains("\"stopReason\":\"aborted\""));
+    }
+
+    @Test
+    void interruptionReapsPiBeforeClosingABlockedPromptWriter() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "never-read\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request(
+                        ShipRun.Stage.DISCOVERY, "x".repeat(1024 * 1024)));
+                failure.set(new AssertionError("Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
+        assertProcessesGone();
+    }
+
+    @Test
+    void reapsFastDetachedProcessGroupMembersBeforeReturning()
+            throws Exception {
+        Files.writeString(fixture.resolve("mode"), "fast-detach\n");
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.EXECUTE, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        long detached = Long.parseLong(
+                Files.readString(fixture.resolve("detached-pid")).trim());
+        awaitGone(detached);
+        Thread.sleep(1200);
+        assertFalse(Files.exists(fixture.resolve("delayed-mutation")));
+    }
+
+    private PiWorker worker(Duration timeout) {
+        return new PiWorker(executable, "0.80.6", timeout);
+    }
+
+    private PiWorker worker(
+            Duration timeout, Map<String, String> environment) {
+        return new PiWorker(
+                executable,
+                "0.80.6",
+                timeout,
+                Clock.systemUTC(),
+                environment);
+    }
+
+    private PiWorker.Request request(ShipRun.Stage stage, String prompt) {
+        return request(stage, prompt, true);
+    }
+
+    private PiWorker.Request request(
+            ShipRun.Stage stage, String prompt, boolean acceptExperimental) {
+        return new PiWorker.Request(
+                RUN_ID,
+                stage,
+                1,
+                workingDirectory,
+                sessions,
+                evidence,
+                inputDigest(),
+                acceptExperimental,
+                prompt);
+    }
+
+    private static String inputDigest() {
+        return ShipDigest.sha256("input".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String sessionId(ShipRun.Stage stage) {
+        return sessionId(RUN_ID, stage, inputDigest());
+    }
+
+    private static String sessionId(
+            String runId, ShipRun.Stage stage, String inputDigest) {
+        return runId + "-" + stage.name().toLowerCase(java.util.Locale.ROOT) + "-"
+               + inputDigest.substring("sha256:".length());
+    }
+
+    private Path assertScratchArgument(
+            String sessionId, List<String> arguments) {
+        assertEquals("--session-dir", arguments.get(4));
+        Path scratch = Path.of(arguments.get(5));
+        assertEquals(sessions, scratch.getParent());
+        assertTrue(scratch.getFileName().toString()
+                .startsWith(".ship-pi-" + sessionId + "-"));
+        assertFalse(Files.exists(scratch));
+        return scratch;
+    }
+
+    private void assertNoScratchDirectories() throws IOException {
+        try (var entries = Files.newDirectoryStream(
+                sessions, ".ship-pi-*")) {
+            assertFalse(entries.iterator().hasNext());
+        }
+    }
+
+    private void assertEvidenceDoesNotContain(String secret)
+            throws IOException {
+        try (var paths = Files.walk(evidence)) {
+            for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                assertFalse(
+                        Files.readString(path).contains(secret),
+                        path.toString());
+            }
+        }
+    }
+
+    private boolean hasSession(String sessionId) throws IOException {
+        try (var files = Files.newDirectoryStream(
+                sessions, "*_" + sessionId + ".jsonl")) {
+            return files.iterator().hasNext();
+        }
+    }
+
+    private Path sessionFile(String sessionId) throws IOException {
+        try (var files = Files.newDirectoryStream(
+                sessions, "*_" + sessionId + ".jsonl")) {
+            return files.iterator().next();
+        }
+    }
+
+    private void assertProcessesGone() throws Exception {
+        long parent = Long.parseLong(Files.readString(fixture.resolve("parent-pid")).trim());
+        long child = Long.parseLong(Files.readString(fixture.resolve("child-pid")).trim());
+        awaitGone(parent);
+        awaitGone(child);
+        assertFalse(ProcessHandle.of(parent).map(ProcessHandle::isAlive).orElse(false));
+        assertFalse(ProcessHandle.of(child).map(ProcessHandle::isAlive).orElse(false));
+    }
+
+    private static void awaitFile(Path path) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (!Files.exists(path)) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Timed out waiting for " + path);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static void awaitGone(long pid) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Process is still alive: " + pid);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static Path writeExecutable(Path path, String script) throws IOException {
+        Files.writeString(path, script);
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"));
+        return path;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -521,12 +521,14 @@ class PiWorkerTest {
         PiWorker.Result result = worker(
                 Duration.ofSeconds(5),
                 Map.of(
+                        "AUTH", "0",
                         "DB_PASSWORD", "test",
                         "COOKIE_NAME", "session",
                         "TOKEN", "1"))
                 .run(request(stage, "test prompt"));
 
         assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertEquals("0.80.6", result.version());
         assertTrue(hasSession(sessionId(stage)));
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -459,9 +459,9 @@ class PiWorkerTest {
     void rejectsSensitiveEnvironmentValuesInAssistantAndToolResults()
             throws Exception {
         List<String> names = List.of(
-                "OPENAI_API_KEY", "AUTH", "JWT", "PASS");
+                "OPENAI_API_KEY", "AUTH", "JWT", "PASS", "TOKEN");
         List<String> values = List.of(
-                "fixture-secret-123", "auth-value", "jwt-value", "xy");
+                "fixture-secret-123", "auth-value", "jwt-value", "xy", "1");
         ShipRun.Stage[] stages = ShipRun.Stage.values();
         for (int index = 0; index < names.size(); index++) {
             String secret = values.get(index);
@@ -497,6 +497,20 @@ class PiWorkerTest {
                 .run(request(ShipRun.Stage.VALIDATE, "pwd"));
         assertEquals(PiWorker.Outcome.SUCCEEDED, allowed.outcome());
         assertEquals(cwd, allowed.assistantText());
+    }
+
+    @Test
+    void ignoresBooleanValuesOnlyForFeatureToggleEnvironmentNames()
+            throws Exception {
+        PiWorker.Result result = worker(
+                Duration.ofSeconds(5),
+                Map.of(
+                        "AUTH_ENABLED", "true",
+                        "USE_JWT", "1",
+                        "ENABLE_COOKIE", "false"))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
     }
 
     @Test
@@ -731,7 +745,8 @@ class PiWorkerTest {
     }
 
     @Test
-    void rejectsAliasedOrOverlappingRuntimeDirectories() throws Exception {
+    void acceptsAncestorSymlinksButRejectsLeafAndOverlappingRuntimeDirectories()
+            throws Exception {
         Path realParent = Files.createDirectory(temporaryDirectory.resolve("real-parent"));
         Path realWorking = Files.createDirectory(realParent.resolve("working"));
         Path aliasParent = temporaryDirectory.resolve("alias-parent");
@@ -741,6 +756,24 @@ class PiWorkerTest {
                 ShipRun.Stage.DISCOVERY,
                 1,
                 aliasParent.resolve(realWorking.getFileName()),
+                sessions,
+                evidence,
+                inputDigest(),
+                true,
+                "prompt");
+        PiWorker.Result aliasedResult = worker(Duration.ofSeconds(5)).run(aliased);
+        assertEquals(PiWorker.Outcome.SUCCEEDED, aliasedResult.outcome());
+        assertEquals(
+                realWorking.toString(),
+                aliasedResult.evidence().workingDirectory());
+
+        Path leafAlias = temporaryDirectory.resolve("working-link");
+        Files.createSymbolicLink(leafAlias, realWorking);
+        PiWorker.Request leaf = new PiWorker.Request(
+                RUN_ID,
+                ShipRun.Stage.DESIGN,
+                1,
+                leafAlias,
                 sessions,
                 evidence,
                 inputDigest(),
@@ -768,9 +801,9 @@ class PiWorkerTest {
                 true,
                 "prompt");
 
-        IOException aliasFailure = assertThrows(
+        IOException leafFailure = assertThrows(
                 IOException.class,
-                () -> worker(Duration.ofSeconds(5)).run(aliased));
+                () -> worker(Duration.ofSeconds(5)).run(leaf));
         IOException workingFailure = assertThrows(
                 IOException.class,
                 () -> worker(Duration.ofSeconds(5)).run(overlapsWorking));
@@ -778,10 +811,9 @@ class PiWorkerTest {
                 IOException.class,
                 () -> worker(Duration.ofSeconds(5)).run(sharedStateDirectory));
 
-        assertTrue(aliasFailure.getMessage().contains("symbolic link"));
+        assertTrue(leafFailure.getMessage().contains("real directory"));
         assertTrue(workingFailure.getMessage().contains("disjoint"));
         assertTrue(stateFailure.getMessage().contains("disjoint"));
-        assertFalse(Files.exists(fixture.resolve("args")));
     }
 
     @Test
@@ -795,18 +827,44 @@ class PiWorkerTest {
                         .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
 
         assertTrue(permissions.getMessage().contains("0700"));
-        Files.setPosixFilePermissions(
-                sessions, PosixFilePermissions.fromString("rwx------"));
-        Files.createSymbolicLink(
-                sessions.resolve("unsafe-entry"), fixture.resolve("version"));
+        assertFalse(Files.exists(fixture.resolve("args")));
+    }
 
-        IOException entry = assertThrows(
+    @Test
+    void ignoresUnrelatedSessionEntriesButRejectsUnsafeMatchingLeaves()
+            throws Exception {
+        Files.createSymbolicLink(
+                sessions.resolve("unrelated-entry"), fixture.resolve("version"));
+
+        PiWorker.Result result = worker(Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        ShipRun.Stage symlinkStage = ShipRun.Stage.DESIGN;
+        Path matchingSymlink = sessions.resolve(
+                "evil_" + sessionId(symlinkStage) + ".jsonl");
+        Files.createSymbolicLink(matchingSymlink, fixture.resolve("version"));
+
+        IOException symlink = assertThrows(
                 IOException.class,
                 () -> worker(Duration.ofSeconds(5))
-                        .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
+                        .run(request(symlinkStage, "prompt")));
 
-        assertTrue(entry.getMessage().contains("unsafe entry"));
-        assertFalse(Files.exists(fixture.resolve("args")));
+        assertTrue(symlink.getMessage().contains("symbolic link"));
+        Files.delete(matchingSymlink);
+        ShipRun.Stage permissionsStage = ShipRun.Stage.PLAN;
+        Path matchingFile = sessions.resolve(
+                "evil_" + sessionId(permissionsStage) + ".jsonl");
+        Files.writeString(matchingFile, "{}\n");
+        Files.setPosixFilePermissions(
+                matchingFile, PosixFilePermissions.fromString("rw-r--r--"));
+
+        IOException permissions = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(permissionsStage, "prompt")));
+
+        assertTrue(permissions.getMessage().contains("0600"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspaceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspaceTest.java
@@ -2,7 +2,6 @@ package io.github.luigidemasi.camelkit.ship.worker;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 
@@ -11,7 +10,6 @@ import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ShipFilesystemException;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -30,21 +28,6 @@ class ShipWorkspaceTest {
 
     @TempDir
     Path temporaryDirectory;
-
-    @AfterEach
-    void makePublishedWorkspacesRemovable() throws Exception {
-        try (var paths = Files.walk(temporaryDirectory)) {
-            for (Path path : paths.filter(item -> {
-                String name = String.valueOf(item.getFileName());
-                return "workspace".equals(name) || name.startsWith(".workspace-");
-            })
-                    .toList()) {
-                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
-                    Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"));
-                }
-            }
-        }
-    }
 
     @Test
     void materializesTheExactMaterialTreeWithoutChangingTheLiveProject() throws Exception {
@@ -69,8 +52,11 @@ class ShipWorkspaceTest {
                 PosixFilePermissions.fromString("rwx------"),
                 Files.getPosixFilePermissions(candidate));
         assertEquals(
-                PosixFilePermissions.fromString("r-x------"),
+                PosixFilePermissions.fromString("rwx------"),
                 Files.getPosixFilePermissions(run.resolve("workspace")));
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(run.resolve("workspace/workspace.json")));
     }
 
     @Test
@@ -135,6 +121,26 @@ class ShipWorkspaceTest {
     }
 
     @Test
+    void upgradesASealedWorkspaceBeforeAdvancingItsAttempt() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Path workspace = candidate.getParent();
+        Path binding = workspace.resolve("workspace.json");
+        Files.setPosixFilePermissions(binding, PosixFilePermissions.fromString("r--------"));
+        Files.setPosixFilePermissions(workspace, PosixFilePermissions.fromString("r-x------"));
+
+        assertEquals(candidate, ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(workspace));
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(binding));
+    }
+
+    @Test
     void recoversTheDisplacedWorkspaceAfterInterruptedPublication() throws Exception {
         Path project = directory("project");
         write(project, "README.md", "baseline");
@@ -170,14 +176,10 @@ class ShipWorkspaceTest {
         Path sourceRun = directory("source-run");
         Path currentCandidate = ShipWorkspace.prepare(project, sourceRun, RUN_ID, 2, INPUT_DIGEST);
         Files.writeString(currentCandidate.resolve("README.md"), "current edit");
-        Files.setPosixFilePermissions(
-                sourceRun.resolve("workspace"), PosixFilePermissions.fromString("rwx------"));
         Files.move(
                 sourceRun.resolve("workspace"),
                 run.resolve("workspace"),
                 java.nio.file.StandardCopyOption.ATOMIC_MOVE);
-        Files.setPosixFilePermissions(
-                run.resolve("workspace"), PosixFilePermissions.fromString("r-x------"));
 
         Path recovered = ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST);
 
@@ -447,24 +449,36 @@ class ShipWorkspaceTest {
     }
 
     @Test
-    void rejectsSymbolicProjectRootsAndAncestors() throws Exception {
+    void rejectsSymbolicRootLeavesButAcceptsBenignAncestorAliases() throws Exception {
         Path realParent = directory("real-parent");
         Path project = Files.createDirectory(realParent.resolve("project"));
         Path rootLink = temporaryDirectory.resolve("project-link");
         Files.createSymbolicLink(rootLink, project);
         Path parentLink = temporaryDirectory.resolve("parent-link");
         Files.createSymbolicLink(parentLink, realParent);
+        Path realRunParent = directory("real-run-parent");
+        Path run = Files.createDirectory(realRunParent.resolve("run"));
+        Path runParentLink = temporaryDirectory.resolve("run-parent-link");
+        Files.createSymbolicLink(runParentLink, realRunParent);
 
         assertThrows(IOException.class,
                 () -> ShipWorkspace.prepare(
                         rootLink, directory("root-link-run"), RUN_ID, 1, INPUT_DIGEST));
-        assertThrows(IOException.class,
-                () -> ShipWorkspace.prepare(
-                        parentLink.resolve("project"),
-                        directory("parent-link-run"),
-                        RUN_ID,
-                        1,
-                        INPUT_DIGEST));
+
+        Path candidate = ShipWorkspace.prepare(
+                parentLink.resolve("project"),
+                runParentLink.resolve("run"),
+                RUN_ID,
+                1,
+                INPUT_DIGEST);
+
+        assertEquals(run.resolve("workspace/candidate").toRealPath(), candidate);
+        assertEquals(candidate.toString(), ShipWorkspace.verify(
+                parentLink.resolve("project"),
+                runParentLink.resolve("run/workspace/candidate"),
+                RUN_ID,
+                1,
+                INPUT_DIGEST).root());
     }
 
     private Path directory(String name) throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspaceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspaceTest.java
@@ -1,0 +1,491 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipFilesystemException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class ShipWorkspaceTest {
+
+    private static final String RUN_ID = "ship-0123456789abcdef0123456789abcdef";
+    private static final String INPUT_DIGEST = digest("input");
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @AfterEach
+    void makePublishedWorkspacesRemovable() throws Exception {
+        try (var paths = Files.walk(temporaryDirectory)) {
+            for (Path path : paths.filter(item -> {
+                String name = String.valueOf(item.getFileName());
+                return "workspace".equals(name) || name.startsWith(".workspace-");
+            })
+                    .toList()) {
+                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                    Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"));
+                }
+            }
+        }
+    }
+
+    @Test
+    void materializesTheExactMaterialTreeWithoutChangingTheLiveProject() throws Exception {
+        Path project = directory("project");
+        Path route = write(project, "routes/orders.camel.yaml", "- route:\n");
+        Files.setPosixFilePermissions(route, PosixFilePermissions.fromString("rw-------"));
+        Files.createDirectory(project.resolve("empty"));
+        ProjectSnapshot before = ProjectEvidenceFiles.capture(project);
+        Path run = directory("run");
+
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+
+        assertEquals(run.resolve("workspace/candidate"), candidate);
+        assertTrue(Files.isRegularFile(run.resolve("workspace/workspace.json")));
+        assertEquals("- route:\n", Files.readString(candidate
+                .resolve("routes/orders.camel.yaml")));
+        assertTrue(Files.isDirectory(candidate.resolve("empty")));
+        assertTrue(ProjectEvidenceFiles.unchanged(before, ProjectEvidenceFiles.capture(project)));
+        assertTrue(ProjectEvidenceFiles.unchangedMaterialTree(
+                before, ProjectEvidenceFiles.captureSealed(candidate)));
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(candidate));
+        assertEquals(
+                PosixFilePermissions.fromString("r-x------"),
+                Files.getPosixFilePermissions(run.resolve("workspace")));
+    }
+
+    @Test
+    void excludesCredentialAndNonMaterialPaths() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "material");
+        write(project, ".env", "TOKEN=secret");
+        write(project, ".ssh/config", "credential");
+        write(project, "target/generated.txt", "generated");
+        write(project, ".idea/workspace.xml", "private");
+        write(project, ".env.example", "TOKEN=");
+
+        Path candidate = ShipWorkspace.prepare(
+                project, directory("run"), RUN_ID, 1, INPUT_DIGEST);
+
+        assertTrue(Files.exists(candidate.resolve("README.md")));
+        assertTrue(Files.exists(candidate.resolve(".env.example")));
+        assertFalse(Files.exists(candidate.resolve(".env")));
+        assertFalse(Files.exists(candidate.resolve(".ssh")));
+        assertFalse(Files.exists(candidate.resolve("target")));
+        assertFalse(Files.exists(candidate.resolve(".idea")));
+    }
+
+    @Test
+    void rejectsUnsafeRealFilenamesWithATypedFailure() throws Exception {
+        Path project = directory("project");
+        Files.writeString(project.resolve("line\nbreak"), "content");
+
+        ShipFilesystemException failure = assertThrows(
+                ShipFilesystemException.class,
+                () -> ShipWorkspace.prepare(
+                        project, directory("run"), RUN_ID, 1, INPUT_DIGEST));
+
+        assertEquals(ShipFilesystemException.UNSAFE_ENTRY, failure.code());
+    }
+
+    @Test
+    void reusesTheBoundWorkspaceWithoutOverwritingPartialEdits() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path first = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        assertEquals(first.toString(),
+                ShipWorkspace.verify(project, first, RUN_ID, 1, INPUT_DIGEST).root());
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.verify(project, first, RUN_ID, 2, INPUT_DIGEST));
+        Files.writeString(first.resolve("README.md"), "partial edit");
+        write(first, "src/new.txt", "partial file");
+        write(first, "target/generated.txt", "partial build output");
+
+        Path resumed = ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST);
+
+        assertEquals(first, resumed);
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.verify(project, resumed, RUN_ID, 1, INPUT_DIGEST));
+        assertEquals(resumed.toString(),
+                ShipWorkspace.verify(project, resumed, RUN_ID, 2, INPUT_DIGEST).root());
+        assertEquals("partial edit", Files.readString(resumed.resolve("README.md")));
+        assertEquals("partial file", Files.readString(resumed.resolve("src/new.txt")));
+        assertEquals("partial build output",
+                Files.readString(resumed.resolve("target/generated.txt")));
+    }
+
+    @Test
+    void recoversTheDisplacedWorkspaceAfterInterruptedPublication() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(candidate.resolve("README.md"), "partial edit");
+        Files.move(
+                run.resolve("workspace"),
+                run.resolve(".workspace-stale"),
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+        Path abandoned = Files.createDirectory(run.resolve(".workspace-interrupted"));
+        Files.createDirectory(abandoned.resolve("candidate"));
+
+        Path recovered = ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST);
+
+        assertEquals(candidate, recovered);
+        assertEquals("partial edit", Files.readString(recovered.resolve("README.md")));
+        assertNoWorkspaceDebris(run);
+    }
+
+    @Test
+    void keepsAValidPublishedWorkspaceWhenCrashDebrisCoexists() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path staleCandidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(staleCandidate.resolve("README.md"), "stale edit");
+        Files.move(
+                run.resolve("workspace"),
+                run.resolve(".workspace-stale"),
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+
+        Path sourceRun = directory("source-run");
+        Path currentCandidate = ShipWorkspace.prepare(project, sourceRun, RUN_ID, 2, INPUT_DIGEST);
+        Files.writeString(currentCandidate.resolve("README.md"), "current edit");
+        Files.setPosixFilePermissions(
+                sourceRun.resolve("workspace"), PosixFilePermissions.fromString("rwx------"));
+        Files.move(
+                sourceRun.resolve("workspace"),
+                run.resolve("workspace"),
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+        Files.setPosixFilePermissions(
+                run.resolve("workspace"), PosixFilePermissions.fromString("r-x------"));
+
+        Path recovered = ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST);
+
+        assertEquals(run.resolve("workspace/candidate"), recovered);
+        assertEquals("current edit", Files.readString(recovered.resolve("README.md")));
+        assertNoWorkspaceDebris(run);
+    }
+
+    @Test
+    void rollsBackAnInvalidPublishedWorkspaceWhenCrashDebrisCoexists() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path staleCandidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(staleCandidate.resolve("README.md"), "partial edit");
+        Files.move(
+                run.resolve("workspace"),
+                run.resolve(".workspace-stale"),
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+        Files.createDirectories(run.resolve("workspace/candidate"));
+        Files.writeString(run.resolve("workspace/candidate/README.md"), "invalid current");
+
+        Path recovered = ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST);
+
+        assertEquals(run.resolve("workspace/candidate"), recovered);
+        assertEquals("partial edit", Files.readString(recovered.resolve("README.md")));
+        assertNoWorkspaceDebris(run);
+    }
+
+    @Test
+    void reusedAttemptCannotAcceptLaterBaselineDrift() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(candidate.resolve("README.md"), "partial edit");
+        assertEquals(candidate,
+                ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+
+        Files.writeString(project.resolve("README.md"), "changed baseline");
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        assertEquals("partial edit", Files.readString(candidate.resolve("README.md")));
+        assertEquals(candidate,
+                ShipWorkspace.prepare(project, run, RUN_ID, 3, INPUT_DIGEST));
+        assertEquals("changed baseline", Files.readString(candidate.resolve("README.md")));
+    }
+
+    @Test
+    void failedVerificationStillConsumesTheLaterAttempt() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(candidate.resolve("README.md"), "partial edit");
+        Path unsafe = write(candidate, "target/.env", "TOKEN=secret");
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        Files.delete(unsafe);
+        Files.writeString(project.resolve("README.md"), "changed baseline");
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        assertEquals("partial edit", Files.readString(candidate.resolve("README.md")));
+        assertEquals(candidate,
+                ShipWorkspace.prepare(project, run, RUN_ID, 3, INPUT_DIGEST));
+        assertEquals("changed baseline", Files.readString(candidate.resolve("README.md")));
+    }
+
+    @Test
+    void rotatesChangedInputOrBaselineOnlyForALaterAttempt() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(candidate.resolve("README.md"), "partial edit");
+        String changedInput = digest("changed-input");
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 1, changedInput));
+
+        Path rebound = ShipWorkspace.prepare(project, run, RUN_ID, 2, changedInput);
+        assertEquals(candidate, rebound);
+        assertEquals("baseline", Files.readString(rebound.resolve("README.md")));
+
+        Files.writeString(project.resolve("README.md"), "new baseline");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, changedInput));
+
+        Path refreshed = ShipWorkspace.prepare(project, run, RUN_ID, 3, changedInput);
+        assertEquals(candidate, refreshed);
+        assertEquals("new baseline", Files.readString(refreshed.resolve("README.md")));
+        assertNoWorkspaceDebris(run);
+
+        for (int attempt = 4; attempt <= 6; attempt++) {
+            assertEquals(candidate, ShipWorkspace.prepare(
+                    project, run, RUN_ID, attempt, digest("input-" + attempt)));
+            assertNoWorkspaceDebris(run);
+        }
+    }
+
+    @Test
+    void rejectsUnsafeStaleWorkspaceBeforeRotationAndLeavesNoDebris() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "baseline");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        Files.writeString(project.resolve("README.md"), "changed baseline");
+
+        Path credential = write(candidate, "target/.env", "TOKEN=secret");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        assertFalse(Files.exists(run.resolve(".workspace-stale")));
+        Files.delete(credential);
+
+        Path link = candidate.resolve("target/link");
+        Files.createSymbolicLink(link, project.resolve("README.md"));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        assertFalse(Files.exists(run.resolve(".workspace-stale")));
+        Files.delete(link);
+
+        assertEquals(candidate,
+                ShipWorkspace.prepare(project, run, RUN_ID, 3, INPUT_DIGEST));
+        assertEquals("changed baseline", Files.readString(candidate.resolve("README.md")));
+        assertNoWorkspaceDebris(run);
+    }
+
+    @Test
+    void portableBaselineIgnoresOwnershipAndSpecialModeBits() throws Exception {
+        Path project = directory("project");
+        Path shared = Files.createDirectory(project.resolve("shared"));
+        Files.setAttribute(shared, "unix:mode", 02750);
+        write(shared, "README.md", "shared material");
+        Path run = directory("run");
+
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+
+        assertEquals(
+                PosixFilePermissions.fromString("rwxr-x---"),
+                Files.getPosixFilePermissions(candidate.resolve("shared")));
+        assertEquals(candidate,
+                ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+    }
+
+    @Test
+    void rejectsAWorkspaceBoundToAnotherProjectInputOrBaseline() throws Exception {
+        Path firstProject = directory("first-project");
+        write(firstProject, "README.md", "same");
+        Path secondProject = directory("second-project");
+        write(secondProject, "README.md", "same");
+        Path run = directory("run");
+        ShipWorkspace.prepare(firstProject, run, RUN_ID, 1, INPUT_DIGEST);
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(secondProject, run, RUN_ID, 1, INPUT_DIGEST));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(
+                        firstProject,
+                        run,
+                        "ship-fedcba9876543210fedcba9876543210",
+                        1,
+                        INPUT_DIGEST));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(
+                        firstProject, run, RUN_ID, 1, digest("changed-input")));
+
+        Files.writeString(firstProject.resolve("README.md"), "changed");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(firstProject, run, RUN_ID, 1, INPUT_DIGEST));
+    }
+
+    @Test
+    void cleansAnUnpublishedTemporaryWorkspace() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "material");
+        Path run = directory("run");
+        Path interrupted = Files.createDirectory(run.resolve(".workspace-interrupted"));
+        Files.createDirectory(interrupted.resolve("candidate"));
+        Files.writeString(interrupted.resolve("workspace.json"), "{");
+
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+
+        assertEquals(run.resolve("workspace/candidate"), candidate);
+        assertFalse(Files.exists(run.resolve(".workspace-interrupted")));
+    }
+
+    @Test
+    void cleansTemporaryWorkspaceWhenMaterializationFails() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "material");
+        Files.createSymbolicLink(
+                project.resolve("unsafe-link"), project.resolve("README.md"));
+        Path run = directory("run");
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST));
+
+        try (var entries = Files.list(run)) {
+            assertTrue(entries.findAny().isEmpty());
+        }
+    }
+
+    @Test
+    void rejectsUnboundAndUnsafeCandidates() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "material");
+
+        Path unboundRun = directory("unbound-run");
+        Files.createDirectory(unboundRun.resolve("workspace"));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, unboundRun, RUN_ID, 1, INPUT_DIGEST));
+
+        Path linkedRun = directory("linked-run");
+        Files.createSymbolicLink(linkedRun.resolve("workspace"), project);
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, linkedRun, RUN_ID, 1, INPUT_DIGEST));
+
+        Path nestedRun = Files.createDirectory(project.resolve("run"));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, nestedRun, RUN_ID, 1, INPUT_DIGEST));
+
+        Path boundRun = directory("bound-run");
+        Path candidate = ShipWorkspace.prepare(project, boundRun, RUN_ID, 1, INPUT_DIGEST);
+        Files.createSymbolicLink(candidate.resolve("linked.txt"), project.resolve("README.md"));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, boundRun, RUN_ID, 1, INPUT_DIGEST));
+    }
+
+    @Test
+    void permitsVolatileBuildOutputButRejectsNonPublishableWorkerAdditions() throws Exception {
+        Path project = directory("project");
+        write(project, "README.md", "material");
+        Path run = directory("run");
+        Path candidate = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
+        write(candidate, "target/generated.txt", "build output");
+
+        assertEquals(candidate, ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+
+        Path nestedCredential = write(candidate, "target/.env", "TOKEN=secret");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        Files.delete(nestedCredential);
+
+        Path nestedPrivate = write(candidate, "target/.idea/workspace.xml", "private");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        Files.delete(nestedPrivate);
+        Files.delete(nestedPrivate.getParent());
+
+        Path nestedLink = candidate.resolve("target/link");
+        Files.createSymbolicLink(nestedLink, project.resolve("README.md"));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        Files.delete(nestedLink);
+
+        Path credential = write(candidate, ".env", "TOKEN=secret");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+        Files.delete(credential);
+
+        write(candidate, ".idea/workspace.xml", "private");
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(project, run, RUN_ID, 2, INPUT_DIGEST));
+    }
+
+    @Test
+    void rejectsSymbolicProjectRootsAndAncestors() throws Exception {
+        Path realParent = directory("real-parent");
+        Path project = Files.createDirectory(realParent.resolve("project"));
+        Path rootLink = temporaryDirectory.resolve("project-link");
+        Files.createSymbolicLink(rootLink, project);
+        Path parentLink = temporaryDirectory.resolve("parent-link");
+        Files.createSymbolicLink(parentLink, realParent);
+
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(
+                        rootLink, directory("root-link-run"), RUN_ID, 1, INPUT_DIGEST));
+        assertThrows(IOException.class,
+                () -> ShipWorkspace.prepare(
+                        parentLink.resolve("project"),
+                        directory("parent-link-run"),
+                        RUN_ID,
+                        1,
+                        INPUT_DIGEST));
+    }
+
+    private Path directory(String name) throws IOException {
+        return Files.createDirectory(temporaryDirectory.resolve(name));
+    }
+
+    private static Path write(Path root, String relative, String content) throws IOException {
+        Path file = root.resolve(relative);
+        Files.createDirectories(file.getParent());
+        return Files.writeString(file, content);
+    }
+
+    private static void assertNoWorkspaceDebris(Path run) throws IOException {
+        try (var entries = Files.list(run)) {
+            assertEquals(
+                    java.util.List.of("workspace"),
+                    entries.map(path -> String.valueOf(path.getFileName())).sorted().toList());
+        }
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+}

--- a/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
+++ b/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
@@ -1,0 +1,635 @@
+#!/bin/sh
+fixture=$(dirname "$0")
+if [ "${1:-}" = "--version" ]; then
+  cat "$fixture/version"
+  exit 0
+fi
+
+: > "$fixture/args"
+session=""
+session_dir=""
+while [ "$#" -gt 0 ]; do
+  printf '%s\n' "$1" >> "$fixture/args"
+  if [ "$1" = "--session-id" ]; then
+    shift
+    session="$1"
+    printf '%s\n' "$1" >> "$fixture/args"
+  elif [ "$1" = "--session-dir" ]; then
+    shift
+    session_dir="$1"
+    printf '%s\n' "$1" >> "$fixture/args"
+  fi
+  shift
+done
+pwd > "$fixture/cwd"
+printf '%s\n' "$session_dir" >> "$fixture/session-dirs"
+printf '%s\n' "$session" >> "$fixture/session-ids"
+
+session_file=""
+for existing in "$session_dir"/*_"$session".jsonl; do
+  if [ -f "$existing" ]; then
+    session_file="$existing"
+    printf '%s\n' "$session" >> "$fixture/resumed-sessions"
+    break
+  fi
+done
+if [ -z "$session_file" ]; then
+  session_file="$session_dir/2026-07-24T00-00-00-000Z_$session.jsonl"
+fi
+
+mode=$(cat "$fixture/mode")
+if [ "$mode" = "never-read" ]; then
+  sleep 300 &
+  child=$!
+  printf '%s\n' "$$" > "$fixture/parent-pid"
+  printf '%s\n' "$child" > "$fixture/child-pid"
+  trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 143' TERM HUP INT
+  touch "$fixture/ready"
+  wait "$child"
+  exit 0
+fi
+
+IFS= read -r prompt || exit 6
+printf '%s\n' "$prompt" > "$fixture/prompt"
+prompt_content=${prompt#'{"id":"prompt-1","type":"prompt","message":'}
+prompt_content=${prompt_content%'}'}
+user_message='{"role":"user","content":'"$prompt_content"',"timestamp":1}'
+user_emitted=0
+entry_count=0
+last_id=""
+current_user_id=""
+append_count=0
+
+initialize_state() {
+  if [ -f "$session_file" ]; then
+    entry_count=$(($(wc -l < "$session_file") - 1))
+    last_id=$(sed -n 's/^{"type":"[^"]*","id":"\([^"]*\)".*/\1/p' "$session_file" | tail -n 1)
+  fi
+}
+
+ensure_session() {
+  if [ -f "$session_file" ]; then
+    initialize_state
+    if [ "$mode" = "rewrite-session" ]; then
+      printf '{"type":"session","version":3,"id":"%s","timestamp":"2026-07-24T00:00:01.000Z","cwd":"%s"}\n' \
+        "$session" "$PWD" > "$session_file"
+      printf '%s\n' '{"type":"rewrite-padding","padding":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}' >> "$session_file"
+      initialize_state
+    fi
+    return
+  fi
+  header_id="$session"
+  header_cwd="$PWD"
+  if [ "$mode" = "session-mismatch" ]; then
+    header_id="ship-ffffffffffffffffffffffffffffffff-discovery"
+  elif [ "$mode" = "session-cwd" ]; then
+    header_cwd="/wrong/project"
+  fi
+  printf '{"type":"session","version":3,"id":"%s","timestamp":"2026-07-24T00:00:00.000Z","cwd":"%s"}\n' \
+    "$header_id" "$header_cwd" > "$session_file"
+  if [ "$mode" = "header-only" ]; then
+    return
+  fi
+  printf '%s\n' '{"type":"model_change","id":"e1","parentId":null,"timestamp":"2026-07-24T00:00:00.001Z","provider":"fixture","modelId":"fixture-model"}' >> "$session_file"
+  printf '%s\n' '{"type":"thinking_level_change","id":"e2","parentId":"e1","timestamp":"2026-07-24T00:00:00.002Z","thinkingLevel":"off"}' >> "$session_file"
+  entry_count=2
+  last_id="e2"
+}
+
+append_message() {
+  message="$1"
+  role="$2"
+  ensure_session
+  if [ "$mode" = "header-only" ] || [ "$mode" = "unchanged-session" ]; then
+    return
+  fi
+  if [ "$append_count" -eq 0 ]; then
+    if [ "$mode" = "session-whitespace" ]; then
+      printf ' \t\n' >> "$session_file"
+    elif [ "$mode" = "session-malformed-turn" ]; then
+      printf '%s\n' 'not-json' >> "$session_file"
+    elif [ "$mode" = "session-malformed-secret" ]; then
+      printf '{"type":"message","credential":%s\n' \
+        "$(cat "$fixture/secret")" >> "$session_file"
+    elif [ "$mode" = "session-assistant-first" ]; then
+      entry_count=$((entry_count + 1))
+      printf '{"type":"message","id":"e%s","parentId":"%s","timestamp":"2026-07-24T00:00:00.010Z","message":{"role":"assistant","content":[],"stopReason":"stop","timestamp":0}}\n' \
+        "$entry_count" "$last_id" >> "$session_file"
+      last_id="e$entry_count"
+    fi
+  fi
+  append_count=$((append_count + 1))
+  entry_count=$((entry_count + 1))
+  id="e$entry_count"
+  parent="$last_id"
+  if [ "$mode" = "session-wrong-parent" ] && [ "$append_count" -eq 1 ]; then
+    parent="not-the-parent"
+  elif [ "$mode" = "session-duplicate-id" ] && [ "$append_count" -eq 1 ]; then
+    id="$last_id"
+  fi
+  persisted="$message"
+  if [ "$role" = "user" ] && [ "$mode" = "session-unrelated-prompt" ]; then
+    persisted='{"role":"user","content":"unrelated","timestamp":1}'
+  elif [ "$role" = "assistant" ] && [ "$mode" = "session-missing-stop" ]; then
+    persisted='{"role":"assistant","content":[],"timestamp":2}'
+  elif [ "$role" = "assistant" ] && [ "$mode" = "session-wrong-stop" ]; then
+    persisted='{"role":"assistant","content":[],"stopReason":"error","timestamp":2}'
+  elif [ "$role" = "assistant" ] \
+      && { [ "$mode" = "session-content-mismatch" ] \
+           || [ "$mode" = "terminal-content-mismatch" ]; }; then
+    persisted='{"role":"assistant","content":[{"type":"text","text":"different"}],"stopReason":"stop","timestamp":2}'
+  fi
+  printf '{"type":"message","id":"%s","parentId":"%s","timestamp":"2026-07-24T00:00:00.010Z","message":%s}\n' \
+    "$id" "$parent" "$persisted" >> "$session_file"
+  last_id="$id"
+  if [ "$role" = "user" ]; then
+    current_user_id="$id"
+  fi
+}
+
+emit_message() {
+  message="$1"
+  role="$2"
+  printf '{"type":"message_end","message":%s}\n' "$message"
+  append_message "$message" "$role"
+  if [ "$role" = "user" ]; then
+    user_emitted=1
+  fi
+}
+
+append_compaction() {
+  ensure_session
+  entry_count=$((entry_count + 1))
+  id="e$entry_count"
+  printf '{"type":"compaction","id":"%s","parentId":"%s","timestamp":"2026-07-24T00:00:00.020Z","summary":"summary","firstKeptEntryId":"%s","tokensBefore":10,"details":{"readFiles":[],"modifiedFiles":[]},"fromHook":false}\n' \
+    "$id" "$last_id" "$current_user_id" >> "$session_file"
+  last_id="$id"
+}
+
+begin_turn() {
+  ensure_session
+  if [ "$user_emitted" -eq 0 ]; then
+    emit_message "$user_message" user
+  fi
+}
+
+abort_turn() {
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" >> "$fixture/abort"
+  if [ "$abort" != '{"id":"abort-1","type":"abort"}' ]; then
+    exit 8
+  fi
+  if [ "$mode" = "repeated-interrupt-abort" ]; then
+    touch "$fixture/abort-received"
+    while [ ! -e "$fixture/release" ]; do sleep 0.01; done
+  fi
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  begin_turn
+  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":2}'
+  emit_message "$aborted" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  printf '%s\n' '{"type":"agent_settled"}'
+  if [ "$mode" = "late-abort-exit" ]; then
+    if IFS= read -r unexpected; then exit 9; fi
+    touch "$fixture/ready"
+    while [ ! -e "$fixture/release" ]; do sleep 0.01; done
+    exit 0
+  fi
+  cat >/dev/null
+}
+
+if [ "$mode" = "block" ]; then
+  sleep 300 &
+  child=$!
+  printf '%s\n' "$$" > "$fixture/parent-pid"
+  printf '%s\n' "$child" > "$fixture/child-pid"
+  trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 143' TERM HUP INT
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  touch "$fixture/ready"
+  abort_turn
+  kill "$child" 2>/dev/null
+  wait "$child" 2>/dev/null
+  trap - TERM HUP INT
+  exit 0
+fi
+if [ "$mode" = "late-abort-exit" ] || [ "$mode" = "repeated-interrupt-abort" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  if [ "$mode" = "repeated-interrupt-abort" ]; then
+    touch "$fixture/ready"
+  fi
+  abort_turn
+  exit 0
+fi
+
+case "$mode" in
+  unacknowledged-abort)
+    printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+    IFS= read -r abort || exit 6
+    printf '%s\n' "$abort" > "$fixture/abort"
+    exit 0
+    ;;
+  malformed)
+    printf 'not-json\n'
+    abort_turn
+    exit 0
+    ;;
+  invalid-utf)
+    printf '\377\n'
+    abort_turn
+    exit 0
+    ;;
+  duplicate)
+    printf '%s\n' '{"id":"prompt-1","type":"response","type":"response","command":"prompt","success":true}'
+    abort_turn
+    exit 0
+    ;;
+  response-wrong-bool)
+    printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":"true"}'
+    abort_turn
+    exit 0
+    ;;
+  response-wrong-id)
+    printf '%s\n' '{"id":"other","type":"response","command":"prompt","success":true}'
+    abort_turn
+    exit 0
+    ;;
+  response-wrong-command)
+    printf '%s\n' '{"id":"prompt-1","type":"response","command":"abort","success":true}'
+    abort_turn
+    exit 0
+    ;;
+  response-extra-field)
+    printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true,"extra":true}'
+    abort_turn
+    exit 0
+    ;;
+  metadata-secret)
+    printf '%s\n' '{"type":"fixture-secret-fragment"}'
+    printf '%s\n' '{"id":"fixture-secret-fragment","type":"response","command":"fixture-secret-fragment","success":true}'
+    abort_turn
+    exit 0
+    ;;
+esac
+
+if [ "$mode" = "nonzero" ]; then
+  printf 'Pi failed\n' >&2
+  exit 7
+fi
+if [ "$mode" = "oversized" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  dd if=/dev/zero bs=1048576 count=17 >&2 2>/dev/null
+  abort_turn
+  exit 0
+fi
+if [ "$mode" = "material-output-burst" ] \
+    || [ "$mode" = "material-output-burst-trailing" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  dd if=/dev/zero bs=1048576 count=1 2>/dev/null \
+    | tr '\000' x > "$fixture/material-payload"
+  burst=0
+  while [ "$burst" -lt 17 ]; do
+    printf '%s' '{"type":"material","payload":"'
+    cat "$fixture/material-payload"
+    printf '%s\n' '"}'
+    burst=$((burst + 1))
+  done
+  rm -f "$fixture/material-payload"
+  abort_turn
+  if [ "$mode" = "material-output-burst-trailing" ]; then
+    printf '%s' '{"type":"trailing","payload":"'
+    dd if=/dev/zero bs=1048576 count=17 2>/dev/null | tr '\000' x
+    printf '%s\n' '"}'
+  fi
+  exit 0
+fi
+
+if [ "$mode" = "preflight-hang" ]; then
+  printf '%s\n' '{"type":"compaction_start","reason":"threshold"}'
+  touch "$fixture/ready"
+  sleep 300
+  exit 0
+fi
+
+if [ "$mode" = "preflight-compaction-block" ]; then
+  ensure_session
+  current_user_id=$(sed -n 's/^{"type":"message","id":"\([^"]*\)".*"role":"user".*/\1/p' "$session_file" | tail -n 1)
+  printf '%s\n' '{"type":"compaction_start","reason":"threshold"}'
+  touch "$fixture/compaction-ready"
+  while [ ! -e "$fixture/release-compaction" ]; do sleep 0.01; done
+  append_compaction
+  printf '%s\n' '{"type":"compaction_end","reason":"threshold","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":false}'
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" >> "$fixture/abort"
+  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":2}'
+  emit_message "$aborted" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  printf '%s\n' '{"type":"agent_settled"}'
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  cat >/dev/null
+  exit 0
+fi
+
+if [ "$mode" = "queued-natural-exit" ]; then
+  touch "$fixture/ready"
+  while [ ! -e "$fixture/release" ]; do sleep 0.01; done
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
+  emit_message "$natural" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"
+  printf '%s\n' '{"type":"agent_settled"}'
+  exit 0
+fi
+
+if [ "$mode" != "terminal-before-response" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+fi
+if [ "$mode" = "pre-user-compaction" ]; then
+  ensure_session
+  current_user_id=$(sed -n 's/^{"type":"message","id":"\([^"]*\)".*"role":"user".*/\1/p' "$session_file" | tail -n 1)
+  if [ -z "$current_user_id" ]; then
+    current_user_id="e1"
+  fi
+  append_compaction
+  printf '%s\n' '{"type":"compaction_end","reason":"threshold","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":false}'
+fi
+begin_turn
+
+if [ "$mode" = "missing-content" ]; then
+  printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","stopReason":"stop","timestamp":2}],"willRetry":false}'
+  abort_turn
+  exit 0
+fi
+if [ "$mode" = "retry-wrong-bool" ]; then
+  printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[],"stopReason":"stop","timestamp":2}],"willRetry":"false"}'
+  abort_turn
+  exit 0
+fi
+
+if [ "$mode" = "stop-error" ] || [ "$mode" = "stop-length" ]; then
+  reason=${mode#stop-}
+  semantic='{"role":"assistant","content":[],"stopReason":"'"$reason"'","timestamp":2}'
+  emit_message "$semantic" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$semantic"
+  printf '%s\n' '{"type":"agent_settled"}'
+  exit 0
+fi
+
+if [ "$mode" = "retry-delay-block" ]; then
+  retry='{"role":"assistant","content":[],"stopReason":"error","timestamp":2}'
+  emit_message "$retry" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":true}\n' "$retry"
+  touch "$fixture/ready"
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" >> "$fixture/abort"
+  if [ "$abort" != '{"id":"abort-1","type":"abort"}' ]; then
+    exit 8
+  fi
+  printf '%s\n' '{"type":"agent_settled"}'
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  cat >/dev/null
+  exit 0
+fi
+
+if [ "$mode" = "abort-hang" ]; then
+  touch "$fixture/ready"
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" > "$fixture/abort"
+  sleep 300
+  exit 0
+fi
+
+if [ "$mode" = "terminal-no-settled" ]; then
+  natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
+  emit_message "$natural" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"
+  touch "$fixture/ready"
+  while IFS= read -r unexpected; do
+    printf '%s\n' "$unexpected" >> "$fixture/unexpected-input"
+  done
+  exit 0
+fi
+
+if [ "$mode" = "natural-stop-after-abort" ]; then
+  touch "$fixture/ready"
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" >> "$fixture/abort"
+  natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
+  emit_message "$natural" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"
+  printf '%s\n' '{"type":"compaction_start","reason":"threshold"}'
+  append_compaction
+  printf '%s\n' '{"type":"compaction_end","reason":"threshold","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":false}'
+  printf '%s\n' '{"type":"agent_settled"}'
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  cat >/dev/null
+  exit 0
+fi
+
+if [ "$mode" = "overflow-compaction-abort" ]; then
+  retry='{"role":"assistant","content":[],"stopReason":"error","timestamp":2}'
+  emit_message "$retry" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$retry"
+  printf '%s\n' '{"type":"compaction_start","reason":"overflow"}'
+  touch "$fixture/compaction-ready"
+  early_abort=$(timeout 0.5 sh -c 'IFS= read -r value && printf "%s" "$value"')
+  if [ -n "$early_abort" ]; then
+    printf '%s\n' "$early_abort" > "$fixture/abort"
+    touch "$fixture/abort-received"
+    touch "$fixture/premature-abort"
+  fi
+  while [ ! -e "$fixture/release-compaction" ]; do sleep 0.01; done
+  append_compaction
+  printf '%s\n' '{"type":"compaction_end","reason":"overflow","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":true}'
+  touch "$fixture/compaction-ended"
+  if [ -z "$early_abort" ]; then
+    IFS= read -r abort || exit 6
+    printf '%s\n' "$abort" > "$fixture/abort"
+    touch "$fixture/abort-received"
+  fi
+  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":3}'
+  emit_message "$aborted" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  printf '%s\n' '{"type":"agent_settled"}'
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  cat >/dev/null
+  exit 0
+fi
+
+if [ "$mode" = "partial-tool-abort" ]; then
+  tools='{"role":"assistant","content":[{"type":"toolCall","id":"call-a","name":"read","arguments":{"path":"README.md"}},{"type":"toolCall","id":"call-b","name":"read","arguments":{"path":"pom.xml"}}],"stopReason":"toolUse","timestamp":2}'
+  emit_message "$tools" assistant
+  printf '%s\n' "call-a" >> "$fixture/tool-executions"
+  result_a='{"role":"toolResult","toolCallId":"call-a","toolName":"read","content":[{"type":"text","text":"README"}],"details":{"path":"README.md"},"isError":false,"timestamp":3}'
+  emit_message "$result_a" toolResult
+  touch "$fixture/ready"
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" > "$fixture/abort"
+  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":4}'
+  emit_message "$aborted" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  printf '%s\n' '{"type":"agent_settled"}'
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  cat >/dev/null
+  exit 0
+fi
+
+if [ "$mode" = "overflow-continuation-tool-abort" ]; then
+  retry='{"role":"assistant","content":[],"stopReason":"error","timestamp":2}'
+  emit_message "$retry" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$retry"
+  append_compaction
+  printf '%s\n' '{"type":"compaction_end","reason":"overflow","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":true}'
+  tools='{"role":"assistant","content":[{"type":"toolCall","id":"call-a","name":"read","arguments":{"path":"README.md"}},{"type":"toolCall","id":"call-b","name":"read","arguments":{"path":"pom.xml"}}],"stopReason":"toolUse","timestamp":3}'
+  emit_message "$tools" assistant
+  printf '%s\n' "call-a" >> "$fixture/tool-executions"
+  result_a='{"role":"toolResult","toolCallId":"call-a","toolName":"read","content":[{"type":"text","text":"README"}],"details":{"path":"README.md"},"isError":false,"timestamp":4}'
+  emit_message "$result_a" toolResult
+  touch "$fixture/ready"
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" > "$fixture/abort"
+  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":5}'
+  emit_message "$aborted" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  printf '%s\n' '{"type":"agent_settled"}'
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  cat >/dev/null
+  exit 0
+fi
+
+printf '%s\n' 'Authorization=Bearer fixture-secret' >&2
+assistant_text=$(cat "$fixture/assistant-text")
+if [ "$mode" = "leak-assistant" ]; then
+  assistant_text=$(cat "$fixture/secret")
+fi
+final='{"role":"assistant","content":[{"type":"text","text":"'"$assistant_text"'"}],"stopReason":"stop","timestamp":2}'
+if [ "$mode" = "leak-assistant-key" ]; then
+  secret=$(cat "$fixture/secret")
+  final='{"role":"assistant","content":[{"type":"text","text":"done","details":{"'"$secret"'":true}}],"stopReason":"stop","timestamp":2}'
+fi
+
+if [ "$mode" = "cumulative-update-burst" ] \
+    || [ "$mode" = "cumulative-tool-update-burst" ]; then
+  partial=""
+  update=0
+  while [ "$update" -lt 2050 ]; do
+    partial="${partial}xxxx"
+    if [ "$mode" = "cumulative-update-burst" ]; then
+      printf '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"xxxx","partial":{"role":"assistant","content":[{"type":"text","text":"%s"}]}},"message":{"role":"assistant","content":[{"type":"text","text":"%s"}]}}\n' \
+        "$partial" "$partial"
+    else
+      printf '{"type":"tool_execution_update","toolCallId":"call-1","toolName":"bash","args":{"command":"generate"},"partialResult":{"content":[{"type":"text","text":"%s"}],"details":{"output":"%s"}}}\n' \
+        "$partial" "$partial"
+    fi
+    update=$((update + 1))
+  done
+fi
+
+if [ "$mode" = "retry-then-success" ] \
+    || [ "$mode" = "retry-length-then-success" ] \
+    || [ "$mode" = "auto-retry-success" ]; then
+  retry_reason="error"
+  if [ "$mode" = "retry-length-then-success" ]; then
+    retry_reason="length"
+  fi
+  retry='{"role":"assistant","content":[],"stopReason":"'"$retry_reason"'","timestamp":2}'
+  emit_message "$retry" assistant
+  if [ "$mode" = "retry-then-success" ] \
+      || [ "$mode" = "retry-length-then-success" ]; then
+    printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$retry"
+    printf '%s\n' '{"type":"compaction_start","reason":"overflow"}'
+    append_compaction
+    printf '%s\n' '{"type":"compaction_end","reason":"overflow","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":true}'
+  else
+    printf '{"type":"agent_end","messages":[%s],"willRetry":true}\n' "$retry"
+    printf '%s\n' '{"type":"auto_retry_start","attempt":1,"maxAttempts":3,"delayMs":1,"error":"retry"}'
+  fi
+elif [ "$mode" = "tool-sequence" ] \
+    || [ "$mode" = "leak-tool" ] \
+    || [ "$mode" = "leak-tool-number" ] \
+    || [ "$mode" = "tool-orphan-stop" ]; then
+  if [ "$mode" = "tool-orphan-stop" ]; then
+    tool_assistant='{"role":"assistant","content":[{"type":"toolCall","id":"call-1","name":"read","arguments":{"path":"README.md"}},{"type":"toolCall","id":"call-2","name":"read","arguments":{"path":"pom.xml"}}],"stopReason":"toolUse","timestamp":2}'
+  else
+    tool_assistant='{"role":"assistant","content":[{"type":"toolCall","id":"call-1","name":"read","arguments":{"path":"README.md"}}],"stopReason":"toolUse","timestamp":2}'
+  fi
+  emit_message "$tool_assistant" assistant
+  tool_text="tool output"
+  if [ "$mode" = "leak-tool" ]; then
+    tool_text=$(cat "$fixture/secret")
+  fi
+  tool_result='{"role":"toolResult","toolCallId":"call-1","toolName":"read","content":[{"type":"text","text":"'"$tool_text"'"}],"details":{"path":"README.md"},"isError":false,"timestamp":3}'
+  if [ "$mode" = "leak-tool-number" ]; then
+    secret=$(cat "$fixture/secret")
+    tool_result='{"role":"toolResult","toolCallId":"call-1","toolName":"read","content":[{"type":"text","text":"tool output"}],"details":{"nested":{"value":'"$secret"'}},"isError":false,"timestamp":3}'
+  fi
+  emit_message "$tool_result" toolResult
+elif [ "$mode" = "unrelated-intermediate" ]; then
+  unrelated='{"role":"assistant","content":[],"stopReason":"stop","timestamp":2}'
+  emit_message "$unrelated" assistant
+fi
+
+emit_message "$final" assistant
+printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$final"
+
+if [ "$mode" = "compaction-success" ] || [ "$mode" = "compact-after-stop" ]; then
+  printf '%s\n' '{"type":"compaction_start","reason":"threshold"}'
+  append_compaction
+  printf '%s\n' '{"type":"compaction_end","reason":"threshold","result":{"summary":"summary","firstKeptEntryId":"'"$current_user_id"'","tokensBefore":10,"estimatedTokensAfter":4,"details":{"readFiles":[],"modifiedFiles":[]}},"aborted":false,"willRetry":false}'
+elif [ "$mode" = "compaction-failed" ]; then
+  printf '%s\n' '{"type":"compaction_start","reason":"threshold"}'
+  printf '%s\n' '{"type":"compaction_end","reason":"threshold","aborted":false,"willRetry":false,"errorMessage":"compaction failed"}'
+elif [ "$mode" = "compaction-aborted" ]; then
+  printf '%s\n' '{"type":"compaction_start","reason":"threshold"}'
+  printf '%s\n' '{"type":"compaction_end","reason":"threshold","aborted":true,"willRetry":false}'
+fi
+
+if [ "$mode" = "missing-settled" ]; then
+  exit 0
+elif [ "$mode" = "settled-extra" ]; then
+  printf '%s\n' '{"type":"agent_settled","extra":true}'
+else
+  printf '%s\n' '{"type":"agent_settled"}'
+fi
+
+if [ "$mode" = "terminal-before-response" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+fi
+if [ "$mode" = "trailing" ]; then
+  printf '%s\n' '{"type":"message_update"}'
+fi
+if [ "$mode" = "session-duplicate" ]; then
+  cp "$session_file" "$session_dir/2026-07-24T00-00-01-000Z_$session.jsonl"
+fi
+if [ "$mode" = "settled-nonzero" ]; then
+  exit 7
+fi
+if [ "$mode" = "retention-failure" ]; then
+  chmod 500 "$(dirname "$PWD")/evidence"
+  exit 0
+fi
+if [ "$mode" = "settled-hang" ]; then
+  trap '' TERM HUP INT
+  sleep 300
+fi
+if [ "$mode" = "late-terminal-exit" ]; then
+  if IFS= read -r unexpected; then exit 9; fi
+  touch "$fixture/ready"
+  while [ ! -e "$fixture/release" ]; do sleep 0.01; done
+  exit 0
+fi
+if [ "$mode" = "fast-detach" ]; then
+  (
+    trap '' TERM HUP INT
+    sleep 1
+    touch "$fixture/delayed-mutation"
+  ) >/dev/null 2>&1 &
+  printf '%s\n' "$!" > "$fixture/detached-pid"
+  exit 0
+fi
+cat >/dev/null

--- a/distribution.properties
+++ b/distribution.properties
@@ -84,7 +84,7 @@ forage.version.4.18.2=1.3
 forage.catalog.artifact=io.kaoto.forage:forage-catalog
 
 # ─── Pi Agent Versions ─────────────────────────────────────────────────────
-pi.version=0.80.3
+pi.version=0.80.6
 pi.mcp.adapter.version=2.11.0
 
 # ─── MCP Repos ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #149

## Summary

- add controller-owned, attempt-bound Execute staging and safe staged-result capture
- add a bounded Linux Pi RPC worker with cancellation, copy-on-write session handling, strict transcript validation, and atomic validated session publication
- add bounded local command execution plus strict local Stamp and retained-log persistence
- update the maintained Pi pin to 0.80.6 because the completion protocol requires `agent_settled`
- canonicalize state, project, catalog, and evidence paths through benign ancestor aliases while retaining leaf and containment checks
- separate bounded raw control parsing from redacted retained evidence, retain short-value evidence scrubbing, and require at least eight characters only for fail-closed Pi transcript collision checks
- simplify artifact, process, Pi-session, and workspace checks to the stated local same-user threat model

## Why RPC

A one-shot Pi process terminated before the first assistant response did not persist resumable context. The RPC path did persist an aborted turn and expose the final lifecycle events needed to validate settlement. This slice therefore uses one bounded process for one prompt over RPC.

## Scope and limits

This remains internal, unregistered, and experimental. It does not register `camel-kit ship`, claim a supported Pi configuration, or complete the real Pi/Linux end-to-end gate.

The worker's `workingDirectory` is a working directory, not an OS sandbox. This slice does not attempt hostile same-user containment.

This PR provides atomic, validated Pi-session publication only. It does not yet provide exactly-once composition between that publication and the `ShipRun` transition. The next slice will add a durable worker-result marker keyed by run ID, stage, input digest, and attempt so a forced crash after session publication can replay the result without prompting again. It will also scan changed workspace files for known secrets before controller composition and publication.

## Verification

- exact `AUTH=0` version-collision regression passed
- focused follow-up suite under `AUTH=0`: 70 Pi worker and local-command redaction tests passed
- `./mvnw -B -Psourcecheck validate`
- `./mvnw -B clean install` (six-module reactor; 768 core tests)

## Website impact

Required. The maintained Pi baseline also feeds generated Pi guidance. Issue #149 keeps the repository and website documentation checkbox open for the public Ship cutover; this PR does not register the command.
