### PR TITLE
Add recoverable Ship worker results

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -33,6 +33,7 @@ import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classificatio
 import io.github.luigidemasi.camelkit.ship.worker.ChangedWorkspaceSecretScanner;
 import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace;
 import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.StaleBaselineException;
+import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.Verification;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -425,7 +426,7 @@ public final class ShipController {
                         active.attempts(),
                         active.inputDigest(),
                         locked.directory());
-                rejectChangedWorkspaceSecrets(project, workspaceEvidence.snapshot());
+                rejectChangedWorkspaceSecrets(workspaceEvidence);
                 artifactRoot = workspaceEvidence.candidate();
             } else {
                 normalizedArtifacts = normalizeArtifactPaths(project, artifacts);
@@ -751,14 +752,15 @@ public final class ShipController {
             Path runDirectory) {
         try {
             Path expected = expectedWorkspace(runDirectory);
-            ProjectSnapshot snapshot = ShipWorkspace.verify(
+            Verification verification = ShipWorkspace.verify(
                     project, candidate, runId, attempt, inputDigest);
-            Path verified = Path.of(snapshot.root());
+            Path verified = Path.of(verification.candidate().root());
             if (!verified.equals(expected)) {
                 throw new IOException(
                         "Ship workspace is outside the controller-owned run directory");
             }
-            return new WorkspaceEvidence(verified, snapshot);
+            return new WorkspaceEvidence(
+                    verified, verification.baseline(), verification.candidate());
         } catch (StaleBaselineException e) {
             throw failure(
                     "stale-stage-input",
@@ -772,12 +774,11 @@ public final class ShipController {
         }
     }
 
-    private static void rejectChangedWorkspaceSecrets(
-            Path project, ProjectSnapshot candidate) {
+    private static void rejectChangedWorkspaceSecrets(WorkspaceEvidence workspace) {
         try {
             List<String> findings = ChangedWorkspaceSecretScanner.scan(
-                    ProjectEvidenceFiles.capture(project),
-                    candidate,
+                    workspace.baseline(),
+                    workspace.snapshot(),
                     System.getenv());
             if (!findings.isEmpty()) {
                 throw failure(
@@ -1249,7 +1250,8 @@ public final class ShipController {
         }
     }
 
-    private record WorkspaceEvidence(Path candidate, ProjectSnapshot snapshot) {
+    private record WorkspaceEvidence(
+            Path candidate, ProjectSnapshot baseline, ProjectSnapshot snapshot) {
     }
 
     public static final class Failure extends RuntimeException {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -30,6 +30,7 @@ import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+import io.github.luigidemasi.camelkit.ship.worker.ChangedWorkspaceSecretScanner;
 import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace;
 import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.StaleBaselineException;
 
@@ -424,6 +425,7 @@ public final class ShipController {
                         active.attempts(),
                         active.inputDigest(),
                         locked.directory());
+                rejectChangedWorkspaceSecrets(project, workspaceEvidence.snapshot());
                 artifactRoot = workspaceEvidence.candidate();
             } else {
                 normalizedArtifacts = normalizeArtifactPaths(project, artifacts);
@@ -766,6 +768,29 @@ public final class ShipController {
             throw failure(
                     "artifact-invalid",
                     "Ship workspace does not match the active stage",
+                    e);
+        }
+    }
+
+    private static void rejectChangedWorkspaceSecrets(
+            Path project, ProjectSnapshot candidate) {
+        try {
+            List<String> findings = ChangedWorkspaceSecretScanner.scan(
+                    ProjectEvidenceFiles.capture(project),
+                    candidate,
+                    System.getenv());
+            if (!findings.isEmpty()) {
+                throw failure(
+                        "workspace-secret-detected",
+                        "Ship workspace contains a known secret in changed files: "
+                                                     + String.join(", ", findings));
+            }
+        } catch (Failure e) {
+            throw e;
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "workspace-secret-scan-failed",
+                    "Could not scan changed Ship workspace files for known secrets",
                     e);
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScanner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScanner.java
@@ -1,0 +1,75 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.FileEntry;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+
+/** Rejects known environment secrets introduced into material workspace files. */
+public final class ChangedWorkspaceSecretScanner {
+
+    private static final int MIN_SECRET_LENGTH = 8;
+
+    private ChangedWorkspaceSecretScanner() {
+    }
+
+    public static List<String> scan(
+            ProjectSnapshot baseline,
+            ProjectSnapshot candidate,
+            Map<String, String> environment)
+            throws IOException {
+        Objects.requireNonNull(baseline, "baseline");
+        Objects.requireNonNull(candidate, "candidate");
+        Objects.requireNonNull(environment, "environment");
+        List<byte[]> secrets = environment.entrySet().stream()
+                .filter(entry -> LocalCommandRunner.isSensitiveEnvironmentValue(
+                        entry.getKey(), entry.getValue()))
+                .map(Map.Entry::getValue)
+                .filter(value -> value.length() >= MIN_SECRET_LENGTH)
+                .distinct()
+                .map(value -> value.getBytes(StandardCharsets.UTF_8))
+                .toList();
+        if (secrets.isEmpty()) {
+            return List.of();
+        }
+
+        Path root = Path.of(candidate.root());
+        List<String> findings = new ArrayList<>();
+        for (Map.Entry<String, FileEntry> entry : candidate.files().entrySet()) {
+            String path = entry.getKey();
+            FileEntry file = entry.getValue();
+            FileEntry previous = baseline.files().get(path);
+            if (file.classification() != Classification.MATERIAL
+                    || file.size() == 0
+                    || (previous != null && previous.digest().equals(file.digest()))) {
+                continue;
+            }
+            byte[] content = ProjectEvidenceFiles.readMaterial(
+                    root, path, Math.toIntExact(file.size()));
+            if (secrets.stream().anyMatch(secret -> contains(content, secret))) {
+                findings.add(path);
+            }
+        }
+        return List.copyOf(findings);
+    }
+
+    private static boolean contains(byte[] content, byte[] secret) {
+        outer : for (int offset = 0; offset <= content.length - secret.length; offset++) {
+            for (int index = 0; index < secret.length; index++) {
+                if (content[offset + index] != secret[index]) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScanner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScanner.java
@@ -26,6 +26,7 @@ public final class ChangedWorkspaceSecretScanner {
             ProjectSnapshot candidate,
             Map<String, String> environment)
             throws IOException {
+        // Exact UTF-8 matches are the intentional local leak floor; encoded transformations are not detected.
         Objects.requireNonNull(baseline, "baseline");
         Objects.requireNonNull(candidate, "candidate");
         Objects.requireNonNull(environment, "environment");

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
@@ -272,6 +273,7 @@ public final class PiWorker {
             versionRun.deleteLogs();
             versionLogsDeleted = true;
             if (turn.validatedSession() != null) {
+                PiWorkerResultStore.write(request, result);
                 publishSession(
                         turn.validatedSession(),
                         sessionDirectory,
@@ -332,6 +334,11 @@ public final class PiWorker {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /** Returns the durable result for this exact attempt without launching Pi. */
+    public Optional<Result> recover(Request request) throws IOException {
+        return PiWorkerResultStore.read(Objects.requireNonNull(request, "request"));
     }
 
     private RpcRun runRpc(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -286,7 +286,10 @@ public final class PiWorker {
                     // did not publish the result. Indeterminate attribute reads
                     // retain the marker and are reported with the original failure.
                     try {
-                        if (existsNoFollow(turn.validatedSession())) {
+                        if (attributesIfPresent(
+                                turn.validatedSession(),
+                                "Could not determine whether the Pi scratch session remains")
+                            != null) {
                             PiWorkerResultStore.delete(request);
                         }
                     } catch (IOException cleanupFailure) {
@@ -1476,30 +1479,34 @@ public final class PiWorker {
                 StandardCopyOption.REPLACE_EXISTING);
     }
 
-    private static boolean existsNoFollow(Path path) throws IOException {
+    static BasicFileAttributes attributesIfPresent(
+            Path path, String inspectionFailure)
+            throws IOException {
         try {
-            Files.readAttributes(
+            return Files.readAttributes(
                     path,
                     BasicFileAttributes.class,
                     LinkOption.NOFOLLOW_LINKS);
-            return true;
         } catch (NoSuchFileException e) {
-            return false;
+            return null;
         } catch (SecurityException e) {
-            throw new IOException(
-                    "Could not determine whether the Pi scratch session remains",
-                    e);
+            throw new IOException(inspectionFailure, e);
         }
     }
 
     private static void deleteTree(Path path) throws IOException {
-        if (path == null || !Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        if (path == null) {
             return;
         }
-        if (Files.isSymbolicLink(path)) {
+        BasicFileAttributes attributes = attributesIfPresent(
+                path, "Pi scratch cleanup path could not be inspected");
+        if (attributes == null) {
+            return;
+        }
+        if (attributes.isSymbolicLink()) {
             throw new IOException("Pi scratch cleanup refused a symbolic link");
         }
-        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+        if (attributes.isDirectory()) {
             try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
                 for (Path entry : entries) {
                     deleteTree(entry);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -670,6 +670,53 @@ public final class PiWorker {
                             previousSession,
                             prompt,
                             reconciliation.turn());
+                    if (process.exitValue() == 0
+                            && reconciliation.naturalCompletion()
+                            && !stdout.protocolUnverifiable()) {
+                        List<String> stdoutSecrets = new ArrayList<>(
+                                sensitiveValues.size() + 1);
+                        stdoutSecrets.add(prompt);
+                        stdoutSecrets.addAll(sensitiveValues);
+                        RetainedLog retainedStdout = LocalCommandRunner.retain(
+                                stdout.safeBytes(),
+                                evidenceDirectory,
+                                ".stdout.log",
+                                MAX_LOG_BYTES,
+                                stdoutSecrets);
+                        RetainedLog retainedStderr;
+                        try {
+                            retainedStderr = LocalCommandRunner.retain(
+                                    stderr.metadata(),
+                                    evidenceDirectory,
+                                    ".stderr.log",
+                                    MAX_LOG_BYTES,
+                                    sensitiveValues);
+                        } catch (IOException | RuntimeException retentionFailure) {
+                            Files.deleteIfExists(retainedStdout.path());
+                            throw retentionFailure;
+                        }
+                        Instant endedAt = clock.instant();
+                        if (endedAt.isBefore(startedAt)) {
+                            endedAt = startedAt;
+                        }
+                        interrupted = false;
+                        completedNormally = true;
+                        return new RpcRun(
+                                startedAt,
+                                endedAt,
+                                false,
+                                false,
+                                0,
+                                retainedStdout.path(),
+                                retainedStdout.digest(),
+                                retainedStderr.path(),
+                                retainedStderr.digest(),
+                                reconciliation.turn().terminal().text(),
+                                reconciliation.turn().terminal().stopReason(),
+                                null,
+                                validatedSession,
+                                true);
+                    }
                     if (process.exitValue() == 0) {
                         publishSession(
                                 validatedSession,

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -15,9 +15,11 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipal;
@@ -280,16 +282,15 @@ public final class PiWorker {
                             sessionDirectory,
                             previousSession);
                 } catch (IOException publicationFailure) {
-                    // If the atomic rename did not consume the scratch file, the
-                    // result was not published and a clean retry is safe.
-                    if (Files.exists(
-                            turn.validatedSession(),
-                            LinkOption.NOFOLLOW_LINKS)) {
-                        try {
+                    // Only a remaining scratch file proves that the atomic rename
+                    // did not publish the result. Indeterminate attribute reads
+                    // retain the marker and are reported with the original failure.
+                    try {
+                        if (existsNoFollow(turn.validatedSession())) {
                             PiWorkerResultStore.delete(request);
-                        } catch (IOException cleanupFailure) {
-                            publicationFailure.addSuppressed(cleanupFailure);
                         }
+                    } catch (IOException cleanupFailure) {
+                        publicationFailure.addSuppressed(cleanupFailure);
                     }
                     throw publicationFailure;
                 }
@@ -673,9 +674,10 @@ public final class PiWorker {
                             stderrReader,
                             "Interrupted Pi RPC error output did not close");
                     Thread.interrupted();
-                    if (stdout.limited() || stderr.limited()) {
-                        throw new IOException(
-                                "Interrupted Pi RPC exceeded its retained-output limit");
+                    outputLimited = stdout.limited() || stderr.limited();
+                    if (outputLimited) {
+                        e.addSuppressed(new IOException(
+                                "Interrupted Pi RPC exceeded its retained-output limit"));
                     }
                     validatedSession = validatePersistedSession(
                             sessionDirectory,
@@ -687,6 +689,7 @@ public final class PiWorker {
                             reconciliation.turn());
                     if (process.exitValue() == 0
                             && reconciliation.naturalCompletion()
+                            && !outputLimited
                             && !stdout.protocolUnverifiable()
                             && protocolFailure == null) {
                         List<String> stdoutSecrets = new ArrayList<>(
@@ -733,15 +736,15 @@ public final class PiWorker {
                                 validatedSession,
                                 true);
                     }
-                    if (process.exitValue() == 0) {
-                        if (!stdout.protocolUnverifiable()
-                                && protocolFailure == null) {
-                            publishSession(
-                                    validatedSession,
-                                    canonicalSessionDirectory,
-                                    canonicalPreviousSession);
-                        }
-                    } else {
+                    if (process.exitValue() == 0
+                            && !reconciliation.naturalCompletion()
+                            && !stdout.protocolUnverifiable()
+                            && protocolFailure == null) {
+                        publishSession(
+                                validatedSession,
+                                canonicalSessionDirectory,
+                                canonicalPreviousSession);
+                    } else if (process.exitValue() != 0) {
                         e.addSuppressed(new IOException(
                                 "Pi abort session was not published after a nonzero process exit"));
                     }
@@ -1471,6 +1474,22 @@ public final class PiWorker {
                 target,
                 StandardCopyOption.ATOMIC_MOVE,
                 StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private static boolean existsNoFollow(Path path) throws IOException {
+        try {
+            Files.readAttributes(
+                    path,
+                    BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            return true;
+        } catch (NoSuchFileException e) {
+            return false;
+        } catch (SecurityException e) {
+            throw new IOException(
+                    "Could not determine whether the Pi scratch session remains",
+                    e);
+        }
     }
 
     private static void deleteTree(Path path) throws IOException {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -274,10 +274,25 @@ public final class PiWorker {
             versionLogsDeleted = true;
             if (turn.validatedSession() != null) {
                 PiWorkerResultStore.write(request, result);
-                publishSession(
-                        turn.validatedSession(),
-                        sessionDirectory,
-                        previousSession);
+                try {
+                    publishSession(
+                            turn.validatedSession(),
+                            sessionDirectory,
+                            previousSession);
+                } catch (IOException publicationFailure) {
+                    // If the atomic rename did not consume the scratch file, the
+                    // result was not published and a clean retry is safe.
+                    if (Files.exists(
+                            turn.validatedSession(),
+                            LinkOption.NOFOLLOW_LINKS)) {
+                        try {
+                            PiWorkerResultStore.delete(request);
+                        } catch (IOException cleanupFailure) {
+                            publicationFailure.addSuppressed(cleanupFailure);
+                        }
+                    }
+                    throw publicationFailure;
+                }
                 published = true;
             }
             return result;
@@ -672,7 +687,8 @@ public final class PiWorker {
                             reconciliation.turn());
                     if (process.exitValue() == 0
                             && reconciliation.naturalCompletion()
-                            && !stdout.protocolUnverifiable()) {
+                            && !stdout.protocolUnverifiable()
+                            && protocolFailure == null) {
                         List<String> stdoutSecrets = new ArrayList<>(
                                 sensitiveValues.size() + 1);
                         stdoutSecrets.add(prompt);
@@ -718,10 +734,13 @@ public final class PiWorker {
                                 true);
                     }
                     if (process.exitValue() == 0) {
-                        publishSession(
-                                validatedSession,
-                                canonicalSessionDirectory,
-                                canonicalPreviousSession);
+                        if (!stdout.protocolUnverifiable()
+                                && protocolFailure == null) {
+                            publishSession(
+                                    validatedSession,
+                                    canonicalSessionDirectory,
+                                    canonicalPreviousSession);
+                        }
                     } else {
                         e.addSuppressed(new IOException(
                                 "Pi abort session was not published after a nonzero process exit"));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -11,8 +11,10 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Locale;
 import java.util.Optional;
 
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Result;
 
@@ -46,6 +48,9 @@ final class PiWorkerResultStore {
 
     static Optional<Result> read(Request request) throws IOException {
         Path path = resultPath(request, false);
+        if (path == null) {
+            return Optional.empty();
+        }
         if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
             return Optional.empty();
         }
@@ -66,6 +71,9 @@ final class PiWorkerResultStore {
             marker = JSON.readValue(encoded, Marker.class);
         } catch (JsonProcessingException e) {
             throw new IOException("Pi stage result marker is malformed", e);
+        }
+        if (marker.schemaVersion() != SCHEMA_VERSION) {
+            throw new IOException("Pi stage result marker has an unsupported schema version");
         }
         if (!marker.matches(request)) {
             throw new IOException("Pi stage result marker does not match its attempt");
@@ -130,10 +138,14 @@ final class PiWorkerResultStore {
 
     private static Path resultPath(Request request, boolean createDirectory)
             throws IOException {
+        if (!createDirectory
+                && !Files.exists(request.sessionDirectory(), LinkOption.NOFOLLOW_LINKS)) {
+            return null;
+        }
         Path sessions = request.sessionDirectory().toRealPath();
         Path directory = sessions.resolve(DIRECTORY);
-        if (createDirectory && !Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
-            Files.createDirectory(
+        if (createDirectory) {
+            Files.createDirectories(
                     directory,
                     PosixFilePermissions.asFileAttribute(
                             PosixFilePermissions.fromString("rwx------")));
@@ -143,7 +155,8 @@ final class PiWorkerResultStore {
                         && !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS))) {
             throw new IOException("Pi stage result directory is invalid");
         }
-        String name = request.stage().name().toLowerCase(java.util.Locale.ROOT)
+        String name = request.runId()
+                      + '-' + request.stage().name().toLowerCase(Locale.ROOT)
                       + '-' + request.inputDigest().substring("sha256:".length())
                       + '-' + request.attempt() + ".json";
         return directory.resolve(name);
@@ -152,14 +165,13 @@ final class PiWorkerResultStore {
     private record Marker(
             int schemaVersion,
             String runId,
-            io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage stage,
+            Stage stage,
             int attempt,
             String inputDigest,
             Result result) {
 
         private boolean matches(Request request) {
-            return schemaVersion == SCHEMA_VERSION
-                    && runId.equals(request.runId())
+            return runId.equals(request.runId())
                     && stage == request.stage()
                     && attempt == request.attempt()
                     && inputDigest.equals(request.inputDigest())

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -1,0 +1,169 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Optional;
+
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Result;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Atomic recovery marker for a completed Pi stage attempt. */
+final class PiWorkerResultStore {
+
+    private static final int SCHEMA_VERSION = 1;
+    private static final int MAX_RESULT_BYTES = 20 * 1024 * 1024;
+    private static final String DIRECTORY = ".camel-kit-results";
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+
+    private PiWorkerResultStore() {
+    }
+
+    static Optional<Result> read(Request request) throws IOException {
+        Path path = resultPath(request, false);
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            return Optional.empty();
+        }
+        if (Files.isSymbolicLink(path)
+                || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Pi stage result marker is invalid");
+        }
+        byte[] encoded;
+        try (InputStream input = Files.newInputStream(
+                path, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+            encoded = input.readNBytes(MAX_RESULT_BYTES + 1);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_RESULT_BYTES) {
+            throw new IOException("Pi stage result marker has an invalid size");
+        }
+        final Marker marker;
+        try {
+            marker = JSON.readValue(encoded, Marker.class);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Pi stage result marker is malformed", e);
+        }
+        if (!marker.matches(request)) {
+            throw new IOException("Pi stage result marker does not match its attempt");
+        }
+        return Optional.of(marker.result());
+    }
+
+    static void write(Request request, Result result) throws IOException {
+        Path path = resultPath(request, true);
+        byte[] encoded;
+        try {
+            encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(
+                    new Marker(
+                            SCHEMA_VERSION,
+                            request.runId(),
+                            request.stage(),
+                            request.attempt(),
+                            request.inputDigest(),
+                            result));
+        } catch (JsonProcessingException e) {
+            throw new IOException("Pi stage result marker cannot be encoded", e);
+        }
+        if (encoded.length > MAX_RESULT_BYTES) {
+            throw new IOException("Pi stage result marker exceeds its size limit");
+        }
+        Path temporary = Files.createTempFile(
+                path.getParent(),
+                ".result-",
+                ".tmp",
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        boolean moved = false;
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                ByteBuffer content = ByteBuffer.wrap(encoded);
+                while (content.hasRemaining()) {
+                    channel.write(content);
+                }
+                channel.force(true);
+            }
+            try {
+                Files.move(
+                        temporary,
+                        path,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw new IOException(
+                        "Filesystem does not support atomic Pi stage result replacement",
+                        e);
+            }
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private static Path resultPath(Request request, boolean createDirectory)
+            throws IOException {
+        Path sessions = request.sessionDirectory().toRealPath();
+        Path directory = sessions.resolve(DIRECTORY);
+        if (createDirectory && !Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createDirectory(
+                    directory,
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rwx------")));
+        }
+        if (Files.isSymbolicLink(directory)
+                || (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)
+                        && !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException("Pi stage result directory is invalid");
+        }
+        String name = request.stage().name().toLowerCase(java.util.Locale.ROOT)
+                      + '-' + request.inputDigest().substring("sha256:".length())
+                      + '-' + request.attempt() + ".json";
+        return directory.resolve(name);
+    }
+
+    private record Marker(
+            int schemaVersion,
+            String runId,
+            io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage stage,
+            int attempt,
+            String inputDigest,
+            Result result) {
+
+        private boolean matches(Request request) {
+            return schemaVersion == SCHEMA_VERSION
+                    && runId.equals(request.runId())
+                    && stage == request.stage()
+                    && attempt == request.attempt()
+                    && inputDigest.equals(request.inputDigest())
+                    && result != null;
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -7,9 +7,11 @@ import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Locale;
 import java.util.Objects;
@@ -52,11 +54,11 @@ final class PiWorkerResultStore {
         if (path == null) {
             return Optional.empty();
         }
-        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        BasicFileAttributes attributes = attributesIfPresent(path);
+        if (attributes == null) {
             return Optional.empty();
         }
-        if (Files.isSymbolicLink(path)
-                || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+        if (attributes.isSymbolicLink() || !attributes.isRegularFile()) {
             throw new IOException("Pi stage result marker is invalid");
         }
         byte[] encoded;
@@ -147,10 +149,17 @@ final class PiWorkerResultStore {
     private static Path resultPath(Request request, boolean createDirectory)
             throws IOException {
         if (!createDirectory
-                && !Files.exists(request.sessionDirectory(), LinkOption.NOFOLLOW_LINKS)) {
+                && attributesIfPresent(request.sessionDirectory()) == null) {
             return null;
         }
-        Path sessions = request.sessionDirectory().toRealPath();
+        Path sessions;
+        try {
+            sessions = request.sessionDirectory().toRealPath();
+        } catch (SecurityException e) {
+            throw new IOException(
+                    "Pi session directory could not be inspected",
+                    e);
+        }
         Path directory = sessions.resolve(DIRECTORY);
         if (createDirectory) {
             Files.createDirectories(
@@ -158,9 +167,14 @@ final class PiWorkerResultStore {
                     PosixFilePermissions.asFileAttribute(
                             PosixFilePermissions.fromString("rwx------")));
         }
-        if (Files.isSymbolicLink(directory)
-                || (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)
-                        && !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS))) {
+        BasicFileAttributes attributes = attributesIfPresent(directory);
+        if (attributes == null) {
+            if (!createDirectory) {
+                return null;
+            }
+            throw new IOException("Pi stage result directory disappeared");
+        }
+        if (attributes.isSymbolicLink() || !attributes.isDirectory()) {
             throw new IOException("Pi stage result directory is invalid");
         }
         String name = request.runId()
@@ -168,6 +182,22 @@ final class PiWorkerResultStore {
                       + '-' + request.inputDigest().substring("sha256:".length())
                       + '-' + request.attempt() + ".json";
         return directory.resolve(name);
+    }
+
+    private static BasicFileAttributes attributesIfPresent(Path path)
+            throws IOException {
+        try {
+            return Files.readAttributes(
+                    path,
+                    BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+        } catch (NoSuchFileException e) {
+            return null;
+        } catch (SecurityException e) {
+            throw new IOException(
+                    "Pi stage result path could not be inspected",
+                    e);
+        }
     }
 
     private record Marker(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -7,7 +7,6 @@ import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -186,18 +185,8 @@ final class PiWorkerResultStore {
 
     private static BasicFileAttributes attributesIfPresent(Path path)
             throws IOException {
-        try {
-            return Files.readAttributes(
-                    path,
-                    BasicFileAttributes.class,
-                    LinkOption.NOFOLLOW_LINKS);
-        } catch (NoSuchFileException e) {
-            return null;
-        } catch (SecurityException e) {
-            throw new IOException(
-                    "Pi stage result path could not be inspected",
-                    e);
-        }
+        return PiWorker.attributesIfPresent(
+                path, "Pi stage result path could not be inspected");
     }
 
     private record Marker(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -12,6 +12,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
@@ -136,6 +137,13 @@ final class PiWorkerResultStore {
         }
     }
 
+    static void delete(Request request) throws IOException {
+        Path path = resultPath(request, false);
+        if (path != null) {
+            Files.deleteIfExists(path);
+        }
+    }
+
     private static Path resultPath(Request request, boolean createDirectory)
             throws IOException {
         if (!createDirectory
@@ -171,10 +179,10 @@ final class PiWorkerResultStore {
             Result result) {
 
         private boolean matches(Request request) {
-            return runId.equals(request.runId())
+            return Objects.equals(runId, request.runId())
                     && stage == request.stage()
                     && attempt == request.attempt()
-                    && inputDigest.equals(request.inputDigest())
+                    && Objects.equals(inputDigest, request.inputDigest())
                     && result != null;
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
@@ -86,13 +86,13 @@ public final class ShipWorkspace {
                     advanceAttempt(workspace, binding, attempt);
                 }
                 try {
-                    ProjectSnapshot snapshot = verify(
+                    Verification verification = verify(
                             project,
                             workspace.resolve(CANDIDATE),
                             runId,
                             attempt,
                             inputDigest);
-                    return Path.of(snapshot.root());
+                    return Path.of(verification.candidate().root());
                 } catch (StaleBaselineException e) {
                     if (!wasLaterAttempt) {
                         throw e;
@@ -140,7 +140,7 @@ public final class ShipWorkspace {
     /**
      * Verifies one published candidate against the exact controller stage that prepared it.
      */
-    public static ProjectSnapshot verify(
+    public static Verification verify(
             Path liveProject,
             Path suppliedCandidate,
             String runId,
@@ -163,13 +163,13 @@ public final class ShipWorkspace {
                 || !inputDigest.equals(binding.inputDigest())) {
             throw new IOException("Ship workspace binding does not match the active stage");
         }
-        ProjectSnapshot snapshot = ProjectEvidenceFiles.captureStaged(candidate);
-        String currentBaseline = materialIdentity(ProjectEvidenceFiles.capture(project));
-        if (!currentBaseline.equals(binding.baselineDigest())) {
+        ProjectSnapshot candidateSnapshot = ProjectEvidenceFiles.captureStaged(candidate);
+        ProjectSnapshot baseline = ProjectEvidenceFiles.capture(project);
+        if (!materialIdentity(baseline).equals(binding.baselineDigest())) {
             throw new StaleBaselineException(
                     "Ship workspace baseline no longer matches the live project");
         }
-        return snapshot;
+        return new Verification(baseline, candidateSnapshot);
     }
 
     private static Path realProject(Path supplied) throws IOException {
@@ -491,6 +491,14 @@ public final class ShipWorkspace {
 
         private StaleBaselineException(String message) {
             super(message);
+        }
+    }
+
+    public record Verification(ProjectSnapshot baseline, ProjectSnapshot candidate) {
+
+        public Verification {
+            Objects.requireNonNull(baseline, "baseline");
+            Objects.requireNonNull(candidate, "candidate");
         }
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScannerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScannerTest.java
@@ -1,0 +1,56 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ChangedWorkspaceSecretScannerTest {
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void reportsKnownSecretsOnlyInChangedMaterialFiles() throws Exception {
+        Path baselineRoot = Files.createDirectory(directory.resolve("baseline"));
+        Files.writeString(baselineRoot.resolve("unchanged.txt"), "token-12345678");
+        Files.writeString(baselineRoot.resolve("changed.txt"), "safe");
+        ProjectSnapshot baseline = ProjectEvidenceFiles.captureStaged(baselineRoot);
+
+        Path candidateRoot = Files.createDirectory(directory.resolve("candidate"));
+        Files.writeString(candidateRoot.resolve("unchanged.txt"), "token-12345678");
+        Files.writeString(candidateRoot.resolve("changed.txt"), "prefix token-12345678 suffix");
+        Files.writeString(candidateRoot.resolve("short.txt"), "0");
+        ProjectSnapshot candidate = ProjectEvidenceFiles.captureStaged(candidateRoot);
+
+        assertEquals(
+                java.util.List.of("changed.txt"),
+                ChangedWorkspaceSecretScanner.scan(
+                        baseline,
+                        candidate,
+                        Map.of("API_TOKEN", "token-12345678", "AUTH", "0")));
+    }
+
+    @Test
+    void acceptsChangedFilesWhenNoKnownSecretIsPresent() throws Exception {
+        Path baselineRoot = Files.createDirectory(directory.resolve("baseline"));
+        Files.writeString(baselineRoot.resolve("route.yaml"), "from: direct:old");
+        ProjectSnapshot baseline = ProjectEvidenceFiles.captureStaged(baselineRoot);
+
+        Path candidateRoot = Files.createDirectory(directory.resolve("candidate"));
+        Files.writeString(candidateRoot.resolve("route.yaml"), "from: direct:new");
+        ProjectSnapshot candidate = ProjectEvidenceFiles.captureStaged(candidateRoot);
+
+        assertEquals(
+                java.util.List.of(),
+                ChangedWorkspaceSecretScanner.scan(
+                        baseline, candidate, Map.of("API_TOKEN", "token-12345678")));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -59,6 +59,16 @@ class PiWorkerResultStoreTest {
         assertTrue(assertThrows(IOException.class,
                 () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
 
+        Files.writeString(marker, encoded.replace(
+                "\"runId\" : \"" + RUN_A + "\"", "\"runId\" : null"));
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
+
+        Files.writeString(marker, encoded.replace(
+                "\"inputDigest\" : \"" + DIGEST + "\"", "\"inputDigest\" : null"));
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
+
         Files.writeString(marker, encoded.replace("\"schemaVersion\" : 1", "\"schemaVersion\" : 2"));
         assertTrue(assertThrows(IOException.class,
                 () -> PiWorkerResultStore.read(request)).getMessage().contains("schema version"));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -12,6 +12,8 @@ import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
 import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,6 +47,34 @@ class PiWorkerResultStoreTest {
     void returnsEmptyWhenTheSessionDirectoryDoesNotExist() throws Exception {
         assertTrue(PiWorkerResultStore.read(
                 request(RUN_A, directory.resolve("missing"))).isEmpty());
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void doesNotTreatIndeterminatePathsAsMissing() throws Exception {
+        Path loop = directory.resolve("loop");
+        Files.createSymbolicLink(loop, Path.of("loop"));
+        PiWorker.Request request = request(
+                RUN_A,
+                loop.resolve("sessions"));
+
+        assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request));
+        assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.delete(request));
+
+        Path dangling = directory.resolve("dangling");
+        Files.createSymbolicLink(dangling, Path.of("missing"));
+        PiWorker.Request danglingRequest = request(RUN_A, dangling);
+
+        assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(danglingRequest));
+        assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.delete(danglingRequest));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -1,0 +1,135 @@
+package io.github.luigidemasi.camelkit.ship.worker;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PiWorkerResultStoreTest {
+
+    private static final String RUN_A = "ship-0123456789abcdef0123456789abcdef";
+    private static final String RUN_B = "ship-fedcba9876543210fedcba9876543210";
+    private static final String DIGEST = ShipDigest.sha256("input".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void keepsResultsForDifferentRunsInOneSessionDirectory() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request first = request(RUN_A, sessions);
+        PiWorker.Request second = request(RUN_B, sessions);
+
+        PiWorkerResultStore.write(first, result("first"));
+        PiWorkerResultStore.write(second, result("second"));
+
+        assertEquals("first", PiWorkerResultStore.read(first).orElseThrow().assistantText());
+        assertEquals("second", PiWorkerResultStore.read(second).orElseThrow().assistantText());
+        try (var files = Files.list(sessions.resolve(".camel-kit-results"))) {
+            assertEquals(2, files.count());
+        }
+    }
+
+    @Test
+    void returnsEmptyWhenTheSessionDirectoryDoesNotExist() throws Exception {
+        assertTrue(PiWorkerResultStore.read(
+                request(RUN_A, directory.resolve("missing"))).isEmpty());
+    }
+
+    @Test
+    void rejectsMismatchedAndUnsupportedMarkers() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorkerResultStore.write(request, result("done"));
+        Path marker = marker(sessions);
+        String encoded = Files.readString(marker);
+
+        Files.writeString(marker, encoded.replace(RUN_A, RUN_B));
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
+
+        Files.writeString(marker, encoded.replace("\"schemaVersion\" : 1", "\"schemaVersion\" : 2"));
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("schema version"));
+    }
+
+    @Test
+    void rejectsEmptyMalformedAndOversizedMarkers() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorkerResultStore.write(request, result("done"));
+        Path marker = marker(sessions);
+
+        Files.write(marker, new byte[0]);
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("size"));
+
+        Files.writeString(marker, "{");
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("malformed"));
+
+        try (RandomAccessFile file = new RandomAccessFile(marker.toFile(), "rw")) {
+            file.setLength(20L * 1024 * 1024 + 1);
+        }
+        assertTrue(assertThrows(IOException.class,
+                () -> PiWorkerResultStore.read(request)).getMessage().contains("size"));
+    }
+
+    private PiWorker.Request request(String runId, Path sessions) {
+        return new PiWorker.Request(
+                runId,
+                ShipRun.Stage.DISCOVERY,
+                1,
+                directory.toAbsolutePath(),
+                sessions,
+                directory.resolve("evidence"),
+                DIGEST,
+                true,
+                "prompt");
+    }
+
+    private PiWorker.Result result(String text) {
+        String timestamp = "2026-07-28T08:00:00Z";
+        CommandRun command = new CommandRun(
+                directory.resolve("pi").toAbsolutePath().toString(),
+                "0.80.6",
+                List.of("--mode", "rpc"),
+                directory.toAbsolutePath().toString(),
+                List.of(DIGEST),
+                true,
+                false,
+                false,
+                0,
+                timestamp,
+                timestamp,
+                directory.resolve("stdout.log").toAbsolutePath().toString(),
+                ShipDigest.sha256(new byte[0]),
+                directory.resolve("stderr.log").toAbsolutePath().toString(),
+                ShipDigest.sha256(new byte[0]));
+        return new PiWorker.Result(
+                PiWorker.Outcome.SUCCEEDED,
+                ShipLocalStamp.Support.EXPERIMENTAL,
+                "0.80.6",
+                "experimental",
+                text,
+                null,
+                command);
+    }
+
+    private static Path marker(Path sessions) throws IOException {
+        try (var files = Files.list(sessions.resolve(".camel-kit-results"))) {
+            return files.findFirst().orElseThrow();
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -65,6 +65,8 @@ class PiWorkerResultStoreTest {
                 IOException.class,
                 () -> PiWorkerResultStore.delete(request));
 
+        // Companion coverage: dangling final symlinks fail in toRealPath(),
+        // while the loop above pins checked indeterminate-path probing.
         Path dangling = directory.resolve("dangling");
         Files.createSymbolicLink(dangling, Path.of("missing"));
         PiWorker.Request danglingRequest = request(RUN_A, dangling);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -1240,6 +1240,48 @@ class PiWorkerTest {
     }
 
     @Test
+    void interruptionDoesNotPublishAnUnverifiableNaturalStop() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "malformed-natural-stop-after-eof\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request);
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        Thread.sleep(250);
+        Files.writeString(fixture.resolve("release"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertFalse(hasSession(sessionId(ShipRun.Stage.DESIGN)));
+        assertTrue(worker.recover(request).isEmpty());
+        assertFalse(Files.exists(fixture.resolve("abort")));
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result retried = worker.run(request);
+        assertEquals(PiWorker.Outcome.SUCCEEDED, retried.outcome());
+        assertEquals(retried, worker.recover(request).orElseThrow());
+    }
+
+    @Test
     void interruptionDrainsAQueuedNaturalTurnAsPiExits()
             throws Exception {
         Files.writeString(fixture.resolve("mode"), "queued-natural-exit\n");
@@ -1646,6 +1688,25 @@ class PiWorkerTest {
         assertEquals(
                 1,
                 Files.readAllLines(fixture.resolve("session-ids")).size());
+    }
+
+    @Test
+    void failedSessionPublicationRemovesTheUnpublishedResult() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "publication-failure\n");
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        PiWorker.Request request = request(ShipRun.Stage.DISCOVERY, "prompt");
+
+        assertThrows(IOException.class, () -> worker.run(request));
+
+        assertTrue(worker.recover(request).isEmpty());
+        Path publicationTarget = Path.of(
+                Files.readString(fixture.resolve("publication-target")).trim());
+        Files.delete(publicationTarget.resolve("block"));
+        Files.delete(publicationTarget);
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result retried = worker.run(request);
+        assertEquals(PiWorker.Outcome.SUCCEEDED, retried.outcome());
+        assertEquals(retried, worker.recover(request).orElseThrow());
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -1289,6 +1289,104 @@ class PiWorkerTest {
     }
 
     @Test
+    void interruptionDoesNotPublishAnOutputLimitedNaturalStop() throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"),
+                "interrupt-output-limit-natural-stop\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        PiWorker.Request request = request(ShipRun.Stage.EXECUTE, "prompt");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<InterruptedException> interruption = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request);
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                interruption.set(expected);
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(15).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(1, interruption.get().getSuppressed().length);
+        assertEquals(
+                "Interrupted Pi RPC exceeded its retained-output limit",
+                interruption.get().getSuppressed()[0].getMessage());
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.EXECUTE)));
+        assertTrue(worker.recover(request).isEmpty());
+        assertNoScratchDirectories();
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result retried = worker.run(request);
+        assertEquals(PiWorker.Outcome.SUCCEEDED, retried.outcome());
+        assertEquals(retried, worker.recover(request).orElseThrow());
+        assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void interruptionDoesNotPublishAProtocolInvalidAbort() throws Exception {
+        Files.writeString(
+                fixture.resolve("mode"),
+                "duplicate-response-abort-after-blocked-prompt\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        PiWorker.Request request = request(
+                ShipRun.Stage.VALIDATE, "x".repeat(1024 * 1024));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<InterruptedException> interruption = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request);
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                interruption.set(expected);
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        awaitPiWorkerMethod(invocation, "awaitExit");
+        invocation.interrupt();
+        Files.writeString(fixture.resolve("release-prompt"), "release\n");
+        invocation.join(Duration.ofSeconds(15).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(0, interruption.get().getSuppressed().length);
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+        assertFalse(hasSession(sessionId(ShipRun.Stage.VALIDATE)));
+        assertTrue(worker.recover(request).isEmpty());
+        assertNoScratchDirectories();
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result retried = worker.run(request);
+        assertEquals(PiWorker.Outcome.SUCCEEDED, retried.outcome());
+        assertEquals(retried, worker.recover(request).orElseThrow());
+        assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
     void interruptionDoesNotPublishAnUnverifiableNaturalStop() throws Exception {
         assertInterruptedInvalidNaturalStopIsRetryable(
                 "malformed-natural-stop-after-eof",
@@ -2032,6 +2130,22 @@ class PiWorkerTest {
         while (!Files.exists(path)) {
             if (System.nanoTime() >= deadline) {
                 throw new AssertionError("Timed out waiting for " + path);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static void awaitPiWorkerMethod(Thread thread, String method)
+            throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (java.util.Arrays.stream(thread.getStackTrace())
+                .noneMatch(frame -> frame.getClassName().equals(PiWorker.class.getName())
+                        && frame.getMethodName().equals(method))) {
+            if (!thread.isAlive()) {
+                throw new AssertionError("Pi invocation exited before reaching " + method);
+            }
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Timed out waiting for PiWorker." + method);
             }
             Thread.sleep(10);
         }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -1240,11 +1240,12 @@ class PiWorkerTest {
     }
 
     @Test
-    void interruptionDoesNotPublishAnUnverifiableNaturalStop() throws Exception {
-        Files.writeString(fixture.resolve("mode"), "malformed-natural-stop-after-eof\n");
+    void interruptionPublishesAProtocolVerifiableOutputLimitedAbort() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "interrupt-output-limit\n");
         PiWorker worker = worker(Duration.ofSeconds(30));
-        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
+        PiWorker.Request request = request(ShipRun.Stage.EXECUTE, "prompt");
         AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<InterruptedException> interruption = new AtomicReference<>();
         AtomicBoolean interrupted = new AtomicBoolean();
         Thread invocation = new Thread(() -> {
             try {
@@ -1253,9 +1254,7 @@ class PiWorkerTest {
                         "Pi invocation unexpectedly completed"));
             } catch (InterruptedException expected) {
                 interrupted.set(Thread.currentThread().isInterrupted());
-                if (expected.getSuppressed().length > 0) {
-                    failure.set(expected.getSuppressed()[0]);
-                }
+                interruption.set(expected);
             } catch (Throwable unexpected) {
                 failure.set(unexpected);
             }
@@ -1264,21 +1263,43 @@ class PiWorkerTest {
         invocation.start();
         awaitFile(fixture.resolve("ready"));
         invocation.interrupt();
-        Thread.sleep(250);
-        Files.writeString(fixture.resolve("release"), "release\n");
-        invocation.join(Duration.ofSeconds(10).toMillis());
+        invocation.join(Duration.ofSeconds(15).toMillis());
 
         assertFalse(invocation.isAlive());
         assertNull(failure.get());
         assertTrue(interrupted.get());
-        assertFalse(hasSession(sessionId(ShipRun.Stage.DESIGN)));
+        assertTrue(java.util.Arrays.stream(
+                interruption.get().getSuppressed())
+                .anyMatch(cause -> cause.getMessage().contains(
+                        "retained-output limit")));
+        String sessionId = sessionId(ShipRun.Stage.EXECUTE);
+        assertTrue(hasSession(sessionId));
+        assertTrue(Files.readString(sessionFile(sessionId))
+                .contains("\"stopReason\":\"aborted\""));
         assertTrue(worker.recover(request).isEmpty());
-        assertFalse(Files.exists(fixture.resolve("abort")));
+        assertNoScratchDirectories();
 
         Files.writeString(fixture.resolve("mode"), "success\n");
         PiWorker.Result retried = worker.run(request);
         assertEquals(PiWorker.Outcome.SUCCEEDED, retried.outcome());
         assertEquals(retried, worker.recover(request).orElseThrow());
+        assertEquals(
+                List.of(sessionId),
+                Files.readAllLines(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void interruptionDoesNotPublishAnUnverifiableNaturalStop() throws Exception {
+        assertInterruptedInvalidNaturalStopIsRetryable(
+                "malformed-natural-stop-after-eof",
+                ShipRun.Stage.DESIGN);
+    }
+
+    @Test
+    void interruptionDoesNotPublishAProtocolInvalidNaturalStop() throws Exception {
+        assertInterruptedInvalidNaturalStopIsRetryable(
+                "duplicate-response-natural-stop-after-eof",
+                ShipRun.Stage.PLAN);
     }
 
     @Test
@@ -1893,6 +1914,51 @@ class PiWorkerTest {
                 inputDigest(),
                 acceptExperimental,
                 prompt);
+    }
+
+    private void assertInterruptedInvalidNaturalStopIsRetryable(
+            String mode, ShipRun.Stage stage)
+            throws Exception {
+        Files.writeString(fixture.resolve("mode"), mode + "\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        PiWorker.Request request = request(stage, "prompt");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                worker.run(request);
+                failure.set(new AssertionError(
+                        "Pi invocation unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                if (expected.getSuppressed().length > 0) {
+                    failure.set(expected.getSuppressed()[0]);
+                }
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        Thread.sleep(250);
+        Files.writeString(fixture.resolve("release"), "release\n");
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertFalse(hasSession(sessionId(stage)));
+        assertTrue(worker.recover(request).isEmpty());
+        assertEquals(
+                "",
+                Files.readString(fixture.resolve("post-prompt-input")));
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        PiWorker.Result retried = worker.run(request);
+        assertEquals(PiWorker.Outcome.SUCCEEDED, retried.outcome());
+        assertEquals(retried, worker.recover(request).orElseThrow());
     }
 
     private static String inputDigest() {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -1207,22 +1207,51 @@ class PiWorkerTest {
     }
 
     @Test
+    void interruptionRecoversANaturalStopThatWinsAfterAbort() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "natural-stop-after-abort\n");
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                result.set(worker.run(request));
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
+        assertEquals("done", result.get().assistantText());
+        assertEquals(result.get(), worker.recover(request).orElseThrow());
+        assertEquals(
+                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
+                Files.readAllLines(fixture.resolve("abort")));
+    }
+
+    @Test
     void interruptionDrainsAQueuedNaturalTurnAsPiExits()
             throws Exception {
         Files.writeString(fixture.resolve("mode"), "queued-natural-exit\n");
         PiWorker worker = worker(Duration.ofSeconds(30));
         AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
         AtomicBoolean interrupted = new AtomicBoolean();
+        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
         Thread invocation = new Thread(() -> {
             try {
-                worker.run(request(ShipRun.Stage.DESIGN, "prompt"));
-                failure.set(new AssertionError(
-                        "Pi invocation unexpectedly completed"));
-            } catch (InterruptedException expected) {
+                result.set(worker.run(request));
                 interrupted.set(Thread.currentThread().isInterrupted());
-                if (expected.getSuppressed().length > 0) {
-                    failure.set(expected.getSuppressed()[0]);
-                }
             } catch (Throwable unexpected) {
                 failure.set(unexpected);
             }
@@ -1238,6 +1267,8 @@ class PiWorkerTest {
         assertFalse(invocation.isAlive());
         assertNull(failure.get());
         assertTrue(interrupted.get());
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
+        assertEquals(result.get(), worker.recover(request).orElseThrow());
         assertFalse(Files.exists(fixture.resolve("abort")));
         List<String> persisted = Files.readAllLines(
                 sessionFile(sessionId(ShipRun.Stage.DESIGN)));
@@ -1252,17 +1283,13 @@ class PiWorkerTest {
                 fixture.resolve("mode"), "terminal-no-settled\n");
         PiWorker worker = worker(Duration.ofSeconds(30));
         AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
         AtomicBoolean interrupted = new AtomicBoolean();
+        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
         Thread invocation = new Thread(() -> {
             try {
-                worker.run(request(ShipRun.Stage.DESIGN, "prompt"));
-                failure.set(new AssertionError(
-                        "Pi invocation unexpectedly completed"));
-            } catch (InterruptedException expected) {
+                result.set(worker.run(request));
                 interrupted.set(Thread.currentThread().isInterrupted());
-                if (expected.getSuppressed().length > 0) {
-                    failure.set(expected.getSuppressed()[0]);
-                }
             } catch (Throwable unexpected) {
                 failure.set(unexpected);
             }
@@ -1276,6 +1303,8 @@ class PiWorkerTest {
         assertFalse(invocation.isAlive());
         assertNull(failure.get());
         assertTrue(interrupted.get());
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
+        assertEquals(result.get(), worker.recover(request).orElseThrow());
         assertFalse(Files.exists(fixture.resolve("unexpected-input")));
         List<String> persisted = Files.readAllLines(
                 sessionFile(sessionId(ShipRun.Stage.DESIGN)));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -1605,6 +1605,21 @@ class PiWorkerTest {
     }
 
     @Test
+    void completedAttemptReturnsItsDurableResultWithoutRunningPiAgain() throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(30));
+        PiWorker.Request request = request(ShipRun.Stage.DISCOVERY, "prompt");
+
+        PiWorker.Result first = worker.run(request);
+        Files.writeString(fixture.resolve("mode"), "fail-before-session\n");
+        PiWorker.Result recovered = worker.recover(request).orElseThrow();
+
+        assertEquals(first, recovered);
+        assertEquals(
+                1,
+                Files.readAllLines(fixture.resolve("session-ids")).size());
+    }
+
+    @Test
     void repeatedInterruptsReuseOneAbortCommandAndDeadline() throws Exception {
         Files.writeString(fixture.resolve("mode"), "repeated-interrupt-abort\n");
         PiWorker worker = worker(Duration.ofSeconds(30));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspaceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspaceTest.java
@@ -100,7 +100,7 @@ class ShipWorkspaceTest {
         Path run = directory("run");
         Path first = ShipWorkspace.prepare(project, run, RUN_ID, 1, INPUT_DIGEST);
         assertEquals(first.toString(),
-                ShipWorkspace.verify(project, first, RUN_ID, 1, INPUT_DIGEST).root());
+                ShipWorkspace.verify(project, first, RUN_ID, 1, INPUT_DIGEST).candidate().root());
         assertThrows(IOException.class,
                 () -> ShipWorkspace.verify(project, first, RUN_ID, 2, INPUT_DIGEST));
         Files.writeString(first.resolve("README.md"), "partial edit");
@@ -113,7 +113,7 @@ class ShipWorkspaceTest {
         assertThrows(IOException.class,
                 () -> ShipWorkspace.verify(project, resumed, RUN_ID, 1, INPUT_DIGEST));
         assertEquals(resumed.toString(),
-                ShipWorkspace.verify(project, resumed, RUN_ID, 2, INPUT_DIGEST).root());
+                ShipWorkspace.verify(project, resumed, RUN_ID, 2, INPUT_DIGEST).candidate().root());
         assertEquals("partial edit", Files.readString(resumed.resolve("README.md")));
         assertEquals("partial file", Files.readString(resumed.resolve("src/new.txt")));
         assertEquals("partial build output",
@@ -478,7 +478,7 @@ class ShipWorkspaceTest {
                 runParentLink.resolve("run/workspace/candidate"),
                 RUN_ID,
                 1,
-                INPUT_DIGEST).root());
+                INPUT_DIGEST).candidate().root());
     }
 
     private Path directory(String name) throws IOException {

--- a/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
+++ b/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
@@ -48,6 +48,12 @@ if [ "$mode" = "never-read" ]; then
   wait "$child"
   exit 0
 fi
+if [ "$mode" = "duplicate-response-abort-after-blocked-prompt" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  touch "$fixture/ready"
+  while [ ! -e "$fixture/release-prompt" ]; do sleep 0.01; done
+fi
 
 IFS= read -r prompt || exit 6
 printf '%s\n' "$prompt" > "$fixture/prompt"
@@ -198,6 +204,11 @@ abort_turn() {
   cat >/dev/null
 }
 
+if [ "$mode" = "duplicate-response-abort-after-blocked-prompt" ]; then
+  abort_turn
+  exit 0
+fi
+
 if [ "$mode" = "block" ]; then
   sleep 300 &
   child=$!
@@ -222,7 +233,8 @@ if [ "$mode" = "late-abort-exit" ] || [ "$mode" = "repeated-interrupt-abort" ]; 
   abort_turn
   exit 0
 fi
-if [ "$mode" = "interrupt-output-limit" ]; then
+if [ "$mode" = "interrupt-output-limit" ] \
+    || [ "$mode" = "interrupt-output-limit-natural-stop" ]; then
   printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
   begin_turn
   touch "$fixture/ready"
@@ -233,9 +245,13 @@ if [ "$mode" = "interrupt-output-limit" ]; then
   fi
   dd if=/dev/zero bs=1048576 count=17 >&2 2>/dev/null
   printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
-  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":2}'
-  emit_message "$aborted" assistant
-  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  if [ "$mode" = "interrupt-output-limit-natural-stop" ]; then
+    terminal='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
+  else
+    terminal='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":2}'
+  fi
+  emit_message "$terminal" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$terminal"
   printf '%s\n' '{"type":"agent_settled"}'
   cat >/dev/null
   exit 0

--- a/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
+++ b/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
@@ -222,6 +222,24 @@ if [ "$mode" = "late-abort-exit" ] || [ "$mode" = "repeated-interrupt-abort" ]; 
   abort_turn
   exit 0
 fi
+if [ "$mode" = "interrupt-output-limit" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  touch "$fixture/ready"
+  IFS= read -r abort || exit 6
+  printf '%s\n' "$abort" > "$fixture/abort"
+  if [ "$abort" != '{"id":"abort-1","type":"abort"}' ]; then
+    exit 8
+  fi
+  dd if=/dev/zero bs=1048576 count=17 >&2 2>/dev/null
+  printf '%s\n' '{"id":"abort-1","type":"response","command":"abort","success":true}'
+  aborted='{"role":"assistant","content":[],"stopReason":"aborted","timestamp":2}'
+  emit_message "$aborted" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$aborted"
+  printf '%s\n' '{"type":"agent_settled"}'
+  cat >/dev/null
+  exit 0
+fi
 
 case "$mode" in
   unacknowledged-abort)
@@ -346,11 +364,16 @@ if [ "$mode" = "queued-natural-exit" ]; then
   exit 0
 fi
 
-if [ "$mode" = "malformed-natural-stop-after-eof" ]; then
+if [ "$mode" = "malformed-natural-stop-after-eof" ] \
+    || [ "$mode" = "duplicate-response-natural-stop-after-eof" ]; then
   printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
   begin_turn
-  printf '%s\n' 'not-json'
-  cat >/dev/null
+  if [ "$mode" = "malformed-natural-stop-after-eof" ]; then
+    printf '%s\n' 'not-json'
+  else
+    printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  fi
+  cat > "$fixture/post-prompt-input"
   natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
   emit_message "$natural" assistant
   printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"

--- a/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
+++ b/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh
@@ -346,6 +346,20 @@ if [ "$mode" = "queued-natural-exit" ]; then
   exit 0
 fi
 
+if [ "$mode" = "malformed-natural-stop-after-eof" ]; then
+  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
+  begin_turn
+  printf '%s\n' 'not-json'
+  cat >/dev/null
+  natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
+  emit_message "$natural" assistant
+  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"
+  printf '%s\n' '{"type":"agent_settled"}'
+  touch "$fixture/ready"
+  while [ ! -e "$fixture/release" ]; do sleep 0.01; done
+  exit 0
+fi
+
 if [ "$mode" != "terminal-before-response" ]; then
   printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
 fi
@@ -631,5 +645,11 @@ if [ "$mode" = "fast-detach" ]; then
   ) >/dev/null 2>&1 &
   printf '%s\n' "$!" > "$fixture/detached-pid"
   exit 0
+fi
+if [ "$mode" = "publication-failure" ]; then
+  publication_target="$(dirname "$session_dir")/$(basename "$session_file")"
+  mkdir "$publication_target"
+  touch "$publication_target/block"
+  printf '%s\n' "$publication_target" > "$fixture/publication-target"
 fi
 cat >/dev/null


### PR DESCRIPTION
## Summary

- persist each validated Pi attempt result atomically, keyed by run, stage, input digest, and attempt
- expose explicit result recovery so the controller can close the session/state crash window without replaying Pi
- preserve and recover a natural Pi completion that wins the interruption/abort race
- keep protocol-unverifiable or protocol-invalid interrupted turns unpublished
- preserve protocol-verifiable acknowledged aborts for resume even when interruption races the output limit
- roll back only definitely unpublished result markers and surface indeterminate filesystem access
- reject null/corrupt result-marker identities with checked diagnostics
- reject known environment secrets introduced into changed material workspace files before EXECUTE completion
- reuse the staleness-validated project baseline for changed-workspace secret scanning

## Verification

- focused interruption, publication, and result-store regressions (9 tests)
- `./mvnw -B -pl camel-kit-core -Dtest=PiWorkerTest,PiWorkerResultStoreTest test` (63 tests)
- `./mvnw -B clean install` (six-module reactor; 781 core tests)
- `./mvnw -B -Psourcecheck validate`

## Scope

This is an internal composition substrate for #149. It does not register `camel-kit ship`, claim supported Pi, or complete the real Pi/Linux end-to-end Delivery gate.

Website impact: **required** for the later public cutover; no website change in this internal slice.

Closes no issue; advances #149.

## Summary by Sourcery

Persist and recover completed Pi stage attempt results and enforce secret scanning on changed Ship workspaces.

New Features:
- Persist validated Pi stage attempt results durably per run, stage, input digest, and attempt for later reuse.
- Expose a Pi worker recovery path that returns a previously completed attempt result without relaunching Pi.
- Reject Ship workspace executions when changed material files contain known environment-derived secrets.

Tests:
- Add tests verifying Pi worker recovers a completed attempt result without rerunning Pi.
- Add tests verifying changed workspace secret scanning flags only changed files containing known secrets and accepts clean changes.
