### PR TITLE
Add local Ship workflow coordinator

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactManifestReader.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactManifestReader.java
@@ -1,0 +1,181 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Draft202012;
+import com.networknt.schema.resource.SchemaLoader;
+
+/** Strictly reads a controller-owned artifact manifest from a candidate workspace. */
+public final class ArtifactManifestReader {
+
+    private static final int MAX_MANIFEST_BYTES = 16 * 1024 * 1024;
+    private static final String SCHEMA_ID
+            = "https://github.com/luigidemasi/camel-kit/schemas/ship/v1/artifact-manifest.schema.json";
+    private static final String SCHEMA_RESOURCE = "ship/schema/artifact-manifest.schema.json";
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(100)
+                            .maxStringLength(MAX_MANIFEST_BYTES)
+                            .build())
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+
+    private ArtifactManifestReader() {
+    }
+
+    public static Document read(Path candidateRoot, Path manifestPath)
+            throws IOException {
+        ManifestFile file = manifestFile(candidateRoot, manifestPath);
+        byte[] encoded = ProjectEvidenceFiles.readMaterial(
+                file.root(), file.relativePath(), MAX_MANIFEST_BYTES);
+        String text = decode(encoded);
+
+        JsonNode document;
+        try {
+            document = JSON.readTree(text);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Artifact manifest is not strict JSON");
+        }
+        if (document == null) {
+            throw new IOException("Artifact manifest is not strict JSON");
+        }
+
+        Schema schema = schema();
+        try {
+            if (!schema.validate(document).isEmpty()) {
+                throw new IOException("Artifact manifest does not match its schema");
+            }
+        } catch (RuntimeException e) {
+            throw new IOException("Artifact manifest schema validation failed");
+        }
+
+        try {
+            return new Document(
+                    JSON.treeToValue(document, ArtifactManifest.class),
+                    ShipDigest.sha256(encoded));
+        } catch (JsonProcessingException e) {
+            throw new IOException("Artifact manifest cannot be decoded");
+        }
+    }
+
+    private static ManifestFile manifestFile(
+            Path suppliedRoot, Path suppliedManifest)
+            throws IOException {
+        if (suppliedRoot == null) {
+            throw new IOException("Artifact candidate root is required");
+        }
+        if (suppliedManifest == null) {
+            throw new IOException("Artifact manifest path is required");
+        }
+
+        Path normalizedRoot = suppliedRoot.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalizedRoot)
+                || !Files.isDirectory(normalizedRoot, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Artifact candidate root must be a real directory");
+        }
+        Path root = normalizedRoot.toRealPath();
+        if (!root.equals(normalizedRoot)) {
+            throw new IOException(
+                    "Artifact candidate root must not traverse symbolic links");
+        }
+        Path requested = suppliedManifest.isAbsolute()
+                ? suppliedManifest.toAbsolutePath().normalize()
+                : root.resolve(suppliedManifest).normalize();
+        if (!requested.startsWith(root) || requested.equals(root)) {
+            throw new IOException("Artifact manifest must be a contained real regular file");
+        }
+        String relative = root.relativize(requested)
+                .toString()
+                .replace(File.separatorChar, '/');
+        return new ManifestFile(root, relative);
+    }
+
+    private static String decode(byte[] encoded) throws IOException {
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(encoded))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            throw new IOException("Artifact manifest is not valid UTF-8");
+        }
+    }
+
+    private static Schema schema() throws IOException {
+        String source;
+        try (InputStream input = ArtifactManifestReader.class.getClassLoader()
+                .getResourceAsStream(SCHEMA_RESOURCE)) {
+            if (input == null) {
+                throw new IOException("Artifact manifest schema is unavailable");
+            }
+            byte[] encoded = input.readNBytes(MAX_MANIFEST_BYTES + 1);
+            if (encoded.length == 0 || encoded.length > MAX_MANIFEST_BYTES) {
+                throw new IOException("Artifact manifest schema has an invalid size");
+            }
+            source = decode(encoded);
+        }
+
+        try {
+            SchemaLoader loader = SchemaLoader.builder()
+                    .resourceLoaders(loaders -> loaders.resources(Map.of(SCHEMA_ID, source)))
+                    .allow(iri -> SCHEMA_ID.equals(iri.toString()))
+                    .build();
+            Schema schema = SchemaRegistry.withDialect(
+                    Draft202012.getInstance(), builder -> builder.schemaLoader(loader))
+                    .getSchema(SchemaLocation.of(SCHEMA_ID));
+            schema.initializeValidators();
+            return schema;
+        } catch (RuntimeException e) {
+            throw new IOException("Artifact manifest schema is unavailable");
+        }
+    }
+
+    /** The typed manifest and digest of the exact bytes parsed for acceptance. */
+    public record Document(ArtifactManifest manifest, String digest) {
+
+        public Document {
+            Objects.requireNonNull(manifest, "artifact manifest");
+            if (!ShipDigest.isSha256(digest)) {
+                throw new IllegalArgumentException(
+                        "Artifact manifest digest must be SHA-256");
+            }
+        }
+    }
+
+    private record ManifestFile(Path root, String relativePath) {
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -2,18 +2,21 @@ package io.github.luigidemasi.camelkit.ship.controller;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -26,6 +29,9 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageRecord;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStampStore;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStampStore.VerifiedStamp;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
@@ -57,14 +63,26 @@ public final class ShipController {
 
     private final ShipRunStore store;
     private final Clock clock;
+    private final Map<String, String> environment;
 
     public ShipController(Path stateRoot) {
-        this(stateRoot, Clock.systemUTC());
+        this(stateRoot, Clock.systemUTC(), System.getenv());
+    }
+
+    public ShipController(Path stateRoot, Map<String, String> environment) {
+        this(stateRoot, Clock.systemUTC(), environment);
     }
 
     ShipController(Path stateRoot, Clock clock) {
+        this(stateRoot, clock, System.getenv());
+    }
+
+    ShipController(
+                   Path stateRoot, Clock clock, Map<String, String> environment) {
         this.store = new ShipRunStore(Objects.requireNonNull(stateRoot, "state root"));
         this.clock = Objects.requireNonNull(clock, "clock");
+        this.environment = Map.copyOf(
+                Objects.requireNonNull(environment, "environment"));
     }
 
     /** Resolves the conventional user-owned Ship state directory. */
@@ -93,6 +111,7 @@ public final class ShipController {
         Path project = requireProject(projectDirectory);
         String pipelineId = inspectProjectState(project);
         ShipContext context = resolveContext(project, inputs);
+        rejectContextSecrets(context);
         List<StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
         stages.set(
                 Stage.DISCOVERY.ordinal(),
@@ -121,10 +140,16 @@ public final class ShipController {
         Stage startStage = Objects.requireNonNull(target, "start stage");
         String pipelineId = inspectProjectState(project);
         ShipContext context = resolveContext(project, inputs);
+        rejectContextSecrets(context);
         if (startStage == Stage.DESIGN && context.sources().isEmpty()) {
             throw failure(
                     "start-from-context-missing",
                     "Starting from DESIGN requires text or document context");
+        }
+        if (startStage == Stage.DESIGN && pipelineId == null) {
+            throw failure(
+                    "start-from-pipeline-missing",
+                    "Starting from DESIGN requires a controller-bound active pipeline");
         }
         List<StageRecord> stages = new ArrayList<>(ShipRun.pendingStages());
 
@@ -179,12 +204,19 @@ public final class ShipController {
             if (current.status() == RunStatus.ABORTED) {
                 throw failure("run-aborted", "Ship run is aborted and cannot resume: " + runId);
             }
-            if (current.status() == RunStatus.COMPLETED) {
-                throw failure("run-completed", "Ship run is already complete: " + runId);
+            boolean completedWithLocalStamp = current.status() == RunStatus.COMPLETED;
+            if (completedWithLocalStamp) {
+                StageRecord validation = current.stage(Stage.VALIDATE);
+                if (validation.attempts() <= 0
+                        || !isLocalStampEvidence(locked.directory(), validation)) {
+                    throw failure(
+                            "run-completed", "Ship run is already complete: " + runId);
+                }
             }
 
             Path project = requireProject(Path.of(current.projectDirectory()));
             ShipContext refreshed = refreshContext(current.context());
+            rejectContextSecrets(refreshed);
             List<StageRecord> stages = new ArrayList<>(current.stages());
             int restart = stages.size();
 
@@ -201,16 +233,28 @@ public final class ShipController {
                         requireExecuteRoot(
                                 record.artifacts(), expectedWorkspace(locked.directory()));
                     }
-                    refreshedArtifacts = readRecordedArtifacts(
-                            project,
-                            current.id(),
-                            record.stage(),
-                            record.attempts(),
-                            record.inputDigest(),
-                            locked.directory(),
-                            record.artifacts(),
-                            stagedExecute);
-                } catch (Failure e) {
+                    if (record.stage() == Stage.VALIDATE
+                            && record.attempts() > 0
+                            && isLocalStampEvidence(
+                                    locked.directory(), record)) {
+                        Path evidence = validationEvidenceDirectory(
+                                locked.directory(), record.attempts());
+                        VerifiedStamp stamp = ShipLocalStampStore.readVerified(
+                                evidence, current.id());
+                        refreshedArtifacts = List.of(new ArtifactRef(
+                                stamp.path().toString(), stamp.digest()));
+                    } else {
+                        refreshedArtifacts = readRecordedArtifacts(
+                                project,
+                                current.id(),
+                                record.stage(),
+                                record.attempts(),
+                                record.inputDigest(),
+                                locked.directory(),
+                                record.artifacts(),
+                                stagedExecute);
+                    }
+                } catch (Failure | IOException e) {
                     restart = Math.min(restart, index);
                     break;
                 }
@@ -248,6 +292,10 @@ public final class ShipController {
 
             ShipRun resumed;
             if (restart == stages.size()) {
+                if (completedWithLocalStamp) {
+                    throw failure(
+                            "run-completed", "Ship run is already complete: " + runId);
+                }
                 resumed = copy(
                         current,
                         RunStatus.COMPLETED,
@@ -279,6 +327,72 @@ public final class ShipController {
             throw failure(e.code(), e.getMessage(), e);
         } catch (IOException e) {
             throw failure("state-write-failed", "Could not resume Ship run " + runId, e);
+        }
+    }
+
+    /**
+     * Restarts a completed generated predecessor whose controller-consumed Pi result is no longer recoverable.
+     */
+    ShipRun restartGeneratedStage(
+            StageAttempt currentAttempt, StageRecord unavailable) {
+        Objects.requireNonNull(currentAttempt, "current attempt");
+        Objects.requireNonNull(unavailable, "unavailable stage");
+        if (unavailable.stage() == Stage.VALIDATE
+                || unavailable.attempts() <= 0) {
+            throw failure(
+                    "stage-result-invalid",
+                    "Only a generated Pi predecessor can be restarted");
+        }
+        String runId = currentAttempt.run().id();
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            StageRecord active = requireActiveAttempt(
+                    current,
+                    currentAttempt.stage().stage(),
+                    currentAttempt.stage().attempts(),
+                    currentAttempt.stage().inputDigest());
+            requireCurrentInputs(current, active, locked.directory());
+            StageRecord recorded = current.stage(unavailable.stage());
+            if (recorded.stage().ordinal() >= active.stage().ordinal()
+                    || recorded.status() != StageStatus.COMPLETED
+                    || recorded.attempts() != unavailable.attempts()
+                    || !recorded.inputDigest().equals(
+                            unavailable.inputDigest())) {
+                throw failure(
+                        "stale-stage-attempt",
+                        "Unavailable Pi result no longer matches the completed predecessor");
+            }
+
+            List<StageRecord> stages = new ArrayList<>(current.stages());
+            int restart = recorded.stage().ordinal();
+            for (int index = restart; index < stages.size(); index++) {
+                stages.set(index, stages.get(index).reset());
+            }
+            stages.set(
+                    restart,
+                    startStage(
+                            stages.get(restart),
+                            ShipRun.inputDigest(
+                                    current.context(),
+                                    stages,
+                                    recorded.stage())));
+            ShipRun resumed = copy(
+                    current,
+                    RunStatus.RUNNING,
+                    recorded.stage(),
+                    current.context(),
+                    stages,
+                    null);
+            locked.write(resumed);
+            return resumed;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure(
+                    "state-write-failed",
+                    "Could not restart Ship stage " + unavailable.stage()
+                                          + " for " + runId,
+                    e);
         }
     }
 
@@ -331,6 +445,11 @@ public final class ShipController {
                     "workspace-required",
                     "Ship EXECUTE results require a workspace bound to the active stage");
         }
+        if (stage == Stage.VALIDATE) {
+            throw failure(
+                    "validation-controller-owned",
+                    "Ship VALIDATE results require a controller-derived local Stamp");
+        }
         return completeStage(
                 runId,
                 stage,
@@ -339,7 +458,33 @@ public final class ShipController {
                 outputDigest,
                 artifacts,
                 false,
-                materialAmbiguity);
+                materialAmbiguity,
+                null);
+    }
+
+    /** Records a typed DISCOVERY result and binds its controller-approved pipeline ID. */
+    ShipRun completeDiscoveryStage(
+            String runId,
+            int attempt,
+            String inputDigest,
+            String outputDigest,
+            String pipelineId,
+            boolean materialAmbiguity) {
+        if (!ShipRun.isPipelineId(pipelineId)) {
+            throw failure(
+                    "stage-result-invalid",
+                    "Ship discovery result has an invalid pipeline ID");
+        }
+        return completeStage(
+                runId,
+                Stage.DISCOVERY,
+                attempt,
+                inputDigest,
+                outputDigest,
+                List.of(),
+                false,
+                materialAmbiguity,
+                pipelineId);
     }
 
     /**
@@ -360,7 +505,8 @@ public final class ShipController {
                 null,
                 artifacts,
                 true,
-                materialAmbiguity);
+                materialAmbiguity,
+                null);
     }
 
     /** Prepares the controller-owned workspace for the active EXECUTE attempt. */
@@ -390,6 +536,59 @@ public final class ShipController {
         }
     }
 
+    /**
+     * Resolves one authoritative stage attempt and prepares its private worker directories.
+     *
+     * <p>
+     * The run lock is released before worker execution.
+     */
+    StageAttempt prepareAttempt(String runId) {
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            StageRecord active = requireActiveAttempt(
+                    current,
+                    current.currentStage(),
+                    current.stage(current.currentStage()).attempts(),
+                    current.stage(current.currentStage()).inputDigest());
+            requireCurrentInputs(current, active, locked.directory());
+            Path runDirectory = locked.directory().toRealPath();
+            Path sessions = privateDirectory(runDirectory, "sessions");
+            Path inputs = privateDirectory(runDirectory, "inputs");
+            Path evidenceRoot = privateDirectory(runDirectory, "evidence");
+            Path evidence = privateDirectory(
+                    evidenceRoot,
+                    active.stage().name().toLowerCase(Locale.ROOT)
+                                  + "-" + active.attempts());
+            Path workingDirectory = active.stage() == Stage.EXECUTE
+                    ? ShipWorkspace.prepare(
+                            Path.of(current.projectDirectory()),
+                            runDirectory,
+                            current.id(),
+                            active.attempts(),
+                            active.inputDigest())
+                    : Path.of(current.projectDirectory());
+            return new StageAttempt(
+                    current,
+                    workingDirectory,
+                    sessions,
+                    evidence,
+                    inputs,
+                    runDirectory);
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (StaleBaselineException e) {
+            throw failure(
+                    "stale-stage-input",
+                    "Ship workspace baseline changed; resume the run",
+                    e);
+        } catch (IOException | SecurityException | UnsupportedOperationException e) {
+            throw failure(
+                    "worker-preparation-failed",
+                    "Could not prepare the Ship worker attempt for " + runId,
+                    e);
+        }
+    }
+
     private ShipRun completeStage(
             String runId,
             Stage stage,
@@ -398,7 +597,8 @@ public final class ShipController {
             String outputDigest,
             List<Path> artifacts,
             boolean execute,
-            boolean materialAmbiguity) {
+            boolean materialAmbiguity,
+            String discoveredPipelineId) {
         Objects.requireNonNull(stage, "stage");
         Objects.requireNonNull(artifacts, "artifacts");
         if (execute != (stage == Stage.EXECUTE)) {
@@ -410,6 +610,14 @@ public final class ShipController {
         try (ShipRunStore.LockedRun locked = store.lock(runId)) {
             ShipRun current = locked.read();
             StageRecord active = requireActiveAttempt(current, stage, attempt, inputDigest);
+            if (discoveredPipelineId != null
+                    && (stage != Stage.DISCOVERY
+                            || current.pipelineId() != null
+                                    && !current.pipelineId().equals(discoveredPipelineId))) {
+                throw failure(
+                        "stage-result-invalid",
+                        "Ship discovery result conflicts with the active pipeline");
+            }
             requireCurrentInputs(current, active, locked.directory());
             Path project = Path.of(current.projectDirectory());
             Path artifactRoot;
@@ -477,6 +685,9 @@ public final class ShipController {
 
             ShipRun completed = copy(
                     current,
+                    discoveredPipelineId == null
+                            ? current.pipelineId()
+                            : discoveredPipelineId,
                     status,
                     currentStage,
                     current.context(),
@@ -521,6 +732,65 @@ public final class ShipController {
         }
     }
 
+    /** Commits a controller-derived local Stamp and lets its status decide validation. */
+    ShipRun completeValidationStage(
+            String runId,
+            int attempt,
+            String inputDigest,
+            ShipLocalStamp suppliedStamp) {
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            StageRecord active = requireActiveAttempt(
+                    current, Stage.VALIDATE, attempt, inputDigest);
+            requireCurrentInputs(current, active, locked.directory());
+            Path evidenceDirectory = validationEvidenceDirectory(
+                    locked.directory(), attempt);
+            VerifiedStamp verified = ShipLocalStampStore.readVerified(
+                    evidenceDirectory, runId);
+            ShipLocalStamp stamp = verified.stamp();
+            if (!stamp.equals(Objects.requireNonNull(suppliedStamp, "local Stamp"))) {
+                throw failure(
+                        "validation-stamp-invalid",
+                        "Persisted local Stamp differs from the validation result");
+            }
+            ArtifactRef reference = new ArtifactRef(
+                    verified.path().toString(), verified.digest());
+            List<StageRecord> stages = new ArrayList<>(current.stages());
+            RunStatus status;
+            String message = null;
+            if (stamp.status() == ShipLocalStamp.Status.FAIL) {
+                stages.set(
+                        Stage.VALIDATE.ordinal(),
+                        active.fail(reference.digest(), List.of(reference)));
+                status = RunStatus.FAILED;
+                message = "Mandatory validation checks failed; inspect the retained local Stamp";
+            } else {
+                stages.set(
+                        Stage.VALIDATE.ordinal(),
+                        active.complete(reference.digest(), List.of(reference)));
+                status = current.oversight().pausesAfter(Stage.VALIDATE, false)
+                        ? RunStatus.PAUSED
+                        : RunStatus.COMPLETED;
+            }
+            ShipRun completed = copy(
+                    current,
+                    status,
+                    Stage.VALIDATE,
+                    current.context(),
+                    stages,
+                    message);
+            locked.write(completed);
+            return completed;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "validation-stamp-invalid",
+                    "Could not verify the local Stamp for " + runId,
+                    e);
+        }
+    }
+
     private ShipRun newRun(
             String runId,
             Path project,
@@ -562,11 +832,29 @@ public final class ShipController {
             ShipContext context,
             List<StageRecord> stages,
             String message) {
+        return copy(
+                run,
+                run.pipelineId(),
+                status,
+                currentStage,
+                context,
+                stages,
+                message);
+    }
+
+    private ShipRun copy(
+            ShipRun run,
+            String pipelineId,
+            RunStatus status,
+            Stage currentStage,
+            ShipContext context,
+            List<StageRecord> stages,
+            String message) {
         return new ShipRun(
                 run.schemaVersion(),
                 run.id(),
                 run.projectDirectory(),
-                run.pipelineId(),
+                pipelineId,
                 run.oversight(),
                 status,
                 currentStage,
@@ -774,12 +1062,12 @@ public final class ShipController {
         }
     }
 
-    private static void rejectChangedWorkspaceSecrets(WorkspaceEvidence workspace) {
+    private void rejectChangedWorkspaceSecrets(WorkspaceEvidence workspace) {
         try {
             List<String> findings = ChangedWorkspaceSecretScanner.scan(
                     workspace.baseline(),
                     workspace.snapshot(),
-                    System.getenv());
+                    environment);
             if (!findings.isEmpty()) {
                 throw failure(
                         "workspace-secret-detected",
@@ -824,6 +1112,87 @@ public final class ShipController {
 
     private static Path expectedWorkspace(Path runDirectory) {
         return runDirectory.resolve("workspace/candidate").toAbsolutePath().normalize();
+    }
+
+    private static Path validationEvidenceDirectory(
+            Path runDirectory, int attempt) {
+        if (attempt <= 0) {
+            throw failure(
+                    "validation-stamp-invalid",
+                    "Local Stamp attempt is invalid");
+        }
+        Path root = runDirectory.toAbsolutePath().normalize();
+        Path evidence = root.resolve("evidence")
+                .resolve("validate-" + attempt)
+                .normalize();
+        try {
+            if (!evidence.startsWith(root)
+                    || Files.isSymbolicLink(evidence)
+                    || !Files.isDirectory(evidence, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException(
+                        "Local Stamp evidence directory is missing or unsafe");
+            }
+            Path realRoot = root.toRealPath();
+            Path evidenceRoot = root.resolve("evidence");
+            Path realEvidenceRoot = evidenceRoot.toRealPath();
+            Path realEvidence = evidence.toRealPath();
+            if (!realEvidenceRoot.equals(realRoot.resolve("evidence"))
+                    || !realEvidence.equals(realEvidenceRoot.resolve(
+                            "validate-" + attempt))) {
+                throw new IOException(
+                        "Local Stamp evidence directory escaped its run");
+            }
+            return realEvidence;
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "validation-stamp-invalid",
+                    "Local Stamp evidence directory is invalid",
+                    e);
+        }
+    }
+
+    private static boolean isLocalStampEvidence(
+            Path runDirectory, StageRecord record) {
+        if (record.artifacts().size() != 1) {
+            return false;
+        }
+        Path expected = runDirectory.toAbsolutePath().normalize()
+                .resolve("evidence")
+                .resolve("validate-" + record.attempts())
+                .resolve("stamp.json")
+                .normalize();
+        return expected.toString().equals(record.artifacts().get(0).path())
+                && record.artifacts().get(0).digest().equals(record.outputDigest());
+    }
+
+    private static Path privateDirectory(Path parent, String name)
+            throws IOException {
+        Path root = parent.toAbsolutePath().normalize();
+        Path directory = root.resolve(name).normalize();
+        if (!root.equals(directory.getParent())
+                || Files.isSymbolicLink(directory)) {
+            throw new IOException("Ship worker directory escaped its private parent");
+        }
+        if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createDirectory(
+                    directory,
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rwx------")));
+        }
+        if (Files.isSymbolicLink(directory)
+                || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)
+                || !PosixFilePermissions.fromString("rwx------").equals(
+                        Files.getPosixFilePermissions(
+                                directory, LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException(
+                    "Ship worker directory must be a private real directory: "
+                                  + directory);
+        }
+        Path real = directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (!real.getParent().equals(root.toRealPath(LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException("Ship worker directory escaped its private parent");
+        }
+        return real;
     }
 
     private static ArtifactRef requireExecuteRoot(
@@ -959,6 +1328,44 @@ public final class ShipController {
             return ShipContext.resolve(project, Objects.requireNonNull(inputs, "context inputs"));
         } catch (ShipContext.Failure e) {
             throw failure(contextCode(e), e.getMessage(), e);
+        }
+    }
+
+    private void rejectContextSecrets(ShipContext context) {
+        for (ShipContext.Source source : context.sources()) {
+            byte[] content = source.kind() == ShipContext.Kind.TEXT
+                    ? source.value().getBytes(StandardCharsets.UTF_8)
+                    : readResolvedDocument(source);
+            boolean sensitivePath = ChangedWorkspaceSecretScanner
+                    .containsSensitiveValue(
+                            source.value().getBytes(StandardCharsets.UTF_8),
+                            environment);
+            if (sensitivePath
+                    || ChangedWorkspaceSecretScanner.containsSensitiveValue(
+                            content, environment)) {
+                throw failure(
+                        "context-secret-detected",
+                        "Ship context contains a sensitive environment value");
+            }
+        }
+    }
+
+    private static byte[] readResolvedDocument(ShipContext.Source source) {
+        int expected = Math.toIntExact(source.byteCount());
+        try (InputStream input = Files.newInputStream(Path.of(source.value()))) {
+            byte[] content = input.readNBytes(expected + 1);
+            if (content.length != expected
+                    || !source.digest().equals(ShipDigest.sha256(content))) {
+                throw failure(
+                        "context-changed",
+                        "Ship context changed while it was being verified");
+            }
+            return content;
+        } catch (IOException | SecurityException e) {
+            throw failure(
+                    "context-unreadable",
+                    "Ship context could not be verified",
+                    e);
         }
     }
 
@@ -1252,6 +1659,28 @@ public final class ShipController {
 
     private record WorkspaceEvidence(
             Path candidate, ProjectSnapshot baseline, ProjectSnapshot snapshot) {
+    }
+
+    record StageAttempt(
+            ShipRun run,
+            Path workingDirectory,
+            Path sessionDirectory,
+            Path evidenceDirectory,
+            Path inputDirectory,
+            Path runDirectory) {
+
+        StageAttempt {
+            Objects.requireNonNull(run, "run");
+            Objects.requireNonNull(workingDirectory, "working directory");
+            Objects.requireNonNull(sessionDirectory, "session directory");
+            Objects.requireNonNull(evidenceDirectory, "evidence directory");
+            Objects.requireNonNull(inputDirectory, "input directory");
+            Objects.requireNonNull(runDirectory, "run directory");
+        }
+
+        StageRecord stage() {
+            return run.stage(run.currentStage());
+        }
     }
 
     public static final class Failure extends RuntimeException {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -1122,9 +1122,7 @@ public final class ShipController {
                     "Local Stamp attempt is invalid");
         }
         Path root = runDirectory.toAbsolutePath().normalize();
-        Path evidence = root.resolve("evidence")
-                .resolve("validate-" + attempt)
-                .normalize();
+        Path evidence = ShipRunStore.validationStampPath(root, attempt).getParent();
         try {
             if (!evidence.startsWith(root)
                     || Files.isSymbolicLink(evidence)
@@ -1136,9 +1134,10 @@ public final class ShipController {
             Path evidenceRoot = root.resolve("evidence");
             Path realEvidenceRoot = evidenceRoot.toRealPath();
             Path realEvidence = evidence.toRealPath();
-            if (!realEvidenceRoot.equals(realRoot.resolve("evidence"))
-                    || !realEvidence.equals(realEvidenceRoot.resolve(
-                            "validate-" + attempt))) {
+            Path expectedEvidence = ShipRunStore.validationStampPath(
+                    realRoot, attempt).getParent();
+            if (!realEvidenceRoot.equals(expectedEvidence.getParent())
+                    || !realEvidence.equals(expectedEvidence)) {
                 throw new IOException(
                         "Local Stamp evidence directory escaped its run");
             }
@@ -1156,11 +1155,8 @@ public final class ShipController {
         if (record.artifacts().size() != 1) {
             return false;
         }
-        Path expected = runDirectory.toAbsolutePath().normalize()
-                .resolve("evidence")
-                .resolve("validate-" + record.attempts())
-                .resolve("stamp.json")
-                .normalize();
+        Path expected = ShipRunStore.validationStampPath(
+                runDirectory, record.attempts());
         return expected.toString().equals(record.artifacts().get(0).path())
                 && record.artifacts().get(0).digest().equals(record.outputDigest());
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -1,0 +1,1085 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService.Snapshot;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+import io.github.luigidemasi.camelkit.ship.controller.ShipController.StageAttempt;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageRecord;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.worker.ChangedWorkspaceSecretScanner;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Outcome;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Recovery;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Result;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.SessionBusyException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Concrete local composition of the compact Ship controller, Pi worker, and deterministic Main validation.
+ *
+ * <p>
+ * The command remains unregistered until the live Pi/Linux and publication gates pass.
+ */
+public final class ShipCoordinator {
+
+    private static final int MAX_BRIEFING_BYTES = 16 * 1024 * 1024;
+    private static final int PLAN_CONTRACT_VERSION = 1;
+    private static final String MANIFEST_SCHEMA_RESOURCE
+            = "/ship/schema/artifact-manifest.schema.json";
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final Path stateRoot;
+    private final ShipController controller;
+    private final PiWorker worker;
+    private final CatalogProvider catalogs;
+    private final ShipMainValidator validator;
+    private final DistributionConfig distribution;
+    private final Map<String, String> environment;
+    private final boolean acceptExperimental;
+    private final Clock clock;
+
+    public ShipCoordinator(
+                           Path stateRoot,
+                           Path piExecutable,
+                           Path localMavenRepository,
+                           DistributionConfig distribution,
+                           Duration timeout,
+                           boolean acceptExperimental) {
+        Map<String, String> environment = Map.copyOf(System.getenv());
+        this.stateRoot = Objects.requireNonNull(stateRoot, "state root")
+                .toAbsolutePath()
+                .normalize();
+        this.controller = new ShipController(this.stateRoot, environment);
+        this.distribution = Objects.requireNonNull(distribution, "distribution");
+        this.worker = new PiWorker(
+                piExecutable,
+                distribution.piVersion(),
+                timeout,
+                environment);
+        this.catalogs = new ShipCatalogService(localMavenRepository)::snapshot;
+        this.validator = new ShipMainValidator();
+        this.environment = environment;
+        this.acceptExperimental = acceptExperimental;
+        this.clock = Clock.systemUTC();
+    }
+
+    ShipCoordinator(
+                    Path stateRoot,
+                    ShipController controller,
+                    PiWorker worker,
+                    ShipCatalogService catalogs,
+                    ShipMainValidator validator,
+                    DistributionConfig distribution,
+                    boolean acceptExperimental,
+                    Clock clock) {
+        this(
+             stateRoot,
+             controller,
+             worker,
+             catalogs::snapshot,
+             validator,
+             distribution,
+             Map.of(),
+             acceptExperimental,
+             clock);
+    }
+
+    ShipCoordinator(
+                    Path stateRoot,
+                    ShipController controller,
+                    PiWorker worker,
+                    CatalogProvider catalogs,
+                    ShipMainValidator validator,
+                    DistributionConfig distribution,
+                    Map<String, String> environment,
+                    boolean acceptExperimental,
+                    Clock clock) {
+        this.stateRoot = Objects.requireNonNull(stateRoot, "state root")
+                .toAbsolutePath()
+                .normalize();
+        this.controller = Objects.requireNonNull(controller, "controller");
+        this.worker = Objects.requireNonNull(worker, "worker");
+        this.catalogs = Objects.requireNonNull(catalogs, "catalogs");
+        this.validator = Objects.requireNonNull(validator, "validator");
+        this.distribution = Objects.requireNonNull(distribution, "distribution");
+        this.environment = Map.copyOf(
+                Objects.requireNonNull(environment, "environment"));
+        this.acceptExperimental = acceptExperimental;
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /** Runs authoritative stages until an oversight gate or terminal outcome is reached. */
+    public ShipRun run(String runId) throws IOException, InterruptedException {
+        try {
+            controller.status(runId);
+            try (AttemptLease lease = tryCoordinatorLease(runId)) {
+                return lease == null
+                        ? controller.status(runId)
+                        : runAvailable(runId);
+            }
+        } catch (SessionBusyException e) {
+            return controller.status(runId);
+        } catch (ShipController.Failure e) {
+            if (concurrentTransition(e)) {
+                return controller.status(runId);
+            }
+            throw e;
+        }
+    }
+
+    private ShipRun runAvailable(String runId)
+            throws IOException, InterruptedException {
+        ShipRun current = controller.status(runId);
+        while (current.status() == RunStatus.RUNNING
+                && !Thread.currentThread().isInterrupted()) {
+            StageAttempt attempt = controller.prepareAttempt(current.id());
+            Optional<ShipRun> restarted = restartStalePredecessor(
+                    attempt);
+            if (restarted.isPresent()) {
+                current = restarted.orElseThrow();
+                continue;
+            }
+            Step step = attempt.stage().stage() == Stage.VALIDATE
+                    ? validate(attempt)
+                    : advancePi(attempt);
+            current = step.run();
+            if (!step.progressed() || Thread.currentThread().isInterrupted()) {
+                return current;
+            }
+        }
+        return current;
+    }
+
+    /**
+     * Recovers an exact durable Pi result before retrying; deterministic validation restarts in a fresh attempt.
+     */
+    public ShipRun resume(String runId) throws IOException, InterruptedException {
+        try {
+            controller.status(runId);
+            try (AttemptLease lease = tryCoordinatorLease(runId)) {
+                return lease == null
+                        ? controller.status(runId)
+                        : resumeAvailable(runId);
+            }
+        } catch (SessionBusyException e) {
+            return controller.status(runId);
+        } catch (ShipController.Failure e) {
+            if (concurrentTransition(e)) {
+                return controller.status(runId);
+            }
+            throw e;
+        }
+    }
+
+    private ShipRun resumeAvailable(String runId)
+            throws IOException, InterruptedException {
+        requireNotInterrupted();
+        ShipRun current = controller.status(runId);
+        if (current.status() == RunStatus.RUNNING) {
+            final StageAttempt attempt;
+            try {
+                attempt = controller.prepareAttempt(runId);
+            } catch (ShipController.Failure e) {
+                if (!"stale-stage-input".equals(e.code())) {
+                    throw e;
+                }
+                requireNotInterrupted();
+                current = controller.resume(runId);
+                return current.status() == RunStatus.RUNNING
+                        ? runAvailable(runId)
+                        : current;
+            }
+            Optional<ShipRun> restarted = restartStalePredecessor(
+                    attempt);
+            if (restarted.isPresent()) {
+                return runAvailable(runId);
+            }
+            if (attempt.stage().stage() == Stage.VALIDATE) {
+                requireNotInterrupted();
+                current = controller.resume(runId);
+            } else {
+                Request request = request(attempt);
+                try (Recovery recovery = worker.lockRecovery(request)) {
+                    if (recovery.result().isPresent()) {
+                        current = commitPi(
+                                attempt,
+                                recovery.result().orElseThrow())
+                                .run();
+                    } else {
+                        requireNotInterrupted();
+                        current = controller.resume(runId);
+                    }
+                } catch (SessionBusyException e) {
+                    throw e;
+                } catch (IOException e) {
+                    requireNotInterrupted();
+                    current = optimisticFailure(
+                            attempt,
+                            "Durable Pi stage result could not be recovered");
+                }
+            }
+        } else {
+            requireNotInterrupted();
+            current = controller.resume(runId);
+        }
+        return current.status() == RunStatus.RUNNING
+                ? runAvailable(runId)
+                : current;
+    }
+
+    private Step advancePi(StageAttempt attempt)
+            throws IOException, InterruptedException {
+        Request request = request(attempt);
+        final Optional<Result> recovered;
+        try {
+            recovered = worker.recover(request);
+        } catch (SessionBusyException e) {
+            return new Step(
+                    controller.status(attempt.run().id()), false);
+        } catch (IOException e) {
+            requireNotInterrupted();
+            return new Step(
+                    optimisticFailure(
+                            attempt,
+                            "Durable Pi stage result could not be recovered"),
+                    true);
+        }
+        Result result;
+        if (recovered.isPresent()) {
+            result = recovered.orElseThrow();
+        } else {
+            try {
+                result = worker.run(request);
+            } catch (SessionBusyException e) {
+                return new Step(
+                        controller.status(attempt.run().id()), false);
+            } catch (IOException e) {
+                Optional<Result> afterFailure = worker.recover(request);
+                if (afterFailure.isEmpty()) {
+                    return new Step(
+                            optimisticFailure(
+                                    attempt,
+                                    "Pi stage could not run: " + safeMessage(e)),
+                            true);
+                }
+                result = afterFailure.orElseThrow();
+            }
+        }
+        return commitPi(attempt, result);
+    }
+
+    private Optional<ShipRun> restartStalePredecessor(
+            StageAttempt attempt)
+            throws InterruptedException, SessionBusyException {
+        for (Stage stage : Stage.values()) {
+            if (stage.ordinal() >= attempt.stage().stage().ordinal()) {
+                break;
+            }
+            StageRecord predecessor = attempt.run().stage(stage);
+            if (predecessor.attempts() <= 0) {
+                continue;
+            }
+            try {
+                Result result = completedPiResult(attempt, predecessor);
+                ShipStageResult typed = ShipStageResult.parse(
+                        stage, result.assistantText());
+                if (stage == Stage.PLAN) {
+                    requireDistributionPolicy(typed.artifactPolicy());
+                }
+            } catch (SessionBusyException e) {
+                throw e;
+            } catch (IOException | IllegalArgumentException e) {
+                requireNotInterrupted();
+                return Optional.of(controller.restartGeneratedStage(
+                        attempt, predecessor));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Step commitPi(StageAttempt attempt, Result result) {
+        StageRecord stage = attempt.stage();
+        if (result.outcome() != Outcome.SUCCEEDED) {
+            return new Step(
+                    optimisticFailure(
+                            attempt,
+                            result.failure() == null
+                                    ? "Pi stage failed"
+                                    : result.failure()),
+                    true);
+        }
+
+        final ShipStageResult typed;
+        try {
+            typed = ShipStageResult.parse(stage.stage(), result.assistantText());
+            if (stage.stage() == Stage.PLAN) {
+                requireDistributionPolicy(typed.artifactPolicy());
+            }
+        } catch (IOException | IllegalArgumentException e) {
+            return new Step(
+                    optimisticFailure(
+                            attempt,
+                            "Pi returned an invalid "
+                                     + stage.stage().name().toLowerCase(
+                                             java.util.Locale.ROOT)
+                                     + " result"),
+                    true);
+        }
+
+        String outputDigest = ShipDigest.sha256(
+                result.assistantText().getBytes(StandardCharsets.UTF_8));
+        boolean restoreInterrupt = Thread.interrupted();
+        try {
+            ShipRun committed;
+            if (stage.stage() == Stage.DISCOVERY) {
+                committed = controller.completeDiscoveryStage(
+                        attempt.run().id(),
+                        stage.attempts(),
+                        stage.inputDigest(),
+                        outputDigest,
+                        typed.pipelineId(),
+                        typed.materialAmbiguity());
+            } else if (stage.stage() == Stage.EXECUTE) {
+                Path manifest;
+                try {
+                    manifest = manifestPath(attempt.run(), attempt.workingDirectory());
+                    readBounded(manifest, MAX_BRIEFING_BYTES);
+                } catch (IOException e) {
+                    return new Step(
+                            optimisticFailure(
+                                    attempt,
+                                    "Pi did not produce the required artifact manifest"),
+                            true);
+                }
+                committed = controller.completeExecuteStage(
+                        attempt.run().id(),
+                        stage.attempts(),
+                        stage.inputDigest(),
+                        List.of(manifest),
+                        typed.materialAmbiguity());
+            } else {
+                committed = controller.completeStage(
+                        attempt.run().id(),
+                        stage.stage(),
+                        stage.attempts(),
+                        stage.inputDigest(),
+                        outputDigest,
+                        List.of(),
+                        typed.materialAmbiguity());
+            }
+            return new Step(committed, true);
+        } catch (ShipController.Failure e) {
+            if ("stage-result-invalid".equals(e.code())) {
+                return new Step(
+                        optimisticFailure(
+                                attempt,
+                                "Pi result conflicts with controller-owned stage state"),
+                        true);
+            }
+            if (!"stale-stage-attempt".equals(e.code())) {
+                throw e;
+            }
+            ShipRun current = controller.status(attempt.run().id());
+            StageRecord recorded = current.stage(stage.stage());
+            if (recorded.attempts() == stage.attempts()
+                    && stage.inputDigest().equals(recorded.inputDigest())
+                    && (recorded.status() == StageStatus.COMPLETED
+                            || recorded.status() == StageStatus.FAILED)) {
+                return new Step(current, true);
+            }
+            throw e;
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private Step validate(StageAttempt attempt)
+            throws IOException, InterruptedException {
+        ArtifactPolicy policy = acceptedPolicy(attempt);
+        requireDistributionPolicy(policy);
+        Path workspace = executeWorkspace(attempt.run());
+        Path manifest = manifestPath(attempt.run(), workspace);
+        CatalogTarget target = new CatalogTarget(
+                policy.runtime(),
+                policy.camelVersion(),
+                policy.platformVersion(),
+                policy.springBootVersion());
+        Result executeResult = completedPiResult(
+                attempt, attempt.run().stage(Stage.EXECUTE));
+        ShipLocalStamp.ToolVersion pi = new ShipLocalStamp.ToolVersion(
+                "pi",
+                executeResult.evidence().executable(),
+                executeResult.version(),
+                executeResult.support(),
+                executeResult.warning());
+        ShipMainValidator.Result validated = validator.validate(
+                attempt.run().id(),
+                workspace,
+                manifest,
+                policy,
+                catalogs.snapshot(target),
+                attempt.evidenceDirectory(),
+                pi,
+                clock);
+        requireNotInterrupted();
+        return new Step(
+                commitValidation(attempt, validated.stamp()),
+                true);
+    }
+
+    private Request request(StageAttempt attempt) throws IOException {
+        Path briefing = briefing(attempt);
+        Path policyContract = attempt.stage().stage() == Stage.PLAN
+                ? contract(
+                        attempt.inputDirectory(),
+                        "artifact-policy",
+                        policyContract())
+                : null;
+        Path manifestSchema = attempt.stage().stage() == Stage.EXECUTE
+                ? contract(
+                        attempt.inputDirectory(),
+                        "artifact-manifest-schema",
+                        manifestSchema())
+                : null;
+        String workerInputDigest = workerInputDigest(attempt.stage());
+        return new Request(
+                attempt.run().id(),
+                attempt.stage().stage(),
+                attempt.stage().attempts(),
+                attempt.workingDirectory(),
+                attempt.sessionDirectory(),
+                attempt.evidenceDirectory(),
+                workerInputDigest,
+                acceptExperimental,
+                prompt(
+                        attempt,
+                        briefing,
+                        policyContract,
+                        manifestSchema,
+                        workerInputDigest));
+    }
+
+    private byte[] policyContract() throws IOException {
+        ArtifactPolicy fixed = new ArtifactPolicy(
+                "main",
+                distribution.camelMainVersion(),
+                null,
+                null,
+                "yaml",
+                "simple",
+                distribution.citrusVersion(),
+                CitrusDependencyPolicy.required(
+                        distribution.citrusVersion()),
+                JavaPolicy.FORBIDDEN,
+                List.of(),
+                List.of(),
+                true,
+                true);
+        return JSON.writerWithDefaultPrettyPrinter()
+                .writeValueAsBytes(fixed);
+    }
+
+    private static byte[] manifestSchema() throws IOException {
+        try (InputStream input = ShipCoordinator.class.getResourceAsStream(
+                MANIFEST_SCHEMA_RESOURCE)) {
+            if (input == null) {
+                throw new IOException(
+                        "Bundled Ship artifact manifest schema is missing");
+            }
+            byte[] schema = input.readNBytes(MAX_BRIEFING_BYTES + 1);
+            if (schema.length == 0
+                    || schema.length > MAX_BRIEFING_BYTES) {
+                throw new IOException(
+                        "Bundled Ship artifact manifest schema is invalid");
+            }
+            return schema;
+        }
+    }
+
+    private static Path contract(
+            Path directory, String name, byte[] content)
+            throws IOException {
+        String digest = ShipDigest.sha256(content)
+                .substring("sha256:".length());
+        return writeOnce(
+                directory.resolve(name + '-' + digest + ".json"),
+                content);
+    }
+
+    private String workerInputDigest(StageRecord stage)
+            throws IOException {
+        String contract = switch (stage.stage()) {
+            case PLAN -> "plan:"
+                         + PLAN_CONTRACT_VERSION + ':'
+                         + ShipDigest.sha256(policyContract());
+            case EXECUTE -> "execute:"
+                            + ShipMainValidator.CONTRACT_VERSION + ':'
+                            + ShipDigest.sha256(manifestSchema());
+            default -> null;
+        };
+        if (contract == null) {
+            return stage.inputDigest();
+        }
+        return ShipDigest.sha256(
+                (stage.inputDigest() + '\n' + contract)
+                        .getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Path briefing(StageAttempt attempt) throws IOException {
+        StringBuilder text = new StringBuilder();
+        text.append("# Controller input\n\n");
+        text.append("Run: ").append(attempt.run().id()).append('\n');
+        text.append("Stage: ").append(attempt.stage().stage()).append('\n');
+        text.append("Pipeline: ")
+                .append(attempt.run().pipelineId() == null
+                        ? "not assigned"
+                        : attempt.run().pipelineId())
+                .append('\n');
+        text.append("Input digest: ").append(attempt.stage().inputDigest())
+                .append("\n\n## Initial context\n");
+        if (attempt.run().context().sources().isEmpty()) {
+            text.append("\nNo initial context was supplied.\n");
+        }
+        for (int index = 0;
+             index < attempt.run().context().sources().size();
+             index++) {
+            ShipContext.Source source = attempt.run().context().sources().get(index);
+            text.append("\n### Source ").append(index + 1)
+                    .append(" (").append(source.kind()).append(")\n\n");
+            if (source.kind() == ShipContext.Kind.TEXT) {
+                text.append(source.value()).append('\n');
+            } else {
+                text.append("Path: ").append(source.value()).append("\n\n");
+                byte[] content = readBounded(
+                        Path.of(source.value()),
+                        ShipContext.MAX_DOCUMENT_BYTES);
+                if (!source.digest().equals(ShipDigest.sha256(content))) {
+                    throw new IOException(
+                            "Ship context document changed before Pi composition");
+                }
+                text.append(new String(content, StandardCharsets.UTF_8))
+                        .append('\n');
+            }
+        }
+
+        for (Stage stage : Stage.values()) {
+            if (stage.ordinal() >= attempt.stage().stage().ordinal()) {
+                break;
+            }
+            StageRecord predecessor = attempt.run().stage(stage);
+            text.append("\n## ").append(stage).append(" result\n\n");
+            if (predecessor.attempts() > 0) {
+                ShipStageResult result = ShipStageResult.parse(
+                        stage,
+                        completedPiResult(attempt, predecessor).assistantText());
+                text.append(result.report()).append('\n');
+                if (result.artifactPolicy() != null) {
+                    text.append("\nApproved artifact policy:\n\n```json\n")
+                            .append(JSON.writeValueAsString(
+                                    result.artifactPolicy()))
+                            .append("\n```\n");
+                }
+            } else {
+                appendImportedArtifacts(
+                        text,
+                        predecessor,
+                        Path.of(attempt.run().projectDirectory()));
+            }
+            requireBriefingSize(text);
+        }
+        byte[] encoded = text.toString().getBytes(StandardCharsets.UTF_8);
+        if (encoded.length == 0 || encoded.length > MAX_BRIEFING_BYTES) {
+            throw new IOException("Ship Pi briefing exceeds its size limit");
+        }
+        if (ChangedWorkspaceSecretScanner.containsSensitiveValue(
+                encoded, environment)) {
+            throw new IOException(
+                    "Ship coordinator input contains a sensitive environment value");
+        }
+        String suffix = attempt.stage().inputDigest()
+                .substring("sha256:".length());
+        Path target = attempt.inputDirectory()
+                .resolve(attempt.stage().stage().name().toLowerCase(
+                        java.util.Locale.ROOT) + "-" + suffix + ".md");
+        return writeOnce(target, encoded);
+    }
+
+    private Result completedPiResult(
+            StageAttempt current, StageRecord completed)
+            throws IOException {
+        if (completed.attempts() <= 0) {
+            throw new IOException(
+                    "Imported Ship stage has no Pi result: " + completed.stage());
+        }
+        Path working = completed.stage() == Stage.EXECUTE
+                ? executeWorkspace(current.run())
+                : Path.of(current.run().projectDirectory());
+        Path evidence = current.runDirectory()
+                .resolve("evidence")
+                .resolve(completed.stage().name().toLowerCase(
+                        java.util.Locale.ROOT) + "-" + completed.attempts());
+        Request request = new Request(
+                current.run().id(),
+                completed.stage(),
+                completed.attempts(),
+                working,
+                current.sessionDirectory(),
+                evidence,
+                workerInputDigest(completed),
+                true,
+                "Recover the controller-owned completed Ship stage result.");
+        Result result = worker.recover(request).orElseThrow(() -> new IOException(
+                "Durable Pi result is missing for completed stage "
+                                                                                  + completed.stage()));
+        if (result.outcome() != Outcome.SUCCEEDED) {
+            throw new IOException(
+                    "Completed Ship stage has a non-successful Pi result");
+        }
+        if (completed.stage() != Stage.EXECUTE
+                && !completed.outputDigest().equals(ShipDigest.sha256(
+                        result.assistantText().getBytes(StandardCharsets.UTF_8)))) {
+            throw new IOException(
+                    "Durable Pi result differs from the committed "
+                                  + completed.stage() + " output");
+        }
+        return result;
+    }
+
+    private ArtifactPolicy acceptedPolicy(StageAttempt attempt)
+            throws IOException {
+        StageRecord plan = attempt.run().stage(Stage.PLAN);
+        if (plan.attempts() <= 0) {
+            throw new IOException(
+                    "Validation requires a controller-approved generated artifact policy");
+        }
+        ShipStageResult result = ShipStageResult.parse(
+                Stage.PLAN,
+                completedPiResult(attempt, plan).assistantText());
+        return result.artifactPolicy();
+    }
+
+    private void requireDistributionPolicy(ArtifactPolicy policy) {
+        if (policy == null
+                || !"main".equals(policy.runtime())
+                || !distribution.camelMainVersion().equals(
+                        policy.camelVersion())
+                || policy.platformVersion() != null
+                || policy.springBootVersion() != null
+                || !"yaml".equals(policy.routeDsl())
+                || !"simple".equals(policy.expressionLanguage())
+                || !distribution.citrusVersion().equals(
+                        policy.citrusVersion())
+                || !CitrusDependencyPolicy.required(
+                        distribution.citrusVersion())
+                        .equals(policy.citrusDependencies())
+                || policy.javaPolicy() != JavaPolicy.FORBIDDEN
+                || !policy.approvedJavaExceptions().isEmpty()
+                || !policy.citrusTestsRequired()
+                || !policy.oneCitrusTestPerRoute()) {
+            throw new IllegalArgumentException(
+                    "Ship plan differs from the controller's Main policy");
+        }
+    }
+
+    private static String prompt(
+            StageAttempt attempt,
+            Path briefing,
+            Path policyContract,
+            Path manifestSchema,
+            String workerInputDigest)
+            throws IOException {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("You are the bounded Pi worker for Camel Kit Ship stage ")
+                .append(attempt.stage().stage()).append(".\n")
+                .append("Read the complete controller input from this exact file: ")
+                .append(briefing).append("\n")
+                .append("This is controller attempt ")
+                .append(attempt.stage().attempts()).append(".\n")
+                .append("The authoritative input digest is ")
+                .append(attempt.stage().inputDigest()).append(".\n")
+                .append("The bounded worker input identity is ")
+                .append(workerInputDigest).append(".\n");
+        switch (attempt.stage().stage()) {
+            case DISCOVERY -> {
+                prompt.append(
+                        "Analyze supplied material before unresolved requirements. ");
+                if (attempt.run().pipelineId() == null) {
+                    prompt.append(
+                            "Choose one unused pipeline ID matching "
+                                  + "<three-or-more-digits>-<lowercase-slug>.\n");
+                } else {
+                    prompt.append("Reuse the controller-bound pipeline ID ")
+                            .append(attempt.run().pipelineId())
+                            .append(".\n");
+                }
+            }
+            case DESIGN -> prompt.append(
+                    "Produce the complete Camel integration design. "
+                                         + "Do not change application source.\n");
+            case PLAN -> prompt.append(
+                    "Produce an implementation plan and its independent artifact policy. "
+                                       + "Read the fixed controller policy from ")
+                    .append(Objects.requireNonNull(policyContract))
+                    .append(
+                            ". Copy every fixed field exactly and replace the empty routes array "
+                            + "with one object per planned route using fields routeId, routePath, "
+                            + "and citrusTestPath. For each route, routePath's file name must "
+                            + "equal <routeId>.camel.yaml and citrusTestPath must equal "
+                            + "test/<routeId>.camel.it.yaml. Sort routes canonically by routeId, "
+                            + "then routePath, then citrusTestPath.\n");
+            case EXECUTE -> prompt.append(
+                    "Implement only inside the supplied working directory. "
+                                          + "Read and satisfy the exact bundled manifest JSON Schema at ")
+                    .append(Objects.requireNonNull(manifestSchema))
+                    .append(
+                            ". Match the approved PLAN policy in the controller input. "
+                            + "Write the strict artifact manifest to ")
+                    .append(manifestPath(
+                            attempt.run(), attempt.workingDirectory()))
+                    .append(".\n");
+            case VALIDATE -> throw new IOException(
+                    "Pi does not decide deterministic validation");
+        }
+        prompt.append(
+                "Return only one JSON object with exactly these fields: "
+                      + "schemaVersion, pipelineId, report, artifactPolicy, "
+                      + "materialAmbiguity. Use schemaVersion 1. "
+                      + "Use JSON null for fields not allowed by this stage; "
+                      + "do not use Markdown fences or surrounding prose.");
+        return prompt.toString();
+    }
+
+    private static Path manifestPath(ShipRun run, Path candidate)
+            throws IOException {
+        if (run.pipelineId() == null) {
+            throw new IOException(
+                    "Ship execution requires a controller-approved pipeline ID");
+        }
+        return candidate.resolve("docs/camel-kit")
+                .resolve(run.pipelineId())
+                .resolve("artifact-manifest.json")
+                .toAbsolutePath()
+                .normalize();
+    }
+
+    private static Path executeWorkspace(ShipRun run) throws IOException {
+        return run.stage(Stage.EXECUTE).artifacts().stream()
+                .map(ShipRun.ArtifactRef::path)
+                .map(Path::of)
+                .filter(Files::isDirectory)
+                .findFirst()
+                .orElseThrow(() -> new IOException(
+                        "Ship EXECUTE workspace evidence is missing"));
+    }
+
+    private static void appendImportedArtifacts(
+            StringBuilder text, StageRecord predecessor, Path project)
+            throws IOException {
+        if (predecessor.artifacts().isEmpty()) {
+            text.append("No imported artifact content.\n");
+            return;
+        }
+        for (ShipRun.ArtifactRef artifact : predecessor.artifacts()) {
+            Path path = Path.of(artifact.path());
+            if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                continue;
+            }
+            byte[] encoded = readBounded(path, MAX_BRIEFING_BYTES);
+            if (!artifact.digest().equals(ShipDigest.sha256(encoded))) {
+                throw new IOException(
+                        "Imported Ship artifact changed before Pi composition");
+            }
+            text.append("Artifact: ")
+                    .append(project.relativize(path))
+                    .append("\n\n")
+                    .append(new String(encoded, StandardCharsets.UTF_8))
+                    .append('\n');
+            requireBriefingSize(text);
+        }
+    }
+
+    private ShipRun optimisticFailure(StageAttempt attempt, String message) {
+        boolean restoreInterrupt = Thread.interrupted();
+        try {
+            return controller.failStage(
+                    attempt.run().id(),
+                    attempt.stage().stage(),
+                    attempt.stage().attempts(),
+                    attempt.stage().inputDigest(),
+                    truncate(message));
+        } catch (ShipController.Failure e) {
+            if (!"stale-stage-attempt".equals(e.code())) {
+                throw e;
+            }
+            return controller.status(attempt.run().id());
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private ShipRun commitValidation(
+            StageAttempt attempt, ShipLocalStamp stamp) {
+        boolean restoreInterrupt = Thread.interrupted();
+        try {
+            return controller.completeValidationStage(
+                    attempt.run().id(),
+                    attempt.stage().attempts(),
+                    attempt.stage().inputDigest(),
+                    stamp);
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private AttemptLease tryCoordinatorLease(String runId)
+            throws IOException {
+        Path root = stateRoot.toRealPath();
+        Path run = stateRoot.resolve(runId).toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(run)
+                || !Files.isDirectory(run, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(
+                    "Ship coordinator run directory is missing or unsafe");
+        }
+        Path realRun = run.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        if (!realRun.equals(root.resolve(runId))) {
+            throw new IOException(
+                    "Ship coordinator run directory escaped its state root");
+        }
+        return tryLease(
+                realRun.resolve(".coordinator.lock"),
+                "Ship coordinator lease");
+    }
+
+    private static AttemptLease tryLease(Path lockPath, String label)
+            throws IOException {
+        String userName = System.getProperty("user.name");
+        if (userName == null || userName.isBlank()) {
+            throw new IOException(
+                    "Could not determine the current user for " + label);
+        }
+        UserPrincipal owner = lockPath.getFileSystem()
+                .getUserPrincipalLookupService()
+                .lookupPrincipalByName(userName);
+        if (!owner.equals(Files.getOwner(
+                lockPath.getParent(), LinkOption.NOFOLLOW_LINKS))) {
+            throw new IOException(
+                    label + " directory must be owned by the current user");
+        }
+        FileChannel channel = FileChannel.open(
+                lockPath,
+                Set.of(
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        LinkOption.NOFOLLOW_LINKS),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        try {
+            PosixFileAttributes attributes = Files.readAttributes(
+                    lockPath,
+                    PosixFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            if (attributes.isSymbolicLink()
+                    || !attributes.isRegularFile()
+                    || !owner.equals(attributes.owner())
+                    || !PosixFilePermissions.fromString("rw-------").equals(
+                            attributes.permissions())) {
+                throw new IOException(
+                        label
+                                      + " must be a current-user-owned 0600 regular file");
+            }
+            FileLock lock;
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException e) {
+                channel.close();
+                return null;
+            }
+            if (lock == null) {
+                channel.close();
+                return null;
+            }
+            return new AttemptLease(channel, lock);
+        } catch (IOException | RuntimeException e) {
+            if (channel.isOpen()) {
+                channel.close();
+            }
+            throw e;
+        }
+    }
+
+    private static boolean concurrentTransition(
+            ShipController.Failure failure) {
+        return "operation-in-progress".equals(failure.code())
+                || "stale-stage-attempt".equals(failure.code());
+    }
+
+    private static Path writeOnce(Path target, byte[] encoded)
+            throws IOException {
+        if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] current = readBounded(target, MAX_BRIEFING_BYTES);
+            if (!java.security.MessageDigest.isEqual(current, encoded)) {
+                throw new IOException(
+                        "Controller-owned Pi briefing differs from its durable input");
+            }
+            return target.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        }
+        Path temporary = Files.createTempFile(
+                target.getParent(),
+                ".briefing-",
+                ".tmp",
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    LinkOption.NOFOLLOW_LINKS)) {
+                ByteBuffer content = ByteBuffer.wrap(encoded);
+                while (content.hasRemaining()) {
+                    channel.write(content);
+                }
+                channel.force(true);
+            }
+            try {
+                Files.createLink(target, temporary);
+            } catch (FileAlreadyExistsException e) {
+                byte[] current = readBounded(target, MAX_BRIEFING_BYTES);
+                if (!java.security.MessageDigest.isEqual(current, encoded)) {
+                    throw new IOException(
+                            "Concurrent Ship briefing differs from its input",
+                            e);
+                }
+            }
+            return target.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static byte[] readBounded(Path path, int maximum)
+            throws IOException {
+        if (Files.isSymbolicLink(path)
+                || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Ship coordinator input is missing or unsafe");
+        }
+        try (InputStream input = Files.newInputStream(
+                path, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] encoded = input.readNBytes(maximum + 1);
+            if (encoded.length > maximum) {
+                throw new IOException(
+                        "Ship coordinator input exceeds its size limit");
+            }
+            return encoded;
+        }
+    }
+
+    private static void requireBriefingSize(StringBuilder text)
+            throws IOException {
+        if (text.length() > MAX_BRIEFING_BYTES
+                || text.toString().getBytes(StandardCharsets.UTF_8).length
+                   > MAX_BRIEFING_BYTES) {
+            throw new IOException("Ship Pi briefing exceeds its size limit");
+        }
+    }
+
+    private static String truncate(String value) {
+        String message = value == null || value.isBlank()
+                ? "Ship stage failed"
+                : value.replace('\0', ' ').strip();
+        return message.length() <= 1024
+                ? message
+                : message.substring(0, 1024);
+    }
+
+    private static String safeMessage(IOException failure) {
+        String message = failure.getMessage();
+        return message == null || message.isBlank()
+                ? failure.getClass().getSimpleName()
+                : message;
+    }
+
+    private static void requireNotInterrupted()
+            throws InterruptedException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException(
+                    "Interrupted before advancing the Ship run");
+        }
+    }
+
+    private record Step(ShipRun run, boolean progressed) {
+    }
+
+    @FunctionalInterface
+    interface CatalogProvider {
+
+        Snapshot snapshot(CatalogTarget target) throws IOException;
+    }
+
+    private record AttemptLease(FileChannel channel, FileLock lock)
+            implements
+                AutoCloseable {
+
+        @Override
+        public void close() throws IOException {
+            IOException failure = null;
+            try {
+                lock.release();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                channel.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -10,8 +10,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipal;
@@ -45,6 +47,7 @@ import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Recovery;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Result;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.SessionBusyException;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.UntrustedResultException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -304,7 +307,7 @@ public final class ShipCoordinator {
 
     private Optional<ShipRun> restartStalePredecessor(
             StageAttempt attempt)
-            throws InterruptedException, SessionBusyException {
+            throws IOException, InterruptedException {
         for (Stage stage : Stage.values()) {
             if (stage.ordinal() >= attempt.stage().stage().ordinal()) {
                 break;
@@ -313,15 +316,21 @@ public final class ShipCoordinator {
             if (predecessor.attempts() <= 0) {
                 continue;
             }
+            final Result result;
             try {
-                Result result = completedPiResult(attempt, predecessor);
+                result = completedPiResult(attempt, predecessor);
+            } catch (UntrustedResultException
+                     | StalePredecessorException e) {
+                requireNotInterrupted();
+                return Optional.of(controller.restartGeneratedStage(
+                        attempt, predecessor));
+            }
+            try {
                 ShipStageResult typed = ShipStageResult.parse(
                         stage, result.assistantText());
                 if (stage == Stage.PLAN) {
                     requireDistributionPolicy(typed.artifactPolicy());
                 }
-            } catch (SessionBusyException e) {
-                throw e;
             } catch (IOException | IllegalArgumentException e) {
                 requireNotInterrupted();
                 return Optional.of(controller.restartGeneratedStage(
@@ -431,36 +440,46 @@ public final class ShipCoordinator {
 
     private Step validate(StageAttempt attempt)
             throws IOException, InterruptedException {
-        ArtifactPolicy policy = acceptedPolicy(attempt);
-        requireDistributionPolicy(policy);
-        Path workspace = executeWorkspace(attempt.run());
-        Path manifest = manifestPath(attempt.run(), workspace);
-        CatalogTarget target = new CatalogTarget(
-                policy.runtime(),
-                policy.camelVersion(),
-                policy.platformVersion(),
-                policy.springBootVersion());
-        Result executeResult = completedPiResult(
-                attempt, attempt.run().stage(Stage.EXECUTE));
-        ShipLocalStamp.ToolVersion pi = new ShipLocalStamp.ToolVersion(
-                "pi",
-                executeResult.evidence().executable(),
-                executeResult.version(),
-                executeResult.support(),
-                executeResult.warning());
-        ShipMainValidator.Result validated = validator.validate(
-                attempt.run().id(),
-                workspace,
-                manifest,
-                policy,
-                catalogs.snapshot(target),
-                attempt.evidenceDirectory(),
-                pi,
-                clock);
-        requireNotInterrupted();
-        return new Step(
-                commitValidation(attempt, validated.stamp()),
-                true);
+        try {
+            ArtifactPolicy policy = acceptedPolicy(attempt);
+            requireDistributionPolicy(policy);
+            Path workspace = executeWorkspace(attempt.run());
+            Path manifest = manifestPath(attempt.run(), workspace);
+            CatalogTarget target = new CatalogTarget(
+                    policy.runtime(),
+                    policy.camelVersion(),
+                    policy.platformVersion(),
+                    policy.springBootVersion());
+            Result executeResult = completedPiResult(
+                    attempt, attempt.run().stage(Stage.EXECUTE));
+            ShipLocalStamp.ToolVersion pi = new ShipLocalStamp.ToolVersion(
+                    "pi",
+                    executeResult.evidence().executable(),
+                    executeResult.version(),
+                    executeResult.support(),
+                    executeResult.warning());
+            ShipMainValidator.Result validated = validator.validate(
+                    attempt.run().id(),
+                    workspace,
+                    manifest,
+                    policy,
+                    catalogs.snapshot(target),
+                    attempt.evidenceDirectory(),
+                    pi,
+                    clock);
+            return new Step(
+                    commitValidation(attempt, validated.stamp()),
+                    true);
+        } catch (SessionBusyException e) {
+            throw e;
+        } catch (IOException e) {
+            requireNotInterrupted();
+            return new Step(
+                    optimisticFailure(
+                            attempt,
+                            "Ship validation could not run"),
+                    true);
+        }
     }
 
     private Request request(StageAttempt attempt) throws IOException {
@@ -664,19 +683,20 @@ public final class ShipCoordinator {
                 workerInputDigest(completed),
                 true,
                 "Recover the controller-owned completed Ship stage result.");
-        Result result = worker.recover(request).orElseThrow(() -> new IOException(
-                "Durable Pi result is missing for completed stage "
-                                                                                  + completed.stage()));
+        Result result = worker.recover(request).orElseThrow(
+                () -> new StalePredecessorException(
+                        "Durable Pi result is missing for completed stage "
+                                                    + completed.stage()));
         if (result.outcome() != Outcome.SUCCEEDED) {
-            throw new IOException(
+            throw new StalePredecessorException(
                     "Completed Ship stage has a non-successful Pi result");
         }
         if (completed.stage() != Stage.EXECUTE
                 && !completed.outputDigest().equals(ShipDigest.sha256(
                         result.assistantText().getBytes(StandardCharsets.UTF_8)))) {
-            throw new IOException(
+            throw new StalePredecessorException(
                     "Durable Pi result differs from the committed "
-                                  + completed.stage() + " output");
+                                                + completed.stage() + " output");
         }
         return result;
     }
@@ -799,13 +819,23 @@ public final class ShipCoordinator {
     }
 
     private static Path executeWorkspace(ShipRun run) throws IOException {
-        return run.stage(Stage.EXECUTE).artifacts().stream()
-                .map(ShipRun.ArtifactRef::path)
-                .map(Path::of)
-                .filter(Files::isDirectory)
-                .findFirst()
-                .orElseThrow(() -> new IOException(
-                        "Ship EXECUTE workspace evidence is missing"));
+        for (ShipRun.ArtifactRef artifact : run.stage(Stage.EXECUTE).artifacts()) {
+            Path candidate = Path.of(artifact.path());
+            final BasicFileAttributes attributes;
+            try {
+                attributes = Files.readAttributes(
+                        candidate,
+                        BasicFileAttributes.class,
+                        LinkOption.NOFOLLOW_LINKS);
+            } catch (NoSuchFileException e) {
+                continue;
+            }
+            if (attributes.isDirectory()) {
+                return candidate;
+            }
+        }
+        throw new StalePredecessorException(
+                "Ship EXECUTE workspace evidence is missing");
     }
 
     private static void appendImportedArtifacts(
@@ -1023,10 +1053,14 @@ public final class ShipCoordinator {
         }
     }
 
-    private static String truncate(String value) {
+    private String truncate(String value) {
         String message = value == null || value.isBlank()
                 ? "Ship stage failed"
                 : value.replace('\0', ' ').strip();
+        if (ChangedWorkspaceSecretScanner.containsSensitiveValue(
+                message.getBytes(StandardCharsets.UTF_8), environment)) {
+            return "Failed";
+        }
         return message.length() <= 1024
                 ? message
                 : message.substring(0, 1024);
@@ -1044,6 +1078,15 @@ public final class ShipCoordinator {
         if (Thread.currentThread().isInterrupted()) {
             throw new InterruptedException(
                     "Interrupted before advancing the Ship run");
+        }
+    }
+
+    private static final class StalePredecessorException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        private StalePredecessorException(String message) {
+            super(message);
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidator.java
@@ -1,0 +1,870 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifestReader;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifestReader.Document;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactValidationResult;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactValidator;
+import io.github.luigidemasi.camelkit.ship.catalog.CamelYamlCatalogUsageExtractor;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogComponentModel;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogEvidenceSet;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogSubject.Kind;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceCommand;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceRunner;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadArchive;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipJvmPayloadBootstrap;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Check;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.ToolVersion;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStampStore;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+
+/** Composes the deterministic controller checks currently available for Camel Main. */
+final class ShipMainValidator {
+
+    /** Bump whenever accepted manifest or mandatory validation semantics change. */
+    static final int CONTRACT_VERSION = 1;
+    static final int MAX_EVIDENCE_COMMANDS = 64;
+    static final Duration MAX_EVIDENCE_TIMEOUT_BUDGET = Duration.ofHours(12);
+
+    private static final int DIRECT_JVM_PREFIX_SIZE = 4;
+    private static final int MAX_LOG_BYTES = 64 * 1024 * 1024;
+    private static final long MAX_TOTAL_LOG_BYTES = 64L * 1024 * 1024;
+    private static final long MAX_EXECUTABLE_BYTES = 128L * 1024 * 1024;
+    private static final Map<String, String> LOCALE = Map.of("LC_ALL", "C", "LANG", "C");
+
+    private final EvidenceExecutor executor;
+
+    ShipMainValidator() {
+        this(new EvidenceExecutor() {
+            private final EvidenceRunner runner = new EvidenceRunner();
+
+            @Override
+            public CommandEvidence run(Path candidate, Path directory, EvidenceCommand command)
+                    throws IOException {
+                return runner.run(candidate, directory, command);
+            }
+
+            @Override
+            public void cleanup(Path directory, EvidenceCommand command, CommandEvidence evidence)
+                    throws IOException {
+                EvidenceRunner.cleanupEphemeral(directory, command, evidence);
+            }
+        });
+    }
+
+    ShipMainValidator(EvidenceExecutor executor) {
+        this.executor = Objects.requireNonNull(executor, "evidence executor must not be null");
+    }
+
+    Result validate(
+            String runId,
+            Path candidateRoot,
+            Path manifestPath,
+            ArtifactPolicy policy,
+            ShipCatalogService.Snapshot catalog,
+            Path evidenceRoot,
+            ToolVersion pi,
+            Clock clock)
+            throws IOException, InterruptedException {
+        requireNotInterrupted();
+        Objects.requireNonNull(policy, "artifact policy must not be null");
+        Objects.requireNonNull(catalog, "catalog snapshot must not be null");
+        Objects.requireNonNull(pi, "Pi tool version must not be null");
+        Objects.requireNonNull(clock, "clock must not be null");
+        Path evidence = privateDirectory(evidenceRoot);
+        Path candidate = realDirectory(candidateRoot, "candidate root");
+        List<Check> checks = new ArrayList<>();
+
+        ArtifactManifest manifest;
+        String manifestDigest;
+        try {
+            Document document = ArtifactManifestReader.read(
+                    candidate, manifestPath);
+            manifest = document.manifest();
+            manifestDigest = document.digest();
+        } catch (IOException | RuntimeException e) {
+            checks.add(check("artifact-policy", Outcome.FAIL,
+                    summary("Artifact manifest was rejected", e), null));
+            checks.add(skipped("catalog-usage", "Catalog validation requires an accepted artifact manifest"));
+            return persist(runId, pi, checks, evidence, clock);
+        }
+
+        ArtifactValidationResult artifacts;
+        boolean main;
+        try {
+            artifacts = ArtifactValidator.validate(candidate, manifest, policy);
+            main = "main".equals(policy.runtime()) && "main".equals(manifest.runtime());
+        } catch (RuntimeException e) {
+            checks.add(check("artifact-policy", Outcome.FAIL,
+                    summary("Artifact validation failed", e), null));
+            checks.add(skipped("catalog-usage", "Catalog validation requires accepted artifacts"));
+            return persist(runId, pi, checks, evidence, clock);
+        }
+        if (!artifacts.passed() || !main) {
+            String detail = !main
+                    ? "Only the Camel Main runtime has deterministic controller evidence"
+                    : finding("Artifact validation failed", artifacts);
+            checks.add(check("artifact-policy", Outcome.FAIL, detail, null));
+            checks.add(skipped("catalog-usage", "Catalog validation requires accepted artifacts"));
+            return persist(runId, pi, checks, evidence, clock);
+        }
+        checks.add(check("artifact-policy", Outcome.PASS,
+                "Artifacts match the independent Camel Main policy", null));
+
+        CatalogClosure closure;
+        try {
+            closure = catalog(candidate, manifest, policy, catalog);
+        } catch (IOException | RuntimeException e) {
+            checks.add(check("catalog-usage", Outcome.FAIL,
+                    summary("Catalog validation failed", e), null));
+            return persist(runId, pi, checks, evidence, clock);
+        }
+        if (!closure.binding().validation().passed() || closure.binding().pomDigest() == null) {
+            checks.add(check("catalog-usage", Outcome.FAIL,
+                    finding("Catalog dependency validation failed", closure.binding().validation()), null));
+            return persist(runId, pi, checks, evidence, clock);
+        }
+        checks.add(check("catalog-usage", Outcome.PASS,
+                "Route usage and runtime dependencies match the frozen catalog", null));
+
+        String candidateDigest;
+        List<EvidenceCommand> commands;
+        try {
+            candidateDigest = ProjectEvidenceFiles.capture(candidate).digest();
+            commands = commands(
+                    manifest,
+                    manifestDigest,
+                    candidateDigest,
+                    closure.evidence().digest(),
+                    closure.binding());
+        } catch (IOException | RuntimeException e) {
+            checks.add(check("evidence-plan", Outcome.FAIL,
+                    summary("Evidence plan was rejected", e), null));
+            return persist(runId, pi, checks, evidence, clock);
+        }
+
+        for (EvidenceCommand command : commands) {
+            checks.add(execute(candidate, evidence, manifest, command));
+        }
+        return persist(runId, pi, checks, evidence, clock);
+    }
+
+    private Check execute(
+            Path candidate,
+            Path evidenceRoot,
+            ArtifactManifest manifest,
+            EvidenceCommand command)
+            throws InterruptedException {
+        Path directory = evidenceRoot.resolve(command.id());
+        CommandEvidence raw = null;
+        try {
+            requireNotInterrupted(directory, command, null);
+            raw = executor.run(candidate, directory, command);
+            requireNotInterrupted(directory, command, raw);
+            VerifiedEvidence verified = verify(candidate, evidenceRoot, manifest, command, raw);
+            Check result = outcome(command.id(), raw, verified.command());
+            try {
+                executor.cleanup(directory, command, raw);
+            } catch (IOException e) {
+                return check(command.id(), Outcome.FAIL,
+                        summary("Evidence cleanup failed", e), verified.command());
+            }
+            requireNotInterrupted(directory, command, null);
+            return result;
+        } catch (IOException | RuntimeException e) {
+            requireNotInterrupted(directory, command, raw);
+            if (raw != null) {
+                try {
+                    executor.cleanup(directory, command, raw);
+                } catch (IOException cleanup) {
+                    e.addSuppressed(cleanup);
+                }
+            }
+            return check(command.id(), Outcome.FAIL, summary("Command evidence was rejected", e), null);
+        }
+    }
+
+    private void requireNotInterrupted(
+            Path directory, EvidenceCommand command, CommandEvidence evidence)
+            throws InterruptedException {
+        if (!Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        Thread.interrupted();
+        InterruptedException interrupted = new InterruptedException(
+                "Interrupted while collecting deterministic Ship evidence");
+        try {
+            if (evidence != null) {
+                executor.cleanup(directory, command, evidence);
+            }
+        } catch (IOException cleanup) {
+            interrupted.addSuppressed(cleanup);
+        } finally {
+            Thread.currentThread().interrupt();
+        }
+        throw interrupted;
+    }
+
+    private static CatalogClosure catalog(
+            Path candidate,
+            ArtifactManifest manifest,
+            ArtifactPolicy policy,
+            ShipCatalogService.Snapshot snapshot)
+            throws IOException {
+        CatalogTarget expected = new CatalogTarget(
+                policy.runtime(),
+                policy.camelVersion(),
+                policy.platformVersion(),
+                policy.springBootVersion());
+        if (!expected.equals(snapshot.target())) {
+            throw new IOException("Catalog snapshot target differs from the independent artifact policy");
+        }
+
+        CamelYamlCatalogUsageExtractor extractor = new CamelYamlCatalogUsageExtractor();
+        List<CatalogSubject> available = snapshot.availableSubjects();
+        List<ArtifactManifest.RouteArtifact> routes = orderedRoutes(manifest);
+        TreeSet<CatalogSubject> subjects = new TreeSet<>();
+        for (ArtifactManifest.RouteArtifact route : routes) {
+            CamelYamlCatalogUsageExtractor.Extraction extraction
+                    = extractor.extractBound(candidate.resolve(route.path()), available);
+            requireRouteDigest(route, extraction);
+            subjects.addAll(extraction.subjects());
+        }
+
+        List<CatalogSubject> components = subjects.stream()
+                .filter(subject -> subject.kind() == Kind.COMPONENT)
+                .toList();
+        List<CatalogComponentModel> models = snapshot.componentModelsFor(components);
+        TreeSet<CatalogSubject> boundSubjects = new TreeSet<>();
+        for (ArtifactManifest.RouteArtifact route : routes) {
+            CamelYamlCatalogUsageExtractor.Extraction extraction
+                    = extractor.extractBound(candidate.resolve(route.path()), available, models);
+            requireRouteDigest(route, extraction);
+            boundSubjects.addAll(extraction.subjects());
+        }
+        if (!subjects.equals(boundSubjects)) {
+            throw new IOException("Catalog subjects changed between extraction passes");
+        }
+
+        CatalogEvidenceSet evidence = snapshot.evidenceFor(subjects);
+        ArtifactValidator.CatalogDependencyBinding binding
+                = ArtifactValidator.bindCatalogDependencies(candidate, policy, evidence);
+        return new CatalogClosure(evidence, binding);
+    }
+
+    private static List<EvidenceCommand> commands(
+            ArtifactManifest manifest,
+            String manifestDigest,
+            String candidateDigest,
+            String catalogDigest,
+            ArtifactValidator.CatalogDependencyBinding binding) {
+        validateBudget(manifest);
+        JvmPayloadRequest mainPayload = JvmPayloadRequest.camelMain(
+                manifest.camelVersion(), binding.runtimeDependencies());
+        List<String> inputs = List.of(
+                manifestDigest,
+                candidateDigest,
+                catalogDigest,
+                binding.pomDigest(),
+                mainPayload.digest());
+        List<ArtifactManifest.RouteArtifact> routes = orderedRoutes(manifest);
+        List<EvidenceCommand> result = new ArrayList<>();
+
+        List<String> routeArguments = directJvmArguments();
+        routes.forEach(route -> routeArguments.add("/workspace/" + route.path()));
+        result.add(command(
+                "route-schema",
+                routeArguments,
+                Duration.ofMinutes(10),
+                inputs,
+                JvmPayloadRequest.yamlValidator(manifest.camelVersion())));
+
+        List<String> packageArguments = directJvmArguments();
+        packageArguments.add("--candidate-digest=" + candidateDigest);
+        packageArguments.add("--manifest-digest=" + manifestDigest);
+        packageArguments.add("--catalog-usage-digest=" + catalogDigest);
+        packageArguments.add("--pom-digest=" + binding.pomDigest());
+        packageArguments.add("--main-payload-digest=" + mainPayload.digest());
+        routes.forEach(route -> {
+            packageArguments.add("--route=" + route.path());
+            packageArguments.add("--route-digest=" + route.digest());
+        });
+        result.add(command(
+                "main-package-and-inspect",
+                packageArguments,
+                Duration.ofMinutes(10),
+                inputs,
+                JvmPayloadRequest.mainPackage(manifest.camelVersion())));
+
+        List<String> mainArguments = directJvmArguments();
+        routes.forEach(route -> {
+            mainArguments.add("--route=/workspace/" + route.path());
+            mainArguments.add("--expected-route=" + route.routeId());
+        });
+        result.add(command(
+                "main-runtime-resolve-and-start",
+                mainArguments,
+                Duration.ofMinutes(10),
+                inputs,
+                mainPayload));
+
+        List<ArtifactManifest.TestArtifact> tests = manifest.citrusTests().stream()
+                .sorted(Comparator.comparing(ArtifactManifest.TestArtifact::path)
+                        .thenComparing(ArtifactManifest.TestArtifact::routeId))
+                .toList();
+        for (int index = 0; index < tests.size(); index++) {
+            ArtifactManifest.TestArtifact test = tests.get(index);
+            ArtifactManifest.RouteArtifact route = routes.stream()
+                    .filter(candidate -> candidate.routeId().equals(test.routeId()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "Citrus test has no accepted route: " + test.routeId()));
+            List<String> arguments = directJvmArguments();
+            arguments.add("--route=/workspace/" + route.path());
+            arguments.add("--expected-route=" + route.routeId());
+            arguments.add("--test=/workspace/" + test.path());
+            result.add(command(
+                    String.format(java.util.Locale.ROOT, "citrus-integration-test-%03d", index + 1),
+                    arguments,
+                    Duration.ofMinutes(30),
+                    inputs,
+                    JvmPayloadRequest.citrus(
+                            manifest.camelVersion(),
+                            manifest.citrusVersion(),
+                            manifest.citrusDependencies(),
+                            binding.runtimeDependencies())));
+        }
+        return List.copyOf(result);
+    }
+
+    private static EvidenceCommand command(
+            String id,
+            List<String> arguments,
+            Duration timeout,
+            List<String> inputs,
+            JvmPayloadRequest payload) {
+        List<String> versionArguments = directJvmArguments();
+        versionArguments.add("--payload-version");
+        return new EvidenceCommand(
+                id,
+                arguments,
+                versionArguments,
+                null,
+                timeout,
+                inputs,
+                LOCALE,
+                null,
+                null,
+                payload);
+    }
+
+    private static VerifiedEvidence verify(
+            Path candidate,
+            Path evidenceRoot,
+            ArtifactManifest manifest,
+            EvidenceCommand expected,
+            CommandEvidence evidence)
+            throws IOException {
+        Path commandRoot = realDirectory(
+                evidenceRoot.resolve(expected.id()), "command evidence root");
+        if (evidence == null
+                || evidence.schemaVersion() != CommandEvidence.SCHEMA_VERSION
+                || !expected.id().equals(evidence.commandId())
+                || !expected.arguments().equals(evidence.arguments())
+                || !expected.inputDigests().equals(evidence.inputDigests())
+                || !candidate.equals(path(evidence.workingDirectory(), "working directory"))
+                || evidence.startedAt() == null
+                || evidence.endedAt() == null
+                || evidence.endedAt().isBefore(evidence.startedAt())) {
+            throw new IOException("Command evidence identity differs from the controller plan");
+        }
+
+        String jdkDigest = evidence.controlledEnvironment().get("CAMEL_KIT_JDK_DIGEST");
+        if (!ShipDigest.isSha256(jdkDigest)
+                || !EvidenceRunner.expectedEnvironment(expected, jdkDigest)
+                        .equals(evidence.controlledEnvironment())) {
+            throw new IOException("Command evidence environment differs from controller policy");
+        }
+        CommandEvidence.SandboxIdentity sandbox = evidence.sandbox();
+        if (sandbox == null
+                || !EvidenceRunner.SANDBOX_PROVIDER.equals(sandbox.provider())
+                || !sandbox.intact()
+                || !ShipDigest.isSha256(sandbox.executableDigest())
+                || !EvidenceRunner.expectedSandboxProfileDigest(expected, jdkDigest)
+                        .equals(sandbox.profileDigest())) {
+            throw new IOException("Command evidence did not use the expected intact sandbox");
+        }
+        requireExecutableDigest(
+                sandbox.executable(), sandbox.executableDigest(), "sandbox executable");
+        if (!ShipDigest.isSha256(evidence.toolchainDigest())
+                || !evidence.toolchainDigest().equals(evidence.postToolchainDigest())
+                || !ShipDigest.isSha256(evidence.toolchainSnapshotDigest())
+                || !ShipDigest.isSha256(evidence.executableDigest())
+                || !evidence.executableDigest().equals(evidence.postExecutableDigest())) {
+            throw new IOException("Command execution authority changed during collection");
+        }
+        requireContained(
+                commandRoot,
+                requireExecutableDigest(
+                        evidence.executable(), evidence.executableDigest(), "command executable"),
+                "command executable");
+        Path toolchain = path(evidence.toolchainSnapshot(), "toolchain snapshot");
+        requireContained(commandRoot, toolchain, "toolchain snapshot");
+        JvmPayloadArchive.Identity identity
+                = JvmPayloadArchive.verify(toolchain, expected.jvmPayload(), jdkDigest);
+        if (!evidence.toolchainDigest().equals(identity.aggregateDigest())
+                || !evidence.toolchainSnapshotDigest().equals(identity.archiveDigest())) {
+            throw new IOException("Command toolchain identity differs from its retained snapshot");
+        }
+        if (!expectedVersion(expected.jvmPayload(), manifest).equals(evidence.executableVersion())) {
+            throw new IOException("Command launcher version differs from the controller policy");
+        }
+
+        RetainedLogs logs = retainLogs(commandRoot, evidenceRoot, expected.id(), evidence);
+        if (expected.jvmPayload().kind() == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT
+                && evidence.passed()) {
+            ShipMainPackageMain.verifySummary(
+                    logs.stdout(),
+                    candidate,
+                    expected.arguments().subList(DIRECT_JVM_PREFIX_SIZE, expected.arguments().size()));
+        }
+        CommandRun command = new CommandRun(
+                path(evidence.executable(), "command executable").toString(),
+                evidence.executableVersion(),
+                expected.arguments(),
+                candidate.toString(),
+                expected.inputDigests(),
+                evidence.launched(),
+                evidence.timedOut(),
+                false,
+                evidence.exitCode(),
+                evidence.startedAt().toString(),
+                evidence.endedAt().toString(),
+                logs.stdoutPath().toString(),
+                evidence.stdoutDigest(),
+                logs.stderrPath().toString(),
+                evidence.stderrDigest());
+        return new VerifiedEvidence(command);
+    }
+
+    private static RetainedLogs retainLogs(
+            Path commandRoot,
+            Path evidenceRoot,
+            String commandId,
+            CommandEvidence evidence)
+            throws IOException {
+        byte[] stdout = readLog(commandRoot, evidence.stdoutLog(), evidence.stdoutDigest());
+        byte[] stderr = readLog(commandRoot, evidence.stderrLog(), evidence.stderrDigest());
+        if ((long) stdout.length + stderr.length > MAX_TOTAL_LOG_BYTES) {
+            throw new IOException("Command logs exceed the local Stamp retention limit");
+        }
+        Path stdoutPath = evidenceRoot.resolve(commandId + ".stdout.log");
+        Path stderrPath = evidenceRoot.resolve(commandId + ".stderr.log");
+        requireRetentionBudget(evidenceRoot, stdoutPath, stderrPath, stdout.length, stderr.length);
+        stdoutPath = privateFile(stdoutPath, stdout);
+        stderrPath = privateFile(stderrPath, stderr);
+        return new RetainedLogs(stdoutPath, stdout, stderrPath);
+    }
+
+    private static void requireRetentionBudget(
+            Path evidenceRoot,
+            Path replacedStdout,
+            Path replacedStderr,
+            int stdoutBytes,
+            int stderrBytes)
+            throws IOException {
+        long total = (long) stdoutBytes + stderrBytes;
+        try (var files = Files.list(evidenceRoot)) {
+            var iterator = files.iterator();
+            while (iterator.hasNext()) {
+                Path file = iterator.next();
+                String name = file.getFileName().toString();
+                if (!name.endsWith(".stdout.log") && !name.endsWith(".stderr.log")) {
+                    continue;
+                }
+                BasicFileAttributes attributes = Files.readAttributes(
+                        file, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                if (!attributes.isRegularFile() || attributes.isSymbolicLink()) {
+                    throw new IOException("Retained validation log is unsafe");
+                }
+                if (file.equals(replacedStdout) || file.equals(replacedStderr)) {
+                    continue;
+                }
+                if (attributes.size() > MAX_TOTAL_LOG_BYTES - total) {
+                    throw new IOException("Command logs exceed the local Stamp retention limit");
+                }
+                total += attributes.size();
+            }
+        }
+    }
+
+    private static byte[] readLog(Path commandRoot, String value, String digest)
+            throws IOException {
+        Path file = path(value, "command log");
+        requireContained(commandRoot, file, "command log");
+        if (!ShipDigest.isSha256(digest)
+                || Files.isSymbolicLink(file)
+                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
+                || Files.size(file) > MAX_LOG_BYTES) {
+            throw new IOException("Command log is missing, unsafe, or oversized");
+        }
+        byte[] content;
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            content = input.readNBytes(MAX_LOG_BYTES + 1);
+        }
+        if (content.length > MAX_LOG_BYTES || !digest.equals(ShipDigest.sha256(content))) {
+            throw new IOException("Command log differs from its recorded digest");
+        }
+        return content;
+    }
+
+    private static Path requireExecutableDigest(
+            String value, String expectedDigest, String label)
+            throws IOException {
+        Path file = path(value, label);
+        if (Files.isSymbolicLink(file)
+                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isExecutable(file)
+                || Files.size(file) <= 0
+                || Files.size(file) > MAX_EXECUTABLE_BYTES
+                || !expectedDigest.equals(digest(file))) {
+            throw new IOException(label + " differs from command evidence");
+        }
+        return file;
+    }
+
+    private static String digest(Path file) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] buffer = new byte[16_384];
+            for (int count; (count = input.read(buffer)) != -1;) {
+                digest.update(buffer, 0, count);
+            }
+        }
+        return "sha256:" + HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static void requireContained(Path root, Path supplied, String label)
+            throws IOException {
+        Path real = supplied.toRealPath();
+        if (!real.startsWith(root) || !real.equals(supplied)) {
+            throw new IOException(label + " escaped its command evidence root");
+        }
+    }
+
+    private static Check outcome(String id, CommandEvidence evidence, CommandRun command) {
+        if (evidence.timedOut()) {
+            return check(id, Outcome.TIMED_OUT, "Controller command timed out", command);
+        }
+        if (evidence.launched() && evidence.exitCode() != null && evidence.exitCode() != 0) {
+            return check(id, Outcome.NONZERO,
+                    "Controller command exited with status " + evidence.exitCode(), command);
+        }
+        if (!evidence.passed()) {
+            return check(id, Outcome.FAIL, "Controller command evidence failed closed", command);
+        }
+        return check(id, Outcome.PASS, "Controller command completed successfully", command);
+    }
+
+    private static Result persist(
+            String runId,
+            ToolVersion pi,
+            List<Check> checks,
+            Path evidence,
+            Clock clock)
+            throws IOException, InterruptedException {
+        requireNotInterrupted();
+        ShipLocalStamp stamp = ShipLocalStamp.create(runId, List.of(pi), checks, clock.instant());
+        requireNotInterrupted();
+        Path published = ShipLocalStampStore.write(evidence, runId, stamp);
+        try {
+            requireNotInterrupted();
+        } catch (InterruptedException e) {
+            try {
+                Files.deleteIfExists(published);
+            } catch (IOException cleanup) {
+                e.addSuppressed(cleanup);
+            }
+            throw e;
+        }
+        return new Result(stamp);
+    }
+
+    private static void requireNotInterrupted()
+            throws InterruptedException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException(
+                    "Interrupted before publishing deterministic Ship evidence");
+        }
+    }
+
+    private static Check check(String id, Outcome outcome, String summary, CommandRun command) {
+        return new Check(id, true, outcome, summary, null, command);
+    }
+
+    private static Check skipped(String id, String summary) {
+        return check(id, Outcome.SKIPPED, summary, null);
+    }
+
+    private static String finding(String prefix, ArtifactValidationResult validation) {
+        return validation.findings().stream()
+                .findFirst()
+                .map(finding -> prefix + ": " + finding.code())
+                .orElse(prefix);
+    }
+
+    private static String summary(String prefix, Exception failure) {
+        String message = failure.getMessage();
+        String value = prefix + (message == null || message.isBlank() ? "" : ": " + message);
+        value = value.replaceAll("\\p{Cntrl}", " ").replaceAll("\\s+", " ").strip();
+        return value.length() <= 4_096 ? value : value.substring(0, 4_096);
+    }
+
+    private static void requireRouteDigest(
+            ArtifactManifest.RouteArtifact route,
+            CamelYamlCatalogUsageExtractor.Extraction extraction)
+            throws IOException {
+        if (!route.digest().equals(extraction.digest())) {
+            throw new IOException("Route changed during catalog extraction: " + route.path());
+        }
+    }
+
+    private static void validateBudget(ArtifactManifest manifest) {
+        long count = Math.addExact(3L, manifest.citrusTests().size());
+        Duration timeout;
+        try {
+            timeout = Duration.ofMinutes(30)
+                    .plus(Duration.ofMinutes(Math.multiplyExact(30L, manifest.citrusTests().size())));
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("Evidence timeout budget overflowed", e);
+        }
+        if (count > MAX_EVIDENCE_COMMANDS
+                || timeout.compareTo(MAX_EVIDENCE_TIMEOUT_BUDGET) > 0) {
+            throw new IllegalArgumentException(
+                    "Evidence plan exceeds " + MAX_EVIDENCE_COMMANDS + " commands or "
+                                               + MAX_EVIDENCE_TIMEOUT_BUDGET);
+        }
+    }
+
+    private static List<ArtifactManifest.RouteArtifact> orderedRoutes(ArtifactManifest manifest) {
+        return manifest.routes().stream()
+                .sorted(Comparator.comparing(ArtifactManifest.RouteArtifact::path)
+                        .thenComparing(ArtifactManifest.RouteArtifact::routeId))
+                .toList();
+    }
+
+    private static List<String> directJvmArguments() {
+        return new ArrayList<>(
+                List.of(
+                        EvidenceRunner.JAVA_EXECUTABLE,
+                        "-cp",
+                        JvmPayloadArchive.SANDBOX_ARCHIVE,
+                        ShipJvmPayloadBootstrap.class.getName()));
+    }
+
+    private static String expectedVersion(
+            JvmPayloadRequest payload, ArtifactManifest manifest) {
+        return switch (payload.kind()) {
+            case CAMEL_YAML_VALIDATE -> "Camel direct YAML validator " + manifest.camelVersion();
+            case MAIN_PACKAGE_INSPECT -> ShipMainPackageMain.PAYLOAD_VERSION;
+            case CAMEL_MAIN_START -> "Camel direct Main bootstrap " + manifest.camelVersion();
+            case CITRUS_YAML -> "Citrus direct YAML " + manifest.citrusVersion()
+                                + " with Camel " + manifest.camelVersion();
+            default -> throw new IllegalArgumentException(
+                    "Unsupported evidence payload: " + payload.kind().id());
+        };
+    }
+
+    private static Path realDirectory(Path supplied, String label) throws IOException {
+        if (supplied == null) {
+            throw new IOException(label + " is required");
+        }
+        Path path = supplied.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(path)
+                || !Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(label + " must be a real directory");
+        }
+        Path real = path.toRealPath();
+        if (!real.equals(path)) {
+            throw new IOException(label + " must not traverse symbolic links");
+        }
+        return real;
+    }
+
+    private static Path privateDirectory(Path supplied) throws IOException {
+        if (supplied == null) {
+            throw new IOException("Evidence root is required");
+        }
+        Path path = supplied.toAbsolutePath().normalize();
+        Path parent = path.getParent();
+        if (parent == null || !parent.toRealPath().equals(parent)) {
+            throw new IOException(
+                    "Evidence root parent must be a real directory");
+        }
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(
+                    path,
+                    BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            if (!attributes.isDirectory() || attributes.isSymbolicLink()) {
+                throw new IOException("Evidence root must be a real directory");
+            }
+        } catch (java.nio.file.NoSuchFileException e) {
+            Files.createDirectory(
+                    path,
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rwx------")));
+        }
+        if (Files.getFileAttributeView(
+                path, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS)
+            != null) {
+            if (!Files.getPosixFilePermissions(
+                    path, LinkOption.NOFOLLOW_LINKS)
+                    .equals(PosixFilePermissions.fromString("rwx------"))) {
+                throw new IOException(
+                        "Evidence root permissions must be 0700");
+            }
+        }
+        return realDirectory(path, "evidence root");
+    }
+
+    private static Path privateFile(Path path, byte[] content) throws IOException {
+        Path parent = path.getParent();
+        if (Files.getFileAttributeView(
+                parent, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS)
+            == null) {
+            throw new IOException("Retained validation logs require POSIX permissions");
+        }
+        Path temporary = Files.createTempFile(
+                parent,
+                ".retained-log-",
+                ".tmp",
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        boolean moved = false;
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    LinkOption.NOFOLLOW_LINKS)) {
+                ByteBuffer encoded = ByteBuffer.wrap(content);
+                while (encoded.hasRemaining()) {
+                    channel.write(encoded);
+                }
+                channel.force(true);
+            }
+            try {
+                Files.move(
+                        temporary,
+                        path,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw new IOException(
+                        "Filesystem does not support atomic retained-log replacement",
+                        e);
+            }
+            moved = true;
+            if (!Files.getPosixFilePermissions(
+                    path, LinkOption.NOFOLLOW_LINKS)
+                    .equals(PosixFilePermissions.fromString("rw-------"))) {
+                throw new IOException("Retained validation log permissions must be 0600");
+            }
+            return path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private static Path path(String value, String label) throws IOException {
+        try {
+            Path path = Path.of(value);
+            if (!path.isAbsolute()
+                    || !path.normalize().equals(path)
+                    || !path.toString().equals(value)) {
+                throw new IOException(label + " must be normalized and absolute");
+            }
+            return path;
+        } catch (RuntimeException e) {
+            throw new IOException(label + " is invalid", e);
+        }
+    }
+
+    record Result(ShipLocalStamp stamp) {
+    }
+
+    @FunctionalInterface
+    interface EvidenceExecutor {
+
+        CommandEvidence run(Path candidate, Path directory, EvidenceCommand command)
+                throws IOException;
+
+        default void cleanup(Path directory, EvidenceCommand command, CommandEvidence evidence)
+                throws IOException {
+        }
+    }
+
+    private record CatalogClosure(
+            CatalogEvidenceSet evidence,
+            ArtifactValidator.CatalogDependencyBinding binding) {
+    }
+
+    private record VerifiedEvidence(CommandRun command) {
+    }
+
+    private record RetainedLogs(Path stdoutPath, byte[] stdout, Path stderrPath) {
+
+        private RetainedLogs {
+            stdout = stdout.clone();
+        }
+
+        @Override
+        public byte[] stdout() {
+            return stdout.clone();
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
@@ -29,7 +29,7 @@ public record ShipRun(
         String updatedAt,
         String message) {
 
-    public static final int SCHEMA_VERSION = 2;
+    public static final int SCHEMA_VERSION = 3;
 
     private static final Pattern RUN_ID = Pattern.compile("ship-[0-9a-f]{32}");
     private static final Pattern PIPELINE_ID = Pattern.compile("[0-9]{3,}-[a-z0-9]+(?:-[a-z0-9]+)*");
@@ -286,8 +286,13 @@ public record ShipRun(
                 case RUNNING -> require(attempts > 0 && inputDigest != null && outputDigest == null
                         && artifacts.isEmpty());
                 case COMPLETED -> require(inputDigest != null && outputDigest != null);
-                case FAILED -> require(attempts > 0 && inputDigest != null && outputDigest == null
-                        && artifacts.isEmpty());
+                case FAILED -> require(
+                        attempts > 0
+                                && inputDigest != null
+                                && (outputDigest == null && artifacts.isEmpty()
+                                        || stage == Stage.VALIDATE
+                                                && outputDigest != null
+                                                && !artifacts.isEmpty()));
                 case ABORTED -> require(outputDigest == null && artifacts.isEmpty());
             }
         }
@@ -328,6 +333,21 @@ public record ShipRun(
             return new StageRecord(
                     stage, StageStatus.FAILED, attempts,
                     inputDigest, null, List.of());
+        }
+
+        StageRecord fail(String digest, List<ArtifactRef> references) {
+            if (status != StageStatus.RUNNING || references == null
+                    || references.isEmpty()) {
+                throw new IllegalStateException(
+                        "Only a running Ship stage can fail with evidence");
+            }
+            return new StageRecord(
+                    stage,
+                    StageStatus.FAILED,
+                    attempts,
+                    inputDigest,
+                    digest,
+                    references);
         }
 
         StageRecord abort() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -57,6 +57,13 @@ final class ShipRunStore {
         this.posix = this.stateRoot.getFileSystem().supportedFileAttributeViews().contains("posix");
     }
 
+    static Path validationStampPath(Path runDirectory, int attempt) {
+        return runDirectory.toAbsolutePath().normalize()
+                .resolve("evidence")
+                .resolve("validate-" + attempt)
+                .resolve("stamp.json");
+    }
+
     void create(ShipRun initial) throws IOException {
         requireCurrent(initial);
         Path root = resolvedStateRoot("state-root-invalid");
@@ -277,11 +284,7 @@ final class ShipRunStore {
                 && validation.status() != StageStatus.COMPLETED) {
             return;
         }
-        Path expected = runRoot.resolve("evidence")
-                .resolve("validate-" + validation.attempts())
-                .resolve("stamp.json")
-                .toAbsolutePath()
-                .normalize();
+        Path expected = validationStampPath(runRoot, validation.attempts());
         boolean localStamp = validation.artifacts().size() == 1
                 && expected.toString().equals(
                         validation.artifacts().get(0).path())

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -143,6 +143,7 @@ final class ShipRunStore {
         }
         requireDisjoint(runRoot, run, "state-corrupt");
         requireWorkspaceEvidence(runRoot, run, "state-corrupt");
+        requireLocalStampEvidence(runRoot, run, "state-corrupt");
         return run;
     }
 
@@ -180,6 +181,7 @@ final class ShipRunStore {
         }
         requireDisjoint(runRoot, run, "state-invalid");
         requireWorkspaceEvidence(runRoot, run, "state-invalid");
+        requireLocalStampEvidence(runRoot, run, "state-invalid");
         byte[] encoded;
         try {
             encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(run);
@@ -262,6 +264,35 @@ final class ShipRunStore {
                 || !ShipRun.executeOutputDigest(root).equals(execute.outputDigest())) {
             throw invalidWorkspaceEvidence(run, code);
         }
+    }
+
+    private static void requireLocalStampEvidence(
+            Path runRoot, ShipRun run, String code)
+            throws StoreException {
+        StageRecord validation = run.stage(Stage.VALIDATE);
+        if (validation.attempts() <= 0) {
+            return;
+        }
+        if (validation.artifacts().isEmpty()
+                && validation.status() != StageStatus.COMPLETED) {
+            return;
+        }
+        Path expected = runRoot.resolve("evidence")
+                .resolve("validate-" + validation.attempts())
+                .resolve("stamp.json")
+                .toAbsolutePath()
+                .normalize();
+        boolean localStamp = validation.artifacts().size() == 1
+                && expected.toString().equals(
+                        validation.artifacts().get(0).path())
+                && validation.outputDigest().equals(
+                        validation.artifacts().get(0).digest());
+        if (localStamp) {
+            return;
+        }
+        throw new StoreException(
+                code,
+                "Completed Ship validation evidence is invalid for run " + run.id());
     }
 
     private static void requireImportedEvidence(ShipRun run, String code)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResult.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResult.java
@@ -1,0 +1,281 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy.RouteContract;
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogTarget;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Strict typed boundary for one Pi stage response. */
+record ShipStageResult(
+        int schemaVersion,
+        String pipelineId,
+        String report,
+        ArtifactPolicy artifactPolicy,
+        boolean materialAmbiguity) {
+
+    static final int SCHEMA_VERSION = 1;
+
+    private static final int MAX_ASSISTANT_BYTES = 1024 * 1024;
+    private static final int MAX_REPORT_BYTES = MAX_ASSISTANT_BYTES;
+    private static final Pattern ROUTE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}");
+    private static final Comparator<RouteContract> ROUTE_ORDER = Comparator
+            .comparing(RouteContract::routeId)
+            .thenComparing(RouteContract::routePath)
+            .thenComparing(RouteContract::citrusTestPath);
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+
+    static ShipStageResult parse(Stage stage, String assistantText) throws IOException {
+        if (stage == null) {
+            throw new IOException("Pi stage result has no stage");
+        }
+        WireResult wire;
+        try {
+            wire = JSON.readValue(utf8(assistantText, MAX_ASSISTANT_BYTES, "assistant response"), WireResult.class);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Pi stage result is malformed", e);
+        }
+        if (wire.schemaVersion() != SCHEMA_VERSION) {
+            throw new IOException("Pi stage result has an unsupported schema version");
+        }
+        String pipelineId = nullableText(wire.pipelineId(), "pipelineId");
+        String report = requiredText(wire.report(), "report");
+        requireReport(report);
+
+        boolean hasPolicy = wire.artifactPolicy() != null && !wire.artifactPolicy().isNull();
+        ArtifactPolicy policy = null;
+        switch (stage) {
+            case DISCOVERY -> {
+                if (!ShipRun.isPipelineId(pipelineId) || hasPolicy) {
+                    throw new IOException("Pi Discovery result has invalid stage fields");
+                }
+            }
+            case DESIGN, EXECUTE -> {
+                if (pipelineId != null || hasPolicy) {
+                    throw new IOException("Pi " + stage + " result has invalid stage fields");
+                }
+            }
+            case PLAN -> {
+                if (pipelineId != null || !hasPolicy) {
+                    throw new IOException("Pi Plan result has invalid stage fields");
+                }
+                policy = parsePolicy(wire.artifactPolicy());
+            }
+            case VALIDATE -> throw new IOException("Pi does not produce the Validate stage result");
+        }
+        return new ShipStageResult(
+                SCHEMA_VERSION,
+                pipelineId,
+                report,
+                policy,
+                wire.materialAmbiguity());
+    }
+
+    private static ArtifactPolicy parsePolicy(JsonNode document) throws IOException {
+        if (!document.isObject()) {
+            throw new IOException("Pi Plan artifact policy is not an object");
+        }
+        requirePolicyTypes(document);
+        final ArtifactPolicy policy;
+        try {
+            policy = JSON.treeToValue(document, ArtifactPolicy.class);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Pi Plan artifact policy is malformed", e);
+        }
+
+        if (!"main".equals(policy.runtime())
+                || policy.platformVersion() != null
+                || policy.springBootVersion() != null
+                || !"yaml".equals(policy.routeDsl())
+                || !"simple".equals(policy.expressionLanguage())
+                || policy.javaPolicy() != JavaPolicy.FORBIDDEN) {
+            throw new IOException("Pi Plan artifact policy has invalid Main fields");
+        }
+        try {
+            new CatalogTarget(
+                    policy.runtime(),
+                    policy.camelVersion(),
+                    policy.platformVersion(),
+                    policy.springBootVersion());
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Pi Plan artifact policy has an invalid Camel version", e);
+        }
+        List<String> citrusViolations = CitrusDependencyPolicy.violations(
+                policy.citrusVersion(), policy.citrusDependencies());
+        if (!citrusViolations.isEmpty()) {
+            throw new IOException("Pi Plan artifact policy has invalid Citrus dependencies");
+        }
+        if (!policy.approvedJavaExceptions().isEmpty()
+                || !policy.citrusTestsRequired()
+                || !policy.oneCitrusTestPerRoute()) {
+            throw new IOException("Pi Plan artifact policy weakens required validation");
+        }
+        validateRoutes(policy.routes());
+        return policy;
+    }
+
+    private static void validateRoutes(List<RouteContract> routes) throws IOException {
+        if (routes.isEmpty()) {
+            throw new IOException("Pi Plan artifact policy has no route contracts");
+        }
+        Set<String> routeIds = new HashSet<>();
+        Set<String> routePaths = new HashSet<>();
+        Set<String> testPaths = new HashSet<>();
+        for (RouteContract route : routes) {
+            if (route == null
+                    || !ROUTE_ID.matcher(nullToEmpty(route.routeId())).matches()
+                    || !safeMaterialPath(route.routePath())
+                    || !safeMaterialPath(route.citrusTestPath())
+                    || !route.routePath().endsWith(".camel.yaml")
+                    || !fileName(route.routePath()).equals(route.routeId() + ".camel.yaml")
+                    || !route.citrusTestPath().equals("test/" + route.routeId() + ".camel.it.yaml")
+                    || !routeIds.add(route.routeId())
+                    || !routePaths.add(route.routePath())
+                    || !testPaths.add(route.citrusTestPath())) {
+                throw new IOException("Pi Plan artifact policy has an invalid route contract");
+            }
+        }
+        if (!routes.equals(routes.stream().sorted(ROUTE_ORDER).toList())) {
+            throw new IOException("Pi Plan route contracts are not sorted canonically");
+        }
+    }
+
+    private static boolean safeMaterialPath(String value) {
+        try {
+            return ShipTreePolicy.current().classify(value) == Classification.MATERIAL;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static String fileName(String path) {
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static void requirePolicyTypes(JsonNode policy) throws IOException {
+        for (String field : List.of(
+                "runtime", "camelVersion", "routeDsl", "expressionLanguage", "citrusVersion", "javaPolicy")) {
+            requiredText(policy.get(field), "artifactPolicy." + field);
+        }
+        nullableText(policy.get("platformVersion"), "artifactPolicy.platformVersion");
+        nullableText(policy.get("springBootVersion"), "artifactPolicy.springBootVersion");
+        requireTextArray(policy.get("citrusDependencies"), "artifactPolicy.citrusDependencies");
+        requireTextArray(policy.get("approvedJavaExceptions"), "artifactPolicy.approvedJavaExceptions");
+        JsonNode routes = policy.get("routes");
+        if (routes == null || !routes.isArray()) {
+            throw new IOException("Pi artifactPolicy.routes has an invalid JSON type");
+        }
+        for (JsonNode route : routes) {
+            if (!route.isObject()) {
+                throw new IOException("Pi artifactPolicy.routes has an invalid JSON type");
+            }
+            requiredText(route.get("routeId"), "artifactPolicy.routes.routeId");
+            requiredText(route.get("routePath"), "artifactPolicy.routes.routePath");
+            requiredText(route.get("citrusTestPath"), "artifactPolicy.routes.citrusTestPath");
+        }
+        requireBoolean(policy.get("citrusTestsRequired"), "artifactPolicy.citrusTestsRequired");
+        requireBoolean(policy.get("oneCitrusTestPerRoute"), "artifactPolicy.oneCitrusTestPerRoute");
+    }
+
+    private static void requireTextArray(JsonNode value, String label) throws IOException {
+        if (value == null || !value.isArray()) {
+            throw new IOException("Pi " + label + " has an invalid JSON type");
+        }
+        for (JsonNode item : value) {
+            requiredText(item, label);
+        }
+    }
+
+    private static String requiredText(JsonNode value, String label) throws IOException {
+        if (value == null || !value.isTextual()) {
+            throw new IOException("Pi " + label + " has an invalid JSON type");
+        }
+        return value.textValue();
+    }
+
+    private static String nullableText(JsonNode value, String label) throws IOException {
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return requiredText(value, label);
+    }
+
+    private static void requireBoolean(JsonNode value, String label) throws IOException {
+        if (value == null || !value.isBoolean()) {
+            throw new IOException("Pi " + label + " has an invalid JSON type");
+        }
+    }
+
+    private static void requireReport(String report) throws IOException {
+        if (report == null || report.isBlank() || report.indexOf('\0') >= 0) {
+            throw new IOException("Pi stage report is invalid");
+        }
+        utf8(report, MAX_REPORT_BYTES, "stage report");
+    }
+
+    private static byte[] utf8(String value, int maximum, String label) throws IOException {
+        if (value == null || value.length() > maximum) {
+            throw new IOException("Pi " + label + " exceeds its size limit");
+        }
+        try {
+            ByteBuffer encoded = StandardCharsets.UTF_8.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .encode(CharBuffer.wrap(value));
+            if (encoded.remaining() > maximum) {
+                throw new IOException("Pi " + label + " exceeds its size limit");
+            }
+            byte[] bytes = new byte[encoded.remaining()];
+            encoded.get(bytes);
+            return bytes;
+        } catch (CharacterCodingException e) {
+            throw new IOException("Pi " + label + " is not valid Unicode", e);
+        }
+    }
+
+    private record WireResult(
+            int schemaVersion,
+            JsonNode pipelineId,
+            JsonNode report,
+            JsonNode artifactPolicy,
+            boolean materialAmbiguity) {
+    }
+
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampStore.java
@@ -126,6 +126,12 @@ public final class ShipLocalStampStore {
 
     public static ShipLocalStamp read(Path evidenceDirectory, String expectedRunId)
             throws IOException {
+        return readVerified(evidenceDirectory, expectedRunId).stamp();
+    }
+
+    public static VerifiedStamp readVerified(
+            Path evidenceDirectory, String expectedRunId)
+            throws IOException {
         if (!ShipRun.isRunId(expectedRunId)) {
             throw new IOException("Expected local Stamp run ID is invalid");
         }
@@ -151,10 +157,14 @@ public final class ShipLocalStampStore {
             }
             requireRun(expectedRunId, stamp);
             verifyCommandLogs(directory, owner, stamp);
-            return stamp;
+            return new VerifiedStamp(stamp, file, ShipDigest.sha256(encoded));
         } catch (JsonProcessingException | IllegalArgumentException e) {
             throw new IOException("Local Stamp is invalid: " + file, e);
         }
+    }
+
+    public record VerifiedStamp(
+            ShipLocalStamp stamp, Path path, String digest) {
     }
 
     private static void requireRun(String expectedRunId, ShipLocalStamp stamp)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScanner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ChangedWorkspaceSecretScanner.java
@@ -29,15 +29,7 @@ public final class ChangedWorkspaceSecretScanner {
         // Exact UTF-8 matches are the intentional local leak floor; encoded transformations are not detected.
         Objects.requireNonNull(baseline, "baseline");
         Objects.requireNonNull(candidate, "candidate");
-        Objects.requireNonNull(environment, "environment");
-        List<byte[]> secrets = environment.entrySet().stream()
-                .filter(entry -> LocalCommandRunner.isSensitiveEnvironmentValue(
-                        entry.getKey(), entry.getValue()))
-                .map(Map.Entry::getValue)
-                .filter(value -> value.length() >= MIN_SECRET_LENGTH)
-                .distinct()
-                .map(value -> value.getBytes(StandardCharsets.UTF_8))
-                .toList();
+        List<byte[]> secrets = sensitiveValues(environment);
         if (secrets.isEmpty()) {
             return List.of();
         }
@@ -60,6 +52,26 @@ public final class ChangedWorkspaceSecretScanner {
             }
         }
         return List.copyOf(findings);
+    }
+
+    /** Checks exact UTF-8 content with the same environment policy as workspace promotion. */
+    public static boolean containsSensitiveValue(
+            byte[] content, Map<String, String> environment) {
+        Objects.requireNonNull(content, "content");
+        return sensitiveValues(environment).stream()
+                .anyMatch(secret -> contains(content, secret));
+    }
+
+    private static List<byte[]> sensitiveValues(Map<String, String> environment) {
+        Objects.requireNonNull(environment, "environment");
+        return environment.entrySet().stream()
+                .filter(entry -> LocalCommandRunner.isSensitiveEnvironmentValue(
+                        entry.getKey(), entry.getValue()))
+                .map(Map.Entry::getValue)
+                .filter(value -> value.length() >= MIN_SECRET_LENGTH)
+                .distinct()
+                .map(value -> value.getBytes(StandardCharsets.UTF_8))
+                .toList();
     }
 
     private static boolean contains(byte[] content, byte[] secret) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -58,6 +58,7 @@ final class LocalCommandRunner {
     private static final ObjectMapper JSON = new ObjectMapper();
 
     private final Clock clock;
+    private final Map<String, String> environment;
 
     LocalCommandRunner() {
         this(Clock.systemUTC());
@@ -65,6 +66,13 @@ final class LocalCommandRunner {
 
     LocalCommandRunner(Clock clock) {
         this.clock = Objects.requireNonNull(clock, "clock");
+        this.environment = null;
+    }
+
+    LocalCommandRunner(Clock clock, Map<String, String> environment) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.environment = Map.copyOf(
+                Objects.requireNonNull(environment, "environment"));
     }
 
     Result run(Command command) throws IOException, InterruptedException {
@@ -104,9 +112,13 @@ final class LocalCommandRunner {
         boolean interrupted = false;
         AtomicBoolean outputLimited = new AtomicBoolean();
         try {
-            process = new ProcessBuilder(vector)
-                    .directory(workingDirectory.toFile())
-                    .start();
+            ProcessBuilder builder = new ProcessBuilder(vector)
+                    .directory(workingDirectory.toFile());
+            if (environment != null) {
+                builder.environment().clear();
+                builder.environment().putAll(environment);
+            }
+            process = builder.start();
             Process launched = process;
             launched.getOutputStream().close();
             stdoutPump = pumps.submit(() -> readBounded(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -162,8 +162,8 @@ public final class PiWorker {
         requireDisjoint(sessionDirectory, evidenceDirectory, "session and evidence directories");
         UserPrincipal sessionOwner = requirePrivateSessionDirectory(sessionDirectory);
         String prompt = requirePrompt(request.prompt());
-        List<String> sensitiveValues = List.copyOf(
-                sensitiveEnvironmentValues(environment));
+        Set<String> sensitive = sensitiveEnvironmentValues(environment);
+        List<String> sensitiveValues = List.copyOf(sensitive);
 
         LocalCommandRunner.Result versionRun = null;
         Throwable primary = null;
@@ -213,6 +213,9 @@ public final class PiWorker {
                       + " is experimental until the live Pi end-to-end gate passes"
                     : "Pi " + detectedVersion + " is unverified; the maintained Pi "
                       + supportedVersion + " is also experimental until the live end-to-end gate passes";
+            if (containsSensitiveValue(warning, sensitive)) {
+                throw sensitiveOutput();
+            }
             if (!request.acceptExperimental()) {
                 throw new IOException(
                         warning + "; explicitly accept experimental Pi before starting the stage");
@@ -280,6 +283,9 @@ public final class PiWorker {
                 outcome = Outcome.FAILED;
                 assistantText = null;
                 failure = "Pi assistant settled with stop reason " + turn.stopReason();
+            }
+            if (containsSensitiveValue(failure, sensitive)) {
+                failure = "Failed";
             }
             Result result = new Result(
                     outcome,
@@ -2150,6 +2156,20 @@ public final class PiWorker {
         SUCCEEDED,
         FAILED,
         TIMED_OUT
+    }
+
+    /** A durable Pi result exists but cannot be trusted as controller evidence. */
+    public static final class UntrustedResultException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        UntrustedResultException(String message) {
+            super(message);
+        }
+
+        UntrustedResultException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 
     /** A concurrent coordinator owns the same durable Pi stage session. */

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -74,7 +74,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public final class PiWorker {
 
     private static final int MAX_PROMPT_BYTES = 1024 * 1024;
-    private static final int MAX_LOG_BYTES = 16 * 1024 * 1024;
+    static final int MAX_LOG_BYTES = 16 * 1024 * 1024;
     private static final int MAX_SESSION_HEADER_BYTES = 64 * 1024;
     private static final long MAX_SESSION_BYTES = 64L * 1024 * 1024;
     private static final int MAX_VERSION_LENGTH = 1024;
@@ -112,6 +112,19 @@ public final class PiWorker {
         this(executable, supportedVersion, timeout, Clock.systemUTC());
     }
 
+    public PiWorker(
+                    Path executable,
+                    String supportedVersion,
+                    Duration timeout,
+                    Map<String, String> environment) {
+        this(
+             executable,
+             supportedVersion,
+             timeout,
+             Clock.systemUTC(),
+             environment);
+    }
+
     PiWorker(Path executable, String supportedVersion, Duration timeout, Clock clock) {
         this(executable, supportedVersion, timeout, clock, System.getenv());
     }
@@ -126,8 +139,8 @@ public final class PiWorker {
         this.supportedVersion = requireVersion(supportedVersion, "supported Pi version");
         this.timeout = requireDuration(timeout);
         this.clock = Objects.requireNonNull(clock, "clock");
-        this.commands = new LocalCommandRunner(clock);
         this.environment = Map.copyOf(Objects.requireNonNull(environment, "environment"));
+        this.commands = new LocalCommandRunner(clock, this.environment);
     }
 
     /**
@@ -152,14 +165,7 @@ public final class PiWorker {
         List<String> sensitiveValues = List.copyOf(
                 sensitiveEnvironmentValues(environment));
 
-        LocalCommandRunner.Result versionRun = commands.run(new Command(
-                executable,
-                List.of("--version"),
-                workingDirectory,
-                evidenceDirectory,
-                VERSION_TIMEOUT.compareTo(timeout) < 0 ? VERSION_TIMEOUT : timeout,
-                MAX_LOG_BYTES,
-                sensitiveValues));
+        LocalCommandRunner.Result versionRun = null;
         Throwable primary = null;
         Path scratchDirectory = null;
         SessionLock sessionLock = null;
@@ -167,6 +173,19 @@ public final class PiWorker {
         boolean published = false;
         boolean restoreInterrupt = false;
         try {
+            String sessionId = sessionId(request);
+            sessionLock = lockSession(
+                    sessionDirectory, sessionId, sessionOwner);
+            versionRun = commands.run(new Command(
+                    executable,
+                    List.of("--version"),
+                    workingDirectory,
+                    evidenceDirectory,
+                    VERSION_TIMEOUT.compareTo(timeout) < 0
+                            ? VERSION_TIMEOUT
+                            : timeout,
+                    MAX_LOG_BYTES,
+                    sensitiveValues));
             if (versionRun.timedOut()
                     || versionRun.outputLimited()
                     || versionRun.exitCode() != 0) {
@@ -199,8 +218,6 @@ public final class PiWorker {
                         warning + "; explicitly accept experimental Pi before starting the stage");
             }
 
-            String sessionId = sessionId(request);
-            sessionLock = lockSession(sessionDirectory, sessionId, sessionOwner);
             cleanupAbandonedScratch(sessionDirectory, sessionId, sessionOwner);
             SessionState previousSession = snapshotExistingSession(
                     sessionDirectory, sessionId, workingDirectory, sessionOwner);
@@ -328,7 +345,7 @@ public final class PiWorker {
                     primary.addSuppressed(cleanup);
                 }
             }
-            if (!versionLogsDeleted) {
+            if (!versionLogsDeleted && versionRun != null) {
                 try {
                     versionRun.deleteLogs();
                 } catch (IOException cleanup) {
@@ -355,9 +372,41 @@ public final class PiWorker {
         }
     }
 
-    /** Returns the durable result for this exact attempt without launching Pi. */
+    /**
+     * Returns the durable result for this exact attempt without launching Pi.
+     *
+     * <p>
+     * Recovery shares the stage-session lock with publication, so a marker cannot be observed before its matching
+     * session publication either commits or rolls back.
+     */
     public Optional<Result> recover(Request request) throws IOException {
-        return PiWorkerResultStore.read(Objects.requireNonNull(request, "request"));
+        try (Recovery recovery = lockRecovery(request)) {
+            return recovery.result();
+        }
+    }
+
+    /**
+     * Holds the stage-session lock while a caller atomically decides how to handle a recovered or absent result.
+     */
+    public Recovery lockRecovery(Request request) throws IOException {
+        Request requested = Objects.requireNonNull(request, "request");
+        Path sessionDirectory = realDirectory(
+                requested.sessionDirectory(), "Pi session directory");
+        UserPrincipal owner = requirePrivateSessionDirectory(sessionDirectory);
+        SessionLock lock = lockSession(
+                sessionDirectory, sessionId(requested), owner);
+        try {
+            return new Recovery(
+                    PiWorkerResultStore.read(requested),
+                    lock);
+        } catch (IOException | RuntimeException | Error e) {
+            try {
+                lock.close();
+            } catch (IOException cleanup) {
+                e.addSuppressed(cleanup);
+            }
+            throw e;
+        }
     }
 
     private RpcRun runRpc(
@@ -385,9 +434,11 @@ public final class PiWorker {
         vector.add(executable.toString());
         vector.addAll(arguments);
         Instant startedAt = clock.instant();
-        Process process = new ProcessBuilder(vector)
-                .directory(workingDirectory.toFile())
-                .start();
+        ProcessBuilder builder = new ProcessBuilder(vector)
+                .directory(workingDirectory.toFile());
+        builder.environment().clear();
+        builder.environment().putAll(environment);
+        Process process = builder.start();
         Thread shutdownHook = new Thread(
                 () -> terminateRpc(process, kill),
                 "camel-kit-pi-rpc-shutdown");
@@ -1378,10 +1429,10 @@ public final class PiWorker {
             try {
                 lock = channel.tryLock();
             } catch (OverlappingFileLockException e) {
-                throw new IOException("Pi stage session is already running", e);
+                throw new SessionBusyException(e);
             }
             if (lock == null) {
-                throw new IOException("Pi stage session is already running");
+                throw new SessionBusyException();
             }
             return new SessionLock(channel, lock);
         } catch (IOException | RuntimeException e) {
@@ -2099,6 +2150,41 @@ public final class PiWorker {
         SUCCEEDED,
         FAILED,
         TIMED_OUT
+    }
+
+    /** A concurrent coordinator owns the same durable Pi stage session. */
+    public static final class SessionBusyException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        private SessionBusyException() {
+            super("Pi stage session is already running");
+        }
+
+        private SessionBusyException(Throwable cause) {
+            super("Pi stage session is already running", cause);
+        }
+    }
+
+    /** One exact-attempt recovery observation protected by the Pi session lock. */
+    public static final class Recovery implements AutoCloseable {
+
+        private final Optional<Result> result;
+        private final SessionLock lock;
+
+        private Recovery(Optional<Result> result, SessionLock lock) {
+            this.result = Objects.requireNonNull(result, "result");
+            this.lock = Objects.requireNonNull(lock, "lock");
+        }
+
+        public Optional<Result> result() {
+            return result;
+        }
+
+        @Override
+        public void close() throws IOException {
+            lock.close();
+        }
     }
 
     public record Request(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -12,11 +12,14 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Result;
 
@@ -48,7 +51,8 @@ final class PiWorkerResultStore {
     private PiWorkerResultStore() {
     }
 
-    static Optional<Result> read(Request request) throws IOException {
+    static Optional<Result> read(Request request)
+            throws IOException {
         Path path = resultPath(request, false);
         if (path == null) {
             return Optional.empty();
@@ -80,6 +84,7 @@ final class PiWorkerResultStore {
         if (!marker.matches(request)) {
             throw new IOException("Pi stage result marker does not match its attempt");
         }
+        verifyEvidence(request, marker.result());
         return Optional.of(marker.result());
     }
 
@@ -187,6 +192,120 @@ final class PiWorkerResultStore {
             throws IOException {
         return PiWorker.attributesIfPresent(
                 path, "Pi stage result path could not be inspected");
+    }
+
+    private static void verifyEvidence(
+            Request request, Result result)
+            throws IOException {
+        CommandRun evidence = result.evidence();
+        Path workingDirectory = realDirectory(
+                request.workingDirectory(), "Pi working directory");
+        Path evidenceDirectory = realDirectory(
+                request.evidenceDirectory(), "Pi evidence directory");
+        Path historicalExecutable = normalizedAbsolute(
+                evidence.executable(), "Pi evidence executable");
+        if (!historicalExecutable.toString().equals(evidence.executable())
+                || !Path.of(evidence.workingDirectory()).equals(workingDirectory)
+                || !evidence.inputDigests().equals(List.of(request.inputDigest()))
+                || !evidence.version().equals(result.version())) {
+            throw new IOException(
+                    "Pi stage result evidence does not match its request");
+        }
+
+        VerifiedLog stdout = resolveLog(
+                evidenceDirectory,
+                evidence.stdoutLog(),
+                evidence.stdoutDigest());
+        VerifiedLog stderr = resolveLog(
+                evidenceDirectory,
+                evidence.stderrLog(),
+                evidence.stderrDigest());
+        if (stdout.identity().equals(stderr.identity())
+                || Files.isSameFile(stdout.path(), stderr.path())) {
+            throw new IOException(
+                    "Pi stage result stdout and stderr must be distinct files");
+        }
+        verifyLog(stdout);
+        verifyLog(stderr);
+    }
+
+    private static Path normalizedAbsolute(String supplied, String label)
+            throws IOException {
+        try {
+            Path path = Path.of(Objects.requireNonNull(supplied, label));
+            if (!path.isAbsolute() || !path.normalize().equals(path)) {
+                throw new IOException(label + " is invalid");
+            }
+            return path;
+        } catch (RuntimeException e) {
+            throw new IOException(label + " is invalid", e);
+        }
+    }
+
+    private static Path realDirectory(Path supplied, String label)
+            throws IOException {
+        Path normalized = Objects.requireNonNull(supplied, label)
+                .toAbsolutePath()
+                .normalize();
+        if (Files.isSymbolicLink(normalized)
+                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(label + " must be a real directory");
+        }
+        return normalized.toRealPath();
+    }
+
+    private static VerifiedLog resolveLog(
+            Path evidenceDirectory, String supplied, String digest)
+            throws IOException {
+        Path log = Path.of(supplied).toAbsolutePath().normalize();
+        BasicFileAttributes attributes = attributesIfPresent(log);
+        if (attributes == null
+                || attributes.isSymbolicLink()
+                || !attributes.isRegularFile()) {
+            throw new IOException(
+                    "Pi stage result log is missing or invalid: " + log);
+        }
+        Path real = log.toRealPath();
+        if (!real.startsWith(evidenceDirectory)) {
+            throw new IOException(
+                    "Pi stage result log escaped its evidence directory: " + log);
+        }
+        if (attributes.size() > PiWorker.MAX_LOG_BYTES) {
+            throw new IOException(
+                    "Pi stage result log exceeds its size limit: " + log);
+        }
+        Object identity = attributes.fileKey() == null
+                ? real
+                : attributes.fileKey();
+        return new VerifiedLog(identity, real, attributes.size(), digest);
+    }
+
+    private static void verifyLog(VerifiedLog log) throws IOException {
+        byte[] content;
+        try (InputStream input = Files.newInputStream(
+                log.path(), StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+            content = input.readNBytes(PiWorker.MAX_LOG_BYTES + 1);
+        }
+        BasicFileAttributes after = Files.readAttributes(
+                log.path(), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        Object identity = after.fileKey() == null
+                ? log.path()
+                : after.fileKey();
+        if (!after.isRegularFile()
+                || after.isSymbolicLink()
+                || !identity.equals(log.identity())
+                || content.length > PiWorker.MAX_LOG_BYTES
+                || content.length != log.size()
+                || after.size() != log.size()
+                || !ShipDigest.sha256(content).equals(log.digest())) {
+            throw new IOException(
+                    "Pi stage result log does not match its recorded digest: "
+                                  + log.path());
+        }
+    }
+
+    private record VerifiedLog(
+            Object identity, Path path, long size, String digest) {
     }
 
     private record Marker(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -7,6 +7,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -22,6 +23,7 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Result;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.UntrustedResultException;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -62,27 +64,37 @@ final class PiWorkerResultStore {
             return Optional.empty();
         }
         if (attributes.isSymbolicLink() || !attributes.isRegularFile()) {
-            throw new IOException("Pi stage result marker is invalid");
+            throw new UntrustedResultException(
+                    "Pi stage result marker is invalid");
         }
         byte[] encoded;
         try (InputStream input = Files.newInputStream(
                 path, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
             encoded = input.readNBytes(MAX_RESULT_BYTES + 1);
+        } catch (NoSuchFileException e) {
+            throw new UntrustedResultException(
+                    "Pi stage result marker is missing",
+                    e);
         }
         if (encoded.length == 0 || encoded.length > MAX_RESULT_BYTES) {
-            throw new IOException("Pi stage result marker has an invalid size");
+            throw new UntrustedResultException(
+                    "Pi stage result marker has an invalid size");
         }
         final Marker marker;
         try {
             marker = JSON.readValue(encoded, Marker.class);
         } catch (JsonProcessingException e) {
-            throw new IOException("Pi stage result marker is malformed", e);
+            throw new UntrustedResultException(
+                    "Pi stage result marker is malformed",
+                    e);
         }
         if (marker.schemaVersion() != SCHEMA_VERSION) {
-            throw new IOException("Pi stage result marker has an unsupported schema version");
+            throw new UntrustedResultException(
+                    "Pi stage result marker has an unsupported schema version");
         }
         if (!marker.matches(request)) {
-            throw new IOException("Pi stage result marker does not match its attempt");
+            throw new UntrustedResultException(
+                    "Pi stage result marker does not match its attempt");
         }
         verifyEvidence(request, marker.result());
         return Optional.of(marker.result());
@@ -179,7 +191,8 @@ final class PiWorkerResultStore {
             throw new IOException("Pi stage result directory disappeared");
         }
         if (attributes.isSymbolicLink() || !attributes.isDirectory()) {
-            throw new IOException("Pi stage result directory is invalid");
+            throw new UntrustedResultException(
+                    "Pi stage result directory is invalid");
         }
         String name = request.runId()
                       + '-' + request.stage().name().toLowerCase(Locale.ROOT)
@@ -208,7 +221,7 @@ final class PiWorkerResultStore {
                 || !Path.of(evidence.workingDirectory()).equals(workingDirectory)
                 || !evidence.inputDigests().equals(List.of(request.inputDigest()))
                 || !evidence.version().equals(result.version())) {
-            throw new IOException(
+            throw new UntrustedResultException(
                     "Pi stage result evidence does not match its request");
         }
 
@@ -220,9 +233,16 @@ final class PiWorkerResultStore {
                 evidenceDirectory,
                 evidence.stderrLog(),
                 evidence.stderrDigest());
-        if (stdout.identity().equals(stderr.identity())
-                || Files.isSameFile(stdout.path(), stderr.path())) {
-            throw new IOException(
+        final boolean sameFile;
+        try {
+            sameFile = Files.isSameFile(stdout.path(), stderr.path());
+        } catch (NoSuchFileException e) {
+            throw new UntrustedResultException(
+                    "Pi stage result log is missing",
+                    e);
+        }
+        if (stdout.identity().equals(stderr.identity()) || sameFile) {
+            throw new UntrustedResultException(
                     "Pi stage result stdout and stderr must be distinct files");
         }
         verifyLog(stdout);
@@ -234,11 +254,11 @@ final class PiWorkerResultStore {
         try {
             Path path = Path.of(Objects.requireNonNull(supplied, label));
             if (!path.isAbsolute() || !path.normalize().equals(path)) {
-                throw new IOException(label + " is invalid");
+                throw new UntrustedResultException(label + " is invalid");
             }
             return path;
         } catch (RuntimeException e) {
-            throw new IOException(label + " is invalid", e);
+            throw new UntrustedResultException(label + " is invalid", e);
         }
     }
 
@@ -247,11 +267,20 @@ final class PiWorkerResultStore {
         Path normalized = Objects.requireNonNull(supplied, label)
                 .toAbsolutePath()
                 .normalize();
-        if (Files.isSymbolicLink(normalized)
-                || !Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
-            throw new IOException(label + " must be a real directory");
+        BasicFileAttributes attributes = attributesIfPresent(normalized);
+        if (attributes == null
+                || attributes.isSymbolicLink()
+                || !attributes.isDirectory()) {
+            throw new UntrustedResultException(
+                    label + " must be a real directory");
         }
-        return normalized.toRealPath();
+        try {
+            return normalized.toRealPath();
+        } catch (NoSuchFileException e) {
+            throw new UntrustedResultException(
+                    label + " must be a real directory",
+                    e);
+        }
     }
 
     private static VerifiedLog resolveLog(
@@ -262,16 +291,23 @@ final class PiWorkerResultStore {
         if (attributes == null
                 || attributes.isSymbolicLink()
                 || !attributes.isRegularFile()) {
-            throw new IOException(
+            throw new UntrustedResultException(
                     "Pi stage result log is missing or invalid: " + log);
         }
-        Path real = log.toRealPath();
+        Path real;
+        try {
+            real = log.toRealPath();
+        } catch (NoSuchFileException e) {
+            throw new UntrustedResultException(
+                    "Pi stage result log is missing or invalid: " + log,
+                    e);
+        }
         if (!real.startsWith(evidenceDirectory)) {
-            throw new IOException(
+            throw new UntrustedResultException(
                     "Pi stage result log escaped its evidence directory: " + log);
         }
         if (attributes.size() > PiWorker.MAX_LOG_BYTES) {
-            throw new IOException(
+            throw new UntrustedResultException(
                     "Pi stage result log exceeds its size limit: " + log);
         }
         Object identity = attributes.fileKey() == null
@@ -285,9 +321,22 @@ final class PiWorkerResultStore {
         try (InputStream input = Files.newInputStream(
                 log.path(), StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
             content = input.readNBytes(PiWorker.MAX_LOG_BYTES + 1);
+        } catch (NoSuchFileException e) {
+            throw new UntrustedResultException(
+                    "Pi stage result log is missing: " + log.path(),
+                    e);
         }
-        BasicFileAttributes after = Files.readAttributes(
-                log.path(), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        BasicFileAttributes after;
+        try {
+            after = Files.readAttributes(
+                    log.path(),
+                    BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+        } catch (NoSuchFileException e) {
+            throw new UntrustedResultException(
+                    "Pi stage result log is missing: " + log.path(),
+                    e);
+        }
         Object identity = after.fileKey() == null
                 ? log.path()
                 : after.fileKey();
@@ -298,9 +347,9 @@ final class PiWorkerResultStore {
                 || content.length != log.size()
                 || after.size() != log.size()
                 || !ShipDigest.sha256(content).equals(log.digest())) {
-            throw new IOException(
+            throw new UntrustedResultException(
                     "Pi stage result log does not match its recorded digest: "
-                                  + log.path());
+                                               + log.path());
         }
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -85,6 +85,11 @@ class ShipCommandTest {
     @Test
     void supportsStartFromResumeStatusAndAbort() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path metadata = Files.createDirectories(
+                project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-command\"}\n");
         ShipController controller = controller("state");
 
         RunResult started = run(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactManifestReaderTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactManifestReaderTest.java
@@ -1,0 +1,175 @@
+package io.github.luigidemasi.camelkit.ship.artifact;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifestReader.Document;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@EnabledOnOs(OS.LINUX)
+class ArtifactManifestReaderTest {
+
+    private static final int MAX_MANIFEST_BYTES = 16 * 1024 * 1024;
+    private static final String DIGEST = "sha256:" + "a".repeat(64);
+    private static final String VALID = String.format(Locale.ROOT, """
+            {
+              "schemaVersion": 1,
+              "runtime": "main",
+              "camelVersion": "4.21.0",
+              "platformVersion": null,
+              "springBootVersion": null,
+              "routeDsl": "yaml",
+              "expressionLanguage": "simple",
+              "citrusVersion": "4.9.0",
+              "citrusDependencies": ["org.citrusframework:citrus-core:4.9.0"],
+              "javaPolicy": "FORBIDDEN",
+              "approvedJavaExceptions": [],
+              "routes": [
+                {
+                  "routeId": "orders",
+                  "path": "routes/orders.camel.yaml",
+                  "digest": "%s"
+                }
+              ],
+              "citrusTests": [
+                {
+                  "routeId": "orders",
+                  "path": "test/orders.camel.it.yaml",
+                  "digest": "%s"
+                }
+              ],
+              "artifacts": [
+                {
+                  "kind": "pom",
+                  "path": "pom.xml",
+                  "digest": "%s",
+                  "required": true
+                },
+                {
+                  "kind": "config",
+                  "path": ".camel-kit/config.properties",
+                  "digest": "%s",
+                  "required": true
+                }
+              ],
+              "testsRequired": true,
+              "oneTestPerRoute": true
+            }
+            """, DIGEST, DIGEST, DIGEST, DIGEST);
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void readsCanonicalManifestFromCandidate() throws Exception {
+        Path candidate = Files.createDirectory(temporaryDirectory.resolve("candidate"));
+        Files.writeString(candidate.resolve("artifact-manifest.json"), VALID);
+
+        Document document = ArtifactManifestReader.read(
+                candidate, Path.of("artifact-manifest.json"));
+        ArtifactManifest manifest = document.manifest();
+
+        assertEquals(ArtifactManifest.SCHEMA_VERSION, manifest.schemaVersion());
+        assertEquals("main", manifest.runtime());
+        assertEquals(List.of("orders"),
+                manifest.routes().stream().map(ArtifactManifest.RouteArtifact::routeId).toList());
+        assertEquals(2, manifest.artifacts().size());
+        assertEquals(
+                ShipDigest.sha256(VALID.getBytes(StandardCharsets.UTF_8)),
+                document.digest());
+    }
+
+    @Test
+    void rejectsNonStrictJsonWithoutLeakingIt() throws Exception {
+        Path candidate = Files.createDirectory(temporaryDirectory.resolve("candidate"));
+        List<String> invalid = List.of(
+                VALID.replace(
+                        "\"runtime\": \"main\",",
+                        "\"runtime\": \"top-secret-value\", \"runtime\": \"main\","),
+                VALID + "{}",
+                VALID.substring(0, VALID.lastIndexOf('}'))
+                              + ", \"unknown\": \"top-secret-value\"}",
+                VALID.replace("  \"runtime\": \"main\",\n", ""),
+                VALID.replace("\"runtime\": \"main\"", "\"runtime\": null"),
+                VALID.replace("\"schemaVersion\": 1", "\"schemaVersion\": \"1\""),
+                VALID.replace("\"schemaVersion\": 1", "\"schemaVersion\": 1.0"));
+
+        for (int index = 0; index < invalid.size(); index++) {
+            Path file = Files.writeString(candidate.resolve("invalid-" + index + ".json"),
+                    invalid.get(index));
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> ArtifactManifestReader.read(candidate, file));
+            assertFalse(failure.toString().contains("top-secret-value"));
+        }
+    }
+
+    @Test
+    void rejectsSchemaViolations() throws Exception {
+        Path candidate = Files.createDirectory(temporaryDirectory.resolve("candidate"));
+        for (String invalid : List.of(
+                VALID.replace("\"runtime\": \"main\"", "\"runtime\": \"unsupported\""),
+                VALID.replace(
+                        "\"path\": \"routes/orders.camel.yaml\"",
+                        "\"path\": \"../orders.camel.yaml\""),
+                VALID.replace("\"required\": true", "\"required\": false"))) {
+            Path file = Files.writeString(candidate.resolve("invalid.json"), invalid);
+            assertThrows(IOException.class, () -> ArtifactManifestReader.read(candidate, file));
+        }
+    }
+
+    @Test
+    void rejectsInvalidUtf8() throws Exception {
+        Path candidate = Files.createDirectory(temporaryDirectory.resolve("candidate"));
+        Path file = Files.write(candidate.resolve("artifact-manifest.json"),
+                new byte[]{'{', '"', (byte) 0xc3, '"', '}'});
+
+        assertThrows(IOException.class, () -> ArtifactManifestReader.read(candidate, file));
+    }
+
+    @Test
+    void rejectsCandidateRootThatTraversesASymbolicParent() throws Exception {
+        Path parent = Files.createDirectory(
+                temporaryDirectory.resolve("real-parent"));
+        Path candidate = Files.createDirectory(parent.resolve("candidate"));
+        Files.writeString(candidate.resolve("artifact-manifest.json"), VALID);
+        Path alias = Files.createSymbolicLink(
+                temporaryDirectory.resolve("parent-alias"), parent);
+
+        assertThrows(
+                IOException.class,
+                () -> ArtifactManifestReader.read(
+                        alias.resolve("candidate"),
+                        Path.of("artifact-manifest.json")));
+    }
+
+    @Test
+    void rejectsOutsideLinkedAndOversizedFiles() throws Exception {
+        Path candidate = Files.createDirectory(temporaryDirectory.resolve("candidate"));
+        Path outside = Files.writeString(temporaryDirectory.resolve("outside.json"), VALID);
+        Path linked = Files.createSymbolicLink(
+                candidate.resolve("linked.json"), outside.toAbsolutePath());
+        Path hardLinked = Files.createLink(
+                candidate.resolve("hard-linked.json"), outside);
+        Path oversized = candidate.resolve("oversized.json");
+        Files.write(oversized, new byte[MAX_MANIFEST_BYTES + 1]);
+
+        assertThrows(IOException.class, () -> ArtifactManifestReader.read(candidate, outside));
+        assertThrows(IOException.class, () -> ArtifactManifestReader.read(candidate, linked));
+        assertThrows(IOException.class, () -> ArtifactManifestReader.read(candidate, hardLinked));
+        assertThrows(IOException.class, () -> ArtifactManifestReader.read(candidate, oversized));
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -12,7 +12,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,6 +27,9 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStampStore;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
 import io.github.luigidemasi.camelkit.ship.security.ShipFilesystemException;
@@ -85,6 +91,104 @@ class ShipControllerTest {
         assertEquals(ShipContext.Kind.DOCUMENT, source.kind());
         assertEquals(document.toAbsolutePath().normalize().toString(), source.value());
         assertEquals(ShipDigest.sha256(Files.readAllBytes(document)), source.digest());
+    }
+
+    @Test
+    void rejectsSensitiveInlineContextBeforeCreatingRunState() throws Exception {
+        String secret = "inline-context-secret-12345678";
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(
+                state, Map.of("SHIP_TEST_TOKEN", secret));
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.start(
+                        project,
+                        Oversight.NEVER,
+                        List.of(new ShipContext.TextInput("requirements: " + secret))));
+
+        assertEquals("context-secret-detected", failure.code());
+        assertFalse(failure.toString().contains(secret));
+        assertNull(failure.getCause());
+        assertFalse(Files.exists(state));
+    }
+
+    @Test
+    void rejectsSensitiveDocumentContextBeforeCreatingStartFromState()
+            throws Exception {
+        String secret = "document-context-secret-12345678";
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path document = Files.writeString(
+                project.resolve("requirements.md"), "requirements: " + secret);
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(
+                state, Map.of("SHIP_TEST_TOKEN", secret));
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.startFrom(
+                        project,
+                        Stage.DESIGN,
+                        Oversight.NEVER,
+                        List.of(new ShipContext.DocumentInput(document))));
+
+        assertEquals("context-secret-detected", failure.code());
+        assertFalse(failure.toString().contains(secret));
+        assertNull(failure.getCause());
+        assertFalse(Files.exists(state));
+    }
+
+    @Test
+    void rejectsSensitiveDocumentPathBeforeCreatingRunState()
+            throws Exception {
+        String secret = "document-path-secret-12345678";
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path document = Files.writeString(
+                project.resolve(secret + ".md"), "safe requirements");
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(
+                state, Map.of("SHIP_TEST_TOKEN", secret));
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.start(
+                        project,
+                        Oversight.NEVER,
+                        List.of(new ShipContext.DocumentInput(document))));
+
+        assertEquals("context-secret-detected", failure.code());
+        assertFalse(failure.toString().contains(secret));
+        assertNull(failure.getCause());
+        assertFalse(Files.exists(state));
+    }
+
+    @Test
+    void rejectsSensitiveDocumentRefreshWithoutChangingRunState()
+            throws Exception {
+        String secret = "refreshed-context-secret-12345678";
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path document = Files.writeString(
+                project.resolve("requirements.md"), "safe requirements");
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(
+                state, Map.of("SHIP_TEST_TOKEN", secret));
+        ShipRun started = controller.start(
+                project,
+                Oversight.NEVER,
+                List.of(new ShipContext.DocumentInput(document)));
+        Files.writeString(document, "requirements: " + secret);
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.resume(started.id()));
+
+        assertEquals("context-secret-detected", failure.code());
+        assertFalse(failure.toString().contains(secret));
+        assertNull(failure.getCause());
+        assertEquals(started, controller.status(started.id()));
+        assertFalse(Files.readString(
+                state.resolve(started.id()).resolve("state.json")).contains(secret));
     }
 
     @Test
@@ -263,11 +367,46 @@ class ShipControllerTest {
         ShipRun never = controller.start(project, Oversight.NEVER, List.of());
         for (Stage stage : Stage.values()) {
             assertEquals(stage, never.currentStage());
-            never = complete(controller, never, "never-" + stage);
+            if (stage == Stage.VALIDATE) {
+                ShipController.StageAttempt attempt
+                        = controller.prepareAttempt(never.id());
+                ShipLocalStamp stamp = localStamp(never.id(), Outcome.PASS);
+                ShipLocalStampStore.write(
+                        attempt.evidenceDirectory(), never.id(), stamp);
+                never = controller.completeValidationStage(
+                        never.id(),
+                        never.stage(stage).attempts(),
+                        never.stage(stage).inputDigest(),
+                        stamp);
+            } else {
+                never = complete(controller, never, "never-" + stage);
+            }
         }
         assertEquals(RunStatus.COMPLETED, never.status());
         assertEquals(Stage.VALIDATE, never.currentStage());
         assertTrue(never.stages().stream().allMatch(record -> record.status() == StageStatus.COMPLETED));
+    }
+
+    @Test
+    void rejectsGenericWorkerCompletionForValidation() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun validating = advanceToValidation(
+                controller, project, Oversight.NEVER);
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        validating.id(),
+                        Stage.VALIDATE,
+                        validating.stage(Stage.VALIDATE).attempts(),
+                        validating.stage(Stage.VALIDATE).inputDigest(),
+                        digest("worker-prose-pass"),
+                        List.of(),
+                        false));
+
+        assertEquals("validation-controller-owned", failure.code());
+        assertEquals(validating, controller.status(validating.id()));
     }
 
     @Test
@@ -367,6 +506,311 @@ class ShipControllerTest {
     }
 
     @Test
+    void retainsAndReloadsAPassingLocalStamp() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(state);
+        ShipRun validating = advanceToValidation(
+                controller, project, Oversight.ALWAYS);
+        ShipController.StageAttempt attempt = controller.prepareAttempt(validating.id());
+        ShipLocalStamp stamp = localStamp(validating.id(), Outcome.PASS);
+        Path stampPath = ShipLocalStampStore.write(
+                attempt.evidenceDirectory(), validating.id(), stamp);
+
+        ShipRun paused = controller.completeValidationStage(
+                validating.id(),
+                validating.stage(Stage.VALIDATE).attempts(),
+                validating.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
+
+        ShipRun.StageRecord validation = paused.stage(Stage.VALIDATE);
+        assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals(StageStatus.COMPLETED, validation.status());
+        assertEquals(List.of(stampPath.toRealPath().toString()),
+                validation.artifacts().stream().map(ShipRun.ArtifactRef::path).toList());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(stampPath)),
+                validation.outputDigest());
+        ShipController reloaded = new ShipController(state);
+        assertEquals(paused, reloaded.status(paused.id()));
+
+        ShipRun completed = reloaded.resume(paused.id());
+        assertEquals(RunStatus.COMPLETED, completed.status());
+        assertEquals(validation, completed.stage(Stage.VALIDATE));
+    }
+
+    @Test
+    void restartsValidationWhenAPassingLocalStampIsMissingOrCorrupt()
+            throws Exception {
+        for (String condition : List.of("missing", "corrupt")) {
+            Path project = Files.createDirectory(
+                    directory.resolve(condition + "-project"));
+            Path state = directory.resolve(condition + "-state");
+            ShipController controller = new ShipController(state);
+            ShipRun validating = advanceToValidation(
+                    controller, project, Oversight.ALWAYS);
+            ShipController.StageAttempt attempt
+                    = controller.prepareAttempt(validating.id());
+            ShipLocalStamp stamp = localStamp(validating.id(), Outcome.PASS);
+            Path stampPath = ShipLocalStampStore.write(
+                    attempt.evidenceDirectory(), validating.id(), stamp);
+            ShipRun paused = controller.completeValidationStage(
+                    validating.id(),
+                    validating.stage(Stage.VALIDATE).attempts(),
+                    validating.stage(Stage.VALIDATE).inputDigest(),
+                    stamp);
+
+            if ("missing".equals(condition)) {
+                Files.delete(stampPath);
+            } else {
+                Files.writeString(stampPath, "not a local Stamp");
+            }
+
+            ShipRun resumed = controller.resume(paused.id());
+
+            assertEquals(RunStatus.RUNNING, resumed.status(), condition);
+            assertEquals(Stage.VALIDATE, resumed.currentStage(), condition);
+            assertEquals(
+                    StageStatus.RUNNING,
+                    resumed.stage(Stage.VALIDATE).status(),
+                    condition);
+            assertEquals(
+                    2,
+                    resumed.stage(Stage.VALIDATE).attempts(),
+                    condition);
+            assertTrue(
+                    resumed.stage(Stage.VALIDATE).artifacts().isEmpty(),
+                    condition);
+        }
+    }
+
+    @Test
+    void completedRunRestartsOnlyWhenItsLocalStampIsMissingOrCorrupt()
+            throws Exception {
+        for (String condition : List.of(
+                "intact", "missing", "changed-bytes", "corrupt-stamp", "corrupt-log")) {
+            Path project = Files.createDirectory(
+                    directory.resolve("completed-" + condition + "-project"));
+            Path state = directory.resolve("completed-" + condition + "-state");
+            ShipController controller = new ShipController(state);
+            ShipRun validating = advanceToValidation(
+                    controller, project, Oversight.NEVER);
+            ShipController.StageAttempt attempt
+                    = controller.prepareAttempt(validating.id());
+            ShipLocalStamp stamp = "corrupt-log".equals(condition)
+                    ? localStampWithLogs(validating.id(), attempt.evidenceDirectory())
+                    : localStamp(validating.id(), Outcome.PASS);
+            Path stampPath = ShipLocalStampStore.write(
+                    attempt.evidenceDirectory(), validating.id(), stamp);
+            ShipRun completed = controller.completeValidationStage(
+                    validating.id(),
+                    validating.stage(Stage.VALIDATE).attempts(),
+                    validating.stage(Stage.VALIDATE).inputDigest(),
+                    stamp);
+            assertEquals(RunStatus.COMPLETED, completed.status(), condition);
+
+            if ("intact".equals(condition)) {
+                assertFailure(
+                        "run-completed",
+                        () -> controller.resume(completed.id()));
+                assertEquals(completed, controller.status(completed.id()));
+                continue;
+            }
+            if ("missing".equals(condition)) {
+                Files.delete(stampPath);
+            } else if ("changed-bytes".equals(condition)) {
+                Files.writeString(
+                        stampPath, Files.readString(stampPath) + "\n");
+            } else if ("corrupt-log".equals(condition)) {
+                Files.writeString(
+                        attempt.evidenceDirectory().resolve("stdout.log"),
+                        "corrupt");
+            } else {
+                Files.writeString(stampPath, "not a local Stamp");
+            }
+
+            ShipRun resumed = controller.resume(completed.id());
+
+            assertEquals(RunStatus.RUNNING, resumed.status(), condition);
+            assertEquals(Stage.VALIDATE, resumed.currentStage(), condition);
+            assertEquals(StageStatus.RUNNING,
+                    resumed.stage(Stage.VALIDATE).status(), condition);
+            assertEquals(2, resumed.stage(Stage.VALIDATE).attempts(), condition);
+            assertTrue(resumed.stage(Stage.VALIDATE).artifacts().isEmpty(), condition);
+        }
+    }
+
+    @Test
+    void completedRunRefreshesContextBeforeAcceptingItsLocalStamp()
+            throws Exception {
+        Path project = Files.createDirectory(directory.resolve("context-project"));
+        Path document = Files.writeString(
+                project.resolve("requirements.md"), "requirements-v1");
+        ShipController controller = controller("context-state");
+        ShipRun run = controller.start(
+                project,
+                Oversight.NEVER,
+                List.of(new ShipContext.DocumentInput(document)));
+        while (run.currentStage() != Stage.VALIDATE) {
+            run = complete(controller, run, run.currentStage().name().toLowerCase(Locale.ROOT));
+        }
+        ShipController.StageAttempt attempt = controller.prepareAttempt(run.id());
+        ShipLocalStamp stamp = localStamp(run.id(), Outcome.PASS);
+        ShipLocalStampStore.write(attempt.evidenceDirectory(), run.id(), stamp);
+        ShipRun completed = controller.completeValidationStage(
+                run.id(),
+                run.stage(Stage.VALIDATE).attempts(),
+                run.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
+        assertEquals(RunStatus.COMPLETED, completed.status());
+
+        Files.writeString(document, "requirements-v2");
+        ShipRun resumed = controller.resume(completed.id());
+
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(Stage.DISCOVERY, resumed.currentStage());
+        assertEquals(2, resumed.stage(Stage.DISCOVERY).attempts());
+        assertEquals(StageStatus.PENDING, resumed.stage(Stage.VALIDATE).status());
+    }
+
+    @Test
+    void completedRunRefreshesPredecessorArtifactsBeforeAcceptingItsLocalStamp()
+            throws Exception {
+        Path project = Files.createDirectory(directory.resolve("artifact-project"));
+        Path discovery = Files.writeString(project.resolve("discovery.md"), "discovery-v1");
+        Path design = Files.writeString(project.resolve("design.md"), "design-v1");
+        Path plan = Files.writeString(project.resolve("plan.md"), "plan-v1");
+        ShipController controller = controller("artifact-state");
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery", discovery);
+        run = complete(controller, run, "design", design);
+        run = complete(controller, run, "plan", plan);
+        run = complete(controller, run, "execute");
+        ShipController.StageAttempt attempt = controller.prepareAttempt(run.id());
+        ShipLocalStamp stamp = localStamp(run.id(), Outcome.PASS);
+        ShipLocalStampStore.write(attempt.evidenceDirectory(), run.id(), stamp);
+        ShipRun completed = controller.completeValidationStage(
+                run.id(),
+                run.stage(Stage.VALIDATE).attempts(),
+                run.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
+        assertEquals(RunStatus.COMPLETED, completed.status());
+
+        Files.writeString(design, "design-v2");
+        ShipRun resumed = controller.resume(completed.id());
+
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(Stage.PLAN, resumed.currentStage());
+        assertEquals(2, resumed.stage(Stage.PLAN).attempts());
+        assertEquals(StageStatus.COMPLETED, resumed.stage(Stage.DESIGN).status());
+        assertEquals(ShipDigest.sha256(Files.readAllBytes(design)),
+                resumed.stage(Stage.DESIGN).artifacts().get(0).digest());
+        assertEquals(StageStatus.PENDING, resumed.stage(Stage.VALIDATE).status());
+    }
+
+    @Test
+    void retainsAndReloadsAFailingLocalStampBeforeRetry() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(state);
+        ShipRun validating = advanceToValidation(
+                controller, project, Oversight.NEVER);
+        ShipController.StageAttempt attempt = controller.prepareAttempt(validating.id());
+        ShipLocalStamp stamp = localStamp(validating.id(), Outcome.FAIL);
+        Path stampPath = ShipLocalStampStore.write(
+                attempt.evidenceDirectory(), validating.id(), stamp);
+
+        ShipRun failed = controller.completeValidationStage(
+                validating.id(),
+                validating.stage(Stage.VALIDATE).attempts(),
+                validating.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
+
+        ShipRun.StageRecord validation = failed.stage(Stage.VALIDATE);
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(StageStatus.FAILED, validation.status());
+        assertEquals(stampPath.toRealPath().toString(),
+                validation.artifacts().get(0).path());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(stampPath)),
+                validation.outputDigest());
+        ShipController reloaded = new ShipController(state);
+        assertEquals(failed, reloaded.status(failed.id()));
+
+        ShipRun retried = reloaded.resume(failed.id());
+        assertEquals(RunStatus.RUNNING, retried.status());
+        assertEquals(StageStatus.RUNNING, retried.stage(Stage.VALIDATE).status());
+        assertEquals(2, retried.stage(Stage.VALIDATE).attempts());
+        assertTrue(retried.stage(Stage.VALIDATE).artifacts().isEmpty());
+    }
+
+    @Test
+    void usesTheInjectedEnvironmentToRejectChangedExecuteSecrets() throws Exception {
+        String secret = "correct-horse-battery-staple";
+        Map<String, String> environment = new HashMap<>();
+        environment.put("SHIP_TEST_TOKEN", secret);
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = new ShipController(
+                directory.resolve("state"), environment);
+        environment.clear();
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        run = complete(controller, run, "discovery");
+        run = complete(controller, run, "design");
+        run = complete(controller, run, "plan");
+        Path workspace = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Path route = Files.writeString(
+                workspace.resolve("route.yaml"), "password: " + secret);
+        ShipRun executing = run;
+
+        assertFailure(
+                "workspace-secret-detected",
+                () -> controller.completeExecuteStage(
+                        executing.id(),
+                        executing.stage(Stage.EXECUTE).attempts(),
+                        executing.stage(Stage.EXECUTE).inputDigest(),
+                        List.of(route),
+                        false));
+        assertEquals(executing, controller.status(executing.id()));
+    }
+
+    @Test
+    void preparesPrivateWorkerDirectoriesAndReleasesTheRunLock() throws Exception {
+        Assumptions.assumeTrue(
+                Files.getFileStore(directory).supportsFileAttributeView("posix"));
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(state);
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+
+        ShipController.StageAttempt attempt = controller.prepareAttempt(run.id());
+        Path runDirectory = state.resolve(run.id()).toRealPath();
+
+        assertEquals(runDirectory, attempt.runDirectory());
+        assertEquals(runDirectory.resolve("sessions"), attempt.sessionDirectory());
+        assertEquals(runDirectory.resolve("inputs"), attempt.inputDirectory());
+        assertEquals(
+                runDirectory.resolve("evidence/discovery-1"),
+                attempt.evidenceDirectory());
+        for (Path privateDirectory : List.of(
+                attempt.sessionDirectory(),
+                attempt.inputDirectory(),
+                attempt.evidenceDirectory().getParent(),
+                attempt.evidenceDirectory())) {
+            assertEquals(
+                    PosixFilePermissions.fromString("rwx------"),
+                    Files.getPosixFilePermissions(privateDirectory));
+            assertEquals(Files.getOwner(runDirectory), Files.getOwner(privateDirectory));
+        }
+        try (ShipRunStore.LockedRun locked = new ShipRunStore(state).lock(run.id())) {
+            assertEquals(run, locked.read());
+        }
+        assertTrue(Files.isRegularFile(runDirectory.resolve("run.lock")));
+    }
+
+    @Test
     void resumeRestartsCompletedValidateWhenItsArtifactChanges() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         ShipController controller = controller("state");
@@ -378,13 +822,22 @@ class ShipControllerTest {
         run = controller.resume(run.id());
         run = complete(controller, run, "execute");
         run = controller.resume(run.id());
-        Path artifact = Files.writeString(
-                Files.createDirectories(project.resolve("target")).resolve("validation.txt"),
-                "validated");
-        ShipRun paused = complete(controller, run, "validate", artifact);
+        ShipController.StageAttempt attempt = controller.prepareAttempt(
+                run.id());
+        ShipLocalStamp stamp = localStampWithLogs(
+                run.id(), attempt.evidenceDirectory());
+        ShipLocalStampStore.write(
+                attempt.evidenceDirectory(), run.id(), stamp);
+        ShipRun paused = controller.completeValidationStage(
+                run.id(),
+                run.stage(Stage.VALIDATE).attempts(),
+                run.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
         assertEquals(RunStatus.PAUSED, paused.status());
 
-        Files.writeString(artifact, "changed after validation");
+        Files.writeString(
+                attempt.evidenceDirectory().resolve("stdout.log"),
+                "changed after validation");
         ShipRun resumed = controller.resume(paused.id());
 
         assertEquals(Stage.VALIDATE, resumed.currentStage());
@@ -989,6 +1442,21 @@ class ShipControllerTest {
     }
 
     @Test
+    void startFromDesignRequiresAnActivePipeline() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+
+        ShipController.Failure failure = assertThrows(
+                ShipController.Failure.class,
+                () -> controller("state").startFrom(
+                        project,
+                        Stage.DESIGN,
+                        Oversight.NEVER,
+                        List.of(new ShipContext.TextInput("design the route"))));
+
+        assertEquals("start-from-pipeline-missing", failure.code());
+    }
+
+    @Test
     void startFromLaterStagesRequiresAnActivePipeline() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         ShipController controller = controller("state");
@@ -1035,7 +1503,16 @@ class ShipControllerTest {
         String snapshotDigest = validating.stage(Stage.EXECUTE).artifacts().get(1).digest();
         String executeOutputDigest = validating.stage(Stage.EXECUTE).outputDigest();
 
-        ShipRun paused = complete(controller, validating, "validated");
+        ShipController.StageAttempt attempt = controller.prepareAttempt(
+                validating.id());
+        ShipLocalStamp stamp = localStamp(validating.id(), Outcome.PASS);
+        ShipLocalStampStore.write(
+                attempt.evidenceDirectory(), validating.id(), stamp);
+        ShipRun paused = controller.completeValidationStage(
+                validating.id(),
+                validating.stage(Stage.VALIDATE).attempts(),
+                validating.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
         assertEquals(RunStatus.PAUSED, paused.status());
         Files.writeString(route, "version two");
         Files.writeString(executionReport, "execution two");
@@ -1136,6 +1613,87 @@ class ShipControllerTest {
 
     private ShipController controller(String stateDirectory) {
         return new ShipController(directory.resolve(stateDirectory));
+    }
+
+    private ShipRun advanceToValidation(
+            ShipController controller, Path project, Oversight oversight) {
+        ShipRun run = controller.start(project, oversight, List.of());
+        while (run.currentStage() != Stage.VALIDATE) {
+            if (run.status() == RunStatus.PAUSED) {
+                run = controller.resume(run.id());
+            }
+            run = complete(
+                    controller,
+                    run,
+                    run.currentStage().name().toLowerCase(Locale.ROOT));
+        }
+        return run.status() == RunStatus.PAUSED
+                ? controller.resume(run.id())
+                : run;
+    }
+
+    private static ShipLocalStamp localStamp(String runId, Outcome outcome) {
+        return ShipLocalStamp.create(
+                runId,
+                List.of(new ShipLocalStamp.ToolVersion(
+                        "pi",
+                        null,
+                        "0.80.6",
+                        ShipLocalStamp.Support.SUPPORTED,
+                        null)),
+                List.of(new ShipLocalStamp.Check(
+                        "artifact-policy",
+                        true,
+                        outcome,
+                        "Artifact policy result",
+                        null,
+                        null)),
+                Instant.parse("2026-07-29T12:00:00Z"));
+    }
+
+    private static ShipLocalStamp localStampWithLogs(
+            String runId, Path evidenceDirectory)
+            throws Exception {
+        Path stdout = Files.writeString(
+                evidenceDirectory.resolve("stdout.log"), "stdout");
+        Path stderr = Files.writeString(
+                evidenceDirectory.resolve("stderr.log"), "stderr");
+        Files.setPosixFilePermissions(
+                stdout, PosixFilePermissions.fromString("rw-------"));
+        Files.setPosixFilePermissions(
+                stderr, PosixFilePermissions.fromString("rw-------"));
+        ShipLocalStamp.CommandRun command = new ShipLocalStamp.CommandRun(
+                "/usr/bin/java",
+                "17",
+                List.of("-version"),
+                evidenceDirectory.toString(),
+                List.of(digest("input")),
+                true,
+                false,
+                false,
+                0,
+                "2026-07-29T11:59:58Z",
+                "2026-07-29T11:59:59Z",
+                stdout.toString(),
+                ShipDigest.sha256(Files.readAllBytes(stdout)),
+                stderr.toString(),
+                ShipDigest.sha256(Files.readAllBytes(stderr)));
+        return ShipLocalStamp.create(
+                runId,
+                List.of(new ShipLocalStamp.ToolVersion(
+                        "pi",
+                        null,
+                        "0.80.6",
+                        ShipLocalStamp.Support.SUPPORTED,
+                        null)),
+                List.of(new ShipLocalStamp.Check(
+                        "artifact-policy",
+                        true,
+                        Outcome.PASS,
+                        "Artifact policy result",
+                        null,
+                        command)),
+                Instant.parse("2026-07-29T12:00:00Z"));
     }
 
     private void assertConcurrentArtifactMutationRejected(String name, boolean replace)

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -205,8 +205,48 @@ class ShipCoordinatorTest {
     @Test
     void unavailableGeneratedPredecessorRestartsBeforeTheActiveStage()
             throws Exception {
+        for (String condition : List.of("missing", "corrupt")) {
+            Files.deleteIfExists(fixture.resolve("session-ids"));
+            Files.deleteIfExists(fixture.resolve("resumed-sessions"));
+            ShipRun run = designRun(List.of(
+                    new ShipContext.TextInput(
+                            "restart " + condition + " predecessor")));
+            ShipRun planned = coordinator.run(run.id());
+            ShipRun activePlan = controller.resume(run.id());
+            Path marker = state.resolve(run.id())
+                    .resolve("sessions/.camel-kit-results")
+                    .resolve(run.id() + "-design-"
+                             + planned.stage(Stage.DESIGN).inputDigest()
+                                     .substring("sha256:".length())
+                             + "-1.json");
+            assertTrue(Files.isRegularFile(marker));
+            if ("missing".equals(condition)) {
+                Files.delete(marker);
+            } else {
+                Files.writeString(marker, "{}\n");
+            }
+
+            ShipRun restarted = coordinator.resume(activePlan.id());
+
+            assertDesignPaused(restarted, 2);
+            assertEquals(StageStatus.PENDING,
+                    restarted.stage(Stage.PLAN).status());
+            assertEquals(1, restarted.stage(Stage.PLAN).attempts());
+            String sessionId = sessionId(run);
+            assertEquals(
+                    List.of(sessionId, sessionId),
+                    Files.readAllLines(fixture.resolve("session-ids")));
+            assertEquals(
+                    List.of(sessionId),
+                    Files.readAllLines(fixture.resolve("resumed-sessions")));
+        }
+    }
+
+    @Test
+    void unreadableGeneratedPredecessorDoesNotResetTheRun()
+            throws Exception {
         ShipRun run = designRun(List.of(
-                new ShipContext.TextInput("restart missing predecessor")));
+                new ShipContext.TextInput("retry unreadable predecessor")));
         ShipRun planned = coordinator.run(run.id());
         ShipRun activePlan = controller.resume(run.id());
         Path marker = state.resolve(run.id())
@@ -215,22 +255,20 @@ class ShipCoordinatorTest {
                          + planned.stage(Stage.DESIGN).inputDigest()
                                  .substring("sha256:".length())
                          + "-1.json");
-        assertTrue(Files.isRegularFile(marker));
-        Files.writeString(marker, "{}\n");
+        Files.setPosixFilePermissions(
+                marker, PosixFilePermissions.fromString("---------"));
 
-        ShipRun restarted = coordinator.resume(activePlan.id());
+        try {
+            IOException failure = assertThrows(
+                    IOException.class,
+                    () -> coordinator.resume(activePlan.id()));
 
-        assertDesignPaused(restarted, 2);
-        assertEquals(StageStatus.PENDING,
-                restarted.stage(Stage.PLAN).status());
-        assertEquals(1, restarted.stage(Stage.PLAN).attempts());
-        String sessionId = sessionId(run);
-        assertEquals(
-                List.of(sessionId, sessionId),
-                Files.readAllLines(fixture.resolve("session-ids")));
-        assertEquals(
-                List.of(sessionId),
-                Files.readAllLines(fixture.resolve("resumed-sessions")));
+            assertFalse(failure instanceof PiWorker.UntrustedResultException);
+            assertEquals(activePlan, controller.status(run.id()));
+        } finally {
+            Files.setPosixFilePermissions(
+                    marker, PosixFilePermissions.fromString("rw-------"));
+        }
     }
 
     @Test
@@ -303,6 +341,33 @@ class ShipCoordinatorTest {
             assertFalse(Files.exists(fixture.resolve("session-ids")));
             assertFalse(Files.exists(fixture.resolve("args")));
         }
+    }
+
+    @Test
+    void redactsSensitivePiFailureBeforeWritingRunState()
+            throws Exception {
+        String secret = "Pi assistant settled with stop reason error";
+        Files.writeString(fixture.resolve("mode"), "stop-error\n");
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("redact failure")));
+        ShipCoordinator screened = new ShipCoordinator(
+                state,
+                controller,
+                worker,
+                new ShipCatalogService(directory.resolve("m2"))::snapshot,
+                new ShipMainValidator(),
+                distribution,
+                Map.of("API_TOKEN", secret),
+                true,
+                Clock.systemUTC());
+
+        ShipRun failed = screened.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals("Failed", failed.message());
+        assertFalse(Files.readString(
+                state.resolve(run.id()).resolve("state.json"))
+                .contains(secret));
     }
 
     @Test
@@ -448,6 +513,44 @@ class ShipCoordinatorTest {
     }
 
     @Test
+    void importedExecuteFailsValidationWithoutAGeneratedPolicy()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-coordinator"));
+        Files.writeString(documents.resolve("design-spec.md"), "Imported design");
+        Files.writeString(
+                documents.resolve("implementation-plan.md"),
+                "Imported implementation plan");
+        ShipRun run = controller.startFrom(
+                project,
+                Stage.EXECUTE,
+                Oversight.NEVER,
+                List.of());
+        StageAttempt execute = controller.prepareAttempt(run.id());
+        writeGeneratedMainCandidate(
+                execute.workingDirectory(), mainPolicy());
+        writeWorkerResult("Execution report", null);
+
+        ShipRun failed = coordinator.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(StageStatus.COMPLETED,
+                failed.stage(Stage.EXECUTE).status());
+        assertEquals(Stage.VALIDATE, failed.currentStage());
+        assertEquals(StageStatus.FAILED,
+                failed.stage(Stage.VALIDATE).status());
+        assertEquals(1, failed.stage(Stage.VALIDATE).attempts());
+        assertEquals("Ship validation could not run", failed.message());
+        assertFalse(Files.exists(
+                state.resolve(run.id())
+                        .resolve("evidence/validate-1/stamp.json")));
+    }
+
+    @Test
     void generatedPlanExecuteThenValidatorCommitsPassStampFromStubEvidence()
             throws Exception {
         Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
@@ -522,14 +625,60 @@ class ShipCoordinatorTest {
         assertTrue(Files.readString(manifestSchema)
                 .contains("artifact-manifest.schema.json"));
 
+        ShipCoordinator unavailableCatalog = new ShipCoordinator(
+                state,
+                controller,
+                worker,
+                target -> {
+                    throw new IOException("Catalog unavailable");
+                },
+                new ShipMainValidator(evidence),
+                distribution,
+                Map.of(),
+                true,
+                Clock.systemUTC());
+        ShipRun validating = controller.resume(run.id());
+        List<String> sessionIds = Files.readAllLines(
+                fixture.resolve("session-ids"));
+        String executeSessionId = sessionIds.get(sessionIds.size() - 1);
+        Path sessionLock = state.resolve(run.id())
+                .resolve("sessions")
+                .resolve("." + executeSessionId + ".lock");
+        try (FileChannel channel = FileChannel.open(
+                sessionLock,
+                Set.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+             FileLock ignored = channel.lock()) {
+            ShipRun blocked = deterministic.run(run.id());
+
+            assertEquals(validating, blocked);
+            assertNull(blocked.message());
+            assertFalse(Files.exists(
+                    state.resolve(run.id())
+                            .resolve("evidence/validate-1/stamp.json")));
+        }
+
+        ShipRun failed = unavailableCatalog.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(Stage.VALIDATE, failed.currentStage());
+        assertEquals(StageStatus.FAILED,
+                failed.stage(Stage.VALIDATE).status());
+        assertEquals(1, failed.stage(Stage.VALIDATE).attempts());
+        assertEquals("Ship validation could not run", failed.message());
+        assertFalse(Files.exists(
+                state.resolve(run.id())
+                        .resolve("evidence/validate-1/stamp.json")));
+
         ShipRun completed = deterministic.resume(run.id());
 
         assertEquals(RunStatus.COMPLETED, completed.status());
         assertEquals(StageStatus.COMPLETED,
                 completed.stage(Stage.VALIDATE).status());
-        assertEquals(1, completed.stage(Stage.VALIDATE).attempts());
+        assertEquals(2, completed.stage(Stage.VALIDATE).attempts());
         Path validationEvidence = state.resolve(run.id())
-                .resolve("evidence/validate-1");
+                .resolve("evidence/validate-2");
         ShipLocalStamp stamp = ShipLocalStampStore.read(
                 validationEvidence, run.id());
         assertEquals(ShipLocalStamp.Status.PASS, stamp.status());
@@ -702,15 +851,15 @@ class ShipCoordinatorTest {
         ShipLocalStampStore.write(
                 attempt.evidenceDirectory(), run.id(), stamp);
 
-        assertThrows(IOException.class, () -> coordinator.resume(run.id()));
+        ShipRun failed = coordinator.resume(run.id());
 
-        ShipRun resumed = controller.status(run.id());
-        assertEquals(RunStatus.RUNNING, resumed.status());
-        assertEquals(Stage.VALIDATE, resumed.currentStage());
-        assertEquals(StageStatus.RUNNING,
-                resumed.stage(Stage.VALIDATE).status());
-        assertEquals(2, resumed.stage(Stage.VALIDATE).attempts());
-        assertTrue(resumed.stage(Stage.VALIDATE).artifacts().isEmpty());
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(Stage.VALIDATE, failed.currentStage());
+        assertEquals(StageStatus.FAILED,
+                failed.stage(Stage.VALIDATE).status());
+        assertEquals(2, failed.stage(Stage.VALIDATE).attempts());
+        assertEquals("Ship validation could not run", failed.message());
+        assertTrue(failed.stage(Stage.VALIDATE).artifacts().isEmpty());
         assertEquals(stamp, ShipLocalStampStore.read(
                 attempt.evidenceDirectory(), run.id()));
         assertFalse(Files.exists(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -1,0 +1,1233 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.DeclaredArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.TestArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy.RouteContract;
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogTestVerifier;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
+import io.github.luigidemasi.camelkit.ship.controller.ShipController.StageAttempt;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Oversight;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.RunStatus;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence.SandboxIdentity;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceCommand;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceRunner;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadArchive;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadTestFixture;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStampStore;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain.EntrySummary;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain.Summary;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Outcome;
+import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class ShipCoordinatorTest {
+
+    @TempDir
+    Path directory;
+
+    private Path fixture;
+    private Path project;
+    private Path state;
+    private ShipController controller;
+    private PiWorker worker;
+    private ShipCoordinator coordinator;
+    private DistributionConfig distribution;
+
+    @BeforeEach
+    void prepareFixture() throws Exception {
+        fixture = Files.createDirectory(directory.resolve("fake-pi"));
+        try (var script = Objects.requireNonNull(
+                ShipCoordinatorTest.class.getResourceAsStream(
+                        "/io/github/luigidemasi/camelkit/ship/worker/fake-pi-0.80.6.sh"))) {
+            writeExecutable(
+                    fixture.resolve("pi-rpc"),
+                    new String(script.readAllBytes(), StandardCharsets.UTF_8));
+        }
+        Files.writeString(fixture.resolve("version"), "0.80.6\n");
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        writeDesignResult();
+
+        project = Files.createDirectory(directory.resolve("project"));
+        state = directory.resolve("state");
+        Map<String, String> environment = Map.of();
+        distribution = DistributionConfig.load(new Properties());
+        controller = new ShipController(state, environment);
+        worker = new PiWorker(
+                fixture.resolve("pi-rpc"),
+                distribution.piVersion(),
+                Duration.ofSeconds(30),
+                environment);
+        coordinator = new ShipCoordinator(
+                state,
+                controller,
+                worker,
+                new ShipCatalogService(directory.resolve("m2")),
+                new ShipMainValidator(),
+                distribution,
+                true,
+                Clock.systemUTC());
+    }
+
+    @Test
+    void runRecoversTheExactDurableAttemptBeforeRelaunchingPi()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("recover this result")));
+        seedDurableResult(run);
+        Files.writeString(fixture.resolve("mode"), "nonzero\n");
+
+        ShipRun completed = coordinator.run(run.id());
+
+        assertDesignPaused(completed, 1);
+        assertEquals(
+                List.of(sessionId(run)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+    }
+
+    @Test
+    void resumeRecoversTheExactDurableAttemptBeforeIncrementingIt()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("recover before resume")));
+        seedDurableResult(run);
+        Files.writeString(fixture.resolve("mode"), "nonzero\n");
+
+        ShipRun completed = coordinator.resume(run.id());
+
+        assertDesignPaused(completed, 1);
+        assertEquals(
+                List.of(sessionId(run)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void resumeOnAnAlreadyInterruptedThreadDoesNotStartAnotherAttempt()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("do not resume while interrupted")));
+
+        try {
+            Thread.currentThread().interrupt();
+
+            assertThrows(
+                    InterruptedException.class,
+                    () -> coordinator.resume(run.id()));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+
+        assertEquals(run, controller.status(run.id()));
+        assertFalse(Files.exists(fixture.resolve("session-ids")));
+        assertFalse(Files.exists(
+                state.resolve(run.id()).resolve("evidence/design-2")));
+    }
+
+    @Test
+    void interruptedResumeLeavesADurableResultForTheNextInvocation()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("preserve durable result")));
+        seedDurableResult(run);
+
+        try {
+            Thread.currentThread().interrupt();
+            assertThrows(
+                    InterruptedException.class,
+                    () -> coordinator.resume(run.id()));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+        assertEquals(run, controller.status(run.id()));
+
+        Files.writeString(fixture.resolve("mode"), "nonzero\n");
+        ShipRun completed = coordinator.resume(run.id());
+
+        assertDesignPaused(completed, 1);
+        assertEquals(
+                List.of(sessionId(run)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+    }
+
+    @Test
+    void unavailableGeneratedPredecessorRestartsBeforeTheActiveStage()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("restart missing predecessor")));
+        ShipRun planned = coordinator.run(run.id());
+        ShipRun activePlan = controller.resume(run.id());
+        Path marker = state.resolve(run.id())
+                .resolve("sessions/.camel-kit-results")
+                .resolve(run.id() + "-design-"
+                         + planned.stage(Stage.DESIGN).inputDigest()
+                                 .substring("sha256:".length())
+                         + "-1.json");
+        assertTrue(Files.isRegularFile(marker));
+        Files.writeString(marker, "{}\n");
+
+        ShipRun restarted = coordinator.resume(activePlan.id());
+
+        assertDesignPaused(restarted, 2);
+        assertEquals(StageStatus.PENDING,
+                restarted.stage(Stage.PLAN).status());
+        assertEquals(1, restarted.stage(Stage.PLAN).attempts());
+        String sessionId = sessionId(run);
+        assertEquals(
+                List.of(sessionId, sessionId),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertEquals(
+                List.of(sessionId),
+                Files.readAllLines(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void interruptionLeavesTheAttemptRunningAndResumeReusesItsSession()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("resume interrupted work")));
+        Files.writeString(fixture.resolve("mode"), "block\n");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                coordinator.run(run.id());
+                failure.set(new AssertionError(
+                        "Ship coordinator unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        ShipRun stopped = controller.status(run.id());
+        assertEquals(RunStatus.RUNNING, stopped.status());
+        assertEquals(Stage.DESIGN, stopped.currentStage());
+        assertEquals(StageStatus.RUNNING, stopped.stage(Stage.DESIGN).status());
+        assertEquals(1, stopped.stage(Stage.DESIGN).attempts());
+        assertFixtureProcessesGone();
+
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        ShipRun completed = coordinator.resume(run.id());
+
+        assertDesignPaused(completed, 2);
+        String sessionId = sessionId(run);
+        assertEquals(
+                List.of(sessionId, sessionId),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertEquals(
+                List.of(sessionId),
+                Files.readAllLines(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void busyPiSessionLeavesTheAttemptRunningWithoutProgress()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("busy session")));
+        StageAttempt attempt = controller.prepareAttempt(run.id());
+        Path lock = attempt.sessionDirectory()
+                .resolve("." + sessionId(run) + ".lock");
+
+        try (FileChannel channel = FileChannel.open(
+                lock,
+                Set.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+             FileLock ignored = channel.lock()) {
+            ShipRun blocked = coordinator.run(run.id());
+
+            assertEquals(run, blocked);
+            assertEquals(run, controller.status(run.id()));
+            assertFalse(Files.exists(fixture.resolve("session-ids")));
+            assertFalse(Files.exists(fixture.resolve("args")));
+        }
+    }
+
+    @Test
+    void busyCoordinatorLeaseMakesRunAndResumeReadOnly()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("busy coordinator")));
+        Path lock = state.resolve(run.id()).resolve(".coordinator.lock");
+
+        try (FileChannel channel = FileChannel.open(
+                lock,
+                Set.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE),
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+             FileLock ignored = channel.lock()) {
+            assertEquals(run, coordinator.run(run.id()));
+            assertEquals(run, coordinator.resume(run.id()));
+            assertEquals(run, controller.status(run.id()));
+            assertFalse(Files.exists(fixture.resolve("session-ids")));
+        }
+    }
+
+    @Test
+    void resumeAfterInterruptionRefreshesStaleDocumentAndRelaunchesPi()
+            throws Exception {
+        Path document = Files.writeString(
+                project.resolve("requirements.md"), "original requirements");
+        ShipRun run = controller.start(
+                project,
+                Oversight.ALWAYS,
+                List.of(new ShipContext.DocumentInput(
+                        document.getFileName())));
+        Files.writeString(fixture.resolve("mode"), "block\n");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread invocation = new Thread(() -> {
+            try {
+                coordinator.run(run.id());
+                failure.set(new AssertionError(
+                        "Ship coordinator unexpectedly completed"));
+            } catch (InterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+
+        invocation.start();
+        awaitFile(fixture.resolve("ready"));
+        invocation.interrupt();
+        invocation.join(Duration.ofSeconds(10).toMillis());
+
+        assertFalse(invocation.isAlive());
+        assertNull(failure.get());
+        assertTrue(interrupted.get());
+        ShipRun stopped = controller.status(run.id());
+        assertEquals(RunStatus.RUNNING, stopped.status());
+        assertEquals(1, stopped.stage(Stage.DISCOVERY).attempts());
+        assertFixtureProcessesGone();
+
+        Files.writeString(document, "changed requirements");
+        Files.writeString(fixture.resolve("mode"), "success\n");
+        writeDiscoveryResult();
+
+        ShipRun completed = coordinator.resume(run.id());
+
+        assertEquals(RunStatus.PAUSED, completed.status());
+        assertEquals(Stage.DESIGN, completed.currentStage());
+        assertEquals(StageStatus.COMPLETED,
+                completed.stage(Stage.DISCOVERY).status());
+        assertEquals(2, completed.stage(Stage.DISCOVERY).attempts());
+        assertEquals(StageStatus.PENDING,
+                completed.stage(Stage.DESIGN).status());
+        assertNotEquals(
+                run.stage(Stage.DISCOVERY).inputDigest(),
+                completed.stage(Stage.DISCOVERY).inputDigest());
+        assertNotEquals(run.context(), completed.context());
+        assertEquals(
+                List.of(
+                        sessionId(run, Stage.DISCOVERY),
+                        sessionId(completed, Stage.DISCOVERY)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void invalidTypedResultCanResumeWithADistinctAttemptPrompt()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("retry invalid result")));
+        Files.writeString(
+                fixture.resolve("assistant-text"),
+                "not a typed Ship result");
+
+        ShipRun failed = coordinator.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(StageStatus.FAILED, failed.stage(Stage.DESIGN).status());
+        assertEquals(1, failed.stage(Stage.DESIGN).attempts());
+        String firstPrompt = Files.readString(fixture.resolve("prompt"));
+
+        writeDesignResult();
+        ShipRun completed = coordinator.resume(run.id());
+
+        assertDesignPaused(completed, 2);
+        String secondPrompt = Files.readString(fixture.resolve("prompt"));
+        assertNotEquals(firstPrompt, secondPrompt);
+        String sessionId = sessionId(run);
+        assertEquals(
+                List.of(sessionId, sessionId),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertEquals(
+                List.of(sessionId),
+                Files.readAllLines(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void missingExecuteManifestFailsTheActiveAttempt()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-coordinator"));
+        Files.writeString(documents.resolve("design-spec.md"), "Imported design");
+        Files.writeString(
+                documents.resolve("implementation-plan.md"),
+                "Imported implementation plan");
+        ShipRun run = controller.startFrom(
+                project,
+                Stage.EXECUTE,
+                Oversight.ALWAYS,
+                List.of());
+
+        ShipRun failed = coordinator.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(Stage.EXECUTE, failed.currentStage());
+        assertEquals(StageStatus.FAILED, failed.stage(Stage.EXECUTE).status());
+        assertEquals(1, failed.stage(Stage.EXECUTE).attempts());
+        assertTrue(failed.message().contains("artifact manifest"));
+    }
+
+    @Test
+    void generatedPlanExecuteThenValidatorCommitsPassStampFromStubEvidence()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-coordinator"));
+        Files.writeString(documents.resolve("design-spec.md"), "Imported design");
+
+        ArtifactPolicy policy = mainPolicy();
+        writeWorkerResult("Implementation plan", policy);
+        var snapshot = CatalogTestVerifier.mainSnapshot(
+                Files.createDirectory(directory.resolve("catalog-fixture")));
+        DeterministicEvidenceStub evidence = new DeterministicEvidenceStub();
+        ShipCoordinator deterministic = new ShipCoordinator(
+                state,
+                controller,
+                worker,
+                target -> {
+                    assertEquals(CatalogTestVerifier.TARGET, target);
+                    return snapshot;
+                },
+                new ShipMainValidator(evidence),
+                distribution,
+                Map.of(),
+                true,
+                Clock.fixed(
+                        Instant.parse("2026-07-29T12:00:00Z"),
+                        ZoneOffset.UTC));
+        ShipRun run = controller.startFrom(
+                project,
+                Stage.PLAN,
+                Oversight.SMART,
+                List.of());
+
+        ShipRun planned = deterministic.run(run.id());
+
+        assertEquals(RunStatus.PAUSED, planned.status());
+        assertEquals(Stage.EXECUTE, planned.currentStage());
+        assertEquals(StageStatus.COMPLETED,
+                planned.stage(Stage.PLAN).status());
+        Path inputDirectory = state.resolve(run.id()).resolve("inputs");
+        Path policyContract = fileWithPrefix(
+                inputDirectory, "artifact-policy-");
+        assertTrue(Files.readString(fixture.resolve("prompt"))
+                .contains(policyContract.toString()));
+        var fixedPolicy = new ObjectMapper().readTree(
+                Files.readAllBytes(policyContract));
+        assertEquals(distribution.camelMainVersion(),
+                fixedPolicy.path("camelVersion").textValue());
+        assertEquals(distribution.citrusVersion(),
+                fixedPolicy.path("citrusVersion").textValue());
+        assertTrue(fixedPolicy.path("routes").isEmpty());
+        ShipRun executing = controller.resume(run.id());
+        StageAttempt executeAttempt = controller.prepareAttempt(run.id());
+        writeGeneratedMainCandidate(
+                executeAttempt.workingDirectory(), policy);
+        writeWorkerResult("Execution report", null);
+
+        ShipRun executed = deterministic.run(run.id());
+
+        assertEquals(RunStatus.PAUSED, executed.status());
+        assertEquals(Stage.VALIDATE, executed.currentStage());
+        assertEquals(StageStatus.COMPLETED,
+                executed.stage(Stage.EXECUTE).status());
+        assertEquals(1, executing.stage(Stage.EXECUTE).attempts());
+        Path manifestSchema = fileWithPrefix(
+                inputDirectory, "artifact-manifest-schema-");
+        assertTrue(Files.readString(fixture.resolve("prompt"))
+                .contains(manifestSchema.toString()));
+        assertTrue(Files.readString(manifestSchema)
+                .contains("artifact-manifest.schema.json"));
+
+        ShipRun completed = deterministic.resume(run.id());
+
+        assertEquals(RunStatus.COMPLETED, completed.status());
+        assertEquals(StageStatus.COMPLETED,
+                completed.stage(Stage.VALIDATE).status());
+        assertEquals(1, completed.stage(Stage.VALIDATE).attempts());
+        Path validationEvidence = state.resolve(run.id())
+                .resolve("evidence/validate-1");
+        ShipLocalStamp stamp = ShipLocalStampStore.read(
+                validationEvidence, run.id());
+        assertEquals(ShipLocalStamp.Status.PASS, stamp.status());
+        assertEquals(List.of(
+                "artifact-policy",
+                "catalog-usage",
+                "route-schema",
+                "main-package-and-inspect",
+                "main-runtime-resolve-and-start",
+                "citrus-integration-test-001"),
+                stamp.checks().stream()
+                        .map(ShipLocalStamp.Check::id)
+                        .toList());
+        assertEquals(List.of(
+                "route-schema",
+                "main-package-and-inspect",
+                "main-runtime-resolve-and-start",
+                "citrus-integration-test-001"),
+                evidence.commandIds);
+        Path stampPath = validationEvidence.resolve("stamp.json")
+                .toRealPath();
+        assertEquals(
+                stampPath.toString(),
+                completed.stage(Stage.VALIDATE)
+                        .artifacts().get(0).path());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(stampPath)),
+                completed.stage(Stage.VALIDATE)
+                        .artifacts().get(0).digest());
+    }
+
+    @Test
+    void distributionDriftRestartsGeneratedPlanInsteadOfWedgingValidation()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-coordinator"));
+        Files.writeString(documents.resolve("design-spec.md"), "Imported design");
+        writeWorkerResult("Implementation plan", mainPolicy());
+        ShipRun run = controller.startFrom(
+                project,
+                Stage.PLAN,
+                Oversight.SMART,
+                List.of());
+        ShipRun planned = coordinator.run(run.id());
+        assertEquals(RunStatus.PAUSED, planned.status());
+        assertEquals(Stage.EXECUTE, planned.currentStage());
+        controller.resume(run.id());
+
+        Properties changed = new Properties();
+        changed.setProperty("camel.main.version", "4.99.0");
+        DistributionConfig upgradedDistribution
+                = DistributionConfig.load(changed);
+        ShipCoordinator upgraded = new ShipCoordinator(
+                state,
+                controller,
+                worker,
+                new ShipCatalogService(directory.resolve("m2")),
+                new ShipMainValidator(),
+                upgradedDistribution,
+                true,
+                Clock.systemUTC());
+
+        ShipRun failed = upgraded.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(Stage.PLAN, failed.currentStage());
+        assertEquals(2, failed.stage(Stage.PLAN).attempts());
+        assertEquals(StageStatus.PENDING,
+                failed.stage(Stage.EXECUTE).status());
+        assertTrue(failed.message().contains(
+                "invalid plan result"));
+    }
+
+    @Test
+    void writesOrderedContextToADurableBriefingWithoutPuttingItInArgsOrLogs()
+            throws Exception {
+        Path document = Files.writeString(
+                project.resolve("requirements.md"),
+                "second-document-context");
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("first-inline-context"),
+                new ShipContext.DocumentInput(document.getFileName()),
+                new ShipContext.TextInput("third-inline-context")));
+
+        ShipRun completed = coordinator.run(run.id());
+
+        assertDesignPaused(completed, 1);
+        String digest = run.stage(Stage.DESIGN).inputDigest();
+        Path briefing = state.resolve(run.id())
+                .resolve("inputs")
+                .resolve("design-" + digest.substring("sha256:".length()) + ".md")
+                .toRealPath();
+        assertEquals(
+                String.format(Locale.ROOT, """
+                        # Controller input
+
+                        Run: %s
+                        Stage: DESIGN
+                        Pipeline: 149-coordinator
+                        Input digest: %s
+
+                        ## Initial context
+
+                        ### Source 1 (TEXT)
+
+                        first-inline-context
+
+                        ### Source 2 (DOCUMENT)
+
+                        Path: %s
+
+                        second-document-context
+
+                        ### Source 3 (TEXT)
+
+                        third-inline-context
+
+                        ## DISCOVERY result
+
+                        No imported artifact content.
+                        """, run.id(), digest, document.toAbsolutePath()),
+                Files.readString(briefing));
+
+        String prompt = Files.readString(fixture.resolve("prompt"));
+        assertTrue(prompt.contains(briefing.toString()));
+        assertTrue(prompt.contains(digest));
+        assertFalse(prompt.contains("first-inline-context"));
+        assertFalse(prompt.contains("second-document-context"));
+        assertFalse(prompt.contains("third-inline-context"));
+
+        String arguments = Files.readString(fixture.resolve("args"));
+        String logs = retainedEvidence(run);
+        for (String retained : List.of(
+                briefing.toString(),
+                "You are the bounded Pi worker",
+                "first-inline-context",
+                "second-document-context",
+                "third-inline-context")) {
+            assertFalse(arguments.contains(retained), retained);
+            assertFalse(logs.contains(retained), retained);
+        }
+    }
+
+    @Test
+    void preplantedPassingStampCannotPromoteValidation()
+            throws Exception {
+        ShipRun run = importedValidationRun();
+        StageAttempt attempt = controller.prepareAttempt(run.id());
+        ShipLocalStamp stamp = ShipLocalStamp.create(
+                run.id(),
+                List.of(new ShipLocalStamp.ToolVersion(
+                        "pi",
+                        null,
+                        null,
+                        ShipLocalStamp.Support.UNTESTED,
+                        "Recovered fixture has no Pi diagnostic")),
+                List.of(
+                        new ShipLocalStamp.Check(
+                                "forged-validation",
+                                true,
+                                ShipLocalStamp.Outcome.PASS,
+                                "Preplanted result must not be trusted",
+                                null,
+                                null)),
+                Instant.parse("2026-07-29T12:00:00Z"));
+        ShipLocalStampStore.write(
+                attempt.evidenceDirectory(), run.id(), stamp);
+
+        assertThrows(IOException.class, () -> coordinator.resume(run.id()));
+
+        ShipRun resumed = controller.status(run.id());
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(Stage.VALIDATE, resumed.currentStage());
+        assertEquals(StageStatus.RUNNING,
+                resumed.stage(Stage.VALIDATE).status());
+        assertEquals(2, resumed.stage(Stage.VALIDATE).attempts());
+        assertTrue(resumed.stage(Stage.VALIDATE).artifacts().isEmpty());
+        assertEquals(stamp, ShipLocalStampStore.read(
+                attempt.evidenceDirectory(), run.id()));
+        assertFalse(Files.exists(
+                state.resolve(run.id())
+                        .resolve("evidence/validate-2/stamp.json")));
+        assertFalse(Files.exists(fixture.resolve("session-ids")));
+    }
+
+    @Test
+    void discoveryReusesAnExistingControllerBoundPipeline()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        ShipRun run = controller.start(
+                project, Oversight.SMART, List.of());
+        String result = "{\"schemaVersion\":1,"
+                        + "\"pipelineId\":\"149-coordinator\","
+                        + "\"report\":\"Discovery report\","
+                        + "\"artifactPolicy\":null,"
+                        + "\"materialAmbiguity\":true}";
+        Files.writeString(
+                fixture.resolve("assistant-text"),
+                result.replace("\"", "\\\""));
+
+        ShipRun paused = coordinator.run(run.id());
+
+        assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals(Stage.DESIGN, paused.currentStage());
+        assertEquals("149-coordinator", paused.pipelineId());
+        assertTrue(Files.readString(fixture.resolve("prompt"))
+                .contains("Reuse the controller-bound pipeline ID 149-coordinator"));
+    }
+
+    @Test
+    void discoveryRejectsADifferentControllerBoundPipelineAsRetryableFailure()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        ShipRun run = controller.start(
+                project, Oversight.SMART, List.of());
+        String result = "{\"schemaVersion\":1,"
+                        + "\"pipelineId\":\"150-different\","
+                        + "\"report\":\"Discovery report\","
+                        + "\"artifactPolicy\":null,"
+                        + "\"materialAmbiguity\":true}";
+        Files.writeString(
+                fixture.resolve("assistant-text"),
+                result.replace("\"", "\\\""));
+
+        ShipRun failed = coordinator.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(Stage.DISCOVERY, failed.currentStage());
+        assertEquals(StageStatus.FAILED,
+                failed.stage(Stage.DISCOVERY).status());
+        assertEquals(1, failed.stage(Stage.DISCOVERY).attempts());
+        assertEquals("149-coordinator", failed.pipelineId());
+        assertTrue(failed.message().contains("controller-owned"));
+
+        String corrected = result.replace(
+                "150-different", "149-coordinator");
+        Files.writeString(
+                fixture.resolve("assistant-text"),
+                corrected.replace("\"", "\\\""));
+
+        ShipRun paused = coordinator.resume(run.id());
+
+        assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals(Stage.DESIGN, paused.currentStage());
+        assertEquals(StageStatus.COMPLETED,
+                paused.stage(Stage.DISCOVERY).status());
+        assertEquals(2, paused.stage(Stage.DISCOVERY).attempts());
+        assertEquals("149-coordinator", paused.pipelineId());
+    }
+
+    private ShipRun designRun(List<? extends ShipContext.Input> context)
+            throws IOException {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        return controller.startFrom(
+                project,
+                Stage.DESIGN,
+                Oversight.ALWAYS,
+                context);
+    }
+
+    private ShipRun importedValidationRun() throws IOException {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-coordinator"));
+        Files.writeString(documents.resolve("design-spec.md"), "Imported design");
+        Files.writeString(
+                documents.resolve("implementation-plan.md"),
+                "Imported implementation plan");
+        Files.writeString(
+                documents.resolve("execution-report.md"),
+                "Imported execution report");
+        return controller.startFrom(
+                project,
+                Stage.VALIDATE,
+                Oversight.NEVER,
+                List.of());
+    }
+
+    private ArtifactPolicy mainPolicy() {
+        String camelVersion = distribution.camelMainVersion();
+        String citrusVersion = distribution.citrusVersion();
+        return new ArtifactPolicy(
+                "main",
+                camelVersion,
+                null,
+                null,
+                "yaml",
+                "simple",
+                citrusVersion,
+                CitrusDependencyPolicy.required(citrusVersion),
+                JavaPolicy.FORBIDDEN,
+                List.of(),
+                List.of(new RouteContract(
+                        "orders",
+                        "src/main/resources/routes/orders.camel.yaml",
+                        "test/orders.camel.it.yaml")),
+                true,
+                true);
+    }
+
+    private void writeGeneratedMainCandidate(
+            Path candidate, ArtifactPolicy policy)
+            throws Exception {
+        String routePath = "src/main/resources/routes/orders.camel.yaml";
+        String testPath = "test/orders.camel.it.yaml";
+        write(candidate, routePath, """
+                - route:
+                    id: orders
+                    from:
+                      uri: direct:orders
+                """);
+        write(candidate, testPath, """
+                name: orders-test
+                actions:
+                  - send:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                  - receive:
+                      endpoint: "camel:sync:direct:camel-kit-ship-test-orders"
+                      message:
+                        body:
+                          data: exercise route
+                """);
+        write(candidate, ".camel-kit/config.properties", String.format(Locale.ROOT, """
+                project.runtime=main
+                project.camelVersion=%s
+                project.platformBomVersion=%s
+                citrus.version=%s
+                """,
+                policy.camelVersion(),
+                policy.camelVersion(),
+                policy.citrusVersion()));
+        write(candidate, "pom.xml", String.format(Locale.ROOT, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-main</artifactId>
+                      <version>%1$s</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-yaml-dsl</artifactId>
+                      <version>%1$s</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-direct</artifactId>
+                      <version>%1$s</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """, policy.camelVersion()));
+        RouteArtifact route = new RouteArtifact(
+                "orders",
+                routePath,
+                digest(candidate.resolve(routePath)));
+        TestArtifact test = new TestArtifact(
+                "orders",
+                testPath,
+                digest(candidate.resolve(testPath)));
+        ArtifactManifest manifest = new ArtifactManifest(
+                ArtifactManifest.SCHEMA_VERSION,
+                policy.runtime(),
+                policy.camelVersion(),
+                policy.platformVersion(),
+                policy.springBootVersion(),
+                policy.routeDsl(),
+                policy.expressionLanguage(),
+                policy.citrusVersion(),
+                policy.citrusDependencies(),
+                policy.javaPolicy(),
+                policy.approvedJavaExceptions(),
+                List.of(route),
+                List.of(test),
+                List.of(
+                        new DeclaredArtifact(
+                                "config",
+                                ".camel-kit/config.properties",
+                                digest(candidate.resolve(
+                                        ".camel-kit/config.properties")),
+                                true),
+                        new DeclaredArtifact(
+                                "pom",
+                                "pom.xml",
+                                digest(candidate.resolve("pom.xml")),
+                                true)),
+                policy.citrusTestsRequired(),
+                policy.oneCitrusTestPerRoute());
+        Path manifestPath = candidate.resolve(
+                "docs/camel-kit/149-coordinator/artifact-manifest.json");
+        Files.createDirectories(manifestPath.getParent());
+        new ObjectMapper().writerWithDefaultPrettyPrinter()
+                .writeValue(manifestPath.toFile(), manifest);
+    }
+
+    private static void write(Path root, String relative, String content)
+            throws IOException {
+        Path file = root.resolve(relative);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    private void seedDurableResult(ShipRun run) throws Exception {
+        StageAttempt attempt = controller.prepareAttempt(run.id());
+        Request request = new Request(
+                run.id(),
+                Stage.DESIGN,
+                1,
+                attempt.workingDirectory(),
+                attempt.sessionDirectory(),
+                attempt.evidenceDirectory(),
+                run.stage(Stage.DESIGN).inputDigest(),
+                true,
+                "Seed the exact durable controller attempt.");
+        assertEquals(Outcome.SUCCEEDED, worker.run(request).outcome());
+        assertTrue(worker.recover(request).isPresent());
+    }
+
+    private String retainedEvidence(ShipRun run) throws IOException {
+        try (var files = Files.walk(
+                state.resolve(run.id()).resolve("evidence/design-1"))) {
+            StringBuilder retained = new StringBuilder();
+            for (Path file : files.filter(Files::isRegularFile).sorted().toList()) {
+                retained.append(Files.readString(file));
+            }
+            return retained.toString();
+        }
+    }
+
+    private static void assertDesignPaused(ShipRun run, int attempts) {
+        assertEquals(RunStatus.PAUSED, run.status());
+        assertEquals(Stage.PLAN, run.currentStage());
+        assertEquals(StageStatus.COMPLETED, run.stage(Stage.DESIGN).status());
+        assertEquals(attempts, run.stage(Stage.DESIGN).attempts());
+    }
+
+    private static String sessionId(ShipRun run) {
+        return sessionId(run, Stage.DESIGN);
+    }
+
+    private static String sessionId(ShipRun run, Stage stage) {
+        return run.id() + '-'
+               + stage.name().toLowerCase(java.util.Locale.ROOT) + '-'
+               + run.stage(stage).inputDigest()
+                       .substring("sha256:".length());
+    }
+
+    private void writeDiscoveryResult() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        var result = mapper.createObjectNode();
+        result.put("schemaVersion", 1);
+        result.put("pipelineId", "149-coordinator");
+        result.put("report", "Discovery report");
+        result.putNull("artifactPolicy");
+        result.put("materialAmbiguity", true);
+        Files.writeString(
+                fixture.resolve("assistant-text"),
+                mapper.writeValueAsString(result).replace("\"", "\\\""));
+    }
+
+    private void writeDesignResult() throws IOException {
+        writeWorkerResult("Design report", null);
+    }
+
+    private void writeWorkerResult(
+            String report, ArtifactPolicy policy)
+            throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        var result = mapper.createObjectNode();
+        result.put("schemaVersion", 1);
+        result.putNull("pipelineId");
+        result.put("report", report);
+        if (policy == null) {
+            result.putNull("artifactPolicy");
+        } else {
+            result.set("artifactPolicy", mapper.valueToTree(policy));
+        }
+        result.put("materialAmbiguity", false);
+        Files.writeString(
+                fixture.resolve("assistant-text"),
+                mapper.writeValueAsString(result)
+                        .replace("\"", "\\\""));
+    }
+
+    private final class DeterministicEvidenceStub
+            implements ShipMainValidator.EvidenceExecutor {
+
+        private final List<String> commandIds = new ArrayList<>();
+
+        @Override
+        public CommandEvidence run(
+                Path candidate, Path evidence, EvidenceCommand command)
+                throws IOException {
+            commandIds.add(command.id());
+            Files.createDirectory(evidence);
+            Files.setPosixFilePermissions(
+                    evidence,
+                    PosixFilePermissions.fromString("rwx------"));
+            String jdkDigest = digest("jdk");
+            JvmPayloadArchive.Identity toolchain
+                    = JvmPayloadTestFixture.create(
+                            evidence.resolve("toolchain"),
+                            command.jvmPayload(),
+                            jdkDigest);
+            Path sandbox = writeExecutable(
+                    evidence.resolve("bwrap"), "sandbox");
+            Path java = writeExecutable(
+                    evidence.resolve("java"), "java");
+            byte[] stdout = command.jvmPayload().kind()
+                            == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT
+                                    ? packageSummary(candidate, command)
+                                    : "PASS\n".getBytes(StandardCharsets.UTF_8);
+            Path stdoutPath = writePrivateFile(
+                    evidence.resolve("raw.stdout.log"), stdout);
+            Path stderrPath = writePrivateFile(
+                    evidence.resolve("raw.stderr.log"), new byte[0]);
+            String sandboxDigest = digest(sandbox);
+            String javaDigest = digest(java);
+            Instant started = Instant.parse("2026-07-29T11:59:58Z");
+            Instant ended = Instant.parse("2026-07-29T11:59:59Z");
+            return new CommandEvidence(
+                    CommandEvidence.SCHEMA_VERSION,
+                    command.id(),
+                    new SandboxIdentity(
+                            EvidenceRunner.SANDBOX_PROVIDER,
+                            sandbox.toString(),
+                            sandboxDigest,
+                            sandboxDigest,
+                            null,
+                            EvidenceRunner.expectedSandboxProfileDigest(
+                                    command, jdkDigest)),
+                    toolchain.aggregateDigest(),
+                    toolchain.aggregateDigest(),
+                    toolchain.archive().toString(),
+                    toolchain.archiveDigest(),
+                    java.toString(),
+                    javaDigest,
+                    javaDigest,
+                    null,
+                    payloadVersion(command.jvmPayload()),
+                    command.arguments(),
+                    candidate.toString(),
+                    EvidenceRunner.expectedEnvironment(
+                            command, jdkDigest),
+                    started,
+                    ended,
+                    true,
+                    false,
+                    0,
+                    null,
+                    stdoutPath.toString(),
+                    ShipDigest.sha256(stdout),
+                    stderrPath.toString(),
+                    ShipDigest.sha256(new byte[0]),
+                    command.inputDigests());
+        }
+    }
+
+    private static byte[] packageSummary(
+            Path candidate, EvidenceCommand command)
+            throws IOException {
+        List<EntrySummary> entries = new ArrayList<>();
+        for (int index = 0;
+             index < command.arguments().size();
+             index++) {
+            String argument = command.arguments().get(index);
+            if (!argument.startsWith("--route=")) {
+                continue;
+            }
+            String path = argument.substring("--route=".length());
+            String routeDigest = command.arguments().get(++index)
+                    .substring("--route-digest=".length());
+            entries.add(new EntrySummary(
+                    path,
+                    Files.size(candidate.resolve(path)),
+                    routeDigest));
+        }
+        return new Summary(
+                1,
+                argument(command, "--candidate-digest="),
+                argument(command, "--manifest-digest="),
+                argument(command, "--catalog-usage-digest="),
+                argument(command, "--pom-digest="),
+                argument(command, "--main-payload-digest="),
+                digest("stub-package"),
+                1,
+                entries).encode();
+    }
+
+    private static String argument(
+            EvidenceCommand command, String prefix) {
+        return command.arguments().stream()
+                .filter(argument -> argument.startsWith(prefix))
+                .map(argument -> argument.substring(prefix.length()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static String payloadVersion(JvmPayloadRequest payload) {
+        return switch (payload.kind()) {
+            case CAMEL_YAML_VALIDATE ->
+                "Camel direct YAML validator " + payload.camelVersion();
+            case MAIN_PACKAGE_INSPECT ->
+                ShipMainPackageMain.PAYLOAD_VERSION;
+            case CAMEL_MAIN_START ->
+                "Camel direct Main bootstrap " + payload.camelVersion();
+            case CITRUS_YAML ->
+                "Citrus direct YAML " + payload.citrusVersion()
+                                + " with Camel " + payload.camelVersion();
+            default -> throw new IllegalArgumentException(
+                    "Unexpected deterministic evidence stub payload");
+        };
+    }
+
+    private static String digest(Path file) throws IOException {
+        return ShipDigest.sha256(Files.readAllBytes(file));
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(
+                value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Path writePrivateFile(
+            Path path, byte[] content)
+            throws IOException {
+        Files.write(path, content);
+        Files.setPosixFilePermissions(
+                path, PosixFilePermissions.fromString("rw-------"));
+        return path;
+    }
+
+    private static void awaitFile(Path path) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (!Files.exists(path)) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Timed out waiting for " + path);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static Path fileWithPrefix(Path directory, String prefix)
+            throws IOException {
+        try (var files = Files.list(directory)) {
+            return files.filter(path -> path.getFileName().toString()
+                    .startsWith(prefix))
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    private void assertFixtureProcessesGone() throws Exception {
+        for (String file : List.of("parent-pid", "child-pid")) {
+            long pid = Long.parseLong(
+                    Files.readString(fixture.resolve(file)).strip());
+            long deadline = System.nanoTime()
+                            + Duration.ofSeconds(5).toNanos();
+            while (ProcessHandle.of(pid)
+                    .map(ProcessHandle::isAlive)
+                    .orElse(false)) {
+                if (System.nanoTime() >= deadline) {
+                    throw new AssertionError(
+                            "Fake Pi process is still alive: " + pid);
+                }
+                Thread.sleep(10);
+            }
+        }
+    }
+
+    private static Path writeExecutable(Path path, String script)
+            throws IOException {
+        Files.writeString(path, script);
+        Files.setPosixFilePermissions(
+                path, PosixFilePermissions.fromString("rwx------"));
+        return path;
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidatorTest.java
@@ -1,0 +1,641 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.DeclaredArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.RouteArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.TestArtifact;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy;
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactPolicy.RouteContract;
+import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
+import io.github.luigidemasi.camelkit.ship.catalog.CatalogTestVerifier;
+import io.github.luigidemasi.camelkit.ship.catalog.ShipCatalogService;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence;
+import io.github.luigidemasi.camelkit.ship.evidence.CommandEvidence.SandboxIdentity;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceCommand;
+import io.github.luigidemasi.camelkit.ship.evidence.EvidenceRunner;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadArchive;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadRequest;
+import io.github.luigidemasi.camelkit.ship.evidence.JvmPayloadTestFixture;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Outcome;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.Support;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.ToolVersion;
+import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStampStore;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain.EntrySummary;
+import io.github.luigidemasi.camelkit.ship.evidence.launcher.ShipMainPackageMain.Summary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipMainValidatorTest {
+
+    private static final String RUN_ID = "ship-" + "a".repeat(32);
+    private static final String CITRUS_VERSION = "5.0.0-M2";
+    private static final List<String> CITRUS_DEPENDENCIES
+            = CitrusDependencyPolicy.required(CITRUS_VERSION);
+    private static final Instant STARTED = Instant.parse("2026-07-29T10:00:00Z");
+    private static final Instant ENDED = Instant.parse("2026-07-29T10:00:01Z");
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-07-29T10:00:02Z"), ZoneOffset.UTC);
+    private static final long MAX_TOTAL_LOG_BYTES = 64L * 1024 * 1024;
+    private static final ToolVersion PI = new ToolVersion(
+            "pi",
+            "/usr/bin/pi",
+            "0.80.6",
+            Support.EXPERIMENTAL,
+            "Pi support remains experimental until the live fixture passes");
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void runsTheDeterministicPlanAndPersistsAPassStamp() throws Exception {
+        Project project = project("orders", "payments");
+        RecordingExecutor executor = new RecordingExecutor();
+
+        ShipMainValidator.Result result = validator(executor).validate(
+                RUN_ID,
+                project.root(),
+                project.manifest(),
+                project.policy(),
+                snapshot(),
+                tempDir.resolve("evidence"),
+                PI,
+                CLOCK);
+
+        assertEquals(ShipLocalStamp.Status.PASS, result.stamp().status());
+        assertEquals(List.of(
+                "artifact-policy",
+                "catalog-usage",
+                "route-schema",
+                "main-package-and-inspect",
+                "main-runtime-resolve-and-start",
+                "citrus-integration-test-001",
+                "citrus-integration-test-002"),
+                result.stamp().checks().stream().map(ShipLocalStamp.Check::id).toList());
+        assertEquals(List.of(
+                "route-schema",
+                "main-package-and-inspect",
+                "main-runtime-resolve-and-start",
+                "citrus-integration-test-001",
+                "citrus-integration-test-002"),
+                executor.commands.stream().map(EvidenceCommand::id).toList());
+        String manifestDigest = ShipDigest.sha256(
+                Files.readAllBytes(project.manifest()));
+        assertTrue(executor.commands.stream()
+                .allMatch(command -> manifestDigest.equals(
+                        command.inputDigests().get(0))));
+        EvidenceCommand packageCommand = executor.commands.stream()
+                .filter(command -> "main-package-and-inspect".equals(
+                        command.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                manifestDigest,
+                argument(packageCommand, "--manifest-digest="));
+        assertEquals(result.stamp(),
+                ShipLocalStampStore.read(tempDir.resolve("evidence"), RUN_ID));
+    }
+
+    @Test
+    void invalidArtifactsAndEmptyRequiredTestsLaunchNothing() throws Exception {
+        Project invalid = project("orders");
+        Files.writeString(invalid.root().resolve(".camel-kit/config.properties"), "\nchanged=true\n",
+                java.nio.file.StandardOpenOption.APPEND);
+        RecordingExecutor invalidExecutor = new RecordingExecutor();
+
+        ShipMainValidator.Result invalidResult = validator(invalidExecutor).validate(
+                RUN_ID,
+                invalid.root(),
+                invalid.manifest(),
+                invalid.policy(),
+                snapshot(),
+                tempDir.resolve("invalid-evidence"),
+                PI,
+                CLOCK);
+
+        Project empty = project();
+        RecordingExecutor emptyExecutor = new RecordingExecutor();
+        ShipMainValidator.Result emptyResult = validator(emptyExecutor).validate(
+                RUN_ID,
+                empty.root(),
+                empty.manifest(),
+                empty.policy(),
+                snapshot(),
+                tempDir.resolve("empty-evidence"),
+                PI,
+                CLOCK);
+
+        assertEquals(ShipLocalStamp.Status.FAIL, invalidResult.stamp().status());
+        assertEquals(ShipLocalStamp.Status.FAIL, emptyResult.stamp().status());
+        assertTrue(invalidExecutor.commands.isEmpty());
+        assertTrue(emptyExecutor.commands.isEmpty());
+    }
+
+    @Test
+    void invalidCatalogDependenciesLaunchNothingAndPersistFailure() throws Exception {
+        Project project = project("orders");
+        Path pom = project.root().resolve("pom.xml");
+        Files.writeString(pom, Files.readString(pom).replace(
+                """
+                            <dependency><groupId>org.apache.camel</groupId>
+                              <artifactId>camel-direct</artifactId><version>4.21.0</version></dependency>
+                        """, ""));
+        writeManifest(project.root(), project.routes(), project.tests());
+        RecordingExecutor executor = new RecordingExecutor();
+
+        ShipMainValidator.Result result = validator(executor).validate(
+                RUN_ID,
+                project.root(),
+                project.manifest(),
+                project.policy(),
+                snapshot(),
+                tempDir.resolve("evidence"),
+                PI,
+                CLOCK);
+
+        assertEquals(ShipLocalStamp.Status.FAIL, result.stamp().status());
+        assertEquals(Outcome.FAIL, result.stamp().checks().get(1).outcome());
+        assertTrue(executor.commands.isEmpty());
+        assertEquals(result.stamp(),
+                ShipLocalStampStore.read(tempDir.resolve("evidence"), RUN_ID));
+    }
+
+    @Test
+    void mapsNonzeroAndRejectsAnUnboundPackageSummary() throws Exception {
+        Project nonzeroProject = project("orders");
+        RecordingExecutor nonzero = new RecordingExecutor();
+        nonzero.nonzeroCommand = "citrus-integration-test-001";
+
+        ShipMainValidator.Result nonzeroResult = validator(nonzero).validate(
+                RUN_ID,
+                nonzeroProject.root(),
+                nonzeroProject.manifest(),
+                nonzeroProject.policy(),
+                snapshot(),
+                tempDir.resolve("nonzero-evidence"),
+                PI,
+                CLOCK);
+
+        Project packageProject = project("payments");
+        RecordingExecutor badPackage = new RecordingExecutor();
+        badPackage.invalidPackageSummary = true;
+        ShipMainValidator.Result packageResult = validator(badPackage).validate(
+                RUN_ID,
+                packageProject.root(),
+                packageProject.manifest(),
+                packageProject.policy(),
+                snapshot(),
+                tempDir.resolve("package-evidence"),
+                PI,
+                CLOCK);
+
+        assertEquals(ShipLocalStamp.Status.FAIL, nonzeroResult.stamp().status());
+        assertEquals(Outcome.NONZERO, nonzeroResult.stamp().checks().stream()
+                .filter(check -> "citrus-integration-test-001".equals(check.id()))
+                .findFirst().orElseThrow().outcome());
+        assertEquals(ShipLocalStamp.Status.FAIL, packageResult.stamp().status());
+        assertEquals(Outcome.FAIL, packageResult.stamp().checks().stream()
+                .filter(check -> "main-package-and-inspect".equals(check.id()))
+                .findFirst().orElseThrow().outcome());
+        assertEquals(4, badPackage.commands.size(), "later checks still collect deterministic diagnostics");
+    }
+
+    @Test
+    void interruptionStopsValidationWithoutPublishingAStamp() throws Exception {
+        Project project = project("orders");
+        RecordingExecutor executor = new RecordingExecutor();
+        executor.interruptCommand = "route-schema";
+        Path evidence = tempDir.resolve("interrupted-evidence");
+
+        try {
+            assertThrows(
+                    InterruptedException.class,
+                    () -> validator(executor).validate(
+                            RUN_ID,
+                            project.root(),
+                            project.manifest(),
+                            project.policy(),
+                            snapshot(),
+                            evidence,
+                            PI,
+                            CLOCK));
+
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertEquals(List.of("route-schema"),
+                    executor.commands.stream().map(EvidenceCommand::id).toList());
+            assertFalse(Files.exists(evidence.resolve("stamp.json")));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void interruptionBeforeAnEarlyFailureStampLeavesTheAttemptResumable() throws Exception {
+        Project project = project("orders");
+        Files.writeString(project.manifest(), "not a manifest");
+        Path evidence = tempDir.resolve("early-interrupted-evidence");
+        Clock interruptingClock = new Clock() {
+            @Override
+            public java.time.ZoneId getZone() {
+                return ZoneOffset.UTC;
+            }
+
+            @Override
+            public Clock withZone(java.time.ZoneId zone) {
+                return this;
+            }
+
+            @Override
+            public Instant instant() {
+                Thread.currentThread().interrupt();
+                return CLOCK.instant();
+            }
+        };
+
+        try {
+            assertThrows(
+                    InterruptedException.class,
+                    () -> validator(new RecordingExecutor()).validate(
+                            RUN_ID,
+                            project.root(),
+                            project.manifest(),
+                            project.policy(),
+                            snapshot(),
+                            evidence,
+                            PI,
+                            interruptingClock));
+
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertFalse(Files.exists(evidence.resolve("stamp.json")));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void rejectsNewLogsWhenOtherInterruptedAttemptLogsExhaustAggregateBudget() throws Exception {
+        Project project = project("orders");
+        RecordingExecutor executor = new RecordingExecutor();
+        Path evidence = Files.createDirectory(tempDir.resolve("aggregate-evidence"));
+        Files.setPosixFilePermissions(
+                evidence, PosixFilePermissions.fromString("rwx------"));
+        Path routeStdout = evidence.resolve("route-schema.stdout.log");
+        Path routeStderr = evidence.resolve("route-schema.stderr.log");
+        privateFile(routeStdout, new byte[0]);
+        privateFile(routeStderr, new byte[0]);
+        privateSparseFile(
+                evidence.resolve("main-package-and-inspect.stdout.log"),
+                MAX_TOTAL_LOG_BYTES);
+        privateFile(
+                evidence.resolve("main-package-and-inspect.stderr.log"),
+                new byte[0]);
+
+        ShipMainValidator.Result result = validator(executor).validate(
+                RUN_ID,
+                project.root(),
+                project.manifest(),
+                project.policy(),
+                snapshot(),
+                evidence,
+                PI,
+                CLOCK);
+
+        ShipLocalStamp.Check route = result.stamp().checks().stream()
+                .filter(check -> "route-schema".equals(check.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(Outcome.FAIL, route.outcome());
+        assertTrue(route.summary().contains("retention limit"));
+        assertEquals(0, Files.size(routeStdout));
+        assertEquals(0, Files.size(routeStderr));
+    }
+
+    @Test
+    void replacesRetainedLogsLeftByAnInterruptedAttempt() throws Exception {
+        Project project = project("orders");
+        RecordingExecutor executor = new RecordingExecutor();
+        Path evidence = Files.createDirectory(tempDir.resolve("retry-evidence"));
+        Files.setPosixFilePermissions(
+                evidence, PosixFilePermissions.fromString("rwx------"));
+        Path stdout = evidence.resolve("route-schema.stdout.log");
+        Path stderr = evidence.resolve("route-schema.stderr.log");
+        byte[] partialStderr = "partial stderr".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        privateSparseFile(stdout, MAX_TOTAL_LOG_BYTES - partialStderr.length);
+        privateFile(stderr, partialStderr);
+
+        ShipMainValidator.Result result = validator(executor).validate(
+                RUN_ID,
+                project.root(),
+                project.manifest(),
+                project.policy(),
+                snapshot(),
+                evidence,
+                PI,
+                CLOCK);
+
+        assertEquals(ShipLocalStamp.Status.PASS, result.stamp().status());
+        assertEquals("PASS\n", Files.readString(stdout));
+        assertEquals(0, Files.size(stderr));
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(stdout));
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(stderr));
+        try (var files = Files.list(evidence)) {
+            assertFalse(files.anyMatch(path -> path.getFileName().toString()
+                    .startsWith(".retained-log-")));
+        }
+    }
+
+    private ShipMainValidator validator(RecordingExecutor executor) {
+        return new ShipMainValidator(executor);
+    }
+
+    private ShipCatalogService.Snapshot snapshot() throws Exception {
+        Path directory = Files.createTempDirectory(tempDir, "catalog-");
+        return CatalogTestVerifier.mainSnapshot(directory);
+    }
+
+    private Project project(String... routeIds) throws Exception {
+        Path root = Files.createTempDirectory(tempDir, "candidate-");
+        List<RouteArtifact> routes = new ArrayList<>();
+        List<TestArtifact> tests = new ArrayList<>();
+        List<RouteContract> contracts = new ArrayList<>();
+        for (String routeId : routeIds) {
+            String routePath = "src/main/resources/routes/" + routeId + ".camel.yaml";
+            String testPath = "test/" + routeId + ".camel.it.yaml";
+            write(root, routePath, String.format(Locale.ROOT, """
+                    - route:
+                        id: %s
+                        from:
+                          uri: direct:%s
+                    """, routeId, routeId));
+            write(root, testPath, String.format(Locale.ROOT, """
+                    name: %s-test
+                    actions:
+                      - send:
+                          endpoint: "camel:sync:direct:camel-kit-ship-test-%s"
+                          message:
+                            body:
+                              data: exercise route
+                      - receive:
+                          endpoint: "camel:sync:direct:camel-kit-ship-test-%s"
+                          message:
+                            body:
+                              data: exercise route
+                    """, routeId, routeId, routeId));
+            routes.add(new RouteArtifact(routeId, routePath, digest(root.resolve(routePath))));
+            tests.add(new TestArtifact(routeId, testPath, digest(root.resolve(testPath))));
+            contracts.add(new RouteContract(routeId, routePath, testPath));
+        }
+        write(root, ".camel-kit/config.properties", """
+                project.runtime=main
+                project.camelVersion=4.21.0
+                project.platformBomVersion=4.21.0
+                citrus.version=5.0.0-M2
+                """);
+        write(root, "pom.xml", """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>orders</artifactId><version>1.0.0</version>
+                  <dependencies>
+                    <dependency><groupId>org.apache.camel</groupId>
+                      <artifactId>camel-main</artifactId><version>4.21.0</version></dependency>
+                    <dependency><groupId>org.apache.camel</groupId>
+                      <artifactId>camel-yaml-dsl</artifactId><version>4.21.0</version></dependency>
+                    <dependency><groupId>org.apache.camel</groupId>
+                      <artifactId>camel-direct</artifactId><version>4.21.0</version></dependency>
+                  </dependencies>
+                </project>
+                """);
+        writeManifest(root, routes, tests);
+        ArtifactPolicy policy = new ArtifactPolicy(
+                "main",
+                "4.21.0",
+                null,
+                null,
+                "yaml",
+                "simple",
+                CITRUS_VERSION,
+                CITRUS_DEPENDENCIES,
+                JavaPolicy.FORBIDDEN,
+                List.of(),
+                contracts,
+                true,
+                true);
+        return new Project(root, root.resolve("artifact-manifest.json"), policy, routes, tests);
+    }
+
+    private static void writeManifest(
+            Path root, List<RouteArtifact> routes, List<TestArtifact> tests)
+            throws Exception {
+        ArtifactManifest manifest = new ArtifactManifest(
+                ArtifactManifest.SCHEMA_VERSION,
+                "main",
+                "4.21.0",
+                null,
+                null,
+                "yaml",
+                "simple",
+                CITRUS_VERSION,
+                CITRUS_DEPENDENCIES,
+                JavaPolicy.FORBIDDEN,
+                List.of(),
+                routes,
+                tests,
+                List.of(
+                        new DeclaredArtifact(
+                                "config",
+                                ".camel-kit/config.properties",
+                                digest(root.resolve(".camel-kit/config.properties")),
+                                true),
+                        new DeclaredArtifact("pom", "pom.xml", digest(root.resolve("pom.xml")), true)),
+                true,
+                true);
+        new ObjectMapper().writerWithDefaultPrettyPrinter()
+                .writeValue(root.resolve("artifact-manifest.json").toFile(), manifest);
+    }
+
+    private static void write(Path root, String relative, String content) throws Exception {
+        Path file = root.resolve(relative);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    private static String digest(Path file) throws Exception {
+        return ShipDigest.sha256(Files.readAllBytes(file));
+    }
+
+    private static String digest(String value) {
+        return ShipDigest.sha256(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static String argument(EvidenceCommand command, String prefix) {
+        return command.arguments().stream()
+                .filter(argument -> argument.startsWith(prefix))
+                .map(argument -> argument.substring(prefix.length()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static byte[] packageSummary(Path candidate, EvidenceCommand command)
+            throws Exception {
+        List<EntrySummary> entries = new ArrayList<>();
+        for (int index = 0; index < command.arguments().size(); index++) {
+            String argument = command.arguments().get(index);
+            if (!argument.startsWith("--route=")) {
+                continue;
+            }
+            String path = argument.substring("--route=".length());
+            String routeDigest = command.arguments().get(++index)
+                    .substring("--route-digest=".length());
+            entries.add(new EntrySummary(path, Files.size(candidate.resolve(path)), routeDigest));
+        }
+        return new Summary(
+                1,
+                argument(command, "--candidate-digest="),
+                argument(command, "--manifest-digest="),
+                argument(command, "--catalog-usage-digest="),
+                argument(command, "--pom-digest="),
+                argument(command, "--main-payload-digest="),
+                digest("package"),
+                1,
+                entries).encode();
+    }
+
+    private static String version(JvmPayloadRequest payload) {
+        return switch (payload.kind()) {
+            case CAMEL_YAML_VALIDATE -> "Camel direct YAML validator " + payload.camelVersion();
+            case MAIN_PACKAGE_INSPECT -> ShipMainPackageMain.PAYLOAD_VERSION;
+            case CAMEL_MAIN_START -> "Camel direct Main bootstrap " + payload.camelVersion();
+            case CITRUS_YAML -> "Citrus direct YAML " + payload.citrusVersion()
+                                + " with Camel " + payload.camelVersion();
+            default -> throw new IllegalArgumentException();
+        };
+    }
+
+    private static void privateFile(Path file, byte[] content) throws Exception {
+        Files.write(file, content);
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+    }
+
+    private static void privateSparseFile(Path file, long size) throws Exception {
+        try (RandomAccessFile output = new RandomAccessFile(file.toFile(), "rw")) {
+            output.setLength(size);
+        }
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+    }
+
+    private static Path privateExecutable(Path file, byte[] content) throws Exception {
+        Files.write(file, content);
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rwx------"));
+        return file;
+    }
+
+    private final class RecordingExecutor implements ShipMainValidator.EvidenceExecutor {
+
+        private final List<EvidenceCommand> commands = new ArrayList<>();
+        private String nonzeroCommand;
+        private String interruptCommand;
+        private boolean invalidPackageSummary;
+
+        @Override
+        public CommandEvidence run(Path candidate, Path directory, EvidenceCommand command)
+                throws IOException {
+            commands.add(command);
+            try {
+                Files.createDirectory(directory);
+                Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+                String jdkDigest = digest("jdk");
+                JvmPayloadArchive.Identity toolchain = JvmPayloadTestFixture.create(
+                        directory.resolve("toolchain"), command.jvmPayload(), jdkDigest);
+                Path sandboxExecutable = privateExecutable(
+                        directory.resolve("bwrap"), "sandbox".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                Path javaExecutable = privateExecutable(
+                        directory.resolve("java"), "java".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                byte[] stdout = command.jvmPayload().kind() == JvmPayloadRequest.Kind.MAIN_PACKAGE_INSPECT
+                        ? invalidPackageSummary
+                                ? "not-a-summary\n".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+                                : packageSummary(candidate, command)
+                        : "PASS\n".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                Path stdoutPath = directory.resolve("raw.stdout.log");
+                Path stderrPath = directory.resolve("raw.stderr.log");
+                privateFile(stdoutPath, stdout);
+                privateFile(stderrPath, new byte[0]);
+                String sandboxDigest = digest(sandboxExecutable);
+                String executableDigest = digest(javaExecutable);
+                boolean nonzero = command.id().equals(nonzeroCommand);
+                CommandEvidence evidence = new CommandEvidence(
+                        CommandEvidence.SCHEMA_VERSION,
+                        command.id(),
+                        new SandboxIdentity(
+                                EvidenceRunner.SANDBOX_PROVIDER,
+                                sandboxExecutable.toString(),
+                                sandboxDigest,
+                                sandboxDigest,
+                                null,
+                                EvidenceRunner.expectedSandboxProfileDigest(command, jdkDigest)),
+                        toolchain.aggregateDigest(),
+                        toolchain.aggregateDigest(),
+                        toolchain.archive().toString(),
+                        toolchain.archiveDigest(),
+                        javaExecutable.toString(),
+                        executableDigest,
+                        executableDigest,
+                        null,
+                        version(command.jvmPayload()),
+                        command.arguments(),
+                        candidate.toString(),
+                        EvidenceRunner.expectedEnvironment(command, jdkDigest),
+                        STARTED,
+                        ENDED,
+                        true,
+                        false,
+                        nonzero ? 7 : 0,
+                        null,
+                        stdoutPath.toString(),
+                        ShipDigest.sha256(stdout),
+                        stderrPath.toString(),
+                        ShipDigest.sha256(new byte[0]),
+                        command.inputDigests());
+                if (command.id().equals(interruptCommand)) {
+                    Thread.currentThread().interrupt();
+                }
+                return evidence;
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    private record Project(
+            Path root,
+            Path manifest,
+            ArtifactPolicy policy,
+            List<RouteArtifact> routes,
+            List<TestArtifact> tests) {
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -167,10 +167,12 @@ class ShipRunStoreTest {
                 state, valid.substring(0, closingBrace) + ",\"unexpected\":true}");
         assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
 
-        Files.writeString(state, "{\"schemaVersion\":2}");
+        Files.writeString(
+                state,
+                "{\"schemaVersion\":" + ShipRun.SCHEMA_VERSION + "}");
         assertCode("state-corrupt", () -> store.read(THIRD_RUN_ID));
 
-        Files.writeString(state, "{\"schemaVersion\":1}");
+        Files.writeString(state, "{\"schemaVersion\":2}");
         assertCode("state-version-unsupported", () -> store.read(THIRD_RUN_ID));
 
         Files.writeString(state, valid.replace(THIRD_RUN_ID, OTHER_RUN_ID));
@@ -265,6 +267,40 @@ class ShipRunStoreTest {
 
         assertEquals(0, imported.stage(ShipRun.Stage.EXECUTE).attempts());
         assertEquals(imported, store().read(imported.id()));
+    }
+
+    @Test
+    void rejectsExternalOrAbsentReferencesForAttemptedCompletedValidation()
+            throws Exception {
+        ShipRunStore store = store();
+        ShipRun completed = completedRun(RUN_ID);
+        store.create(completed);
+        Path state = stateRoot().resolve(RUN_ID).resolve("state.json");
+        byte[] valid = Files.readAllBytes(state);
+        ObjectMapper json = new ObjectMapper();
+
+        ObjectNode document = (ObjectNode) json.readTree(valid);
+        ObjectNode validation = stage(document, ShipRun.Stage.VALIDATE);
+        ((ObjectNode) validation.withArray("artifacts").get(0))
+                .put("path", temporaryDirectory.resolve("external-stamp.json").toString());
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+
+        document = (ObjectNode) json.readTree(valid);
+        validation = stage(document, ShipRun.Stage.VALIDATE);
+        ((ObjectNode) validation.withArray("artifacts").get(0))
+                .put(
+                        "path",
+                        Path.of(completed.projectDirectory())
+                                .resolve("generic-validation.txt")
+                                .toString());
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
+
+        document = (ObjectNode) json.readTree(valid);
+        stage(document, ShipRun.Stage.VALIDATE).putArray("artifacts");
+        Files.write(state, json.writeValueAsBytes(document));
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
     }
 
     @Test
@@ -401,6 +437,12 @@ class ShipRunStoreTest {
                         ShipDigest.sha256("workspace".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
                 artifacts = List.of(root);
                 output = ShipRun.executeOutputDigest(root);
+            } else if (stage == ShipRun.Stage.VALIDATE) {
+                ShipRun.ArtifactRef stamp = new ShipRun.ArtifactRef(
+                        stateRoot().resolve(runId).resolve("evidence/validate-1/stamp.json")
+                                .toAbsolutePath().normalize().toString(),
+                        output);
+                artifacts = List.of(stamp);
             }
             stages.set(
                     stage.ordinal(),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResultTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipStageResultTest.java
@@ -1,0 +1,407 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.JavaPolicy;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipStageResultTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String CITRUS_VERSION = "5.0.0-M2";
+
+    @Test
+    void parsesEveryPiOwnedStageShape() throws Exception {
+        ShipStageResult discovery = parse(Stage.DISCOVERY, result("149-local-controller", null));
+        ShipStageResult design = parse(Stage.DESIGN, result(null, null));
+        ObjectNode planResult = result(null, policy("4.21.0", CITRUS_VERSION));
+        planResult.put("materialAmbiguity", true);
+        ShipStageResult plan = parse(Stage.PLAN, planResult);
+        ShipStageResult execute = parse(Stage.EXECUTE, result(null, null));
+
+        assertEquals(ShipStageResult.SCHEMA_VERSION, discovery.schemaVersion());
+        assertEquals("149-local-controller", discovery.pipelineId());
+        assertEquals("Stage report", discovery.report());
+        assertNull(discovery.artifactPolicy());
+        assertFalse(discovery.materialAmbiguity());
+        assertNull(design.pipelineId());
+        assertNull(design.artifactPolicy());
+        assertEquals("main", plan.artifactPolicy().runtime());
+        assertEquals("4.21.0", plan.artifactPolicy().camelVersion());
+        assertEquals("yaml", plan.artifactPolicy().routeDsl());
+        assertEquals("simple", plan.artifactPolicy().expressionLanguage());
+        assertEquals(JavaPolicy.FORBIDDEN, plan.artifactPolicy().javaPolicy());
+        assertTrue(plan.artifactPolicy().citrusTestsRequired());
+        assertTrue(plan.artifactPolicy().oneCitrusTestPerRoute());
+        assertTrue(plan.materialAmbiguity());
+        assertEquals("orders", plan.artifactPolicy().routes().get(0).routeId());
+        assertNull(execute.artifactPolicy());
+
+        assertRejected(Stage.VALIDATE, result(null, null), "Validate is controller-owned");
+    }
+
+    @Test
+    void rejectsMalformedOrNonCanonicalEnvelopeJson() throws Exception {
+        ObjectNode valid = result("149-local-controller", null);
+        for (String field : List.of(
+                "schemaVersion", "pipelineId", "report", "artifactPolicy", "materialAmbiguity")) {
+            ObjectNode missing = valid.deepCopy();
+            missing.remove(field);
+            assertRejected(Stage.DISCOVERY, missing, "missing " + field);
+        }
+
+        ObjectNode unknown = valid.deepCopy();
+        unknown.put("unknown", true);
+        assertRejected(Stage.DISCOVERY, unknown, "unknown property");
+        assertRejected(
+                Stage.DISCOVERY,
+                JSON.writeValueAsString(valid) + "{}",
+                "trailing document");
+        assertRejected(
+                Stage.DISCOVERY,
+                """
+                        {
+                          "schemaVersion": 1,
+                          "schemaVersion": 1,
+                          "pipelineId": "149-local-controller",
+                          "report": "Stage report",
+                          "artifactPolicy": null,
+                          "materialAmbiguity": false
+                        }
+                        """,
+                "duplicate property");
+        assertRejected(Stage.DISCOVERY, "{", "malformed document");
+        assertRejected(Stage.DISCOVERY, "\uD800", "invalid Unicode");
+        assertRejected(Stage.DISCOVERY, " ".repeat(1024 * 1024 + 1), "oversized response");
+        ObjectNode multibyte = valid.deepCopy();
+        multibyte.put("report", "é".repeat(512 * 1024 + 1));
+        assertRejected(Stage.DISCOVERY, multibyte, "oversized UTF-8 response");
+    }
+
+    @Test
+    void rejectsScalarCoercionAndInvalidPrimitiveValues() throws Exception {
+        ObjectNode valid = result("149-local-controller", null);
+
+        for (JsonNode value : List.of(
+                JSON.getNodeFactory().textNode("1"),
+                JSON.getNodeFactory().numberNode(1.0),
+                JSON.getNodeFactory().nullNode())) {
+            ObjectNode invalid = valid.deepCopy();
+            invalid.set("schemaVersion", value);
+            assertRejected(Stage.DISCOVERY, invalid, "invalid schemaVersion " + value);
+        }
+        for (JsonNode value : List.of(
+                JSON.getNodeFactory().textNode("false"),
+                JSON.getNodeFactory().numberNode(0),
+                JSON.getNodeFactory().nullNode())) {
+            ObjectNode invalid = valid.deepCopy();
+            invalid.set("materialAmbiguity", value);
+            assertRejected(Stage.DISCOVERY, invalid, "invalid materialAmbiguity " + value);
+        }
+        ObjectNode numericPipeline = valid.deepCopy();
+        numericPipeline.put("pipelineId", 149);
+        assertRejected(Stage.DISCOVERY, numericPipeline, "numeric pipeline ID");
+
+        ObjectNode numericReport = valid.deepCopy();
+        numericReport.put("report", 149);
+        assertRejected(Stage.DISCOVERY, numericReport, "numeric report");
+
+        ObjectNode wrongSchema = valid.deepCopy();
+        wrongSchema.put("schemaVersion", 2);
+        assertRejected(Stage.DISCOVERY, wrongSchema, "unsupported schema");
+    }
+
+    @Test
+    void rejectsInvalidReportsAndStageSpecificFields() throws Exception {
+        ObjectNode discovery = result("149-local-controller", null);
+        for (String report : List.of("", " \n\t", "bad\0report")) {
+            ObjectNode invalid = discovery.deepCopy();
+            invalid.put("report", report);
+            assertRejected(Stage.DISCOVERY, invalid, "invalid report");
+        }
+        ObjectNode nullReport = discovery.deepCopy();
+        nullReport.putNull("report");
+        assertRejected(Stage.DISCOVERY, nullReport, "null report");
+
+        assertRejected(Stage.DISCOVERY, result(null, null), "missing Discovery pipeline ID");
+        assertRejected(Stage.DISCOVERY, result("orders", null), "invalid Discovery pipeline ID");
+        assertRejected(
+                Stage.DISCOVERY,
+                result("149-local-controller", policy("4.21.0", CITRUS_VERSION)),
+                "Discovery policy");
+        for (Stage stage : List.of(Stage.DESIGN, Stage.EXECUTE)) {
+            assertRejected(stage, result("149-local-controller", null), stage + " pipeline ID");
+            assertRejected(stage, result(null, policy("4.21.0", CITRUS_VERSION)), stage + " policy");
+        }
+        assertRejected(Stage.PLAN, result("149-local-controller", policy("4.21.0", CITRUS_VERSION)),
+                "Plan pipeline ID");
+        assertRejected(Stage.PLAN, result(null, null), "missing Plan policy");
+        assertRejected(Stage.PLAN, result(null, JSON.getNodeFactory().textNode("policy")), "scalar Plan policy");
+        assertThrows(IOException.class, () -> ShipStageResult.parse(null, "{}"));
+    }
+
+    @Test
+    void requiresEveryArtifactPolicyFieldAndRejectsUnknownOrNullFields() throws Exception {
+        ObjectNode valid = result(null, policy("4.21.0", CITRUS_VERSION));
+        for (String field : List.of(
+                "runtime",
+                "camelVersion",
+                "platformVersion",
+                "springBootVersion",
+                "routeDsl",
+                "expressionLanguage",
+                "citrusVersion",
+                "citrusDependencies",
+                "javaPolicy",
+                "approvedJavaExceptions",
+                "routes",
+                "citrusTestsRequired",
+                "oneCitrusTestPerRoute")) {
+            ObjectNode missing = valid.deepCopy();
+            artifactPolicy(missing).remove(field);
+            assertRejected(Stage.PLAN, missing, "missing policy " + field);
+        }
+
+        ObjectNode unknown = valid.deepCopy();
+        artifactPolicy(unknown).put("unknown", true);
+        assertRejected(Stage.PLAN, unknown, "unknown policy property");
+
+        for (String field : List.of(
+                "runtime",
+                "camelVersion",
+                "routeDsl",
+                "expressionLanguage",
+                "citrusVersion",
+                "citrusDependencies",
+                "javaPolicy",
+                "approvedJavaExceptions",
+                "routes")) {
+            ObjectNode invalid = valid.deepCopy();
+            artifactPolicy(invalid).putNull(field);
+            assertRejected(Stage.PLAN, invalid, "null policy " + field);
+        }
+        for (String field : List.of("citrusTestsRequired", "oneCitrusTestPerRoute")) {
+            ObjectNode invalid = valid.deepCopy();
+            artifactPolicy(invalid).putNull(field);
+            assertRejected(Stage.PLAN, invalid, "null policy primitive " + field);
+
+            ObjectNode coerced = valid.deepCopy();
+            artifactPolicy(coerced).put(field, "true");
+            assertRejected(Stage.PLAN, coerced, "coerced policy primitive " + field);
+        }
+
+        ObjectNode numericEnum = valid.deepCopy();
+        artifactPolicy(numericEnum).put("javaPolicy", 0);
+        assertRejected(Stage.PLAN, numericEnum, "numeric Java policy");
+
+        ObjectNode numericVersion = valid.deepCopy();
+        artifactPolicy(numericVersion).put("camelVersion", 421);
+        assertRejected(Stage.PLAN, numericVersion, "numeric Camel version");
+
+        for (String field : List.of("citrusDependencies", "approvedJavaExceptions")) {
+            for (JsonNode value : List.of(
+                    JSON.getNodeFactory().nullNode(),
+                    JSON.getNodeFactory().numberNode(149))) {
+                ObjectNode invalid = valid.deepCopy();
+                ((ArrayNode) artifactPolicy(invalid).get(field)).add(value);
+                assertRejected(Stage.PLAN, invalid, "invalid " + field + " item " + value);
+            }
+        }
+    }
+
+    @Test
+    void acceptsUnpinnedImmutableVersionsButEnforcesMainValidationPolicy() throws Exception {
+        ShipStageResult accepted = parse(
+                Stage.PLAN,
+                result(null, policy("99.1.0", "6.1.2")));
+        assertEquals("99.1.0", accepted.artifactPolicy().camelVersion());
+        assertEquals("6.1.2", accepted.artifactPolicy().citrusVersion());
+
+        ObjectNode valid = result(null, policy("4.21.0", CITRUS_VERSION));
+        assertPolicyMutationRejected(valid, "runtime", "spring-boot");
+        assertPolicyMutationRejected(valid, "camelVersion", "4.21.0-SNAPSHOT");
+        assertPolicyMutationRejected(valid, "platformVersion", "4.21.0");
+        assertPolicyMutationRejected(valid, "springBootVersion", "3.5.0");
+        assertPolicyMutationRejected(valid, "routeDsl", "xml");
+        assertPolicyMutationRejected(valid, "expressionLanguage", "groovy");
+        assertPolicyMutationRejected(valid, "citrusVersion", "LATEST");
+        assertPolicyMutationRejected(valid, "javaPolicy", "ALLOWED");
+
+        ObjectNode dependencies = valid.deepCopy();
+        ((ArrayNode) artifactPolicy(dependencies).get("citrusDependencies")).remove(0);
+        assertRejected(Stage.PLAN, dependencies, "incomplete Citrus dependencies");
+
+        ObjectNode exception = valid.deepCopy();
+        ((ArrayNode) artifactPolicy(exception).get("approvedJavaExceptions")).add("Example.java");
+        assertRejected(Stage.PLAN, exception, "Java exception");
+
+        ObjectNode noRoutes = valid.deepCopy();
+        artifactPolicy(noRoutes).putArray("routes");
+        assertRejected(Stage.PLAN, noRoutes, "empty routes");
+
+        for (String flag : List.of("citrusTestsRequired", "oneCitrusTestPerRoute")) {
+            ObjectNode weakened = valid.deepCopy();
+            artifactPolicy(weakened).put(flag, false);
+            assertRejected(Stage.PLAN, weakened, "false " + flag);
+        }
+    }
+
+    @Test
+    void requiresDistinctSortedOneToOneSafeRouteContracts() throws Exception {
+        ObjectNode valid = result(null, policy("4.21.0", CITRUS_VERSION));
+
+        for (String field : List.of("routeId", "routePath", "citrusTestPath")) {
+            ObjectNode missing = valid.deepCopy();
+            route(missing, 0).remove(field);
+            assertRejected(Stage.PLAN, missing, "missing route " + field);
+
+            ObjectNode nullValue = valid.deepCopy();
+            route(nullValue, 0).putNull(field);
+            assertRejected(Stage.PLAN, nullValue, "null route " + field);
+        }
+        ObjectNode unknown = valid.deepCopy();
+        route(unknown, 0).put("unknown", true);
+        assertRejected(Stage.PLAN, unknown, "unknown route property");
+
+        for (String routePath : List.of(
+                "/orders.camel.yaml",
+                "../orders.camel.yaml",
+                "routes\\orders.camel.yaml",
+                ".git/orders.camel.yaml",
+                "target/orders.camel.yaml",
+                "routes/wrong.camel.yaml",
+                "routes/orders.yaml")) {
+            ObjectNode invalid = valid.deepCopy();
+            route(invalid, 0).put("routePath", routePath);
+            assertRejected(Stage.PLAN, invalid, "unsafe route path " + routePath);
+        }
+        for (String testPath : List.of(
+                "../orders.camel.it.yaml",
+                "test/nested/orders.camel.it.yaml",
+                "test/wrong.camel.it.yaml",
+                "target/orders.camel.it.yaml")) {
+            ObjectNode invalid = valid.deepCopy();
+            route(invalid, 0).put("citrusTestPath", testPath);
+            assertRejected(Stage.PLAN, invalid, "unsafe test path " + testPath);
+        }
+        for (String routeId : List.of("", "bad/id", ".orders", "a".repeat(129))) {
+            ObjectNode invalid = valid.deepCopy();
+            route(invalid, 0).put("routeId", routeId);
+            assertRejected(Stage.PLAN, invalid, "invalid route ID " + routeId);
+        }
+
+        ObjectNode duplicate = valid.deepCopy();
+        ((ArrayNode) artifactPolicy(duplicate).get("routes")).add(route(duplicate, 0).deepCopy());
+        assertRejected(Stage.PLAN, duplicate, "duplicate route");
+
+        ObjectNode nullRoute = valid.deepCopy();
+        ((ArrayNode) artifactPolicy(nullRoute).get("routes")).addNull();
+        assertRejected(Stage.PLAN, nullRoute, "null route");
+
+        ObjectNode sorted = valid.deepCopy();
+        ((ArrayNode) artifactPolicy(sorted).get("routes")).add(route(
+                "payments",
+                "src/main/resources/routes/payments.camel.yaml",
+                "test/payments.camel.it.yaml"));
+        assertEquals(2, parse(Stage.PLAN, sorted).artifactPolicy().routes().size());
+
+        ObjectNode unsorted = valid.deepCopy();
+        ArrayNode routes = (ArrayNode) artifactPolicy(unsorted).get("routes");
+        JsonNode orders = routes.remove(0);
+        routes.add(route(
+                "payments",
+                "src/main/resources/routes/payments.camel.yaml",
+                "test/payments.camel.it.yaml"));
+        routes.add(orders);
+        assertRejected(Stage.PLAN, unsorted, "unsorted routes");
+    }
+
+    private static void assertPolicyMutationRejected(ObjectNode valid, String field, String value)
+            throws Exception {
+        ObjectNode invalid = valid.deepCopy();
+        artifactPolicy(invalid).put(field, value);
+        assertRejected(Stage.PLAN, invalid, "invalid " + field);
+    }
+
+    private static ShipStageResult parse(Stage stage, ObjectNode result) throws Exception {
+        return ShipStageResult.parse(stage, JSON.writeValueAsString(result));
+    }
+
+    private static void assertRejected(Stage stage, ObjectNode result, String label) throws Exception {
+        assertRejected(stage, JSON.writeValueAsString(result), label);
+    }
+
+    private static void assertRejected(Stage stage, String result, String label) {
+        assertThrows(IOException.class, () -> ShipStageResult.parse(stage, result), label);
+    }
+
+    private static ObjectNode result(String pipelineId, JsonNode policy) {
+        ObjectNode result = JSON.createObjectNode();
+        result.put("schemaVersion", ShipStageResult.SCHEMA_VERSION);
+        if (pipelineId == null) {
+            result.putNull("pipelineId");
+        } else {
+            result.put("pipelineId", pipelineId);
+        }
+        result.put("report", "Stage report");
+        if (policy == null) {
+            result.putNull("artifactPolicy");
+        } else {
+            result.set("artifactPolicy", policy);
+        }
+        result.put("materialAmbiguity", false);
+        return result;
+    }
+
+    private static ObjectNode policy(String camelVersion, String citrusVersion) {
+        ObjectNode policy = JSON.createObjectNode();
+        policy.put("runtime", "main");
+        policy.put("camelVersion", camelVersion);
+        policy.putNull("platformVersion");
+        policy.putNull("springBootVersion");
+        policy.put("routeDsl", "yaml");
+        policy.put("expressionLanguage", "simple");
+        policy.put("citrusVersion", citrusVersion);
+        ArrayNode dependencies = policy.putArray("citrusDependencies");
+        dependencies.add("org.citrusframework:citrus-camel:" + citrusVersion);
+        dependencies.add("org.citrusframework:citrus-junit-jupiter:" + citrusVersion);
+        dependencies.add("org.citrusframework:citrus-yaml:" + citrusVersion);
+        policy.put("javaPolicy", "FORBIDDEN");
+        policy.putArray("approvedJavaExceptions");
+        policy.putArray("routes").add(route(
+                "orders",
+                "src/main/resources/routes/orders.camel.yaml",
+                "test/orders.camel.it.yaml"));
+        policy.put("citrusTestsRequired", true);
+        policy.put("oneCitrusTestPerRoute", true);
+        return policy;
+    }
+
+    private static ObjectNode route(String id, String routePath, String testPath) {
+        return JSON.createObjectNode()
+                .put("routeId", id)
+                .put("routePath", routePath)
+                .put("citrusTestPath", testPath);
+    }
+
+    private static ObjectNode artifactPolicy(ObjectNode result) {
+        return (ObjectNode) result.get("artifactPolicy");
+    }
+
+    private static ObjectNode route(ObjectNode result, int index) {
+        return (ObjectNode) artifactPolicy(result).withArray("routes").get(index);
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStampTest.java
@@ -492,6 +492,26 @@ class ShipLocalStampTest {
     }
 
     @Test
+    void verifiedReadBindsTheStampAndDigestToTheSameBytes(@TempDir Path directory)
+            throws Exception {
+        makePrivate(directory);
+        ShipLocalStamp stamp = persistableStamp(directory, 0);
+        Path report = ShipLocalStampStore.write(directory, RUN_ID, stamp);
+        byte[] encoded = Files.readAllBytes(report);
+
+        ShipLocalStampStore.VerifiedStamp verified
+                = ShipLocalStampStore.readVerified(directory, RUN_ID);
+        Files.writeString(report, "changed after the verified read");
+
+        assertAll(
+                () -> assertEquals(stamp, verified.stamp()),
+                () -> assertEquals(report, verified.path()),
+                () -> assertEquals(ShipDigest.sha256(encoded), verified.digest()),
+                () -> assertFalse(verified.digest().equals(
+                        ShipDigest.sha256(Files.readAllBytes(report)))));
+    }
+
+    @Test
     void acceptsSymbolicAncestorButRejectsSymbolicDirectory(@TempDir Path directory)
             throws Exception {
         Path realAncestor = Files.createDirectory(directory.resolve("real-ancestor"));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -36,8 +36,16 @@ class PiWorkerResultStoreTest {
         PiWorkerResultStore.write(first, result("first"));
         PiWorkerResultStore.write(second, result("second"));
 
-        assertEquals("first", PiWorkerResultStore.read(first).orElseThrow().assistantText());
-        assertEquals("second", PiWorkerResultStore.read(second).orElseThrow().assistantText());
+        assertEquals(
+                "first",
+                PiWorkerResultStore.read(first)
+                        .orElseThrow()
+                        .assistantText());
+        assertEquals(
+                "second",
+                PiWorkerResultStore.read(second)
+                        .orElseThrow()
+                        .assistantText());
         try (var files = Files.list(sessions.resolve(".camel-kit-results"))) {
             assertEquals(2, files.count());
         }
@@ -89,21 +97,25 @@ class PiWorkerResultStoreTest {
 
         Files.writeString(marker, encoded.replace(RUN_A, RUN_B));
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("does not match"));
 
         Files.writeString(marker, encoded.replace(
                 "\"runId\" : \"" + RUN_A + "\"", "\"runId\" : null"));
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("does not match"));
 
         Files.writeString(marker, encoded.replace(
                 "\"inputDigest\" : \"" + DIGEST + "\"", "\"inputDigest\" : null"));
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("does not match"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("does not match"));
 
         Files.writeString(marker, encoded.replace("\"schemaVersion\" : 1", "\"schemaVersion\" : 2"));
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("schema version"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("schema version"));
     }
 
     @Test
@@ -115,39 +127,210 @@ class PiWorkerResultStoreTest {
 
         Files.write(marker, new byte[0]);
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("size"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("size"));
 
         Files.writeString(marker, "{");
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("malformed"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("malformed"));
 
         try (RandomAccessFile file = new RandomAccessFile(marker.toFile(), "rw")) {
             file.setLength(20L * 1024 * 1024 + 1);
         }
         assertTrue(assertThrows(IOException.class,
-                () -> PiWorkerResultStore.read(request)).getMessage().contains("size"));
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("size"));
     }
 
-    private PiWorker.Request request(String runId, Path sessions) {
+    @Test
+    void rejectsDeletedTamperedAndOversizedEvidenceLogs() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+
+        PiWorker.Result deleted = result("deleted");
+        PiWorkerResultStore.write(request, deleted);
+        Files.delete(Path.of(deleted.evidence().stdoutLog()));
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("missing or invalid"));
+
+        PiWorker.Result tampered = result("tampered");
+        PiWorkerResultStore.write(request, tampered);
+        Files.writeString(
+                Path.of(tampered.evidence().stderrLog()),
+                "changed");
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("recorded digest"));
+
+        PiWorker.Result oversized = result("oversized");
+        PiWorkerResultStore.write(request, oversized);
+        try (RandomAccessFile file = new RandomAccessFile(
+                Path.of(oversized.evidence().stdoutLog()).toFile(),
+                "rw")) {
+            file.setLength((long) PiWorker.MAX_LOG_BYTES + 1);
+        }
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("size limit"));
+    }
+
+    @Test
+    void rejectsEvidenceLogsOutsideTheirDirectory() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorker.Result original = result("escaped");
+        Path outside = Files.writeString(
+                directory.resolve("outside.stdout.log"),
+                "outside");
+        PiWorker.Result escaped = withEvidence(
+                original,
+                original.evidence().executable(),
+                original.evidence().workingDirectory(),
+                original.evidence().inputDigests(),
+                outside,
+                ShipDigest.sha256(Files.readAllBytes(outside)),
+                Path.of(original.evidence().stderrLog()),
+                original.evidence().stderrDigest(),
+                original.evidence().version());
+
+        PiWorkerResultStore.write(request, escaped);
+
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("escaped"));
+    }
+
+    @Test
+    void validatesCommandEvidenceAgainstItsHistoricalRequest() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorker.Result original = result("mismatch");
+        Path stdout = Path.of(original.evidence().stdoutLog());
+        Path stderr = Path.of(original.evidence().stderrLog());
+
+        Path otherWorking = Files.createDirectory(
+                directory.resolve("other-working"));
+        PiWorkerResultStore.write(
+                request,
+                withEvidence(
+                        original,
+                        original.evidence().executable(),
+                        otherWorking.toString(),
+                        original.evidence().inputDigests(),
+                        stdout,
+                        original.evidence().stdoutDigest(),
+                        stderr,
+                        original.evidence().stderrDigest(),
+                        original.evidence().version()));
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("does not match its request"));
+
+        String otherDigest = ShipDigest.sha256(
+                "other input".getBytes(
+                        java.nio.charset.StandardCharsets.UTF_8));
+        PiWorkerResultStore.write(
+                request,
+                withEvidence(
+                        original,
+                        original.evidence().executable(),
+                        original.evidence().workingDirectory(),
+                        List.of(otherDigest),
+                        stdout,
+                        original.evidence().stdoutDigest(),
+                        stderr,
+                        original.evidence().stderrDigest(),
+                        original.evidence().version()));
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("does not match its request"));
+
+        String historicalExecutable = directory.resolve("retired-pi")
+                .toAbsolutePath()
+                .normalize()
+                .toString();
+        PiWorkerResultStore.write(
+                request,
+                withEvidence(
+                        original,
+                        historicalExecutable,
+                        original.evidence().workingDirectory(),
+                        original.evidence().inputDigests(),
+                        stdout,
+                        original.evidence().stdoutDigest(),
+                        stderr,
+                        original.evidence().stderrDigest(),
+                        original.evidence().version()));
+        assertEquals(
+                historicalExecutable,
+                PiWorkerResultStore.read(request)
+                        .orElseThrow()
+                        .evidence()
+                        .executable());
+
+        PiWorkerResultStore.write(request, original);
+        Path marker = marker(sessions);
+        String encoded = Files.readString(marker);
+        String version = "\"version\" : \"0.80.6\"";
+        int evidenceVersion = encoded.indexOf(
+                version, encoded.indexOf(version) + version.length());
+        assertTrue(evidenceVersion >= 0);
+        Files.writeString(
+                marker,
+                encoded.substring(0, evidenceVersion)
+                        + "\"version\" : \"0.81.1\""
+                        + encoded.substring(evidenceVersion + version.length()));
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("malformed"));
+    }
+
+    private PiWorker.Request request(String runId, Path sessions)
+            throws IOException {
         return new PiWorker.Request(
                 runId,
                 ShipRun.Stage.DISCOVERY,
                 1,
-                directory.toAbsolutePath(),
+                Files.createDirectories(
+                        directory.resolve("working")),
                 sessions,
-                directory.resolve("evidence"),
+                Files.createDirectories(
+                        directory.resolve("evidence")),
                 DIGEST,
                 true,
                 "prompt");
     }
 
-    private PiWorker.Result result(String text) {
+    private PiWorker.Result result(String text) throws IOException {
         String timestamp = "2026-07-28T08:00:00Z";
+        Path evidence = Files.createDirectories(
+                directory.resolve("evidence"));
+        Path stdout = Files.createTempFile(
+                evidence, "pi-", ".stdout.log");
+        Path stderr = Files.createTempFile(
+                evidence, "pi-", ".stderr.log");
+        byte[] stdoutBytes = "stdout".getBytes(
+                java.nio.charset.StandardCharsets.UTF_8);
+        byte[] stderrBytes = "stderr".getBytes(
+                java.nio.charset.StandardCharsets.UTF_8);
+        Files.write(stdout, stdoutBytes);
+        Files.write(stderr, stderrBytes);
         CommandRun command = new CommandRun(
-                directory.resolve("pi").toAbsolutePath().toString(),
+                executable().toString(),
                 "0.80.6",
                 List.of("--mode", "rpc"),
-                directory.toAbsolutePath().toString(),
+                directory.resolve("working")
+                        .toAbsolutePath()
+                        .toString(),
                 List.of(DIGEST),
                 true,
                 false,
@@ -155,10 +338,10 @@ class PiWorkerResultStoreTest {
                 0,
                 timestamp,
                 timestamp,
-                directory.resolve("stdout.log").toAbsolutePath().toString(),
-                ShipDigest.sha256(new byte[0]),
-                directory.resolve("stderr.log").toAbsolutePath().toString(),
-                ShipDigest.sha256(new byte[0]));
+                stdout.toAbsolutePath().toString(),
+                ShipDigest.sha256(stdoutBytes),
+                stderr.toAbsolutePath().toString(),
+                ShipDigest.sha256(stderrBytes));
         return new PiWorker.Result(
                 PiWorker.Outcome.SUCCEEDED,
                 ShipLocalStamp.Support.EXPERIMENTAL,
@@ -167,6 +350,47 @@ class PiWorkerResultStoreTest {
                 text,
                 null,
                 command);
+    }
+
+    private static PiWorker.Result withEvidence(
+            PiWorker.Result result,
+            String executable,
+            String workingDirectory,
+            List<String> inputDigests,
+            Path stdout,
+            String stdoutDigest,
+            Path stderr,
+            String stderrDigest,
+            String version) {
+        CommandRun previous = result.evidence();
+        CommandRun evidence = new CommandRun(
+                executable,
+                version,
+                previous.redactedArguments(),
+                workingDirectory,
+                inputDigests,
+                previous.launched(),
+                previous.timedOut(),
+                previous.outputLimited(),
+                previous.exitCode(),
+                previous.startedAt(),
+                previous.endedAt(),
+                stdout.toAbsolutePath().normalize().toString(),
+                stdoutDigest,
+                stderr.toAbsolutePath().normalize().toString(),
+                stderrDigest);
+        return new PiWorker.Result(
+                result.outcome(),
+                result.support(),
+                version,
+                result.warning(),
+                result.assistantText(),
+                result.failure(),
+                evidence);
+    }
+
+    private Path executable() {
+        return directory.resolve("pi").toAbsolutePath().normalize();
     }
 
     private static Path marker(Path sessions) throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -66,9 +66,10 @@ class PiWorkerResultStoreTest {
                 RUN_A,
                 loop.resolve("sessions"));
 
-        assertThrows(
+        IOException indeterminate = assertThrows(
                 IOException.class,
                 () -> PiWorkerResultStore.read(request));
+        assertFalse(indeterminate instanceof PiWorker.UntrustedResultException);
         assertThrows(
                 IOException.class,
                 () -> PiWorkerResultStore.delete(request));
@@ -79,9 +80,10 @@ class PiWorkerResultStoreTest {
         Files.createSymbolicLink(dangling, Path.of("missing"));
         PiWorker.Request danglingRequest = request(RUN_A, dangling);
 
-        assertThrows(
+        IOException danglingFailure = assertThrows(
                 IOException.class,
                 () -> PiWorkerResultStore.read(danglingRequest));
+        assertFalse(danglingFailure instanceof PiWorker.UntrustedResultException);
         assertThrows(
                 IOException.class,
                 () -> PiWorkerResultStore.delete(danglingRequest));
@@ -96,7 +98,7 @@ class PiWorkerResultStoreTest {
         String encoded = Files.readString(marker);
 
         Files.writeString(marker, encoded.replace(RUN_A, RUN_B));
-        assertTrue(assertThrows(IOException.class,
+        assertTrue(assertThrows(PiWorker.UntrustedResultException.class,
                 () -> PiWorkerResultStore.read(request))
                 .getMessage().contains("does not match"));
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -287,6 +287,48 @@ class PiWorkerTest {
     }
 
     @Test
+    void redactsSensitiveFailureComposedAfterSessionValidation()
+            throws Exception {
+        String secret = "Pi assistant settled with stop reason error";
+        Files.writeString(fixture.resolve("mode"), "stop-error\n");
+        PiWorker.Request request = request(
+                ShipRun.Stage.DISCOVERY, "prompt");
+        PiWorker worker = worker(
+                Duration.ofSeconds(5), Map.of("API_TOKEN", secret));
+
+        PiWorker.Result result = worker.run(request);
+
+        assertEquals(PiWorker.Outcome.FAILED, result.outcome());
+        assertEquals("Failed", result.failure());
+        assertEquals(result, worker.recover(request).orElseThrow());
+        try (var markers = Files.list(
+                sessions.resolve(".camel-kit-results"))) {
+            assertFalse(Files.readString(
+                    markers.findFirst().orElseThrow()).contains(secret));
+        }
+    }
+
+    @Test
+    void rejectsSensitiveVersionDiagnosticsBeforePublication()
+            throws Exception {
+        String secret = "Pi 0.80.6 is experimental until the live Pi end-to-end gate passes";
+        PiWorker.Request request = request(
+                ShipRun.Stage.DISCOVERY, "prompt");
+        PiWorker worker = worker(
+                Duration.ofSeconds(5), Map.of("API_TOKEN", secret));
+
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker.run(request));
+
+        assertEquals(
+                "Pi output contained a sensitive environment value",
+                failure.getMessage());
+        assertTrue(worker.recover(request).isEmpty());
+        assertFalse(Files.exists(fixture.resolve("session-ids")));
+    }
+
+    @Test
     void bindsRetryToolAndCompactionRecordsInRpcOrder() throws Exception {
         PiWorker worker = worker(Duration.ofSeconds(5));
         List<String> modes = List.of(
@@ -1873,15 +1915,15 @@ class PiWorkerTest {
         assertEquals(result, worker.recover(request).orElseThrow());
 
         Files.writeString(stdout, "tampered");
-        IOException tampered = assertThrows(
-                IOException.class,
+        PiWorker.UntrustedResultException tampered = assertThrows(
+                PiWorker.UntrustedResultException.class,
                 () -> worker.recover(request));
         assertTrue(tampered.getMessage().contains("recorded digest"));
 
         Files.write(stdout, stdoutBytes);
         Files.delete(stderr);
-        IOException deleted = assertThrows(
-                IOException.class,
+        PiWorker.UntrustedResultException deleted = assertThrows(
+                PiWorker.UntrustedResultException.class,
                 () -> worker.recover(request));
         assertTrue(deleted.getMessage().contains("missing or invalid"));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -533,6 +533,45 @@ class PiWorkerTest {
     }
 
     @Test
+    void usesTheInjectedEnvironmentForVersionAndRpcProcesses()
+            throws Exception {
+        Path wrapper = writeExecutable(
+                fixture.resolve("pi-env"),
+                """
+                        #!/bin/sh
+                        fixture=$(dirname "$0")
+                        if [ "${1:-}" = "--version" ]; then
+                          /usr/bin/env > "$fixture/version-env"
+                        else
+                          /usr/bin/env > "$fixture/rpc-env"
+                        fi
+                        exec "$fixture/pi-rpc" "$@"
+                        """);
+        String path = Objects.requireNonNull(
+                System.getenv("PATH"), "test PATH");
+        Map<String, String> environment = Map.of(
+                "PATH", path,
+                "PI_WORKER_SENTINEL", "injected");
+
+        PiWorker.Result result = new PiWorker(
+                wrapper,
+                "0.80.6",
+                Duration.ofSeconds(5),
+                environment)
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        for (String phase : List.of("version-env", "rpc-env")) {
+            List<String> observed = Files.readAllLines(
+                    fixture.resolve(phase));
+            assertTrue(observed.contains("PI_WORKER_SENTINEL=injected"));
+            assertTrue(observed.contains("PATH=" + path));
+            assertTrue(observed.stream()
+                    .noneMatch(value -> value.startsWith("HOME=")));
+        }
+    }
+
+    @Test
     void rejectsSensitiveEnvironmentValuesInObjectKeysAndScalarValues()
             throws Exception {
         List<String> modes = List.of(
@@ -1807,6 +1846,44 @@ class PiWorkerTest {
         assertEquals(
                 1,
                 Files.readAllLines(fixture.resolve("session-ids")).size());
+    }
+
+    @Test
+    void recoveryPreservesHistoricalExecutableAndRejectsDeletedOrTamperedEvidence()
+            throws Exception {
+        PiWorker worker = worker(Duration.ofSeconds(5));
+        PiWorker.Request request = request(
+                ShipRun.Stage.DISCOVERY, "prompt");
+        PiWorker.Result result = worker.run(request);
+        Path stdout = Path.of(result.evidence().stdoutLog());
+        Path stderr = Path.of(result.evidence().stderrLog());
+        byte[] stdoutBytes = Files.readAllBytes(stdout);
+
+        Path otherExecutable = writeExecutable(
+                fixture.resolve("pi-other"),
+                Files.readString(executable));
+        assertEquals(
+                result,
+                new PiWorker(
+                        otherExecutable,
+                        "0.80.6",
+                        Duration.ofSeconds(5))
+                        .recover(request)
+                        .orElseThrow());
+        assertEquals(result, worker.recover(request).orElseThrow());
+
+        Files.writeString(stdout, "tampered");
+        IOException tampered = assertThrows(
+                IOException.class,
+                () -> worker.recover(request));
+        assertTrue(tampered.getMessage().contains("recorded digest"));
+
+        Files.write(stdout, stdoutBytes);
+        Files.delete(stderr);
+        IOException deleted = assertThrows(
+                IOException.class,
+                () -> worker.recover(request));
+        assertTrue(deleted.getMessage().contains("missing or invalid"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- compose the Ship controller and bounded Pi worker with run serialization, durable recovery, contract-bound private briefings, and credential guards
- add strict typed stage and manifest boundaries plus deterministic Camel Main artifact, catalog, build, runtime, and Citrus validation
- harden local Stamp provenance, aggregate and atomic log retention, exact environment handling, stale-input and contract invalidation, and foreground interruption recovery

## Scope

- internal generated-workflow coordinator slice; `ship` remains unregistered
- persisted Ship state moves from the pre-release schema v2 to v3
- no supported Pi claim, live end-to-end fixture, active out-of-band worker cancellation, or publication in this PR
- the imported EXECUTE/VALIDATE policy adapter remains deferred

## Testing

- `./mvnw -B -Psourcecheck validate`
- `./mvnw -B clean install`

Part of #149

Website impact: required for public cutover; no website change in this internal slice.

## Summary by Sourcery

Introduce a local Ship workflow coordinator that orchestrates Pi worker stages with strict validation, secret handling, and durable evidence, and extend tests and schema to support the new coordination and validation model.

New Features:
- Support coordinated local Ship runs via a new workflow coordinator that composes the controller, Pi worker, and deterministic Main validation.
- Introduce strict typed Pi stage result parsing and artifact manifest reading/validation to back the new validation pipeline.

Bug Fixes:
- Prevent leakage or acceptance of sensitive values in Ship context, workspaces, and logs by enforcing environment-aware scanning and safer error handling.

Enhancements:
- Add ShipCoordinator and ShipMainValidator to coordinate controller, Pi worker, catalog, and deterministic Main validation.
- Tighten ShipController to manage environment-aware secret detection, local Stamp-based validation, restart logic, and private worker/evidence directories.
- Enhance PiWorker and PiWorkerResultStore to support environment injection, durable recovery with session locking, and strict evidence/log verification.
- Update ShipRun schema and ShipRunStore to enforce canonical validation artifacts and support new validation evidence semantics.
- Refine ChangedWorkspaceSecretScanner and LocalCommandRunner to centralize sensitive value detection and controlled environment execution.

Tests:
- Add ShipCoordinatorTest and ShipMainValidatorTest to cover coordinated workflow, recovery, validation, and evidence handling.
- Expand ShipControllerTest, PiWorkerTest, PiWorkerResultStoreTest, ShipRunStoreTest, ShipLocalStampTest, ShipCommandTest, ShipStageResultTest, and ArtifactManifestReaderTest for new behaviors and validation paths.