### PR TITLE
Wire the Ship command to the workflow coordinator

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -170,9 +170,11 @@ public final class ShipCommand implements Callable<Integer> {
     }
 
     /**
-     * Reports the latest durable state like --abort does instead of surfacing a stack trace. The interrupt flag may
-     * still be set (PiWorker restores it before rethrowing), so it is stashed around the status read — interruptible
-     * channels would fail it otherwise — and restored before returning, mirroring the coordinator's own commit pattern.
+     * Reports the latest durable state like --abort does instead of surfacing a stack trace. Reaching this method
+     * proves an interruption occurred, so the flag is re-asserted unconditionally on exit — restoring it only when
+     * still set would lose the interruption, because a caught InterruptedException usually arrives with the flag
+     * already cleared. The initial clear exists for the ClosedByInterruptException caller, which arrives with the flag
+     * still set and would otherwise fail the interruptible status read.
      */
     private ShipRun statusAfterInterrupt(String runId) {
         Thread.interrupted();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -1,11 +1,16 @@
 package io.github.luigidemasi.camelkit.command.ship;
 
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.github.luigidemasi.camelkit.ship.context.ShipContext;
 import io.github.luigidemasi.camelkit.ship.controller.ShipController;
@@ -22,7 +27,10 @@ import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
 import picocli.CommandLine.TypeConversionException;
 
-/** Local Ship controller command. Kept unregistered until the worker path passes its live gates. */
+/**
+ * Local Ship command. Starting or resuming a run drives the authoritative coordinator workflow; status and abort remain
+ * pure controller operations. Kept unregistered until the publication, interaction, and documentation gates pass.
+ */
 @Command(
          name = "ship",
          mixinStandardHelpOptions = true,
@@ -30,6 +38,7 @@ import picocli.CommandLine.TypeConversionException;
 public final class ShipCommand implements Callable<Integer> {
 
     private final ShipController controller;
+    private final WorkflowLauncher launcher;
 
     @Spec
     CommandLine.Model.CommandSpec spec;
@@ -50,12 +59,45 @@ public final class ShipCommand implements Callable<Integer> {
     @Option(names = "--project-dir", defaultValue = ".", hidden = true)
     Path projectDirectory;
 
+    @Option(
+            names = "--pi",
+            paramLabel = "PATH",
+            description = "Pi executable (default: discovered on PATH)")
+    Path piExecutable;
+
+    @Option(
+            names = "--node",
+            paramLabel = "PATH",
+            description = "Node executable (default: discovered on PATH)")
+    Path nodeExecutable;
+
+    @Option(
+            names = "--maven-repository",
+            paramLabel = "PATH",
+            description = "Private Maven repository for validation catalogs"
+                          + " (default: under the ship state directory)")
+    Path mavenRepository;
+
+    @Option(
+            names = "--stage-timeout",
+            paramLabel = "DURATION",
+            converter = StageTimeoutConverter.class,
+            description = "Time limit for one stage attempt, like 90s, 10m, or 1h (default: 10m)")
+    Duration stageTimeout;
+
+    @Option(
+            names = "--accept-experimental",
+            description = "Accept an experimental Pi or Node version after its warning")
+    Boolean acceptExperimental;
+
     public ShipCommand() {
-        this(new ShipController(ShipController.defaultStateRoot()));
+        this(new ShipController(ShipController.defaultStateRoot()),
+             new ShipRuntime(ShipController.defaultStateRoot()));
     }
 
-    ShipCommand(ShipController controller) {
+    ShipCommand(ShipController controller, WorkflowLauncher launcher) {
         this.controller = controller;
+        this.launcher = launcher;
     }
 
     @Override
@@ -64,29 +106,85 @@ public final class ShipCommand implements Callable<Integer> {
         try {
             ShipRun run = execute();
             printSummary(run);
-            return 0;
+            return workflowOperation() && run.status() == ShipRun.RunStatus.FAILED ? 1 : 0;
         } catch (ShipController.Failure e) {
-            PrintWriter writer = spec.commandLine().getErr();
-            writer.println("Error [" + e.code() + "]: " + e.getMessage());
-            writer.flush();
-            return 1;
+            return failure(e.code(), e.getMessage());
+        } catch (CommandFailure e) {
+            return failure(e.code, e.getMessage());
         }
     }
 
     private ShipRun execute() {
-        if (operation == null) {
-            return controller.start(projectDirectory, selectedOversight(), inputs());
-        }
-        if (operation.resume != null) {
-            return controller.resume(operation.resume);
-        }
-        if (operation.status != null) {
+        if (operation != null && operation.status != null) {
             return controller.status(operation.status);
         }
-        if (operation.abort != null) {
+        if (operation != null && operation.abort != null) {
             return controller.abort(operation.abort);
         }
-        return controller.startFrom(projectDirectory, operation.startFrom, selectedOversight(), inputs());
+        Workflow workflow = launchWorkflow();
+        if (operation != null && operation.resume != null) {
+            return awaitWorkflow(workflow::resume, operation.resume);
+        }
+        ShipRun run = operation == null
+                ? controller.start(projectDirectory, selectedOversight(), inputs())
+                : controller.startFrom(projectDirectory, operation.startFrom, selectedOversight(), inputs());
+        return awaitWorkflow(workflow::run, run.id());
+    }
+
+    private boolean workflowOperation() {
+        return operation == null || operation.resume != null || operation.startFrom != null;
+    }
+
+    private Workflow launchWorkflow() {
+        try {
+            return launcher.launch(new RuntimeSettings(
+                    piExecutable,
+                    nodeExecutable,
+                    mavenRepository,
+                    stageTimeout,
+                    Boolean.TRUE.equals(acceptExperimental)));
+        } catch (IllegalArgumentException e) {
+            throw new CommandFailure("runtime-unavailable", e.getMessage(), e);
+        } catch (IllegalStateException e) {
+            throw new CommandFailure("runtime-unsupported", e.getMessage(), e);
+        }
+    }
+
+    private ShipRun awaitWorkflow(WorkflowStep step, String runId) {
+        try {
+            return step.apply(runId);
+        } catch (ShipController.Failure e) {
+            // Keep the run reachable: without a list command the error line is the only place
+            // the identifier can surface after a post-start failure.
+            throw new CommandFailure(e.code(), e.getMessage() + runReference(runId), e);
+        } catch (ClosedByInterruptException e) {
+            // The abort watcher's interrupt can land inside an interruptible channel operation
+            // and surface as this message-less IOException instead of InterruptedException.
+            return statusAfterInterrupt(runId);
+        } catch (IOException e) {
+            String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            throw new CommandFailure("workflow-failed", message + runReference(runId), e);
+        } catch (InterruptedException e) {
+            return statusAfterInterrupt(runId);
+        }
+    }
+
+    /**
+     * Reports the latest durable state like --abort does instead of surfacing a stack trace. The interrupt flag may
+     * still be set (PiWorker restores it before rethrowing), so it is stashed around the status read — interruptible
+     * channels would fail it otherwise — and restored before returning, mirroring the coordinator's own commit pattern.
+     */
+    private ShipRun statusAfterInterrupt(String runId) {
+        Thread.interrupted();
+        try {
+            return controller.status(runId);
+        } finally {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static String runReference(String runId) {
+        return " (run " + runId + ")";
     }
 
     private void validateArguments() {
@@ -95,6 +193,14 @@ public final class ShipCommand implements Callable<Integer> {
             throw new ParameterException(
                     spec.commandLine(),
                     "--ask, --text, and --document are only valid when starting a run");
+        }
+        if (operation != null && (operation.status != null || operation.abort != null)
+                && (piExecutable != null || nodeExecutable != null || mavenRepository != null
+                        || stageTimeout != null || acceptExperimental != null)) {
+            throw new ParameterException(
+                    spec.commandLine(),
+                    "--pi, --node, --maven-repository, --stage-timeout, and --accept-experimental"
+                                        + " are only valid when starting or resuming a run");
         }
     }
 
@@ -113,6 +219,51 @@ public final class ShipCommand implements Callable<Integer> {
         writer.println("Stage: " + run.currentStage());
         writer.println("Oversight: " + run.oversight());
         writer.flush();
+    }
+
+    private Integer failure(String code, String message) {
+        PrintWriter writer = spec.commandLine().getErr();
+        writer.println("Error [" + code + "]: " + message);
+        writer.flush();
+        return 1;
+    }
+
+    /** Runs the authoritative coordinator workflow over an existing run. */
+    interface Workflow {
+
+        ShipRun run(String runId) throws IOException, InterruptedException;
+
+        ShipRun resume(String runId) throws IOException, InterruptedException;
+    }
+
+    /** Builds the runtime-backed workflow, failing fast before any run state exists. */
+    @FunctionalInterface
+    interface WorkflowLauncher {
+
+        Workflow launch(RuntimeSettings settings);
+    }
+
+    /** Raw runtime option values; the launcher resolves defaults and discovery. */
+    record RuntimeSettings(Path piExecutable, Path nodeExecutable, Path mavenRepository,
+            Duration stageTimeout, boolean acceptExperimental) {
+    }
+
+    @FunctionalInterface
+    private interface WorkflowStep {
+
+        ShipRun apply(String runId) throws IOException, InterruptedException;
+    }
+
+    private static final class CommandFailure extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String code;
+
+        CommandFailure(String code, String message, Throwable cause) {
+            super(message, cause);
+            this.code = code;
+        }
     }
 
     static final class Operation {
@@ -170,6 +321,29 @@ public final class ShipCommand implements Callable<Integer> {
             } catch (IllegalArgumentException e) {
                 throw new TypeConversionException(
                         "expected discovery, design, or plan");
+            }
+        }
+    }
+
+    static final class StageTimeoutConverter implements ITypeConverter<Duration> {
+
+        private static final Pattern DURATION = Pattern.compile("([1-9][0-9]*)([smh])");
+
+        @Override
+        public Duration convert(String value) {
+            Matcher matcher = DURATION.matcher(value);
+            if (!matcher.matches()) {
+                throw new TypeConversionException("expected a duration like 90s, 10m, or 1h");
+            }
+            try {
+                long amount = Long.parseLong(matcher.group(1));
+                return switch (matcher.group(2)) {
+                    case "s" -> Duration.ofSeconds(amount);
+                    case "m" -> Duration.ofMinutes(amount);
+                    default -> Duration.ofHours(amount);
+                };
+            } catch (NumberFormatException | ArithmeticException e) {
+                throw new TypeConversionException("expected a duration like 90s, 10m, or 1h");
             }
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
@@ -1,0 +1,124 @@
+package io.github.luigidemasi.camelkit.command.ship;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
+import io.github.luigidemasi.camelkit.ship.controller.ShipCoordinator;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
+
+/**
+ * Resolves the local Pi runtime and builds the coordinator-backed workflow.
+ *
+ * <p>
+ * Executable paths come from explicit options or PATH discovery; the maintained Pi/Node support pins always come from
+ * the bundled distribution inside {@link ShipCoordinator}, so no option here can promote an unmaintained version beyond
+ * an experimental run. The bundled distribution also drives artifact policy for now: the user config cascade prints
+ * progress to stdout while loading, which would corrupt the command's summary contract, so wiring it up belongs to the
+ * registration slice.
+ * </p>
+ */
+final class ShipRuntime implements ShipCommand.WorkflowLauncher {
+
+    // Mirrored by the --stage-timeout help text in ShipCommand; keep the two in sync.
+    static final Duration DEFAULT_STAGE_TIMEOUT = Duration.ofMinutes(10);
+    static final String CATALOG_REPOSITORY = "catalog-repository";
+
+    private final Path stateRoot;
+    private final String searchPath;
+
+    ShipRuntime(Path stateRoot) {
+        this(stateRoot, System.getenv("PATH"));
+    }
+
+    ShipRuntime(Path stateRoot, String searchPath) {
+        this.stateRoot = Objects.requireNonNull(stateRoot, "state root")
+                .toAbsolutePath()
+                .normalize();
+        this.searchPath = searchPath;
+    }
+
+    @Override
+    public ShipCommand.Workflow launch(ShipCommand.RuntimeSettings settings) {
+        requireLinux();
+        ShipCommand.RuntimeSettings resolved = resolve(settings);
+        ShipCoordinator coordinator = new ShipCoordinator(
+                stateRoot,
+                resolved.piExecutable(),
+                resolved.nodeExecutable(),
+                resolved.mavenRepository(),
+                DistributionConfig.loadBundled(),
+                resolved.stageTimeout(),
+                resolved.acceptExperimental());
+        return new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) throws IOException, InterruptedException {
+                return coordinator.run(runId);
+            }
+
+            @Override
+            public ShipRun resume(String runId) throws IOException, InterruptedException {
+                return coordinator.resume(runId);
+            }
+        };
+    }
+
+    /** Returns the settings with discovery applied and every default filled in. */
+    ShipCommand.RuntimeSettings resolve(ShipCommand.RuntimeSettings settings) {
+        return new ShipCommand.RuntimeSettings(
+                resolveExecutable(settings.piExecutable(), "pi", "Pi"),
+                resolveExecutable(settings.nodeExecutable(), "node", "Node"),
+                settings.mavenRepository() == null
+                        ? stateRoot.resolve(CATALOG_REPOSITORY)
+                        : settings.mavenRepository(),
+                settings.stageTimeout() == null ? DEFAULT_STAGE_TIMEOUT : settings.stageTimeout(),
+                settings.acceptExperimental());
+    }
+
+    private Path resolveExecutable(Path configured, String name, String label) {
+        if (configured != null) {
+            return configured;
+        }
+        return findOnPath(searchPath, name).orElseThrow(() -> new IllegalArgumentException(
+                label + " is missing or not executable; install " + label
+                                                                                           + " and configure its executable path"));
+    }
+
+    static Optional<Path> findOnPath(String searchPath, String name) {
+        if (searchPath == null || searchPath.isBlank()) {
+            return Optional.empty();
+        }
+        for (String entry : searchPath.split(File.pathSeparator, -1)) {
+            if (entry.isBlank()) {
+                continue;
+            }
+            Path directory = Path.of(entry);
+            // Relative PATH entries would resolve against the current (possibly untrusted)
+            // project directory; never discover a stage executable there.
+            if (!directory.isAbsolute()) {
+                continue;
+            }
+            Path candidate = directory.resolve(name);
+            if (Files.isRegularFile(candidate) && Files.isExecutable(candidate)) {
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
+    }
+
+    // Mirrors PiWorker.requireLinux (private there, and only checked inside run); this copy is
+    // what makes the OS gate fire at launch, before any run state exists. Keep messages identical.
+    private static void requireLinux() {
+        String os = System.getProperty("os.name", "");
+        if (!os.toLowerCase(Locale.ROOT).contains("linux")) {
+            throw new IllegalStateException("The first Pi Ship worker supports Linux only");
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
@@ -26,7 +26,7 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
  */
 final class ShipRuntime implements ShipCommand.WorkflowLauncher {
 
-    // Mirrored by the --stage-timeout help text in ShipCommand; keep the two in sync.
+    // Mirrored by the --stage-timeout help text in ShipCommand; ShipCommandTest pins the two together.
     static final Duration DEFAULT_STAGE_TIMEOUT = Duration.ofMinutes(10);
     static final String CATALOG_REPOSITORY = "catalog-repository";
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -429,6 +429,17 @@ class ShipCommandTest {
     }
 
     @Test
+    void advertisesTheStageTimeoutDefaultInHelp() throws Exception {
+        ShipController controller = controller("state");
+
+        RunResult help = run(controller, RecordingLauncher.passThrough(controller), "--help");
+
+        assertEquals(0, help.exitCode(), help.error());
+        assertTrue(help.output().contains("(default: " + ShipRuntime.DEFAULT_STAGE_TIMEOUT.toMinutes() + "m)"),
+                help.output());
+    }
+
+    @Test
     void startFromAdvertisesSupportedStagesAndReportsTheDomainBoundary() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("project"));
         ShipController controller = controller("state");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -1,12 +1,18 @@
 package io.github.luigidemasi.camelkit.command.ship;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import io.github.luigidemasi.camelkit.ship.context.ShipContext.Kind;
 import io.github.luigidemasi.camelkit.ship.controller.ShipController;
@@ -14,10 +20,14 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShipCommandTest {
@@ -29,13 +39,15 @@ class ShipCommandTest {
     void bareStartUsesSmartOversightAndPrintsStableSummary() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("project"));
         ShipController controller = controller("state");
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
 
-        RunResult result = run(controller, "--project-dir", project.toString());
+        RunResult result = run(controller, launcher, "--project-dir", project.toString());
         String id = runId(result.output());
 
         assertEquals(0, result.exitCode(), result.error());
         assertEquals("", result.error());
         assertEquals(summary(id, "RUNNING", "DISCOVERY", "SMART"), result.output());
+        assertEquals(List.of("run:" + id), launcher.invocations);
 
         ShipRun run = controller.status(id);
         assertEquals(project.toAbsolutePath().normalize().toString(), run.projectDirectory());
@@ -50,6 +62,7 @@ class ShipCommandTest {
         for (String policy : List.of("always", "smart", "never")) {
             RunResult result = run(
                     controller,
+                    RecordingLauncher.passThrough(controller),
                     "--project-dir", project.toString(),
                     "--ask", policy);
 
@@ -67,6 +80,7 @@ class ShipCommandTest {
 
         RunResult result = run(
                 controller,
+                RecordingLauncher.passThrough(controller),
                 "--project-dir", project.toString(),
                 "--text", "first",
                 "--document", "requirements.md",
@@ -91,9 +105,11 @@ class ShipCommandTest {
                 metadata.resolve("pipeline.json"),
                 "{\"mode\":\"manual\",\"activePipeline\":\"149-command\"}\n");
         ShipController controller = controller("state");
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
 
         RunResult started = run(
                 controller,
+                launcher,
                 "--project-dir", project.toString(),
                 "--start-from", "design",
                 "--text", "Build an integration");
@@ -101,20 +117,22 @@ class ShipCommandTest {
         assertEquals(0, started.exitCode(), started.error());
         assertEquals(summary(id, "RUNNING", "DESIGN", "SMART"), started.output());
 
-        RunResult resumed = run(controller, "--resume", id);
+        RunResult resumed = run(controller, launcher, "--resume", id);
         assertEquals(0, resumed.exitCode(), resumed.error());
         assertEquals(started.output(), resumed.output());
         assertEquals(2, controller.status(id).stage(ShipRun.Stage.DESIGN).attempts());
+        assertEquals(List.of("run:" + id, "resume:" + id), launcher.invocations);
 
-        RunResult status = run(controller, "--status", id);
+        RunResult status = run(controller, launcher, "--status", id);
         assertEquals(0, status.exitCode(), status.error());
         assertEquals(started.output(), status.output());
 
-        RunResult aborted = run(controller, "--abort", id);
+        RunResult aborted = run(controller, launcher, "--abort", id);
         assertEquals(0, aborted.exitCode(), aborted.error());
         assertEquals(summary(id, "ABORTED", "DESIGN", "SMART"), aborted.output());
+        assertEquals(List.of("run:" + id, "resume:" + id), launcher.invocations);
 
-        RunResult rejected = run(controller, "--resume", id);
+        RunResult rejected = run(controller, launcher, "--resume", id);
         assertEquals(1, rejected.exitCode());
         assertEquals("", rejected.output());
         assertTrue(rejected.error().matches("(?is)Error \\[[^]]+]: .*aborted.*\\R"),
@@ -122,16 +140,307 @@ class ShipCommandTest {
     }
 
     @Test
+    void statusAndAbortNeverLaunchTheRuntime() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher starter = RecordingLauncher.passThrough(controller);
+        String id = runId(run(
+                controller, starter, "--project-dir", project.toString()).output());
+
+        ShipCommand.WorkflowLauncher rejecting = settings -> {
+            throw new AssertionError("status and abort must not launch the runtime");
+        };
+        RunResult status = run(controller, rejecting, "--status", id);
+        assertEquals(0, status.exitCode(), status.error());
+
+        RunResult aborted = run(controller, rejecting, "--abort", id);
+        assertEquals(0, aborted.exitCode(), aborted.error());
+    }
+
+    @Test
+    void launchFailureBeforeStartCreatesNoRunState() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path state = tempDir.resolve("state");
+        ShipController controller = new ShipController(state);
+        ShipCommand.WorkflowLauncher unavailable = settings -> {
+            throw new IllegalArgumentException(
+                    "Pi is missing or not executable; install Pi and configure its executable path");
+        };
+
+        RunResult result = run(controller, unavailable, "--project-dir", project.toString());
+
+        assertEquals(1, result.exitCode());
+        assertEquals("", result.output());
+        assertEquals("Error [runtime-unavailable]: Pi is missing or not executable;"
+                     + " install Pi and configure its executable path" + System.lineSeparator(),
+                result.error());
+        assertFalse(Files.exists(state), "no run state may exist after a launch failure");
+    }
+
+    @Test
+    void unsupportedRuntimeReportsItsOwnCode() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        ShipCommand.WorkflowLauncher unsupported = settings -> {
+            throw new IllegalStateException("The first Pi Ship worker supports Linux only");
+        };
+
+        RunResult result = run(controller, unsupported, "--project-dir", project.toString());
+
+        assertEquals(1, result.exitCode());
+        assertEquals("Error [runtime-unsupported]: The first Pi Ship worker supports Linux only"
+                     + System.lineSeparator(),
+                result.error());
+    }
+
+    @Test
+    void controllerFailureSkipsTheWorkflow() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
+
+        RunResult result = run(
+                controller,
+                launcher,
+                "--project-dir", project.toString(),
+                "--document", project.resolve("missing.txt").toString());
+
+        assertEquals(1, result.exitCode());
+        assertEquals("", result.output());
+        assertEquals(1, launcher.launches, "launch precedes the controller call");
+        assertTrue(launcher.invocations.isEmpty(), "workflow must not run after a start failure");
+    }
+
+    @Test
+    void workflowIoFailureReportsTheRunIdentifierForRecovery() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) throws IOException {
+                throw new IOException(
+                        "Node is installed but `node --version` failed;"
+                                      + " reinstall Node and verify the configured executable");
+            }
+
+            @Override
+            public ShipRun resume(String runId) {
+                throw new AssertionError("not resumed");
+            }
+        });
+
+        RunResult result = run(controller, launcher, "--project-dir", project.toString());
+
+        assertEquals(1, result.exitCode());
+        assertEquals("", result.output());
+        assertTrue(result.error().matches(
+                "(?s)Error \\[workflow-failed]: Node is installed.*\\(run ship-[0-9a-f]{32}\\)\\R"),
+                result.error());
+        String id = result.error().replaceAll("(?s).*\\(run (ship-[0-9a-f]{32})\\).*", "$1");
+        assertEquals(id, controller.status(id).id(), "the reported run must be recoverable");
+    }
+
+    @Test
+    void messageLessIoFailureReportsTheExceptionTypeInsteadOfNull() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) throws IOException {
+                throw new IOException();
+            }
+
+            @Override
+            public ShipRun resume(String runId) {
+                throw new AssertionError("not resumed");
+            }
+        });
+
+        RunResult result = run(controller, launcher, "--project-dir", project.toString());
+
+        assertEquals(1, result.exitCode());
+        assertTrue(result.error().startsWith("Error [workflow-failed]: IOException (run ship-"),
+                result.error());
+    }
+
+    @Test
+    void closedByInterruptReportsTheDurableStateLikeAnAbort() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) throws IOException {
+                throw new ClosedByInterruptException();
+            }
+
+            @Override
+            public ShipRun resume(String runId) {
+                throw new AssertionError("not resumed");
+            }
+        });
+
+        try {
+            RunResult result = run(controller, launcher, "--project-dir", project.toString());
+
+            assertTrue(Thread.currentThread().isInterrupted(), "interrupt status must survive");
+            assertEquals(0, result.exitCode(), result.error());
+            String id = runId(result.output());
+            assertEquals(summary(id, "RUNNING", "DISCOVERY", "SMART"), result.output());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void workflowFailureAfterResumeReportsTheRunIdentifier() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        String id = runId(run(
+                controller,
+                RecordingLauncher.passThrough(controller),
+                "--project-dir", project.toString()).output());
+        RecordingLauncher launcher = new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) {
+                throw new AssertionError("not started");
+            }
+
+            @Override
+            public ShipRun resume(String runId) throws IOException {
+                throw new IOException("Pi stage session is already running");
+            }
+        });
+
+        RunResult result = run(controller, launcher, "--resume", id);
+
+        assertEquals(1, result.exitCode());
+        assertTrue(result.error().startsWith(
+                "Error [workflow-failed]: Pi stage session is already running (run " + id + ")"),
+                result.error());
+    }
+
+    @Test
+    void interruptedWorkflowRestoresTheFlagAndPrintsTheLatestState() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) throws InterruptedException {
+                throw new InterruptedException("aborted by another controller");
+            }
+
+            @Override
+            public ShipRun resume(String runId) {
+                throw new AssertionError("not resumed");
+            }
+        });
+
+        try {
+            RunResult result = run(controller, launcher, "--project-dir", project.toString());
+
+            assertTrue(Thread.currentThread().isInterrupted(), "interrupt status must survive");
+            assertEquals(0, result.exitCode(), result.error());
+            String id = runId(result.output());
+            assertEquals(summary(id, "RUNNING", "DISCOVERY", "SMART"), result.output());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void forwardsRuntimeOptionsToTheLauncher() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
+
+        RunResult result = run(
+                controller,
+                launcher,
+                "--project-dir", project.toString(),
+                "--pi", "/opt/pi/bin/pi",
+                "--node", "/opt/node/bin/node",
+                "--maven-repository", "/tmp/ship-repo",
+                "--stage-timeout", "90s",
+                "--accept-experimental");
+
+        assertEquals(0, result.exitCode(), result.error());
+        ShipCommand.RuntimeSettings settings = launcher.settings;
+        assertEquals(Path.of("/opt/pi/bin/pi"), settings.piExecutable());
+        assertEquals(Path.of("/opt/node/bin/node"), settings.nodeExecutable());
+        assertEquals(Path.of("/tmp/ship-repo"), settings.mavenRepository());
+        assertEquals(Duration.ofSeconds(90), settings.stageTimeout());
+        assertTrue(settings.acceptExperimental());
+    }
+
+    @Test
+    void defaultsRuntimeSettingsToUnsetValues() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
+
+        RunResult result = run(controller, launcher, "--project-dir", project.toString());
+
+        assertEquals(0, result.exitCode(), result.error());
+        ShipCommand.RuntimeSettings settings = launcher.settings;
+        assertNull(settings.piExecutable());
+        assertNull(settings.nodeExecutable());
+        assertNull(settings.mavenRepository());
+        assertNull(settings.stageTimeout());
+        assertFalse(settings.acceptExperimental());
+    }
+
+    @Test
+    void rejectsRuntimeOptionsOnStatusAndAbort() throws Exception {
+        ShipController controller = controller("state");
+        String id = "ship-0123456789abcdef0123456789abcdef";
+
+        for (String[] arguments : List.of(
+                new String[]{"--status", id, "--pi", "/opt/pi"},
+                new String[]{"--status", id, "--stage-timeout", "10m"},
+                new String[]{"--abort", id, "--accept-experimental"},
+                new String[]{"--abort", id, "--maven-repository", "/tmp/repo"},
+                new String[]{"--status", id, "--node", "/opt/node"})) {
+            RunResult result = run(controller, RecordingLauncher.passThrough(controller), arguments);
+            assertEquals(CommandLine.ExitCode.USAGE, result.exitCode());
+            assertTrue(result.error().contains(
+                    "only valid when starting or resuming a run"), result.error());
+        }
+    }
+
+    @Test
+    void rejectsMalformedStageTimeouts() throws Exception {
+        ShipController controller = controller("state");
+
+        for (String timeout : List.of("bananas", "0s", "-5m", "10", "3d", "99999999999999999999s",
+                "9223372036854775807m")) {
+            RunResult result = run(
+                    controller,
+                    RecordingLauncher.passThrough(controller),
+                    "--stage-timeout", timeout);
+            assertEquals(CommandLine.ExitCode.USAGE, result.exitCode(), timeout);
+            assertTrue(result.error().contains("expected a duration like 90s, 10m, or 1h"),
+                    result.error());
+        }
+    }
+
+    @Test
     void startFromAdvertisesSupportedStagesAndReportsTheDomainBoundary() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("project"));
         ShipController controller = controller("state");
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
 
-        RunResult help = run(controller, "--help");
+        RunResult help = run(controller, launcher, "--help");
         assertEquals(0, help.exitCode(), help.error());
         assertTrue(help.output().contains("Start at discovery, design, or plan"), help.output());
 
         RunResult unknown = run(
                 controller,
+                launcher,
                 "--project-dir", project.toString(),
                 "--start-from", "unknown");
         assertEquals(CommandLine.ExitCode.USAGE, unknown.exitCode());
@@ -141,6 +450,7 @@ class ShipCommandTest {
         for (String stage : List.of("execute", "validate")) {
             RunResult result = run(
                     controller,
+                    launcher,
                     "--project-dir", project.toString(),
                     "--start-from", stage);
 
@@ -158,17 +468,17 @@ class ShipCommandTest {
         ShipController controller = controller("state");
         String id = "ship-0123456789abcdef0123456789abcdef";
 
-        RunResult exclusive = run(controller, "--resume", id, "--status", id);
+        RunResult exclusive = run(controller, rejectingLauncher(), "--resume", id, "--status", id);
         assertEquals(CommandLine.ExitCode.USAGE, exclusive.exitCode());
         assertTrue(exclusive.error().contains("mutually exclusive"), exclusive.error());
 
-        RunResult context = run(controller, "--status", id, "--text", "not allowed");
+        RunResult context = run(controller, rejectingLauncher(), "--status", id, "--text", "not allowed");
         assertEquals(CommandLine.ExitCode.USAGE, context.exitCode());
         assertTrue(context.error().contains(
                 "--ask, --text, and --document are only valid when starting a run"),
                 context.error());
 
-        RunResult oversight = run(controller, "--abort", id, "--ask", "never");
+        RunResult oversight = run(controller, rejectingLauncher(), "--abort", id, "--ask", "never");
         assertEquals(CommandLine.ExitCode.USAGE, oversight.exitCode());
         assertTrue(oversight.error().contains(
                 "--ask, --text, and --document are only valid when starting a run"),
@@ -180,7 +490,7 @@ class ShipCommandTest {
         Path arguments = Files.writeString(tempDir.resolve("arguments"), "--ask never");
         ShipController controller = controller("state");
 
-        RunResult result = run(controller, "@" + arguments);
+        RunResult result = run(controller, rejectingLauncher(), "@" + arguments);
 
         assertEquals(CommandLine.ExitCode.USAGE, result.exitCode());
         assertTrue(result.error().contains("Unmatched argument"), result.error());
@@ -213,10 +523,60 @@ class ShipCommandTest {
         }
     }
 
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void realRuntimeDrivesTheCoordinatorThroughTheCommand() throws Exception {
+        Path fixture = Files.createDirectory(tempDir.resolve("fake-pi"));
+        try (var script = Objects.requireNonNull(
+                ShipCommandTest.class.getResourceAsStream(
+                        "/io/github/luigidemasi/camelkit/ship/worker/fake-pi-rpc.sh"))) {
+            writeExecutable(
+                    fixture.resolve("pi-rpc"),
+                    new String(script.readAllBytes(), StandardCharsets.UTF_8));
+        }
+        Path node = writeExecutable(
+                fixture.resolve("node"),
+                """
+                        #!/bin/sh
+                        if [ "${1:-}" = "--version" ]; then
+                          cat "$(dirname "$0")/node-version"
+                        else
+                          exec "$@"
+                        fi
+                        """);
+        Files.writeString(fixture.resolve("node-version"), "v22.22.2\n");
+        Files.writeString(fixture.resolve("version"), "0.81.1\n");
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path state = tempDir.resolve("state");
+        ShipController controller = new ShipController(state);
+
+        RunResult result = run(
+                controller,
+                new ShipRuntime(state),
+                "--project-dir", project.toString(),
+                "--pi", fixture.resolve("pi-rpc").toString(),
+                "--node", node.toString(),
+                "--stage-timeout", "30s",
+                "--text", "unverified Pi must fail the stage");
+
+        assertEquals(1, result.exitCode(), result.error());
+        String id = runId(result.output());
+        assertEquals(summary(id, "FAILED", "DISCOVERY", "SMART"), result.output());
+        RunResult failedStatus = run(controller, new ShipRuntime(state), "--status", id);
+        assertEquals(0, failedStatus.exitCode(),
+                "status queries report failed runs without a failing exit code");
+        assertTrue(controller.status(id).message().contains(
+                "Pi 0.81.1 is unverified; install maintained Pi"),
+                controller.status(id).message());
+        assertFalse(Files.exists(fixture.resolve("args")),
+                "the gate must fire before any Pi process starts");
+    }
+
     private void assertDocumentFailure(
             ShipController controller, Path project, Path document, String expectedCode) {
         RunResult result = run(
                 controller,
+                RecordingLauncher.passThrough(controller),
                 "--project-dir", project.toString(),
                 "--document", document.toString());
 
@@ -231,15 +591,29 @@ class ShipCommandTest {
         return new ShipController(tempDir.resolve(stateDirectory));
     }
 
-    private static RunResult run(ShipController controller, String... args) {
+    private static ShipCommand.WorkflowLauncher rejectingLauncher() {
+        return settings -> {
+            throw new AssertionError("the runtime must not be launched");
+        };
+    }
+
+    private static RunResult run(
+            ShipController controller, ShipCommand.WorkflowLauncher launcher, String... args) {
         StringWriter output = new StringWriter();
         StringWriter error = new StringWriter();
-        CommandLine commandLine = new CommandLine(new ShipCommand(controller));
+        CommandLine commandLine = new CommandLine(new ShipCommand(controller, launcher));
         commandLine.setExpandAtFiles(false);
         commandLine.setOut(new PrintWriter(output, true));
         commandLine.setErr(new PrintWriter(error, true));
         int exitCode = commandLine.execute(args);
         return new RunResult(exitCode, output.toString(), error.toString());
+    }
+
+    private static Path writeExecutable(Path path, String script) throws IOException {
+        Files.writeString(path, script);
+        Files.setPosixFilePermissions(
+                path, PosixFilePermissions.fromString("rwx------"));
+        return path;
     }
 
     private static String runId(String output) {
@@ -254,6 +628,54 @@ class ShipCommandTest {
                 "Stage: " + stage,
                 "Oversight: " + oversight,
                 "");
+    }
+
+    /** Records launches and workflow invocations; the pass-through variant mirrors today's state. */
+    private static final class RecordingLauncher implements ShipCommand.WorkflowLauncher {
+
+        final List<String> invocations = new ArrayList<>();
+        final ShipCommand.Workflow delegate;
+        ShipCommand.RuntimeSettings settings;
+        int launches;
+
+        RecordingLauncher(ShipCommand.Workflow delegate) {
+            this.delegate = delegate;
+        }
+
+        static RecordingLauncher passThrough(ShipController controller) {
+            return new RecordingLauncher(new ShipCommand.Workflow() {
+
+                @Override
+                public ShipRun run(String runId) {
+                    return controller.status(runId);
+                }
+
+                @Override
+                public ShipRun resume(String runId) {
+                    return controller.resume(runId);
+                }
+            });
+        }
+
+        @Override
+        public ShipCommand.Workflow launch(ShipCommand.RuntimeSettings launchSettings) {
+            this.settings = launchSettings;
+            launches++;
+            return new ShipCommand.Workflow() {
+
+                @Override
+                public ShipRun run(String runId) throws IOException, InterruptedException {
+                    invocations.add("run:" + runId);
+                    return delegate.run(runId);
+                }
+
+                @Override
+                public ShipRun resume(String runId) throws IOException, InterruptedException {
+                    invocations.add("resume:" + runId);
+                    return delegate.resume(runId);
+                }
+            };
+        }
     }
 
     private record RunResult(int exitCode, String output, String error) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntimeTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntimeTest.java
@@ -1,0 +1,168 @@
+package io.github.luigidemasi.camelkit.command.ship;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShipRuntimeTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void findsTheFirstExecutableRegularFileOnThePath() throws Exception {
+        Path first = Files.createDirectory(tempDir.resolve("first"));
+        Path second = Files.createDirectory(tempDir.resolve("second"));
+        Files.createDirectory(first.resolve("pi"));
+        writeExecutable(second.resolve("pi"));
+        String searchPath = String.join(File.pathSeparator,
+                first.toString(), "", second.toString());
+
+        Optional<Path> found = ShipRuntime.findOnPath(searchPath, "pi");
+
+        assertEquals(Optional.of(second.resolve("pi")), found);
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void skipsNonExecutableCandidates() throws Exception {
+        Path directory = Files.createDirectory(tempDir.resolve("bin"));
+        Files.writeString(directory.resolve("pi"), "#!/bin/sh\n");
+        Files.setPosixFilePermissions(
+                directory.resolve("pi"), PosixFilePermissions.fromString("rw-------"));
+
+        assertEquals(Optional.empty(), ShipRuntime.findOnPath(directory.toString(), "pi"));
+    }
+
+    @Test
+    void returnsEmptyForMissingOrBlankSearchPaths() {
+        assertEquals(Optional.empty(), ShipRuntime.findOnPath(null, "pi"));
+        assertEquals(Optional.empty(), ShipRuntime.findOnPath("  ", "pi"));
+        assertEquals(Optional.empty(),
+                ShipRuntime.findOnPath(tempDir.resolve("absent").toString(), "pi"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void ignoresRelativeSearchPathEntries() throws Exception {
+        Path relative = Files.createDirectory(tempDir.resolve("rel-bin"));
+        writeExecutable(relative.resolve("pi"));
+        String relativeEntry = Path.of("").toAbsolutePath().relativize(relative).toString();
+
+        assertEquals(Optional.empty(), ShipRuntime.findOnPath(relativeEntry, "pi"),
+                "relative PATH entries must never resolve against the working directory");
+        assertEquals(Optional.of(relative.resolve("pi")),
+                ShipRuntime.findOnPath(relative.toString(), "pi"),
+                "the same directory is discoverable through its absolute entry");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void resolvesExplicitOptionsOverDiscoveryAndAppliesDefaults() throws Exception {
+        Path binDirectory = Files.createDirectory(tempDir.resolve("bin"));
+        writeExecutable(binDirectory.resolve("pi"));
+        writeExecutable(binDirectory.resolve("node"));
+        Path state = tempDir.resolve("state");
+        Path explicitPi = tempDir.resolve("explicit-pi");
+        ShipRuntime runtime = new ShipRuntime(state, binDirectory.toString());
+
+        ShipCommand.RuntimeSettings defaults = runtime.resolve(new ShipCommand.RuntimeSettings(
+                null, null, null, null, false));
+        assertEquals(binDirectory.resolve("pi"), defaults.piExecutable());
+        assertEquals(binDirectory.resolve("node"), defaults.nodeExecutable());
+        assertEquals(state.toAbsolutePath().normalize().resolve(ShipRuntime.CATALOG_REPOSITORY),
+                defaults.mavenRepository());
+        assertEquals(ShipRuntime.DEFAULT_STAGE_TIMEOUT, defaults.stageTimeout());
+        assertFalse(defaults.acceptExperimental());
+
+        ShipCommand.RuntimeSettings explicit = runtime.resolve(new ShipCommand.RuntimeSettings(
+                explicitPi, explicitPi, tempDir.resolve("repo"), Duration.ofSeconds(90), true));
+        assertEquals(explicitPi, explicit.piExecutable());
+        assertEquals(explicitPi, explicit.nodeExecutable());
+        assertEquals(tempDir.resolve("repo"), explicit.mavenRepository());
+        assertEquals(Duration.ofSeconds(90), explicit.stageTimeout());
+        assertTrue(explicit.acceptExperimental());
+    }
+
+    @Test
+    void missingPiOnThePathReportsCanonicalInstallationGuidance() {
+        ShipRuntime runtime = new ShipRuntime(tempDir.resolve("state"), "");
+
+        IllegalArgumentException missing = assertThrows(
+                IllegalArgumentException.class,
+                () -> runtime.resolve(new ShipCommand.RuntimeSettings(
+                        null, null, null, null, false)));
+
+        assertEquals(
+                "Pi is missing or not executable; install Pi and configure its executable path",
+                missing.getMessage());
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void missingNodeOnThePathReportsCanonicalInstallationGuidance() throws Exception {
+        Path binDirectory = Files.createDirectory(tempDir.resolve("bin"));
+        writeExecutable(binDirectory.resolve("pi"));
+        ShipRuntime runtime = new ShipRuntime(tempDir.resolve("state"), binDirectory.toString());
+
+        IllegalArgumentException missing = assertThrows(
+                IllegalArgumentException.class,
+                () -> runtime.resolve(new ShipCommand.RuntimeSettings(
+                        null, null, null, null, false)));
+
+        assertEquals(
+                "Node is missing or not executable; install Node and configure its executable path",
+                missing.getMessage());
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void launchFailsFastOnAMissingConfiguredExecutable() {
+        ShipRuntime runtime = new ShipRuntime(tempDir.resolve("state"), "");
+        Path absent = tempDir.resolve("absent-pi");
+
+        IllegalArgumentException missing = assertThrows(
+                IllegalArgumentException.class,
+                () -> runtime.launch(new ShipCommand.RuntimeSettings(
+                        absent, absent, null, null, false)));
+
+        assertTrue(missing.getMessage().contains("install Pi"), missing.getMessage());
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void launchBuildsACoordinatorBackedWorkflowFromFakeExecutables() throws Exception {
+        Path binDirectory = Files.createDirectory(tempDir.resolve("bin"));
+        writeExecutable(binDirectory.resolve("pi"));
+        writeExecutable(binDirectory.resolve("node"));
+        ShipRuntime runtime = new ShipRuntime(
+                tempDir.resolve("state"), binDirectory.toString());
+
+        ShipCommand.Workflow workflow = runtime.launch(new ShipCommand.RuntimeSettings(
+                null, null, null, Duration.ofSeconds(5), false));
+
+        assertNotNull(workflow);
+    }
+
+    private static void writeExecutable(Path path) throws IOException {
+        Files.writeString(path, "#!/bin/sh\nexit 0\n");
+        Files.setPosixFilePermissions(
+                path, PosixFilePermissions.fromString("rwx------"));
+    }
+}


### PR DESCRIPTION
## Summary

- wire `ShipCommand` start, start-from, and resume through `ShipCoordinator` behind a package-private `WorkflowLauncher` seam, so the wired `--resume` now reaches the coordinator's durable-attempt recovery instead of discarding the in-flight attempt via bare `ShipController.resume`
- add the public runtime bootstrap in `ShipRuntime`: `--pi`/`--node` executable options with absolute-entry-only PATH discovery, `--maven-repository` (default: a ship-owned `catalog-repository` under the state root, never `~/.m2`), `--stage-timeout` (`90s`/`10m`/`1h`, default 10m matching the live certification), and explicit `--accept-experimental` consent
- fail fast before any run state exists: OS gate and coordinator construction run before `ShipController.start`, mapping `IllegalArgumentException`/`IllegalStateException` to `runtime-unavailable`/`runtime-unsupported` with PiWorker's canonical installation guidance
- keep every post-start failure recoverable: workflow errors append `(run <id>)` to the error line (there is no list command), message-less `ClosedByInterruptException` reports the durable state like an abort, and interrupt status is stashed around status reads exactly like the coordinator's commit pattern
- make workflow legs exit 1 when the run ends `FAILED` (status/abort queries keep exit 0), so `--ask never` scripting can rely on the exit code
- `--status` and `--abort` remain pure controller operations and need no Pi runtime

## Scope

- internal wiring slice; `ship` remains unregistered in both entry points
- the coordinator receives `DistributionConfig.loadBundled()` for artifact policy for now: the user-config cascade prints progress to stdout while loading, which would corrupt the command's summary contract — wiring the cascade (and `-c`/`-p`) belongs to the registration slice
- support-pin boundary preserved: the new options feed executable paths only; Pi/Node support pins still come from the bundled distribution inside the coordinator
- guarded publication, pause/question handling, registration, thin skill delegates, and documentation stay in the remaining public-cutover slices

## Validation

- `./mvnw -B -pl camel-kit-core -Dtest=ShipCommandTest,ShipRuntimeTest test` — 32 tests, 0 failures/errors/skips, including a Linux fixture test driving the real `ShipRuntime` + coordinator + fake-Pi RPC scripts through the CLI (unverified Pi fails the stage before any Pi process starts, summary reports `FAILED`, exit code 1)
- `./mvnw -B -pl camel-kit-core -Dtest=DistributionConfigTest,PiWorkerTest,PiWorkerResultStoreTest,ShipMainValidatorTest,ShipCoordinatorTest,ShipControllerTest,ShipCommandTest,ShipRunStoreTest,ShipRuntimeTest test` — 211+ tests green
- `./mvnw -B -Psourcecheck validate` — all six modules
- `./mvnw -B clean install` — full reactor green

Known residual: no test pins the hop from resolved settings into the `ShipCoordinator` constructor for `stageTimeout`/`mavenRepository`/`acceptExperimental=true` (the coordinator exposes no getters); the hop is a direct field-for-field pass-through kept minimal on purpose.

## Website impact

**Required**, still deferred to the public command cutover tracked by #149: this slice does not register `camel-kit ship`.

Part of #149.

## Summary by Sourcery

Wire the local Ship command through a runtime-backed workflow so start/resume operations drive the coordinator while status/abort stay controller-only, adding runtime configuration options and improving workflow failure handling and exit semantics.

New Features:
- Introduce a workflow launcher seam that connects ShipCommand start and resume operations to a coordinator-backed workflow.
- Add ShipRuntime to resolve Pi/Node executables, apply defaults, and construct the coordinator-backed workflow.
- Expose runtime configuration options on ShipCommand for Pi/Node executables, private Maven repository, stage timeout, and experimental version acceptance.

Bug Fixes:
- Ensure workflow-related failures report the run identifier for later recovery instead of losing track of the in-flight run.
- Preserve and restore thread interrupt status around status reads so aborted workflows surface consistent durable state.
- Prevent runtime launch for status and abort operations, keeping them pure controller actions.

Enhancements:
- Adjust ShipCommand exit codes so failed runs from workflow operations return exit code 1 while status/abort queries remain exit 0.
- Map runtime launch IllegalArgumentException and IllegalStateException to runtime-unavailable and runtime-unsupported error codes with clearer guidance messages.
- Improve CLI validation to reject misuse of runtime options on non-start/resume operations and malformed stage timeout values.
- Extend ShipCommand summary printing and error handling to consistently format error codes and messages across controller and workflow failures.

Tests:
- Expand ShipCommand tests to cover workflow launch behavior, runtime option forwarding, failure modes, interrupt handling, and coordinator-driven runs including an OS-gated Linux fixture using the real ShipRuntime.
- Add ShipRuntime tests for PATH-based executable discovery, default resolution, error reporting when Pi/Node are missing or misconfigured, and successful workflow construction from fake executables.