### PR TITLE
Publish the validated Ship candidate into the live project

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -221,6 +221,9 @@ public final class ShipController {
             }
 
             Path project = requireProject(Path.of(current.projectDirectory()));
+            recoverTornPublication(current, project, locked.directory());
+            String publishedIdentity = publishedCandidateIdentity(
+                    current, locked.directory());
             ShipContext refreshed = refreshContext(current.context());
             rejectContextSecrets(refreshed);
             List<StageRecord> stages = new ArrayList<>(current.stages());
@@ -258,7 +261,8 @@ public final class ShipController {
                                 record.inputDigest(),
                                 locked.directory(),
                                 record.artifacts(),
-                                stagedExecute);
+                                stagedExecute,
+                                publishedIdentity);
                     }
                 } catch (Failure | IOException e) {
                     restart = Math.min(restart, index);
@@ -302,13 +306,16 @@ public final class ShipController {
                     throw failure(
                             "run-completed", "Ship run is already complete: " + runId);
                 }
+                // Every stage is verified complete; guarded publication is the remaining step.
                 resumed = copy(
                         current,
-                        RunStatus.COMPLETED,
+                        current.pipelineId(),
+                        RunStatus.RUNNING,
                         Stage.VALIDATE,
                         refreshed,
                         stages,
-                        null);
+                        null,
+                        current.publication());
             } else {
                 for (int index = restart; index < stages.size(); index++) {
                     stages.set(index, stages.get(index).reset());
@@ -319,13 +326,22 @@ public final class ShipController {
                         startStage(
                                 stages.get(restart),
                                 ShipRun.inputDigest(refreshed, stages, stage)));
+                // A restarted EXECUTE produces a new candidate, so the published claim is void.
+                ArtifactRef publication = restart <= Stage.EXECUTE.ordinal()
+                        ? null
+                        : current.publication();
+                if (publication == null && current.publication() != null) {
+                    discardPublicationScratch(current.id(), locked.directory());
+                }
                 resumed = copy(
                         current,
+                        current.pipelineId(),
                         RunStatus.RUNNING,
                         stage,
                         refreshed,
                         stages,
-                        null);
+                        null,
+                        publication);
             }
             locked.write(resumed);
             return resumed;
@@ -382,12 +398,18 @@ public final class ShipController {
                                     current.context(),
                                     stages,
                                     recorded.stage())));
+            // Restarting a generated predecessor always resets EXECUTE, so the published claim is void.
+            if (current.publication() != null) {
+                discardPublicationScratch(current.id(), locked.directory());
+            }
             ShipRun resumed = copy(
                     current,
+                    current.pipelineId(),
                     RunStatus.RUNNING,
                     recorded.stage(),
                     current.context(),
                     stages,
+                    null,
                     null);
             locked.write(resumed);
             return resumed;
@@ -411,6 +433,15 @@ public final class ShipController {
             if (current.status() == RunStatus.COMPLETED) {
                 throw failure("run-completed", "Completed Ship run cannot be aborted: " + runId);
             }
+            // Aborting must stay possible when the project is gone; only a torn uncommitted
+            // publication needs the live project resolved for its rollback.
+            if (current.publication() == null
+                    && ShipPublicationService.journalExists(locked.directory())) {
+                recoverTornPublication(
+                        current,
+                        requireProject(Path.of(current.projectDirectory())),
+                        locked.directory());
+            }
 
             List<StageRecord> stages = new ArrayList<>(current.stages());
             boolean allCompleted = stages.stream()
@@ -433,6 +464,256 @@ public final class ShipController {
         } catch (IOException e) {
             throw failure("state-write-failed", "Could not abort Ship run " + runId, e);
         }
+    }
+
+    /**
+     * Publishes the validated workspace candidate into the live project under the oversight and validation gates, and
+     * commits the run COMPLETED in the same locked operation.
+     *
+     * <p>
+     * The per-run mutation lock is held for the whole guarded apply, so aborts and resumes observe
+     * {@code operation-in-progress} instead of racing the file writes; a torn publication left by process death is
+     * rolled back from its write-ahead journal by the next locked operation.
+     */
+    ShipRun publish(String runId) {
+        try (ShipRunStore.LockedRun locked = store.lock(runId)) {
+            ShipRun current = locked.read();
+            if (!current.publicationPending()) {
+                throw failure(
+                        "stale-stage-attempt",
+                        "Ship publication requires a validated run awaiting publication");
+            }
+            Path project = requireProject(Path.of(current.projectDirectory()));
+            Path runDirectory = locked.directory();
+            recoverTornPublication(current, project, runDirectory);
+            ShipContext refreshed = refreshContext(current.context());
+            if (!refreshed.equals(current.context())) {
+                throw failure(
+                        "stale-stage-input", "Ship stage context changed; resume the run");
+            }
+            WorkspaceEvidence evidence = verifyCompletedStages(current, project, runDirectory);
+
+            StageRecord execute = current.stage(Stage.EXECUTE);
+            final ShipPublicationService.Journal journal;
+            try {
+                journal = ShipPublicationService.plan(
+                        current.id(),
+                        execute.attempts(),
+                        now(),
+                        new Verification(evidence.baseline(), evidence.snapshot()));
+                ShipPublicationService.begin(runDirectory, journal);
+                ShipPublicationService.apply(
+                        project, evidence.candidate(), runDirectory, journal);
+            } catch (ShipPublicationService.StaleLiveTreeException e) {
+                throw failure(
+                        "stale-stage-input",
+                        "Live project changed before Ship publication; resume the run",
+                        e);
+            } catch (IOException e) {
+                // A candidate this protocol cannot publish must fail the run once; retrying it
+                // would loop forever because nothing about the run or the project is stale.
+                return commitPublicationFailure(locked, current, e);
+            }
+            final ArtifactRef record;
+            try {
+                record = ShipPublicationService.commitRecord(runDirectory, journal, now());
+            } catch (IOException e) {
+                try {
+                    ShipPublicationService.rollbackApplied(project, runDirectory, journal);
+                } catch (IOException rollbackFailure) {
+                    e.addSuppressed(rollbackFailure);
+                }
+                return commitPublicationFailure(locked, current, e);
+            }
+            ShipRun published = copy(
+                    current,
+                    current.pipelineId(),
+                    RunStatus.COMPLETED,
+                    Stage.VALIDATE,
+                    current.context(),
+                    current.stages(),
+                    null,
+                    record);
+            locked.write(published);
+            return published;
+        } catch (ShipRunStore.StoreException e) {
+            throw failure(e.code(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw failure(
+                    "publication-failed", "Could not publish Ship run " + runId, e);
+        }
+    }
+
+    /** Verifies every completed stage exactly as recorded before the guarded apply. */
+    private WorkspaceEvidence verifyCompletedStages(
+            ShipRun run, Path project, Path runDirectory) {
+        WorkspaceEvidence evidence = null;
+        for (StageRecord record : run.stages()) {
+            try {
+                if (record.stage() == Stage.VALIDATE) {
+                    if (!isLocalStampEvidence(runDirectory, record)) {
+                        throw failure(
+                                "stale-stage-input",
+                                "Ship validation evidence is not the controller's local Stamp");
+                    }
+                    Path evidenceDirectory = validationEvidenceDirectory(
+                            runDirectory, record.attempts());
+                    VerifiedStamp stamp = ShipLocalStampStore.readVerified(
+                            evidenceDirectory, run.id());
+                    if (!stamp.digest().equals(record.outputDigest())) {
+                        throw failure(
+                                "stale-stage-input",
+                                "Ship local Stamp changed; resume the run");
+                    }
+                } else if (record.stage() == Stage.EXECUTE && record.attempts() > 0) {
+                    ArtifactRef root = requireExecuteRoot(
+                            record.artifacts(), expectedWorkspace(runDirectory));
+                    evidence = verifyWorkspace(
+                            project,
+                            Path.of(root.path()),
+                            run.id(),
+                            record.attempts(),
+                            record.inputDigest(),
+                            runDirectory,
+                            null);
+                    if (!workspaceArtifacts(
+                            evidence,
+                            record.artifacts().stream()
+                                    .map(artifact -> Path.of(artifact.path()))
+                                    .toList())
+                            .equals(record.artifacts())) {
+                        throw failure(
+                                "stale-stage-input",
+                                "A Ship stage artifact changed; resume the run");
+                    }
+                } else if (!readRecordedArtifacts(
+                        project,
+                        run.id(),
+                        record.stage(),
+                        record.attempts(),
+                        record.inputDigest(),
+                        runDirectory,
+                        record.artifacts(),
+                        false,
+                        null)
+                        .equals(record.artifacts())) {
+                    throw failure(
+                            "stale-stage-input",
+                            "A Ship stage artifact changed; resume the run");
+                }
+            } catch (Failure e) {
+                if ("stale-stage-input".equals(e.code())) {
+                    throw e;
+                }
+                throw failure(
+                        "stale-stage-input",
+                        "A Ship stage artifact changed or became unavailable; resume the run",
+                        e);
+            } catch (IOException | SecurityException e) {
+                throw failure(
+                        "stale-stage-input",
+                        "A Ship stage artifact changed or became unavailable; resume the run",
+                        e);
+            }
+        }
+        if (evidence == null) {
+            throw failure(
+                    "state-invalid", "Ship publication requires a staged EXECUTE candidate");
+        }
+        return evidence;
+    }
+
+    /** Rolls back an uncommitted torn publication before any other locked mutation proceeds. */
+    private static void recoverTornPublication(
+            ShipRun current, Path project, Path runDirectory) {
+        if (current.publication() != null
+                || !ShipPublicationService.journalExists(runDirectory)) {
+            return;
+        }
+        try {
+            ShipPublicationService.recover(
+                    project, runDirectory, current.stage(Stage.EXECUTE).attempts());
+        } catch (ShipPublicationService.RecoveryBlockedException e) {
+            throw failure(
+                    "publication-recovery-blocked",
+                    "Ship publication recovery stopped: the live project no longer matches the "
+                                                    + "journalled baseline or candidate; resolve it manually and retry",
+                    e);
+        } catch (IOException e) {
+            throw failure(
+                    "publication-failed",
+                    "Could not recover the torn Ship publication for " + current.id(),
+                    e);
+        }
+    }
+
+    /**
+     * Drops the retained publication scratch of a run that is voiding its published claim.
+     *
+     * <p>
+     * Once the claim is gone, a retained journal would otherwise read as a torn write-ahead log to the next locked
+     * operation, which would roll a committed publication out of the live project.
+     */
+    private static void discardPublicationScratch(String runId, Path runDirectory) {
+        try {
+            ShipPublicationService.discard(runDirectory);
+        } catch (IOException e) {
+            throw failure(
+                    "publication-failed",
+                    "Could not discard the superseded Ship publication record for " + runId,
+                    e);
+        }
+    }
+
+    /** Reads the published candidate identity accepted as a legitimate live baseline. */
+    private static String publishedCandidateIdentity(
+            ShipRun current, Path runDirectory) {
+        if (current.publication() == null) {
+            return null;
+        }
+        try {
+            return ShipPublicationService.readVerifiedRecord(
+                    runDirectory, current.publication(), current.id())
+                    .candidateIdentity();
+        } catch (IOException e) {
+            throw failure(
+                    "state-corrupt",
+                    "Ship publication record is invalid for " + current.id(),
+                    e);
+        }
+    }
+
+    /**
+     * Records why publication failed. A rollback that failed too leaves a partly published project, so the message must
+     * say so rather than claim the live project was restored.
+     */
+    private ShipRun commitPublicationFailure(
+            ShipRunStore.LockedRun locked, ShipRun current, IOException cause)
+            throws IOException {
+        // A retained journal is exactly the evidence that rollback did not finish.
+        String outcome = ShipPublicationService.journalExists(locked.directory())
+                ? "Ship publication failed and its rollback did not finish, so the project may be "
+                  + "partly published; resume to retry recovery"
+                : "Ship publication failed and the live project is unchanged; resume to retry";
+        ShipRun failed = copy(
+                current,
+                RunStatus.FAILED,
+                Stage.VALIDATE,
+                current.context(),
+                current.stages(),
+                publicationMessage(outcome, cause));
+        locked.write(failed);
+        return failed;
+    }
+
+    /** Appends the concrete cause, stripped of control characters and bounded to the run-message limit. */
+    private static String publicationMessage(String outcome, IOException cause) {
+        String detail = cause.getMessage();
+        if (detail == null || detail.isBlank()) {
+            return outcome;
+        }
+        String combined = outcome + ": " + detail.replaceAll("\\p{Cntrl}", " ").trim();
+        return combined.length() > 1024 ? combined.substring(0, 1024) : combined;
     }
 
     /**
@@ -639,7 +920,8 @@ public final class ShipController {
                         current.id(),
                         active.attempts(),
                         active.inputDigest(),
-                        locked.directory());
+                        locked.directory(),
+                        null);
                 rejectChangedWorkspaceSecrets(workspaceEvidence);
                 artifactRoot = workspaceEvidence.candidate();
             } else {
@@ -672,10 +954,9 @@ public final class ShipController {
             RunStatus status;
             Stage currentStage;
             if (next == null) {
-                status = current.oversight().pausesAfter(stage, materialAmbiguity)
-                        ? RunStatus.PAUSED
-                        : RunStatus.COMPLETED;
-                currentStage = Stage.VALIDATE;
+                // VALIDATE completes through completeValidationStage, which owns the publication gate.
+                throw new IllegalStateException(
+                        "Ship final-stage completion is owned by the validation path");
             } else if (current.oversight().pausesAfter(stage, materialAmbiguity)) {
                 status = RunStatus.PAUSED;
                 currentStage = next;
@@ -774,9 +1055,16 @@ public final class ShipController {
                 stages.set(
                         Stage.VALIDATE.ordinal(),
                         active.complete(reference.digest(), List.of(reference)));
-                status = current.oversight().pausesAfter(Stage.VALIDATE, false)
-                        ? RunStatus.PAUSED
-                        : RunStatus.COMPLETED;
+                if (current.publication() != null) {
+                    // A re-validated run keeps its published candidate; nothing is left to gate.
+                    status = RunStatus.COMPLETED;
+                } else {
+                    // A waiver is decision-relevant information the oversight gate has not seen.
+                    boolean waived = stamp.status() == ShipLocalStamp.Status.COMPLETED_WITH_WAIVER;
+                    status = current.oversight().pausesAfter(Stage.VALIDATE, waived)
+                            ? RunStatus.PAUSED
+                            : RunStatus.RUNNING;
+                }
             }
             ShipRun completed = copy(
                     current,
@@ -816,6 +1104,7 @@ public final class ShipController {
                 stage,
                 context,
                 stages,
+                null,
                 timestamp,
                 timestamp,
                 null);
@@ -856,6 +1145,18 @@ public final class ShipController {
             ShipContext context,
             List<StageRecord> stages,
             String message) {
+        return copy(run, pipelineId, status, currentStage, context, stages, message, run.publication());
+    }
+
+    private ShipRun copy(
+            ShipRun run,
+            String pipelineId,
+            RunStatus status,
+            Stage currentStage,
+            ShipContext context,
+            List<StageRecord> stages,
+            String message,
+            ArtifactRef publication) {
         return new ShipRun(
                 run.schemaVersion(),
                 run.id(),
@@ -866,6 +1167,7 @@ public final class ShipController {
                 currentStage,
                 context,
                 stages,
+                publication,
                 run.createdAt(),
                 mutationTime(run),
                 message);
@@ -913,6 +1215,7 @@ public final class ShipController {
                     "Ship stage context changed; resume the run");
         }
 
+        String publishedIdentity = publishedCandidateIdentity(run, runDirectory);
         for (int index = 0; index < active.stage().ordinal(); index++) {
             StageRecord predecessor = run.stages().get(index);
             try {
@@ -930,7 +1233,8 @@ public final class ShipController {
                         predecessor.inputDigest(),
                         runDirectory,
                         predecessor.artifacts(),
-                        stagedExecute)
+                        stagedExecute,
+                        publishedIdentity)
                         .equals(predecessor.artifacts())) {
                     throw failure(
                             "stale-stage-input",
@@ -962,7 +1266,8 @@ public final class ShipController {
             String inputDigest,
             Path runDirectory,
             List<ArtifactRef> artifacts,
-            boolean stagedExecute) {
+            boolean stagedExecute,
+            String publishedIdentity) {
         Path expected = expectedWorkspace(runDirectory);
         List<Path> paths = new ArrayList<>(artifacts.size());
         boolean workspaceRequired = stagedExecute;
@@ -994,7 +1299,9 @@ public final class ShipController {
                     "Imported Ship EXECUTE evidence is unsupported; start from PLAN instead");
         }
         WorkspaceEvidence workspace = workspaceRequired
-                ? verifyWorkspace(project, expected, runId, attempt, inputDigest, runDirectory)
+                ? verifyWorkspace(
+                        project, expected, runId, attempt, inputDigest, runDirectory,
+                        publishedIdentity)
                 : null;
         if (workspace != null) {
             return workspaceArtifacts(workspace, paths);
@@ -1014,11 +1321,12 @@ public final class ShipController {
             String runId,
             int attempt,
             String inputDigest,
-            Path runDirectory) {
+            Path runDirectory,
+            String publishedIdentity) {
         try {
             Path expected = expectedWorkspace(runDirectory);
             Verification verification = ShipWorkspace.verify(
-                    project, candidate, runId, attempt, inputDigest);
+                    project, candidate, runId, attempt, inputDigest, publishedIdentity);
             Path verified = Path.of(verification.candidate().root());
             if (!verified.equals(expected)) {
                 throw new IOException(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -79,7 +79,21 @@ public final class ShipController {
 
     ShipController(
                    Path stateRoot, Clock clock, Map<String, String> environment) {
-        this.store = new ShipRunStore(Objects.requireNonNull(stateRoot, "state root"));
+        this(
+             stateRoot,
+             ShipRunStore.defaultProjectRegistryRoot(),
+             clock,
+             environment);
+    }
+
+    ShipController(
+                   Path stateRoot,
+                   Path projectRegistryRoot,
+                   Clock clock,
+                   Map<String, String> environment) {
+        this.store = new ShipRunStore(
+                Objects.requireNonNull(stateRoot, "state root"),
+                Objects.requireNonNull(projectRegistryRoot, "project registry root"));
         this.clock = Objects.requireNonNull(clock, "clock");
         this.environment = Map.copyOf(
                 Objects.requireNonNull(environment, "environment"));
@@ -221,7 +235,10 @@ public final class ShipController {
             }
 
             Path project = requireProject(Path.of(current.projectDirectory()));
-            recoverTornPublication(current, project, locked.directory());
+            try (ShipRunStore.LockedProject projectLock = store.lockProject(project)) {
+                projectLock.requireNoForeignTornPublication(current.id());
+                recoverTornPublication(current, project, locked.directory());
+            }
             String publishedIdentity = publishedCandidateIdentity(
                     current, locked.directory());
             ShipContext refreshed = refreshContext(current.context());
@@ -437,10 +454,11 @@ public final class ShipController {
             // publication needs the live project resolved for its rollback.
             if (current.publication() == null
                     && ShipPublicationService.journalExists(locked.directory())) {
-                recoverTornPublication(
-                        current,
-                        requireProject(Path.of(current.projectDirectory())),
-                        locked.directory());
+                Path project = requireProject(Path.of(current.projectDirectory()));
+                try (ShipRunStore.LockedProject projectLock = store.lockProject(project)) {
+                    projectLock.requireNoForeignTornPublication(current.id());
+                    recoverTornPublication(current, project, locked.directory());
+                }
             }
 
             List<StageRecord> stages = new ArrayList<>(current.stages());
@@ -471,9 +489,9 @@ public final class ShipController {
      * commits the run COMPLETED in the same locked operation.
      *
      * <p>
-     * The per-run mutation lock is held for the whole guarded apply, so aborts and resumes observe
-     * {@code operation-in-progress} instead of racing the file writes; a torn publication left by process death is
-     * rolled back from its write-ahead journal by the next locked operation.
+     * The per-run and project mutation locks are held for the whole guarded apply, so other runs, aborts, and resumes
+     * observe {@code operation-in-progress} instead of racing the file writes; a torn publication left by process death
+     * is rolled back from its write-ahead journal by the next locked operation.
      */
     ShipRun publish(String runId) {
         try (ShipRunStore.LockedRun locked = store.lock(runId)) {
@@ -484,58 +502,61 @@ public final class ShipController {
                         "Ship publication requires a validated run awaiting publication");
             }
             Path project = requireProject(Path.of(current.projectDirectory()));
-            Path runDirectory = locked.directory();
-            recoverTornPublication(current, project, runDirectory);
-            ShipContext refreshed = refreshContext(current.context());
-            if (!refreshed.equals(current.context())) {
-                throw failure(
-                        "stale-stage-input", "Ship stage context changed; resume the run");
-            }
-            WorkspaceEvidence evidence = verifyCompletedStages(current, project, runDirectory);
-
-            StageRecord execute = current.stage(Stage.EXECUTE);
-            final ShipPublicationService.Journal journal;
-            try {
-                journal = ShipPublicationService.plan(
-                        current.id(),
-                        execute.attempts(),
-                        now(),
-                        new Verification(evidence.baseline(), evidence.snapshot()));
-                ShipPublicationService.begin(runDirectory, journal);
-                ShipPublicationService.apply(
-                        project, evidence.candidate(), runDirectory, journal);
-            } catch (ShipPublicationService.StaleLiveTreeException e) {
-                throw failure(
-                        "stale-stage-input",
-                        "Live project changed before Ship publication; resume the run",
-                        e);
-            } catch (IOException e) {
-                // A candidate this protocol cannot publish must fail the run once; retrying it
-                // would loop forever because nothing about the run or the project is stale.
-                return commitPublicationFailure(locked, current, e);
-            }
-            final ArtifactRef record;
-            try {
-                record = ShipPublicationService.commitRecord(runDirectory, journal, now());
-            } catch (IOException e) {
-                try {
-                    ShipPublicationService.rollbackApplied(project, runDirectory, journal);
-                } catch (IOException rollbackFailure) {
-                    e.addSuppressed(rollbackFailure);
+            try (ShipRunStore.LockedProject projectLock = store.lockProject(project)) {
+                projectLock.requireNoForeignTornPublication(current.id());
+                Path runDirectory = locked.directory();
+                recoverTornPublication(current, project, runDirectory);
+                ShipContext refreshed = refreshContext(current.context());
+                if (!refreshed.equals(current.context())) {
+                    throw failure(
+                            "stale-stage-input", "Ship stage context changed; resume the run");
                 }
-                return commitPublicationFailure(locked, current, e);
+                WorkspaceEvidence evidence = verifyCompletedStages(current, project, runDirectory);
+
+                StageRecord execute = current.stage(Stage.EXECUTE);
+                final ShipPublicationService.Journal journal;
+                try {
+                    journal = ShipPublicationService.plan(
+                            current.id(),
+                            execute.attempts(),
+                            now(),
+                            new Verification(evidence.baseline(), evidence.snapshot()));
+                    ShipPublicationService.begin(runDirectory, journal);
+                    ShipPublicationService.apply(
+                            project, evidence.candidate(), runDirectory, journal);
+                } catch (ShipPublicationService.StaleLiveTreeException e) {
+                    throw failure(
+                            "stale-stage-input",
+                            "Live project changed before Ship publication; resume the run",
+                            e);
+                } catch (IOException e) {
+                    // A candidate this protocol cannot publish must fail the run once; retrying it
+                    // would loop forever because nothing about the run or the project is stale.
+                    return commitPublicationFailure(locked, current, e);
+                }
+                final ArtifactRef record;
+                try {
+                    record = ShipPublicationService.commitRecord(runDirectory, journal, now());
+                } catch (IOException e) {
+                    try {
+                        ShipPublicationService.rollbackApplied(project, runDirectory, journal);
+                    } catch (IOException rollbackFailure) {
+                        e.addSuppressed(rollbackFailure);
+                    }
+                    return commitPublicationFailure(locked, current, e);
+                }
+                ShipRun published = copy(
+                        current,
+                        current.pipelineId(),
+                        RunStatus.COMPLETED,
+                        Stage.VALIDATE,
+                        current.context(),
+                        current.stages(),
+                        null,
+                        record);
+                locked.write(published);
+                return published;
             }
-            ShipRun published = copy(
-                    current,
-                    current.pipelineId(),
-                    RunStatus.COMPLETED,
-                    Stage.VALIDATE,
-                    current.context(),
-                    current.stages(),
-                    null,
-                    record);
-            locked.write(published);
-            return published;
         } catch (ShipRunStore.StoreException e) {
             throw failure(e.code(), e.getMessage(), e);
         } catch (IOException e) {
@@ -632,7 +653,10 @@ public final class ShipController {
         }
         try {
             ShipPublicationService.recover(
-                    project, runDirectory, current.stage(Stage.EXECUTE).attempts());
+                    project,
+                    runDirectory,
+                    current.id(),
+                    current.stage(Stage.EXECUTE).attempts());
         } catch (ShipPublicationService.RecoveryBlockedException e) {
             throw failure(
                     "publication-recovery-blocked",

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -182,6 +182,10 @@ public final class ShipCoordinator {
         ShipRun current = controller.status(runId);
         while (current.status() == RunStatus.RUNNING
                 && !Thread.currentThread().isInterrupted()) {
+            if (current.publicationPending()) {
+                current = publishPending(runId);
+                continue;
+            }
             StageAttempt attempt = controller.prepareAttempt(current.id());
             Optional<ShipRun> restarted = restartStalePredecessor(
                     attempt);
@@ -238,6 +242,9 @@ public final class ShipCoordinator {
         requireNotInterrupted();
         ShipRun current = controller.status(runId);
         if (current.status() == RunStatus.RUNNING) {
+            if (current.publicationPending()) {
+                return continueAvailable(runId, publishPending(runId));
+            }
             final StageAttempt attempt;
             try {
                 attempt = controller.prepareAttempt(runId);
@@ -294,6 +301,21 @@ public final class ShipCoordinator {
         return current.status() == RunStatus.RUNNING
                 ? runAvailable(runId)
                 : current;
+    }
+
+    /**
+     * Drives the guarded publication of a fully validated run; a live project that drifted since EXECUTE routes into
+     * the controller's stale-stage resume path instead of escaping.
+     */
+    private ShipRun publishPending(String runId) throws IOException {
+        try {
+            return controller.publish(runId);
+        } catch (ShipController.Failure e) {
+            if (!"stale-stage-input".equals(e.code())) {
+                throw e;
+            }
+            return controller.resume(runId);
+        }
     }
 
     private Step advancePi(StageAttempt attempt)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
@@ -14,9 +15,11 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
@@ -38,19 +41,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * Write-ahead, journal-recoverable publication of one validated workspace candidate into the live project.
  *
  * <p>
- * The caller holds the per-run mutation lock for the whole operation, so exactly one process can publish, recover, or
- * roll back at a time; a torn publication left by process death is recovered from the journal by the next locked
- * operation. The run-state write recording the publication is the commit point: a journal without a recorded
- * publication is always uncommitted and rolls back to the exact baseline.
+ * The caller holds both the run and project mutation locks for the whole live-tree operation. A torn publication left
+ * by process death is recovered from the journal by the next locked operation. The run-state write recording the
+ * publication is the commit point: a journal without a recorded publication is always uncommitted and rolls back to the
+ * exact baseline.
  */
 final class ShipPublicationService {
 
-    static final int SCHEMA_VERSION = 1;
+    static final int SCHEMA_VERSION = 2;
+    private static final int RECORD_SCHEMA_VERSION = 1;
     static final String DIRECTORY = "publication";
     static final String JOURNAL = "journal.json";
     static final String RECORD = "publication.json";
     static final String BACKUP = "backup";
-    private static final String STAGING_SUFFIX = ".camel-kit-publish.tmp";
+    private static final String APPLICATION = "application.marker";
+    private static final String RECOVERY = "recovery.marker";
+    private static final String STAGING_PREFIX = ".ckp-";
+    private static final String STAGING_SUFFIX = ".tmp";
+    private static final int PRIVATE_STAGING_MODE = 0600;
     private static final int MAX_DOCUMENT_BYTES = 64 * 1024 * 1024;
     private static final ObjectMapper JSON = new ObjectMapper(
             JsonFactory.builder()
@@ -84,7 +92,8 @@ final class ShipPublicationService {
     }
 
     static boolean journalExists(Path runDirectory) {
-        return Files.exists(journalPath(runDirectory), LinkOption.NOFOLLOW_LINKS);
+        // notExists is true only for confirmed absence; an indeterminate lookup must fail closed.
+        return !Files.notExists(journalPath(runDirectory), LinkOption.NOFOLLOW_LINKS);
     }
 
     /** Computes the material publication set from the verified baseline and candidate snapshots. */
@@ -132,14 +141,17 @@ final class ShipPublicationService {
             }
         });
         entries.sort(Comparator.comparing(Entry::path));
-        return new Journal(
+        Journal journal = new Journal(
                 SCHEMA_VERSION,
                 runId,
                 attempt,
+                baseline.rootIdentity(),
                 ShipWorkspace.materialIdentity(baseline),
                 ShipWorkspace.materialIdentity(candidate),
                 createdAt,
                 List.copyOf(entries));
+        requireStagingBindings(journal, baseline, candidate);
+        return journal;
     }
 
     /**
@@ -168,10 +180,16 @@ final class ShipPublicationService {
         if (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
             deleteTree(backupDirectory(runDirectory));
             Files.deleteIfExists(recordPath(runDirectory));
+            Files.deleteIfExists(applicationPath(runDirectory));
+            Files.deleteIfExists(recoveryPath(runDirectory));
         } else {
             Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(
                     PosixFilePermissions.fromString("rwx------")));
         }
+        Files.setPosixFilePermissions(
+                directory, PosixFilePermissions.fromString("rwx------"));
+        deletePermissionProbes(directory);
+        requireOwnerPermissionMask(directory);
         writeAtomically(journalPath(runDirectory), encode(journal));
     }
 
@@ -184,11 +202,15 @@ final class ShipPublicationService {
         Path backup = backupDirectory(runDirectory);
         try {
             backupPhase(project, backup, journal);
+            startApplication(runDirectory, journal);
+            probeStagingPaths(project, journal);
         } catch (IOException | RuntimeException e) {
-            // The backup phase only reads the live project, so nothing was mutated: clear the
-            // scratch instead of leaving a journal that later reads as a torn publication.
             try {
-                clean(runDirectory);
+                // Backup has not touched a target. Only a probe whose own cleanup failed can
+                // leave Ship-owned live-tree scratch that still needs the journal.
+                if (!(e instanceof StagingCleanupException)) {
+                    clean(runDirectory);
+                }
             } catch (IOException cleanupFailure) {
                 e.addSuppressed(cleanupFailure);
             }
@@ -196,9 +218,10 @@ final class ShipPublicationService {
         }
         try {
             applyPhase(project, candidate, journal);
-            String liveIdentity = ShipWorkspace.materialIdentity(
-                    ProjectEvidenceFiles.capture(project));
-            if (!liveIdentity.equals(journal.candidateIdentity())) {
+            ProjectSnapshot published = ProjectEvidenceFiles.capture(project);
+            if (!journal.baselineRootIdentity().equals(published.rootIdentity())
+                    || !ShipWorkspace.materialIdentity(published).equals(
+                            journal.candidateIdentity())) {
                 throw new IOException(
                         "Published Ship project differs from the validated candidate");
             }
@@ -217,7 +240,7 @@ final class ShipPublicationService {
     static ArtifactRef commitRecord(Path runDirectory, Journal journal, String appliedAt)
             throws IOException {
         byte[] encoded = encode(new PublicationRecord(
-                journal.schemaVersion(),
+                RECORD_SCHEMA_VERSION,
                 journal.runId(),
                 journal.attempt(),
                 journal.baselineIdentity(),
@@ -245,12 +268,24 @@ final class ShipPublicationService {
      * A journal describes exactly one Execute candidate. When {@code executeAttempt} no longer matches, that candidate
      * was superseded, the journal can no longer describe the live project, and it is discarded instead of applied.
      */
-    static void recover(Path project, Path runDirectory, int executeAttempt) throws IOException {
+    static void recover(
+            Path project, Path runDirectory, String runId, int executeAttempt)
+            throws IOException {
         if (!journalExists(runDirectory)) {
             return;
         }
         Journal journal = readJournal(runDirectory);
+        if (!runId.equals(journal.runId())) {
+            throw new RecoveryBlockedException(
+                    "Ship publication journal belongs to another run");
+        }
         if (journal.attempt() != executeAttempt) {
+            if (Files.exists(applicationPath(runDirectory), LinkOption.NOFOLLOW_LINKS)
+                    || Files.exists(recoveryPath(runDirectory), LinkOption.NOFOLLOW_LINKS)
+                    || hasStaging(project, journal)) {
+                throw new RecoveryBlockedException(
+                        "Superseded Ship publication journal still owns live recovery scratch");
+            }
             discard(runDirectory);
             return;
         }
@@ -267,6 +302,8 @@ final class ShipPublicationService {
      * publication clears it in {@link #begin}.
      */
     static void discard(Path runDirectory) throws IOException {
+        Files.deleteIfExists(applicationPath(runDirectory));
+        Files.deleteIfExists(recoveryPath(runDirectory));
         Files.deleteIfExists(journalPath(runDirectory));
         deleteTree(backupDirectory(runDirectory));
     }
@@ -285,7 +322,7 @@ final class ShipPublicationService {
             throw new IOException("Ship publication record does not match its recorded digest");
         }
         PublicationRecord record = decode(encoded, PublicationRecord.class, expected);
-        if (record.schemaVersion() != SCHEMA_VERSION || !runId.equals(record.runId())) {
+        if (record.schemaVersion() != RECORD_SCHEMA_VERSION || !runId.equals(record.runId())) {
             throw new IOException("Ship publication record does not match its run");
         }
         return record;
@@ -293,6 +330,22 @@ final class ShipPublicationService {
 
     private static void backupPhase(Path project, Path backup, Journal journal)
             throws IOException {
+        ProjectSnapshot observed = ProjectEvidenceFiles.capture(project);
+        if (!journal.baselineRootIdentity().equals(observed.rootIdentity())
+                || !ShipWorkspace.materialIdentity(observed).equals(journal.baselineIdentity())) {
+            throw new StaleLiveTreeException(
+                    "Live project changed since the publication baseline");
+        }
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (entry.kind() == Kind.FILE
+                    && Files.exists(
+                            stagingPath(journal, index, target(project, entry.path())),
+                            LinkOption.NOFOLLOW_LINKS)) {
+                throw new StaleLiveTreeException(
+                        "Live project gained Ship publication scratch since the baseline");
+            }
+        }
         for (Entry entry : journal.entries()) {
             Path live = target(project, entry.path());
             if (entry.kind() == Kind.DIRECTORY) {
@@ -310,9 +363,11 @@ final class ShipPublicationService {
                 case REPLACE, DELETE -> {
                     Path copy = target(backup, entry.path());
                     Files.createDirectories(copy.getParent());
-                    byte[] content = Files.readAllBytes(live);
+                    byte[] content = ProjectEvidenceFiles.readMaterial(
+                            project, entry.path(), maximumBytes(entry.baselineSize()));
                     if (content.length != entry.baselineSize()
-                            || !ShipDigest.sha256(content).equals(entry.baselineDigest())) {
+                            || !ShipDigest.sha256(content).equals(entry.baselineDigest())
+                            || liveMode(live) != entry.baselineMode()) {
                         throw new StaleLiveTreeException(
                                 "Live project file changed since the publication baseline: "
                                                          + entry.path());
@@ -323,6 +378,8 @@ final class ShipPublicationService {
                             copy,
                             PosixFilePermissions.asFileAttribute(
                                     PosixFilePermissions.fromString("rw-------")));
+                    Files.setPosixFilePermissions(
+                            copy, PosixFilePermissions.fromString("rw-------"));
                     writeFully(copy, content);
                 }
             }
@@ -331,47 +388,56 @@ final class ShipPublicationService {
 
     private static void requireDirectoryBaseline(Entry entry, Path live)
             throws IOException {
-        boolean exists = Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS);
+        boolean present = Files.exists(live, LinkOption.NOFOLLOW_LINKS);
         boolean expected = entry.action() != Action.ADD;
-        if (exists != expected) {
+        if (present != expected
+                || present && (!Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)
+                        || liveMode(live) != entry.baselineMode())) {
             throw new StaleLiveTreeException(
                     "Live project directory changed since the publication baseline: "
                                              + entry.path());
         }
     }
 
-    private static void applyPhase(Path project, Path candidate, Journal journal)
-            throws IOException {
-        for (Entry entry : directories(journal, Action.ADD)) {
-            Files.createDirectory(target(project, entry.path()),
+    private static void requireOwnerPermissionMask(Path publication) throws IOException {
+        Path file = publication.resolve(".permission-probe-file");
+        Path directory = publication.resolve(".permission-probe-directory");
+        boolean fileCreated = false;
+        boolean directoryCreated = false;
+        try {
+            Files.createFile(
+                    file,
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rw-------")));
+            fileCreated = true;
+            Files.createDirectory(
+                    directory,
                     PosixFilePermissions.asFileAttribute(
                             PosixFilePermissions.fromString("rwx------")));
-        }
-        for (Entry entry : journal.entries()) {
-            if (entry.kind() != Kind.FILE || entry.action() == Action.DELETE) {
-                continue;
-            }
-            byte[] content = Files.readAllBytes(target(candidate, entry.path()));
-            if (content.length != entry.candidateSize()
-                    || !ShipDigest.sha256(content).equals(entry.candidateDigest())) {
+            directoryCreated = true;
+            if ((liveMode(file) & 0600) != 0600 || (liveMode(directory) & 0700) != 0700) {
                 throw new IOException(
-                        "Ship candidate file changed during publication: " + entry.path());
+                        "Ship publication requires a POSIX umask that preserves owner permissions");
             }
-            Path live = target(project, entry.path());
-            Path temporary = stagingPath(live);
-            boolean moved = false;
-            try {
-                createStagingFile(temporary);
-                writeFully(temporary, content);
-                Files.setPosixFilePermissions(temporary, permissions(entry.candidateMode()));
-                move(temporary, live);
-                moved = true;
-            } finally {
-                if (!moved) {
-                    Files.deleteIfExists(temporary);
-                }
+        } finally {
+            if (fileCreated) {
+                Files.deleteIfExists(file);
+            }
+            if (directoryCreated) {
+                Files.deleteIfExists(directory);
             }
         }
+    }
+
+    private static void deletePermissionProbes(Path publication) throws IOException {
+        Files.deleteIfExists(publication.resolve(".permission-probe-file"));
+        Files.deleteIfExists(publication.resolve(".permission-probe-directory"));
+    }
+
+    private static void applyPhase(Path project, Path candidate, Journal journal)
+            throws IOException {
+        // Release entry-count and byte quota before consuming it on the candidate side. This
+        // keeps every crash-reachable live mixture within the ordinary snapshot limits.
         for (Entry entry : journal.entries()) {
             if (entry.kind() == Kind.FILE && entry.action() == Action.DELETE) {
                 Files.delete(target(project, entry.path()));
@@ -382,8 +448,6 @@ final class ShipPublicationService {
             try {
                 Files.delete(live);
             } catch (DirectoryNotEmptyException e) {
-                // Build output and other non-publishable content is invisible to the snapshots,
-                // so retrying cannot help until the user clears it.
                 throw new IOException(
                         "Ship cannot remove " + entry.path()
                                       + " because the live project still holds content outside the "
@@ -391,12 +455,59 @@ final class ShipPublicationService {
                         e);
             }
         }
-        for (Entry entry : journal.entries()) {
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (shrinksOnApply(entry)) {
+                publishFile(project, candidate, journal, index, entry);
+            }
+        }
+        for (Entry entry : directories(journal, Action.ADD)) {
+            Path live = target(project, entry.path());
+            Files.createDirectory(live,
+                    PosixFilePermissions.asFileAttribute(
+                            permissions(workMode(entry))));
+            Files.setPosixFilePermissions(live, permissions(workMode(entry)));
+        }
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (entry.kind() != Kind.FILE
+                    || entry.action() == Action.DELETE
+                    || shrinksOnApply(entry)) {
+                continue;
+            }
+            publishFile(project, candidate, journal, index, entry);
+        }
+        for (Entry entry : reversed(journal.entries())) {
             if (entry.kind() == Kind.DIRECTORY && entry.action() != Action.DELETE) {
                 Files.setPosixFilePermissions(
                         target(project, entry.path()), permissions(entry.candidateMode()));
             }
         }
+    }
+
+    private static void publishFile(
+            Path project, Path candidate, Journal journal, int index, Entry entry)
+            throws IOException {
+        byte[] content = ProjectEvidenceFiles.readMaterial(
+                candidate, entry.path(), maximumBytes(entry.candidateSize()));
+        if (content.length != entry.candidateSize()
+                || !ShipDigest.sha256(content).equals(entry.candidateDigest())
+                || liveMode(target(candidate, entry.path())) != entry.candidateMode()) {
+            throw new IOException(
+                    "Ship candidate file changed during publication: " + entry.path());
+        }
+        Path live = target(project, entry.path());
+        replaceAtomically(
+                live,
+                stagingPath(journal, index, live),
+                content,
+                entry.candidateMode());
+    }
+
+    private static boolean shrinksOnApply(Entry entry) {
+        return entry.kind() == Kind.FILE
+                && entry.action() == Action.REPLACE
+                && entry.candidateSize() < entry.baselineSize();
     }
 
     /**
@@ -407,107 +518,288 @@ final class ShipPublicationService {
     private static void rollback(Path project, Path runDirectory, Journal journal)
             throws IOException {
         Path backup = backupDirectory(runDirectory);
-        List<Runnable2> restores = new ArrayList<>();
-        for (Entry entry : journal.entries()) {
-            Runnable2 restore = classify(project, backup, entry);
-            if (restore != null) {
-                restores.add(restore);
+        if (!journal.baselineRootIdentity().equals(ProjectEvidenceFiles.rootIdentity(project))) {
+            throw new RecoveryBlockedException(
+                    "Ship project root no longer matches the publication journal");
+        }
+        boolean applicationStarted = applicationStarted(runDirectory, journal);
+        boolean recoveryStarted = recoveryStarted(runDirectory, journal);
+        cleanupStaging(
+                project,
+                runDirectory.resolve("workspace/candidate"),
+                backup,
+                journal,
+                applicationStarted,
+                recoveryStarted);
+        final ProjectSnapshot observed;
+        try {
+            observed = ProjectEvidenceFiles.capture(project);
+        } catch (IOException | RuntimeException e) {
+            throw recoveryBlocked(
+                    "Live project cannot be safely inspected for publication recovery", e);
+        }
+        if (!journal.baselineRootIdentity().equals(observed.rootIdentity())) {
+            throw new RecoveryBlockedException(
+                    "Ship project root no longer matches the publication journal");
+        }
+        final ProjectSnapshot candidate;
+        try {
+            candidate = ProjectEvidenceFiles.captureStaged(
+                    runDirectory.resolve("workspace/candidate"));
+        } catch (IOException | RuntimeException e) {
+            throw recoveryBlocked(
+                    "Ship candidate cannot be safely inspected for publication recovery", e);
+        }
+        if (!journal.candidateIdentity().equals(ShipWorkspace.materialIdentity(candidate))) {
+            throw new RecoveryBlockedException(
+                    "Ship candidate no longer matches the publication journal");
+        }
+        requireUnchangedMaterialEntries(observed, candidate, journal);
+        List<Classified> classified = new ArrayList<>();
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            Side side = classify(observed, entry, recoveryStarted);
+            if (!applicationStarted && side != Side.BASELINE) {
+                throw new RecoveryBlockedException(
+                        "Live project changed before Ship publication started: " + entry.path());
+            }
+            classified.add(new Classified(index, entry, side));
+            if (side == Side.CANDIDATE
+                    && entry.kind() == Kind.FILE
+                    && entry.action() != Action.ADD) {
+                readBackup(backup, entry);
             }
         }
-        // Remove staging files an interrupted apply left beside their targets; they are material
-        // to the tree policy, so a leftover would otherwise drift the live project's identity.
-        for (Entry entry : journal.entries()) {
-            if (entry.kind() == Kind.FILE) {
-                Files.deleteIfExists(stagingPath(target(project, entry.path())));
+        requireNoForeignAddedDirectoryContent(project, classified);
+        startRecovery(runDirectory, journal, recoveryStarted);
+
+        // Make candidate-side directories writable before removing candidate additions. The
+        // marker makes this private work mode an explicit crash-recoverable journal state.
+        for (Classified item : classified) {
+            Entry entry = item.entry();
+            if (item.side() != Side.CANDIDATE
+                    || entry.kind() != Kind.DIRECTORY
+                    || entry.action() == Action.DELETE) {
+                continue;
             }
+            Files.setPosixFilePermissions(
+                    target(project, entry.path()), permissions(workMode(entry)));
         }
-        // Restoration mutates directory contents, so every touched directory is made owner-writable
-        // first; the exact baseline modes are re-applied as the final step.
-        for (Entry entry : journal.entries()) {
-            if (entry.kind() != Kind.DIRECTORY) {
+
+        // First release candidate-only quota and shrink growing replacements.
+        for (Classified item : classified) {
+            Entry entry = item.entry();
+            if (item.side() != Side.CANDIDATE || entry.kind() != Kind.FILE) {
                 continue;
             }
             Path live = target(project, entry.path());
-            if (entry.action() == Action.DELETE
-                    && !Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
-                Files.createDirectories(live);
+            switch (entry.action()) {
+                case ADD -> Files.delete(live);
+                case REPLACE -> {
+                    if (entry.baselineSize() < entry.candidateSize()) {
+                        restoreBackup(backup, journal, item, live);
+                    }
+                }
+                case DELETE -> {
+                    // Restored after candidate-only directories release their quota.
+                }
             }
-            if (Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
+        }
+
+        for (Classified item : reversed(classified)) {
+            Entry entry = item.entry();
+            if (item.side() != Side.CANDIDATE
+                    || entry.kind() != Kind.DIRECTORY
+                    || entry.action() != Action.ADD) {
+                continue;
+            }
+            Path live = target(project, entry.path());
+            try {
+                Files.delete(live);
+            } catch (DirectoryNotEmptyException e) {
+                throw new RecoveryBlockedException(
+                        "Ship publication-created directory contains foreign content: "
+                                                   + entry.path());
+            }
+        }
+
+        // Recreate baseline-only directory shape in a writable mode, then restore the remaining
+        // files one at a time so recovery never retains the aggregate backup in heap.
+        for (Classified item : classified) {
+            Entry entry = item.entry();
+            if (item.side() == Side.CANDIDATE
+                    && entry.kind() == Kind.DIRECTORY
+                    && entry.action() == Action.DELETE) {
+                Path live = target(project, entry.path());
+                if (!Files.exists(live, LinkOption.NOFOLLOW_LINKS)) {
+                    Files.createDirectory(
+                            live,
+                            PosixFilePermissions.asFileAttribute(permissions(workMode(entry))));
+                    Files.setPosixFilePermissions(live, permissions(workMode(entry)));
+                }
+            }
+        }
+        for (Classified item : classified) {
+            Entry entry = item.entry();
+            if (item.side() != Side.CANDIDATE
+                    || entry.kind() != Kind.FILE
+                    || entry.action() == Action.ADD
+                    || entry.action() == Action.REPLACE
+                            && entry.baselineSize() < entry.candidateSize()) {
+                continue;
+            }
+            restoreBackup(backup, journal, item, target(project, entry.path()));
+        }
+        for (Classified item : reversed(classified)) {
+            Entry entry = item.entry();
+            if (item.side() == Side.CANDIDATE
+                    && entry.kind() == Kind.DIRECTORY
+                    && entry.action() != Action.ADD) {
                 Files.setPosixFilePermissions(
-                        live, PosixFilePermissions.fromString("rwx------"));
+                        target(project, entry.path()), permissions(entry.baselineMode()));
             }
         }
-        for (Runnable2 restore : restores) {
-            restore.run();
+
+        ProjectSnapshot restored = ProjectEvidenceFiles.capture(project);
+        if (!journal.baselineRootIdentity().equals(restored.rootIdentity())
+                || !journal.baselineIdentity().equals(
+                        ShipWorkspace.materialIdentity(restored))) {
+            throw new RecoveryBlockedException(
+                    "Ship publication rollback did not restore the exact baseline");
         }
-        for (Entry entry : reversed(directories(journal, Action.ADD))) {
-            Path live = target(project, entry.path());
-            if (Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
-                try {
-                    Files.delete(live);
-                } catch (DirectoryNotEmptyException e) {
-                    // Something outside the publication landed here while it was torn. Leaving the
-                    // directory keeps that content; failing here would block resume and abort alike.
-                    Files.setPosixFilePermissions(live, permissions(entry.candidateMode()));
-                }
-            }
-        }
-        for (Entry entry : journal.entries()) {
-            if (entry.kind() != Kind.DIRECTORY || entry.action() == Action.ADD) {
+    }
+
+    private static void requireUnchangedMaterialEntries(
+            ProjectSnapshot observed, ProjectSnapshot candidate, Journal journal)
+            throws RecoveryBlockedException {
+        Set<String> changed = new HashSet<>();
+        journal.entries().forEach(entry -> changed.add(entry.path()));
+        for (var item : observed.directories().entrySet()) {
+            if (item.getValue().classification() != Classification.MATERIAL
+                    || changed.contains(item.getKey())) {
                 continue;
             }
-            Path live = target(project, entry.path());
-            if (Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
-                Files.setPosixFilePermissions(live, permissions(entry.baselineMode()));
+            ProjectSnapshot.DirectoryEntry expected = candidate.directories().get(item.getKey());
+            if (expected == null
+                    || mode(item.getValue().unixMode()) != mode(expected.unixMode())) {
+                throw changedOutsidePublication(item.getKey());
+            }
+        }
+        for (var item : candidate.directories().entrySet()) {
+            if (item.getValue().classification() == Classification.MATERIAL
+                    && !changed.contains(item.getKey())
+                    && !observed.directories().containsKey(item.getKey())) {
+                throw changedOutsidePublication(item.getKey());
+            }
+        }
+        for (var item : observed.files().entrySet()) {
+            if (item.getValue().classification() != Classification.MATERIAL
+                    || changed.contains(item.getKey())) {
+                continue;
+            }
+            ProjectSnapshot.FileEntry expected = candidate.files().get(item.getKey());
+            if (expected == null
+                    || item.getValue().size() != expected.size()
+                    || !item.getValue().digest().equals(expected.digest())
+                    || mode(item.getValue().unixMode()) != mode(expected.unixMode())) {
+                throw changedOutsidePublication(item.getKey());
+            }
+        }
+        for (var item : candidate.files().entrySet()) {
+            if (item.getValue().classification() == Classification.MATERIAL
+                    && !changed.contains(item.getKey())
+                    && !observed.files().containsKey(item.getKey())) {
+                throw changedOutsidePublication(item.getKey());
             }
         }
     }
 
-    private static Runnable2 classify(Path project, Path backup, Entry entry)
+    private static RecoveryBlockedException changedOutsidePublication(String path) {
+        return new RecoveryBlockedException(
+                "Live project changed outside the Ship publication set: " + path);
+    }
+
+    private static void restoreBackup(
+            Path backup, Journal journal, Classified item, Path live)
             throws IOException {
-        if (entry.kind() == Kind.DIRECTORY) {
-            return null;
-        }
-        Path live = target(project, entry.path());
-        boolean exists = Files.exists(live, LinkOption.NOFOLLOW_LINKS);
-        String liveDigest = exists && Files.isRegularFile(live, LinkOption.NOFOLLOW_LINKS)
-                ? ShipDigest.sha256(Files.readAllBytes(live))
-                : null;
-        switch (entry.action()) {
-            case ADD -> {
-                if (!exists) {
-                    return null;
-                }
-                if (entry.candidateDigest().equals(liveDigest)) {
-                    return () -> Files.delete(live);
-                }
-            }
-            case REPLACE -> {
-                // A mode-only replace leaves both digests equal, so the mode is the only evidence
-                // of whether it was applied; restoring re-stamps the baseline mode.
-                if (entry.baselineDigest().equals(liveDigest)
-                        && (!exists || liveMode(live) == entry.baselineMode())) {
-                    return null;
-                }
-                if (entry.candidateDigest().equals(liveDigest)) {
-                    return () -> restoreBackup(backup, live, entry);
-                }
-            }
-            case DELETE -> {
-                if (entry.baselineDigest().equals(liveDigest)) {
-                    return null;
-                }
-                if (!exists) {
-                    return () -> restoreBackup(backup, live, entry);
-                }
-            }
-        }
-        throw new RecoveryBlockedException(
-                "Live project file matches neither the publication baseline nor its candidate: "
-                                           + entry.path());
+        Entry entry = item.entry();
+        replaceAtomically(
+                live,
+                stagingPath(journal, item.index(), live),
+                readBackup(backup, entry),
+                entry.baselineMode());
     }
 
-    private static void restoreBackup(Path backup, Path live, Entry entry)
+    private static Side classify(
+            ProjectSnapshot observed, Entry entry, boolean recoveryStarted)
+            throws RecoveryBlockedException {
+        boolean baseline = matches(observed, entry, Side.BASELINE);
+        boolean candidate = matches(observed, entry, Side.CANDIDATE);
+        boolean working = matchesWorking(observed, entry)
+                && (entry.action() == Action.ADD || recoveryStarted);
+        if (baseline && candidate || !baseline && !candidate && !working) {
+            throw new RecoveryBlockedException(
+                    "Live project entry matches neither one exact publication side: "
+                                               + entry.path());
+        }
+        if (baseline) {
+            return Side.BASELINE;
+        }
+        return Side.CANDIDATE;
+    }
+
+    private static boolean matchesWorking(ProjectSnapshot observed, Entry entry) {
+        if (entry.kind() != Kind.DIRECTORY) {
+            return false;
+        }
+        ProjectSnapshot.DirectoryEntry directory = observed.directories().get(entry.path());
+        if (observed.files().get(entry.path()) != null || directory == null) {
+            return false;
+        }
+        int actual = mode(directory.unixMode());
+        int working = workMode(entry);
+        if (entry.action() == Action.REPLACE) {
+            return actual == working;
+        }
+        // ADD and DELETE directories are created by this protocol, so their initial mode can be
+        // filtered through umask before the explicit chmod closes that crash window.
+        return (actual & 0700) == 0700 && (actual & ~working) == 0;
+    }
+
+    private static int workMode(Entry entry) {
+        int desired = entry.action() == Action.ADD
+                ? entry.candidateMode() : entry.baselineMode();
+        return desired | 0700;
+    }
+
+    private static boolean matches(ProjectSnapshot observed, Entry entry, Side side) {
+        boolean expected = side == Side.BASELINE
+                ? entry.action() != Action.ADD
+                : entry.action() != Action.DELETE;
+        ProjectSnapshot.FileEntry file = observed.files().get(entry.path());
+        ProjectSnapshot.DirectoryEntry directory = observed.directories().get(entry.path());
+        if (!expected) {
+            return file == null && directory == null;
+        }
+        Integer expectedMode = side == Side.BASELINE
+                ? entry.baselineMode() : entry.candidateMode();
+        if (entry.kind() == Kind.DIRECTORY) {
+            return file == null
+                    && directory != null
+                    && mode(directory.unixMode()) == expectedMode;
+        }
+        String expectedDigest = side == Side.BASELINE
+                ? entry.baselineDigest() : entry.candidateDigest();
+        Long expectedSize = side == Side.BASELINE
+                ? entry.baselineSize() : entry.candidateSize();
+        return directory == null
+                && file != null
+                && file.size() == expectedSize
+                && file.digest().equals(expectedDigest)
+                && mode(file.unixMode()) == expectedMode;
+    }
+
+    private static byte[] readBackup(Path backup, Entry entry)
             throws IOException {
         byte[] content = Files.readAllBytes(target(backup, entry.path()));
         if (content.length != entry.baselineSize()
@@ -515,42 +807,313 @@ final class ShipPublicationService {
             throw new RecoveryBlockedException(
                     "Ship publication backup does not match its journal entry: " + entry.path());
         }
-        Files.createDirectories(live.getParent());
-        Path temporary = stagingPath(live);
-        boolean moved = false;
-        try {
-            createStagingFile(temporary);
-            writeFully(temporary, content);
-            Files.setPosixFilePermissions(temporary, permissions(entry.baselineMode()));
-            move(temporary, live);
-            moved = true;
-        } finally {
-            if (!moved) {
-                Files.deleteIfExists(temporary);
+        return content;
+    }
+
+    private static void requireNoForeignAddedDirectoryContent(
+            Path project, List<Classified> classified)
+            throws IOException {
+        Set<String> expected = new HashSet<>();
+        for (Classified item : classified) {
+            if (item.side() == Side.CANDIDATE && item.entry().action() != Action.DELETE) {
+                expected.add(item.entry().path());
+            }
+        }
+        for (Classified item : classified) {
+            Entry entry = item.entry();
+            if (item.side() != Side.CANDIDATE
+                    || entry.kind() != Kind.DIRECTORY
+                    || entry.action() != Action.ADD) {
+                continue;
+            }
+            Path live = target(project, entry.path());
+            try (var paths = Files.walk(live)) {
+                for (Path path : paths.toList()) {
+                    if (path.equals(live)) {
+                        continue;
+                    }
+                    String relative = project.relativize(path).toString()
+                            .replace(project.getFileSystem().getSeparator(), "/");
+                    if (!expected.contains(relative)) {
+                        throw new RecoveryBlockedException(
+                                "Ship publication-created directory contains foreign content: "
+                                                           + entry.path());
+                    }
+                }
             }
         }
     }
 
-    /**
-     * Names the staging file deterministically beside its target so a publication torn by process death leaves debris
-     * the journal can still find; a random name would survive every rollback and pollute the live project.
-     */
-    private static Path stagingPath(Path live) {
-        return live.resolveSibling("." + live.getFileName() + STAGING_SUFFIX);
+    private static boolean applicationStarted(Path runDirectory, Journal journal)
+            throws IOException {
+        return validMarker(
+                applicationPath(runDirectory), journal, "application");
     }
 
-    private static void createStagingFile(Path staging) throws IOException {
-        Files.deleteIfExists(staging);
-        Files.createFile(
-                staging,
-                PosixFilePermissions.asFileAttribute(
-                        PosixFilePermissions.fromString("rw-------")));
+    static void startApplication(Path runDirectory, Journal journal) throws IOException {
+        writeAtomically(applicationPath(runDirectory), markerPayload(journal));
+    }
+
+    private static boolean recoveryStarted(Path runDirectory, Journal journal)
+            throws IOException {
+        return validMarker(recoveryPath(runDirectory), journal, "recovery");
+    }
+
+    private static boolean validMarker(Path marker, Journal journal, String phase)
+            throws IOException {
+        if (!Files.exists(marker, LinkOption.NOFOLLOW_LINKS)) {
+            return false;
+        }
+        if (!Files.isRegularFile(marker, LinkOption.NOFOLLOW_LINKS)
+                || !java.util.Arrays.equals(readBounded(marker), markerPayload(journal))) {
+            throw new RecoveryBlockedException(
+                    "Ship publication " + phase + " marker is invalid");
+        }
+        return true;
+    }
+
+    static void startRecovery(
+            Path runDirectory, Journal journal, boolean alreadyStarted)
+            throws IOException {
+        if (!alreadyStarted) {
+            writeAtomically(recoveryPath(runDirectory), markerPayload(journal));
+        }
+    }
+
+    private static byte[] markerPayload(Journal journal) {
+        return (journal.runId() + '\n'
+                + journal.attempt() + '\n'
+                + journal.baselineRootIdentity() + '\n'
+                + journal.baselineIdentity() + '\n')
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static void cleanupStaging(
+            Path project,
+            Path candidate,
+            Path backup,
+            Journal journal,
+            boolean applicationStarted,
+            boolean recoveryStarted)
+            throws IOException {
+        List<Path> owned = new ArrayList<>();
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (entry.kind() != Kind.FILE) {
+                continue;
+            }
+            Path live = target(project, entry.path());
+            Path staging = stagingPath(journal, index, live);
+            if (!Files.exists(staging, LinkOption.NOFOLLOW_LINKS)) {
+                continue;
+            }
+            String relative = stagingRelativePath(journal, index, entry);
+            long maximum = Math.max(
+                    entry.baselineSize() == null ? 0 : entry.baselineSize(),
+                    entry.candidateSize() == null ? 0 : entry.candidateSize());
+            final byte[] actual;
+            final int actualMode;
+            try {
+                actual = ProjectEvidenceFiles.readMaterial(
+                        project, relative, maximumBytes(maximum));
+                actualMode = liveMode(staging);
+            } catch (IOException | RuntimeException e) {
+                throw recoveryBlocked(
+                        "Ship publication staging file is not safely recoverable: " + relative,
+                        e);
+            }
+            boolean matches = false;
+            if (applicationStarted
+                    && !recoveryStarted
+                    && entry.action() != Action.DELETE) {
+                byte[] expected = verifiedCandidate(candidate, entry);
+                matches = expected != null
+                        && stagingPrefix(
+                                actual, actualMode, expected, entry.candidateMode());
+            }
+            if (!matches && recoveryStarted && entry.action() != Action.ADD) {
+                Path source = target(backup, entry.path());
+                if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
+                    byte[] expected = readBackup(backup, entry);
+                    matches = stagingPrefix(
+                            actual, actualMode, expected, entry.baselineMode());
+                }
+            }
+            if (!matches
+                    && applicationStarted
+                    && !recoveryStarted
+                    && entry.action() == Action.DELETE
+                    && actual.length == 0) {
+                Path source = target(backup, entry.path());
+                if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
+                    byte[] expected = readBackup(backup, entry);
+                    matches = stagingPrefix(
+                            actual, actualMode, expected, entry.baselineMode());
+                }
+            }
+            if (!matches) {
+                throw new RecoveryBlockedException(
+                        "Ship publication staging path is occupied by foreign content: "
+                                                   + relative);
+            }
+            owned.add(staging);
+        }
+        for (Path staging : owned) {
+            Files.delete(staging);
+        }
+    }
+
+    private static boolean stagingPrefix(
+            byte[] actual, int actualMode, byte[] expected, int expectedMode) {
+        if (actual.length > expected.length) {
+            return false;
+        }
+        for (int index = 0; index < actual.length; index++) {
+            if (actual[index] != expected[index]) {
+                return false;
+            }
+        }
+        return actual.length < expected.length
+                ? actualMode == PRIVATE_STAGING_MODE
+                : actualMode == PRIVATE_STAGING_MODE || actualMode == expectedMode;
+    }
+
+    private static byte[] verifiedCandidate(Path candidate, Entry entry) {
+        try {
+            byte[] expected = ProjectEvidenceFiles.readMaterial(
+                    candidate, entry.path(), maximumBytes(entry.candidateSize()));
+            return expected.length == entry.candidateSize()
+                    && ShipDigest.sha256(expected).equals(entry.candidateDigest())
+                    && liveMode(target(candidate, entry.path())) == entry.candidateMode()
+                            ? expected : null;
+        } catch (IOException | RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static void replaceAtomically(
+            Path live, Path staging, byte[] content, int targetMode)
+            throws IOException {
+        boolean created = false;
+        boolean moved = false;
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    staging,
+                    Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE),
+                    PosixFilePermissions.asFileAttribute(
+                            permissions(PRIVATE_STAGING_MODE)))) {
+                created = true;
+                Files.setPosixFilePermissions(staging, permissions(PRIVATE_STAGING_MODE));
+                ByteBuffer buffer = ByteBuffer.wrap(content);
+                while (buffer.hasRemaining()) {
+                    channel.write(buffer);
+                }
+                channel.force(true);
+            }
+            Files.setPosixFilePermissions(staging, permissions(targetMode));
+            move(staging, live);
+            moved = true;
+        } finally {
+            if (created && !moved) {
+                Files.deleteIfExists(staging);
+            }
+        }
+    }
+
+    static Path stagingPath(Journal journal, int index, Path live) {
+        Entry entry = journal.entries().get(index);
+        if (entry.kind() != Kind.FILE || live.getParent() == null) {
+            throw new IllegalArgumentException("Ship file publication staging target is invalid");
+        }
+        return live.resolveSibling(stagingFileName(journal, index));
+    }
+
+    private static String stagingRelativePath(Journal journal, int index, Entry entry) {
+        int separator = entry.path().lastIndexOf('/');
+        String name = stagingFileName(journal, index);
+        return separator < 0 ? name : entry.path().substring(0, separator + 1) + name;
+    }
+
+    private static String stagingFileName(Journal journal, int index) {
+        return STAGING_PREFIX
+               + journal.runId().substring("ship-".length())
+               + '-' + Integer.toString(journal.attempt(), Character.MAX_RADIX)
+               + '-' + Integer.toString(index, Character.MAX_RADIX)
+               + STAGING_SUFFIX;
+    }
+
+    private static boolean hasStaging(Path project, Journal journal) throws IOException {
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (entry.kind() == Kind.FILE
+                    && Files.exists(
+                            stagingPath(journal, index, target(project, entry.path())),
+                            LinkOption.NOFOLLOW_LINKS)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void probeStagingPaths(Path project, Journal journal) throws IOException {
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (entry.kind() != Kind.FILE) {
+                continue;
+            }
+            Path staging = stagingPath(journal, index, target(project, entry.path()));
+            // Candidate-only parents do not exist yet. Their scratch path cannot strand a
+            // baseline restore, because a failed ADD is removed rather than replaced.
+            if (!Files.isDirectory(staging.getParent(), LinkOption.NOFOLLOW_LINKS)) {
+                continue;
+            }
+            boolean created = false;
+            Throwable probeFailure = null;
+            try (FileChannel ignored = FileChannel.open(
+                    staging,
+                    Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE),
+                    PosixFilePermissions.asFileAttribute(
+                            permissions(PRIVATE_STAGING_MODE)))) {
+                created = true;
+                Files.setPosixFilePermissions(staging, permissions(PRIVATE_STAGING_MODE));
+            } catch (IOException | RuntimeException e) {
+                probeFailure = e;
+            }
+            if (created) {
+                try {
+                    Files.delete(staging);
+                } catch (IOException cleanupFailure) {
+                    if (probeFailure != null) {
+                        cleanupFailure.addSuppressed(probeFailure);
+                    }
+                    throw new StagingCleanupException(
+                            "Ship could not remove publication path probe: " + staging,
+                            cleanupFailure);
+                }
+            }
+            if (probeFailure instanceof IOException failure) {
+                throw failure;
+            }
+            if (probeFailure instanceof RuntimeException failure) {
+                throw failure;
+            }
+        }
     }
 
     private static void clean(Path runDirectory) throws IOException {
         deleteTree(backupDirectory(runDirectory));
         Files.deleteIfExists(recordPath(runDirectory));
+        Files.deleteIfExists(applicationPath(runDirectory));
+        Files.deleteIfExists(recoveryPath(runDirectory));
         Files.deleteIfExists(journalPath(runDirectory));
+    }
+
+    private static Path applicationPath(Path runDirectory) {
+        return publicationDirectory(runDirectory).resolve(APPLICATION);
+    }
+
+    private static Path recoveryPath(Path runDirectory) {
+        return publicationDirectory(runDirectory).resolve(RECOVERY);
     }
 
     private static Journal readJournal(Path runDirectory) throws IOException {
@@ -581,6 +1144,7 @@ final class ShipPublicationService {
                                                    + entries.get(index).path());
             }
         }
+        requireStagingBindings(decoded, null, null);
         return decoded;
     }
 
@@ -620,8 +1184,39 @@ final class ShipPublicationService {
         return filtered;
     }
 
-    private static List<Entry> reversed(List<Entry> entries) {
-        List<Entry> copy = new ArrayList<>(entries);
+    private static void requireStagingBindings(
+            Journal journal, ProjectSnapshot baseline, ProjectSnapshot candidate)
+            throws UnsupportedChangeException {
+        Set<String> targets = new HashSet<>();
+        journal.entries().forEach(entry -> targets.add(entry.path()));
+        Set<String> staging = new HashSet<>();
+        ShipTreePolicy policy = ShipTreePolicy.current();
+        for (int index = 0; index < journal.entries().size(); index++) {
+            Entry entry = journal.entries().get(index);
+            if (entry.kind() != Kind.FILE) {
+                continue;
+            }
+            String relative = stagingRelativePath(journal, index, entry);
+            if (!staging.add(relative)
+                    || targets.contains(relative)
+                    || policy.classify(relative) != Classification.MATERIAL
+                    || contains(baseline, relative)
+                    || contains(candidate, relative)) {
+                throw new UnsupportedChangeException(
+                        "Ship cannot bind collision-free publication scratch for "
+                                                     + entry.path());
+            }
+        }
+    }
+
+    private static boolean contains(ProjectSnapshot snapshot, String path) {
+        return snapshot != null
+                && (snapshot.files().containsKey(path)
+                        || snapshot.directories().containsKey(path));
+    }
+
+    private static <T> List<T> reversed(List<T> entries) {
+        List<T> copy = new ArrayList<>(entries);
         java.util.Collections.reverse(copy);
         return copy;
     }
@@ -649,6 +1244,17 @@ final class ShipPublicationService {
         return bits;
     }
 
+    private static int maximumBytes(long size) {
+        return Math.toIntExact(Math.max(1, size));
+    }
+
+    private static RecoveryBlockedException recoveryBlocked(
+            String message, Throwable cause) {
+        RecoveryBlockedException blocked = new RecoveryBlockedException(message);
+        blocked.initCause(cause);
+        return blocked;
+    }
+
     private static java.util.Set<java.nio.file.attribute.PosixFilePermission> permissions(int mode) {
         StringBuilder text = new StringBuilder(9);
         int[] shifts = {6, 3, 0};
@@ -663,7 +1269,12 @@ final class ShipPublicationService {
 
     private static byte[] encode(Object document) throws IOException {
         try {
-            return JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(document);
+            byte[] encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(document);
+            if (encoded.length == 0 || encoded.length > MAX_DOCUMENT_BYTES) {
+                throw new IOException(
+                        "Ship publication document exceeds the durable read limit");
+            }
+            return encoded;
         } catch (JsonProcessingException e) {
             throw new IOException("Ship publication document cannot be encoded", e);
         }
@@ -699,6 +1310,8 @@ final class ShipPublicationService {
                         PosixFilePermissions.fromString("rw-------")));
         boolean moved = false;
         try {
+            Files.setPosixFilePermissions(
+                    temporary, PosixFilePermissions.fromString("rw-------"));
             writeFully(temporary, encoded);
             move(temporary, targetPath);
             moved = true;
@@ -741,11 +1354,6 @@ final class ShipPublicationService {
         }
     }
 
-    @FunctionalInterface
-    private interface Runnable2 {
-        void run() throws IOException;
-    }
-
     enum Kind {
         FILE,
         DIRECTORY
@@ -755,6 +1363,14 @@ final class ShipPublicationService {
         ADD,
         REPLACE,
         DELETE
+    }
+
+    private enum Side {
+        BASELINE,
+        CANDIDATE
+    }
+
+    private record Classified(int index, Entry entry, Side side) {
     }
 
     record Entry(
@@ -769,7 +1385,7 @@ final class ShipPublicationService {
             Integer candidateMode) {
 
         Entry {
-            Objects.requireNonNull(path, "entry path");
+            path = ShipTreePolicy.requireCanonicalRelativePath(path);
             Objects.requireNonNull(kind, "entry kind");
             Objects.requireNonNull(action, "entry action");
             boolean baseline = action != Action.ADD;
@@ -779,11 +1395,22 @@ final class ShipPublicationService {
                         && baselineMode != null));
                 require(candidate == (candidateDigest != null && candidateSize != null
                         && candidateMode != null));
+                require(!baseline || validFileSide(
+                        baselineDigest, baselineSize, baselineMode));
+                require(!candidate || validFileSide(
+                        candidateDigest, candidateSize, candidateMode));
+                require(action != Action.REPLACE
+                        || !baselineDigest.equals(candidateDigest)
+                        || !baselineSize.equals(candidateSize)
+                        || !baselineMode.equals(candidateMode));
             } else {
                 require(baselineDigest == null && baselineSize == null
                         && candidateDigest == null && candidateSize == null);
                 require(baseline == (baselineMode != null));
                 require(candidate == (candidateMode != null));
+                require(!baseline || validMode(baselineMode));
+                require(!candidate || validMode(candidateMode));
+                require(action != Action.REPLACE || !baselineMode.equals(candidateMode));
             }
         }
 
@@ -812,19 +1439,52 @@ final class ShipPublicationService {
                         "Ship publication entry does not match its action");
             }
         }
+
+        private static boolean validFileSide(String digest, long size, int mode) {
+            return ShipDigest.isSha256(digest)
+                    && size >= 0
+                    && size <= ShipTreePolicy.DEFAULT_MAX_FILE_BYTES
+                    && validMode(mode);
+        }
+
+        private static boolean validMode(int mode) {
+            return mode >= 0 && mode <= 0777;
+        }
     }
 
     record Journal(
             int schemaVersion,
             String runId,
             int attempt,
+            String baselineRootIdentity,
             String baselineIdentity,
             String candidateIdentity,
             String createdAt,
             List<Entry> entries) {
 
         Journal {
+            if (schemaVersion != SCHEMA_VERSION
+                    || !ShipRun.isRunId(runId)
+                    || attempt < 0
+                    || !ShipDigest.isSha256(baselineRootIdentity)
+                    || !ShipDigest.isSha256(baselineIdentity)
+                    || !ShipDigest.isSha256(candidateIdentity)
+                    || createdAt == null
+                    || createdAt.isBlank()) {
+                throw new IllegalArgumentException("Invalid Ship publication journal identity");
+            }
             entries = List.copyOf(Objects.requireNonNull(entries, "journal entries"));
+            if (entries.size() > 2 * ShipTreePolicy.DEFAULT_MAX_FILE_COUNT) {
+                throw new IllegalArgumentException("Ship publication journal has too many entries");
+            }
+            String previous = null;
+            for (Entry entry : entries) {
+                if (previous != null && previous.compareTo(entry.path()) >= 0) {
+                    throw new IllegalArgumentException(
+                            "Ship publication journal entries are not strictly ordered");
+                }
+                previous = entry.path();
+            }
         }
     }
 
@@ -860,6 +1520,16 @@ final class ShipPublicationService {
 
         RecoveryBlockedException(String message) {
             super(message);
+        }
+    }
+
+    /** A live scratch probe was created but could not be removed safely. */
+    private static final class StagingCleanupException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        private StagingCleanupException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -563,17 +563,22 @@ final class ShipPublicationService {
         // Replay is bound to the policy in force now, not the one that planned the journal: a
         // path that became protected or denied meanwhile must never be restored or removed.
         ShipTreePolicy policy = ShipTreePolicy.current();
-        for (Entry entry : decoded.entries()) {
+        List<Entry> entries = decoded.entries();
+        for (int index = 0; index < entries.size(); index++) {
             Classification classification;
             try {
-                classification = policy.classify(entry.path());
+                classification = policy.classify(entries.get(index).path());
             } catch (RuntimeException e) {
+                // The rejected path is the one input proven unsafe to display, so it is located
+                // by position instead of echoed.
                 throw new RecoveryBlockedException(
-                        "Ship publication journal has an invalid entry path: " + journal);
+                        "Ship publication journal entry " + index
+                                                   + " has an invalid path in " + journal);
             }
             if (classification != Classification.MATERIAL) {
                 throw new RecoveryBlockedException(
-                        "Ship publication journal entry is no longer publishable: " + entry.path());
+                        "Ship publication journal entry is no longer publishable: "
+                                                   + entries.get(index).path());
             }
         }
         return decoded;

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -1,0 +1,870 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.controller.ShipRun.ArtifactRef;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy;
+import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
+import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Write-ahead, journal-recoverable publication of one validated workspace candidate into the live project.
+ *
+ * <p>
+ * The caller holds the per-run mutation lock for the whole operation, so exactly one process can publish, recover, or
+ * roll back at a time; a torn publication left by process death is recovered from the journal by the next locked
+ * operation. The run-state write recording the publication is the commit point: a journal without a recorded
+ * publication is always uncommitted and rolls back to the exact baseline.
+ */
+final class ShipPublicationService {
+
+    static final int SCHEMA_VERSION = 1;
+    static final String DIRECTORY = "publication";
+    static final String JOURNAL = "journal.json";
+    static final String RECORD = "publication.json";
+    static final String BACKUP = "backup";
+    private static final String STAGING_SUFFIX = ".camel-kit-publish.tmp";
+    private static final int MAX_DOCUMENT_BYTES = 64 * 1024 * 1024;
+    private static final ObjectMapper JSON = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+
+    private ShipPublicationService() {
+    }
+
+    static Path publicationDirectory(Path runDirectory) {
+        return runDirectory.toAbsolutePath().normalize().resolve(DIRECTORY);
+    }
+
+    static Path journalPath(Path runDirectory) {
+        return publicationDirectory(runDirectory).resolve(JOURNAL);
+    }
+
+    static Path recordPath(Path runDirectory) {
+        return publicationDirectory(runDirectory).resolve(RECORD);
+    }
+
+    private static Path backupDirectory(Path runDirectory) {
+        return publicationDirectory(runDirectory).resolve(BACKUP);
+    }
+
+    static boolean journalExists(Path runDirectory) {
+        return Files.exists(journalPath(runDirectory), LinkOption.NOFOLLOW_LINKS);
+    }
+
+    /** Computes the material publication set from the verified baseline and candidate snapshots. */
+    static Journal plan(
+            String runId, int attempt, String createdAt, ShipWorkspace.Verification verification)
+            throws IOException {
+        ProjectSnapshot baseline = verification.baseline();
+        ProjectSnapshot candidate = verification.candidate();
+        List<Entry> entries = new ArrayList<>();
+        Map<String, ProjectSnapshot.DirectoryEntry> baselineDirectories
+                = materialDirectories(baseline.directories());
+        Map<String, ProjectSnapshot.DirectoryEntry> candidateDirectories
+                = materialDirectories(candidate.directories());
+        Map<String, ProjectSnapshot.FileEntry> baselineFiles = material(baseline.files());
+        Map<String, ProjectSnapshot.FileEntry> candidateFiles = material(candidate.files());
+        requireStableKind(baselineDirectories.keySet(), candidateFiles.keySet());
+        requireStableKind(candidateDirectories.keySet(), baselineFiles.keySet());
+        candidateDirectories.forEach((path, entry) -> {
+            ProjectSnapshot.DirectoryEntry before = baselineDirectories.get(path);
+            if (before == null) {
+                entries.add(Entry.directory(path, Action.ADD, null, mode(entry.unixMode())));
+            } else if (mode(before.unixMode()) != mode(entry.unixMode())) {
+                entries.add(Entry.directory(
+                        path, Action.REPLACE, mode(before.unixMode()), mode(entry.unixMode())));
+            }
+        });
+        baselineDirectories.forEach((path, entry) -> {
+            if (!candidateDirectories.containsKey(path)) {
+                entries.add(Entry.directory(path, Action.DELETE, mode(entry.unixMode()), null));
+            }
+        });
+        candidateFiles.forEach((path, entry) -> {
+            ProjectSnapshot.FileEntry before = baselineFiles.get(path);
+            if (before == null) {
+                entries.add(Entry.file(path, Action.ADD, null, entry));
+            } else if (before.size() != entry.size()
+                    || !before.digest().equals(entry.digest())
+                    || mode(before.unixMode()) != mode(entry.unixMode())) {
+                entries.add(Entry.file(path, Action.REPLACE, before, entry));
+            }
+        });
+        baselineFiles.forEach((path, entry) -> {
+            if (!candidateFiles.containsKey(path)) {
+                entries.add(Entry.file(path, Action.DELETE, entry, null));
+            }
+        });
+        entries.sort(Comparator.comparing(Entry::path));
+        return new Journal(
+                SCHEMA_VERSION,
+                runId,
+                attempt,
+                ShipWorkspace.materialIdentity(baseline),
+                ShipWorkspace.materialIdentity(candidate),
+                createdAt,
+                List.copyOf(entries));
+    }
+
+    /**
+     * Refuses a path that is a directory on one side and a file on the other. Publishing it would need an ordered
+     * replace of one kind by the other, which this protocol does not model; planning it anyway emits two entries for
+     * the same path that can never both apply.
+     */
+    private static void requireStableKind(
+            java.util.Set<String> directories, java.util.Set<String> files)
+            throws IOException {
+        for (String path : directories) {
+            if (files.contains(path)) {
+                throw new UnsupportedChangeException(
+                        "Ship cannot publish " + path
+                                                     + " because it changes between a file and a directory");
+            }
+        }
+    }
+
+    /** Clears stale scratch from an earlier committed or failed attempt and writes the immutable journal. */
+    static void begin(Path runDirectory, Journal journal) throws IOException {
+        Path directory = publicationDirectory(runDirectory);
+        if (journalExists(runDirectory)) {
+            throw new IOException("Ship publication journal already exists: " + journalPath(runDirectory));
+        }
+        if (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+            deleteTree(backupDirectory(runDirectory));
+            Files.deleteIfExists(recordPath(runDirectory));
+        } else {
+            Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rwx------")));
+        }
+        writeAtomically(journalPath(runDirectory), encode(journal));
+    }
+
+    /**
+     * Backs up, applies, and verifies the publication set; any failure rolls the live project back to the exact
+     * baseline and clears the journal before rethrowing.
+     */
+    static void apply(Path project, Path candidate, Path runDirectory, Journal journal)
+            throws IOException {
+        Path backup = backupDirectory(runDirectory);
+        try {
+            backupPhase(project, backup, journal);
+        } catch (IOException | RuntimeException e) {
+            // The backup phase only reads the live project, so nothing was mutated: clear the
+            // scratch instead of leaving a journal that later reads as a torn publication.
+            try {
+                clean(runDirectory);
+            } catch (IOException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
+            throw e;
+        }
+        try {
+            applyPhase(project, candidate, journal);
+            String liveIdentity = ShipWorkspace.materialIdentity(
+                    ProjectEvidenceFiles.capture(project));
+            if (!liveIdentity.equals(journal.candidateIdentity())) {
+                throw new IOException(
+                        "Published Ship project differs from the validated candidate");
+            }
+        } catch (IOException | RuntimeException applyFailure) {
+            try {
+                rollback(project, runDirectory, journal);
+                clean(runDirectory);
+            } catch (IOException | RuntimeException rollbackFailure) {
+                applyFailure.addSuppressed(rollbackFailure);
+            }
+            throw applyFailure;
+        }
+    }
+
+    /** Writes the retained publication record and returns its state reference. */
+    static ArtifactRef commitRecord(Path runDirectory, Journal journal, String appliedAt)
+            throws IOException {
+        byte[] encoded = encode(new PublicationRecord(
+                journal.schemaVersion(),
+                journal.runId(),
+                journal.attempt(),
+                journal.baselineIdentity(),
+                journal.candidateIdentity(),
+                journal.createdAt(),
+                appliedAt,
+                journal.entries()));
+        Path record = recordPath(runDirectory);
+        writeAtomically(record, encoded);
+        return new ArtifactRef(record.toString(), ShipDigest.sha256(encoded));
+    }
+
+    /** Rolls back an applied but uncommitted publication set and clears the scratch. */
+    static void rollbackApplied(Path project, Path runDirectory, Journal journal)
+            throws IOException {
+        rollback(project, runDirectory, journal);
+        clean(runDirectory);
+    }
+
+    /**
+     * Recovers a torn uncommitted publication left by process death: rolls the live project back to the exact baseline
+     * per journal entry and clears the scratch. Idempotent; a no-op without a journal.
+     *
+     * <p>
+     * A journal describes exactly one Execute candidate. When {@code executeAttempt} no longer matches, that candidate
+     * was superseded, the journal can no longer describe the live project, and it is discarded instead of applied.
+     */
+    static void recover(Path project, Path runDirectory, int executeAttempt) throws IOException {
+        if (!journalExists(runDirectory)) {
+            return;
+        }
+        Journal journal = readJournal(runDirectory);
+        if (journal.attempt() != executeAttempt) {
+            discard(runDirectory);
+            return;
+        }
+        rollback(project, runDirectory, journal);
+        clean(runDirectory);
+    }
+
+    /**
+     * Drops a journal that is no longer a write-ahead log: either the publication it describes committed, or the run
+     * voided its published claim. The live project is never touched.
+     *
+     * <p>
+     * The retained record survives, because the run state may still reference it until the voiding write lands; a later
+     * publication clears it in {@link #begin}.
+     */
+    static void discard(Path runDirectory) throws IOException {
+        Files.deleteIfExists(journalPath(runDirectory));
+        deleteTree(backupDirectory(runDirectory));
+    }
+
+    /** Reads and verifies the retained publication record referenced by the run state. */
+    static PublicationRecord readVerifiedRecord(
+            Path runDirectory, ArtifactRef reference, String runId)
+            throws IOException {
+        Path expected = recordPath(runDirectory);
+        if (!expected.toString().equals(reference.path())) {
+            throw new IOException(
+                    "Ship publication record is outside its run directory: " + reference.path());
+        }
+        byte[] encoded = readBounded(expected);
+        if (!ShipDigest.sha256(encoded).equals(reference.digest())) {
+            throw new IOException("Ship publication record does not match its recorded digest");
+        }
+        PublicationRecord record = decode(encoded, PublicationRecord.class, expected);
+        if (record.schemaVersion() != SCHEMA_VERSION || !runId.equals(record.runId())) {
+            throw new IOException("Ship publication record does not match its run");
+        }
+        return record;
+    }
+
+    private static void backupPhase(Path project, Path backup, Journal journal)
+            throws IOException {
+        for (Entry entry : journal.entries()) {
+            Path live = target(project, entry.path());
+            if (entry.kind() == Kind.DIRECTORY) {
+                requireDirectoryBaseline(entry, live);
+                continue;
+            }
+            switch (entry.action()) {
+                case ADD -> {
+                    if (Files.exists(live, LinkOption.NOFOLLOW_LINKS)) {
+                        throw new StaleLiveTreeException(
+                                "Live project gained a file since the publication baseline: "
+                                                         + entry.path());
+                    }
+                }
+                case REPLACE, DELETE -> {
+                    Path copy = target(backup, entry.path());
+                    Files.createDirectories(copy.getParent());
+                    byte[] content = Files.readAllBytes(live);
+                    if (content.length != entry.baselineSize()
+                            || !ShipDigest.sha256(content).equals(entry.baselineDigest())) {
+                        throw new StaleLiveTreeException(
+                                "Live project file changed since the publication baseline: "
+                                                         + entry.path());
+                    }
+                    // The backup is the only source rollback can restore from, so it is forced to
+                    // disk like every other durability-critical write here.
+                    Files.createFile(
+                            copy,
+                            PosixFilePermissions.asFileAttribute(
+                                    PosixFilePermissions.fromString("rw-------")));
+                    writeFully(copy, content);
+                }
+            }
+        }
+    }
+
+    private static void requireDirectoryBaseline(Entry entry, Path live)
+            throws IOException {
+        boolean exists = Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS);
+        boolean expected = entry.action() != Action.ADD;
+        if (exists != expected) {
+            throw new StaleLiveTreeException(
+                    "Live project directory changed since the publication baseline: "
+                                             + entry.path());
+        }
+    }
+
+    private static void applyPhase(Path project, Path candidate, Journal journal)
+            throws IOException {
+        for (Entry entry : directories(journal, Action.ADD)) {
+            Files.createDirectory(target(project, entry.path()),
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rwx------")));
+        }
+        for (Entry entry : journal.entries()) {
+            if (entry.kind() != Kind.FILE || entry.action() == Action.DELETE) {
+                continue;
+            }
+            byte[] content = Files.readAllBytes(target(candidate, entry.path()));
+            if (content.length != entry.candidateSize()
+                    || !ShipDigest.sha256(content).equals(entry.candidateDigest())) {
+                throw new IOException(
+                        "Ship candidate file changed during publication: " + entry.path());
+            }
+            Path live = target(project, entry.path());
+            Path temporary = stagingPath(live);
+            boolean moved = false;
+            try {
+                createStagingFile(temporary);
+                writeFully(temporary, content);
+                Files.setPosixFilePermissions(temporary, permissions(entry.candidateMode()));
+                move(temporary, live);
+                moved = true;
+            } finally {
+                if (!moved) {
+                    Files.deleteIfExists(temporary);
+                }
+            }
+        }
+        for (Entry entry : journal.entries()) {
+            if (entry.kind() == Kind.FILE && entry.action() == Action.DELETE) {
+                Files.delete(target(project, entry.path()));
+            }
+        }
+        for (Entry entry : reversed(directories(journal, Action.DELETE))) {
+            Path live = target(project, entry.path());
+            try {
+                Files.delete(live);
+            } catch (DirectoryNotEmptyException e) {
+                // Build output and other non-publishable content is invisible to the snapshots,
+                // so retrying cannot help until the user clears it.
+                throw new IOException(
+                        "Ship cannot remove " + entry.path()
+                                      + " because the live project still holds content outside the "
+                                      + "publication, such as build output; remove it and resume",
+                        e);
+            }
+        }
+        for (Entry entry : journal.entries()) {
+            if (entry.kind() == Kind.DIRECTORY && entry.action() != Action.DELETE) {
+                Files.setPosixFilePermissions(
+                        target(project, entry.path()), permissions(entry.candidateMode()));
+            }
+        }
+    }
+
+    /**
+     * Restores the exact baseline per journal entry. Every entry must currently match its baseline side, its candidate
+     * side, or be absent where the journal records a creation; anything else blocks recovery before any file is
+     * touched, so a live tree edited after a tear is never overwritten.
+     */
+    private static void rollback(Path project, Path runDirectory, Journal journal)
+            throws IOException {
+        Path backup = backupDirectory(runDirectory);
+        List<Runnable2> restores = new ArrayList<>();
+        for (Entry entry : journal.entries()) {
+            Runnable2 restore = classify(project, backup, entry);
+            if (restore != null) {
+                restores.add(restore);
+            }
+        }
+        // Remove staging files an interrupted apply left beside their targets; they are material
+        // to the tree policy, so a leftover would otherwise drift the live project's identity.
+        for (Entry entry : journal.entries()) {
+            if (entry.kind() == Kind.FILE) {
+                Files.deleteIfExists(stagingPath(target(project, entry.path())));
+            }
+        }
+        // Restoration mutates directory contents, so every touched directory is made owner-writable
+        // first; the exact baseline modes are re-applied as the final step.
+        for (Entry entry : journal.entries()) {
+            if (entry.kind() != Kind.DIRECTORY) {
+                continue;
+            }
+            Path live = target(project, entry.path());
+            if (entry.action() == Action.DELETE
+                    && !Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
+                Files.createDirectories(live);
+            }
+            if (Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
+                Files.setPosixFilePermissions(
+                        live, PosixFilePermissions.fromString("rwx------"));
+            }
+        }
+        for (Runnable2 restore : restores) {
+            restore.run();
+        }
+        for (Entry entry : reversed(directories(journal, Action.ADD))) {
+            Path live = target(project, entry.path());
+            if (Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
+                try {
+                    Files.delete(live);
+                } catch (DirectoryNotEmptyException e) {
+                    // Something outside the publication landed here while it was torn. Leaving the
+                    // directory keeps that content; failing here would block resume and abort alike.
+                    Files.setPosixFilePermissions(live, permissions(entry.candidateMode()));
+                }
+            }
+        }
+        for (Entry entry : journal.entries()) {
+            if (entry.kind() != Kind.DIRECTORY || entry.action() == Action.ADD) {
+                continue;
+            }
+            Path live = target(project, entry.path());
+            if (Files.isDirectory(live, LinkOption.NOFOLLOW_LINKS)) {
+                Files.setPosixFilePermissions(live, permissions(entry.baselineMode()));
+            }
+        }
+    }
+
+    private static Runnable2 classify(Path project, Path backup, Entry entry)
+            throws IOException {
+        if (entry.kind() == Kind.DIRECTORY) {
+            return null;
+        }
+        Path live = target(project, entry.path());
+        boolean exists = Files.exists(live, LinkOption.NOFOLLOW_LINKS);
+        String liveDigest = exists && Files.isRegularFile(live, LinkOption.NOFOLLOW_LINKS)
+                ? ShipDigest.sha256(Files.readAllBytes(live))
+                : null;
+        switch (entry.action()) {
+            case ADD -> {
+                if (!exists) {
+                    return null;
+                }
+                if (entry.candidateDigest().equals(liveDigest)) {
+                    return () -> Files.delete(live);
+                }
+            }
+            case REPLACE -> {
+                // A mode-only replace leaves both digests equal, so the mode is the only evidence
+                // of whether it was applied; restoring re-stamps the baseline mode.
+                if (entry.baselineDigest().equals(liveDigest)
+                        && (!exists || liveMode(live) == entry.baselineMode())) {
+                    return null;
+                }
+                if (entry.candidateDigest().equals(liveDigest)) {
+                    return () -> restoreBackup(backup, live, entry);
+                }
+            }
+            case DELETE -> {
+                if (entry.baselineDigest().equals(liveDigest)) {
+                    return null;
+                }
+                if (!exists) {
+                    return () -> restoreBackup(backup, live, entry);
+                }
+            }
+        }
+        throw new RecoveryBlockedException(
+                "Live project file matches neither the publication baseline nor its candidate: "
+                                           + entry.path());
+    }
+
+    private static void restoreBackup(Path backup, Path live, Entry entry)
+            throws IOException {
+        byte[] content = Files.readAllBytes(target(backup, entry.path()));
+        if (content.length != entry.baselineSize()
+                || !ShipDigest.sha256(content).equals(entry.baselineDigest())) {
+            throw new RecoveryBlockedException(
+                    "Ship publication backup does not match its journal entry: " + entry.path());
+        }
+        Files.createDirectories(live.getParent());
+        Path temporary = stagingPath(live);
+        boolean moved = false;
+        try {
+            createStagingFile(temporary);
+            writeFully(temporary, content);
+            Files.setPosixFilePermissions(temporary, permissions(entry.baselineMode()));
+            move(temporary, live);
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    /**
+     * Names the staging file deterministically beside its target so a publication torn by process death leaves debris
+     * the journal can still find; a random name would survive every rollback and pollute the live project.
+     */
+    private static Path stagingPath(Path live) {
+        return live.resolveSibling("." + live.getFileName() + STAGING_SUFFIX);
+    }
+
+    private static void createStagingFile(Path staging) throws IOException {
+        Files.deleteIfExists(staging);
+        Files.createFile(
+                staging,
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+    }
+
+    private static void clean(Path runDirectory) throws IOException {
+        deleteTree(backupDirectory(runDirectory));
+        Files.deleteIfExists(recordPath(runDirectory));
+        Files.deleteIfExists(journalPath(runDirectory));
+    }
+
+    private static Journal readJournal(Path runDirectory) throws IOException {
+        Path journal = journalPath(runDirectory);
+        Journal decoded = decode(readBounded(journal), Journal.class, journal);
+        if (decoded.schemaVersion() != SCHEMA_VERSION) {
+            throw new RecoveryBlockedException(
+                    "Unsupported Ship publication journal schema: " + decoded.schemaVersion());
+        }
+        // Replay is bound to the policy in force now, not the one that planned the journal: a
+        // path that became protected or denied meanwhile must never be restored or removed.
+        ShipTreePolicy policy = ShipTreePolicy.current();
+        for (Entry entry : decoded.entries()) {
+            Classification classification;
+            try {
+                classification = policy.classify(entry.path());
+            } catch (RuntimeException e) {
+                throw new RecoveryBlockedException(
+                        "Ship publication journal has an invalid entry path: " + journal);
+            }
+            if (classification != Classification.MATERIAL) {
+                throw new RecoveryBlockedException(
+                        "Ship publication journal entry is no longer publishable: " + entry.path());
+            }
+        }
+        return decoded;
+    }
+
+    private static List<Entry> directories(Journal journal, Action action) {
+        return journal.entries().stream()
+                .filter(entry -> entry.kind() == Kind.DIRECTORY && entry.action() == action)
+                .toList();
+    }
+
+    private static Path target(Path root, String relative) throws IOException {
+        Path resolved = root.resolve(relative).normalize();
+        if (!resolved.startsWith(root) || resolved.equals(root)) {
+            throw new IOException("Ship publication entry escaped its root: " + relative);
+        }
+        return resolved;
+    }
+
+    private static Map<String, ProjectSnapshot.FileEntry> material(
+            Map<String, ProjectSnapshot.FileEntry> files) {
+        TreeMap<String, ProjectSnapshot.FileEntry> filtered = new TreeMap<>();
+        files.forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                filtered.put(path, entry);
+            }
+        });
+        return filtered;
+    }
+
+    private static Map<String, ProjectSnapshot.DirectoryEntry> materialDirectories(
+            Map<String, ProjectSnapshot.DirectoryEntry> directories) {
+        TreeMap<String, ProjectSnapshot.DirectoryEntry> filtered = new TreeMap<>();
+        directories.forEach((path, entry) -> {
+            if (entry.classification() == Classification.MATERIAL) {
+                filtered.put(path, entry);
+            }
+        });
+        return filtered;
+    }
+
+    private static List<Entry> reversed(List<Entry> entries) {
+        List<Entry> copy = new ArrayList<>(entries);
+        java.util.Collections.reverse(copy);
+        return copy;
+    }
+
+    private static int mode(int unixMode) {
+        return unixMode & 0777;
+    }
+
+    private static int liveMode(Path live) throws IOException {
+        int bits = 0;
+        for (java.nio.file.attribute.PosixFilePermission permission : Files.getPosixFilePermissions(live,
+                LinkOption.NOFOLLOW_LINKS)) {
+            bits |= switch (permission) {
+                case OWNER_READ -> 0400;
+                case OWNER_WRITE -> 0200;
+                case OWNER_EXECUTE -> 0100;
+                case GROUP_READ -> 040;
+                case GROUP_WRITE -> 020;
+                case GROUP_EXECUTE -> 010;
+                case OTHERS_READ -> 04;
+                case OTHERS_WRITE -> 02;
+                case OTHERS_EXECUTE -> 01;
+            };
+        }
+        return bits;
+    }
+
+    private static java.util.Set<java.nio.file.attribute.PosixFilePermission> permissions(int mode) {
+        StringBuilder text = new StringBuilder(9);
+        int[] shifts = {6, 3, 0};
+        for (int shift : shifts) {
+            int bits = (mode >> shift) & 07;
+            text.append((bits & 04) != 0 ? 'r' : '-');
+            text.append((bits & 02) != 0 ? 'w' : '-');
+            text.append((bits & 01) != 0 ? 'x' : '-');
+        }
+        return PosixFilePermissions.fromString(text.toString());
+    }
+
+    private static byte[] encode(Object document) throws IOException {
+        try {
+            return JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(document);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Ship publication document cannot be encoded", e);
+        }
+    }
+
+    private static <T> T decode(byte[] encoded, Class<T> type, Path source)
+            throws IOException {
+        try {
+            return JSON.readValue(encoded, type);
+        } catch (IOException e) {
+            RecoveryBlockedException blocked = new RecoveryBlockedException(
+                    "Ship publication document is corrupt: " + source);
+            blocked.initCause(e);
+            throw blocked;
+        }
+    }
+
+    private static byte[] readBounded(Path source) throws IOException {
+        try (InputStream input = Files.newInputStream(source)) {
+            byte[] encoded = input.readNBytes(MAX_DOCUMENT_BYTES + 1);
+            if (encoded.length == 0 || encoded.length > MAX_DOCUMENT_BYTES) {
+                throw new IOException(
+                        "Ship publication document has an invalid size: " + source);
+            }
+            return encoded;
+        }
+    }
+
+    private static void writeAtomically(Path targetPath, byte[] encoded) throws IOException {
+        Path temporary = Files.createTempFile(
+                targetPath.getParent(), ".publication-", ".tmp",
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        boolean moved = false;
+        try {
+            writeFully(temporary, encoded);
+            move(temporary, targetPath);
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private static void writeFully(Path targetPath, byte[] content) throws IOException {
+        try (FileChannel channel = FileChannel.open(
+                targetPath, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            ByteBuffer buffer = ByteBuffer.wrap(content);
+            while (buffer.hasRemaining()) {
+                channel.write(buffer);
+            }
+            channel.force(true);
+        }
+    }
+
+    private static void move(Path source, Path targetPath) throws IOException {
+        try {
+            Files.move(source, targetPath,
+                    StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            throw new IOException(
+                    "Filesystem does not support atomic Ship publication replacement", e);
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        try (var stream = Files.walk(root)) {
+            for (Path path : stream.sorted(Comparator.reverseOrder()).toList()) {
+                Files.delete(path);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface Runnable2 {
+        void run() throws IOException;
+    }
+
+    enum Kind {
+        FILE,
+        DIRECTORY
+    }
+
+    enum Action {
+        ADD,
+        REPLACE,
+        DELETE
+    }
+
+    record Entry(
+            String path,
+            Kind kind,
+            Action action,
+            String baselineDigest,
+            Long baselineSize,
+            Integer baselineMode,
+            String candidateDigest,
+            Long candidateSize,
+            Integer candidateMode) {
+
+        Entry {
+            Objects.requireNonNull(path, "entry path");
+            Objects.requireNonNull(kind, "entry kind");
+            Objects.requireNonNull(action, "entry action");
+            boolean baseline = action != Action.ADD;
+            boolean candidate = action != Action.DELETE;
+            if (kind == Kind.FILE) {
+                require(baseline == (baselineDigest != null && baselineSize != null
+                        && baselineMode != null));
+                require(candidate == (candidateDigest != null && candidateSize != null
+                        && candidateMode != null));
+            } else {
+                require(baselineDigest == null && baselineSize == null
+                        && candidateDigest == null && candidateSize == null);
+                require(baseline == (baselineMode != null));
+                require(candidate == (candidateMode != null));
+            }
+        }
+
+        static Entry file(
+                String path, Action action,
+                ProjectSnapshot.FileEntry baseline, ProjectSnapshot.FileEntry candidate) {
+            return new Entry(
+                    path,
+                    Kind.FILE,
+                    action,
+                    baseline == null ? null : baseline.digest(),
+                    baseline == null ? null : baseline.size(),
+                    baseline == null ? null : baseline.unixMode() & 0777,
+                    candidate == null ? null : candidate.digest(),
+                    candidate == null ? null : candidate.size(),
+                    candidate == null ? null : candidate.unixMode() & 0777);
+        }
+
+        static Entry directory(String path, Action action, Integer baselineMode, Integer candidateMode) {
+            return new Entry(path, Kind.DIRECTORY, action, null, null, baselineMode, null, null, candidateMode);
+        }
+
+        private static void require(boolean condition) {
+            if (!condition) {
+                throw new IllegalArgumentException(
+                        "Ship publication entry does not match its action");
+            }
+        }
+    }
+
+    record Journal(
+            int schemaVersion,
+            String runId,
+            int attempt,
+            String baselineIdentity,
+            String candidateIdentity,
+            String createdAt,
+            List<Entry> entries) {
+
+        Journal {
+            entries = List.copyOf(Objects.requireNonNull(entries, "journal entries"));
+        }
+    }
+
+    record PublicationRecord(
+            int schemaVersion,
+            String runId,
+            int attempt,
+            String baselineIdentity,
+            String candidateIdentity,
+            String createdAt,
+            String appliedAt,
+            List<Entry> entries) {
+
+        PublicationRecord {
+            entries = List.copyOf(Objects.requireNonNull(entries, "record entries"));
+        }
+    }
+
+    /** The live tree drifted from the recorded baseline before any file was mutated. */
+    static final class StaleLiveTreeException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        StaleLiveTreeException(String message) {
+            super(message);
+        }
+    }
+
+    /** Recovery refused to touch a live tree that matches neither baseline nor candidate. */
+    static final class RecoveryBlockedException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        RecoveryBlockedException(String message) {
+            super(message);
+        }
+    }
+
+    /** The candidate carries a change this publication protocol does not model. */
+    static final class UnsupportedChangeException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        UnsupportedChangeException(String message) {
+            super(message);
+        }
+    }
+}

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
@@ -25,11 +25,12 @@ public record ShipRun(
         Stage currentStage,
         ShipContext context,
         List<StageRecord> stages,
+        ArtifactRef publication,
         String createdAt,
         String updatedAt,
         String message) {
 
-    public static final int SCHEMA_VERSION = 3;
+    public static final int SCHEMA_VERSION = 4;
 
     private static final Pattern RUN_ID = Pattern.compile("ship-[0-9a-f]{32}");
     private static final Pattern PIPELINE_ID = Pattern.compile("[0-9]{3,}-[a-z0-9]+(?:-[a-z0-9]+)*");
@@ -62,7 +63,13 @@ public record ShipRun(
         if ((status == RunStatus.FAILED || status == RunStatus.ABORTED) != (message != null)) {
             throw new IllegalArgumentException("Only failed or aborted runs carry a message");
         }
-        requireConsistentProgress(status, currentStage, stages);
+        requireConsistentProgress(status, currentStage, stages, publication);
+    }
+
+    /** True when every stage is complete and only guarded publication remains. */
+    public boolean publicationPending() {
+        return status == RunStatus.RUNNING
+                && stages.stream().allMatch(stage -> stage.status() == StageStatus.COMPLETED);
     }
 
     public static boolean isRunId(String value) {
@@ -130,18 +137,31 @@ public record ShipRun(
     }
 
     private static void requireConsistentProgress(
-            RunStatus status, Stage currentStage, List<StageRecord> stages) {
+            RunStatus status, Stage currentStage, List<StageRecord> stages, ArtifactRef publication) {
         int current = currentStage.ordinal();
         boolean allCompleted = stages.stream().allMatch(stage -> stage.status() == StageStatus.COMPLETED);
+        if (publication != null
+                && (currentStage != Stage.VALIDATE
+                        || stages.get(Stage.EXECUTE.ordinal()).status() != StageStatus.COMPLETED)) {
+            throw new IllegalArgumentException(
+                    "A Ship publication record requires its published EXECUTE candidate");
+        }
         if (status == RunStatus.COMPLETED) {
             if (!allCompleted || currentStage != Stage.VALIDATE) {
                 throw new IllegalArgumentException("Completed Ship run has incomplete stages");
             }
+            if (publication == null) {
+                throw new IllegalArgumentException("Completed Ship run has no publication record");
+            }
             return;
         }
-        if ((status == RunStatus.PAUSED || status == RunStatus.ABORTED)
-                && allCompleted
-                && currentStage == Stage.VALIDATE) {
+        if (allCompleted && currentStage == Stage.VALIDATE) {
+            if (publication != null) {
+                throw new IllegalArgumentException(
+                        "Only a completed Ship run retains a publication record with all stages complete");
+            }
+            // RUNNING means guarded publication is pending; PAUSED is the pre-publication
+            // oversight gate; FAILED is a rolled-back publication; ABORTED is a user stop.
             return;
         }
         for (int index = 0; index < stages.size(); index++) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -14,14 +15,17 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Objects;
 import java.util.Set;
 
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.ArtifactRef;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageRecord;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.StageStatus;
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,8 +39,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 final class ShipRunStore {
 
     private static final int MAX_STATE_BYTES = 64 * 1024 * 1024;
+    private static final int MAX_PROJECT_OWNER_BYTES = 64 * 1024;
+    private static final int MAX_PROCESS_STATUS_BYTES = 64 * 1024;
     private static final String STATE_FILE = "state.json";
     private static final String LOCK_FILE = "run.lock";
+    private static final int PROJECT_OWNER_SCHEMA_VERSION = 1;
     private static final ObjectMapper JSON = new ObjectMapper(
             JsonFactory.builder()
                     .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
@@ -50,11 +57,30 @@ final class ShipRunStore {
             .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
 
     private final Path stateRoot;
+    private final Path projectRegistryRoot;
     private final boolean posix;
 
     ShipRunStore(Path stateRoot) {
+        this(stateRoot, defaultProjectRegistryRoot());
+    }
+
+    ShipRunStore(Path stateRoot, Path projectRegistryRoot) {
         this.stateRoot = Objects.requireNonNull(stateRoot, "stateRoot").toAbsolutePath().normalize();
+        this.projectRegistryRoot = Objects.requireNonNull(
+                projectRegistryRoot, "projectRegistryRoot").toAbsolutePath().normalize();
         this.posix = this.stateRoot.getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+
+    static Path defaultProjectRegistryRoot() {
+        final long uid;
+        try {
+            uid = effectiveUserId();
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not resolve the effective Unix user ID", e);
+        }
+        return Path.of("/var/tmp")
+                .resolve("camel-kit-ship-" + Long.toUnsignedString(uid))
+                .resolve("projects");
     }
 
     static Path validationStampPath(Path runDirectory, int attempt) {
@@ -178,6 +204,51 @@ final class ShipRunStore {
             throw busy;
         }
         return new LockedRun(runId, runRoot, channel, fileLock);
+    }
+
+    LockedProject lockProject(Path projectDirectory) throws IOException {
+        Path project = canonicalize(Objects.requireNonNull(
+                projectDirectory, "projectDirectory"));
+        Path registry = resolvedProjectRegistryRoot();
+        if (registry.startsWith(project) || project.startsWith(registry)) {
+            throw new StoreException(
+                    "state-project-overlap",
+                    "Ship project and publication registry directories must be disjoint");
+        }
+        String projectIdentity = ProjectEvidenceFiles.projectIdentity(project);
+        String key = projectIdentity.substring("sha256:".length());
+        Path lockFile = registry.resolve(key + ".lock");
+        Path ownerFile = registry.resolve(key + ".owner.json");
+        FileChannel channel = FileChannel.open(
+                lockFile,
+                Set.of(
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        LinkOption.NOFOLLOW_LINKS),
+                fileAttributes());
+        if (!Files.isRegularFile(lockFile, LinkOption.NOFOLLOW_LINKS)) {
+            StoreException invalid = new StoreException(
+                    "state-corrupt", "Ship project lock is not a real file");
+            closeAfterFailure(channel, invalid);
+            throw invalid;
+        }
+        FileLock fileLock;
+        try {
+            fileLock = channel.tryLock();
+        } catch (OverlappingFileLockException e) {
+            closeAfterFailure(channel, e);
+            throw projectBusy(project, e);
+        } catch (IOException e) {
+            closeAfterFailure(channel, e);
+            throw e;
+        }
+        if (fileLock == null) {
+            StoreException busy = projectBusy(project, null);
+            closeAfterFailure(channel, busy);
+            throw busy;
+        }
+        return new LockedProject(
+                project, projectIdentity, ownerFile, channel, fileLock);
     }
 
     private void write(Path runRoot, ShipRun run) throws IOException {
@@ -416,6 +487,82 @@ final class ShipRunStore {
         return resolved;
     }
 
+    private Path resolvedProjectRegistryRoot() throws StoreException {
+        if (!projectRegistryRoot.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication ownership requires a POSIX filesystem");
+        }
+        Path parent = projectRegistryRoot.getParent();
+        if (parent == null) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication registry has no parent directory");
+        }
+        try {
+            ensurePrivateDirectory(parent);
+            ensurePrivateDirectory(projectRegistryRoot);
+            return canonicalize(projectRegistryRoot);
+        } catch (IOException | SecurityException e) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication registry is unsafe", e);
+        }
+    }
+
+    private static void ensurePrivateDirectory(Path directory) throws IOException {
+        try {
+            Files.createDirectory(
+                    directory,
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rwx------")));
+        } catch (FileAlreadyExistsException ignored) {
+            // Validate the existing per-user rendezvous below.
+        }
+        if (Files.isSymbolicLink(directory)
+                || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Ship private state path is not a real directory: " + directory);
+        }
+        long owner = ((Number) Files.getAttribute(
+                directory, "unix:uid", LinkOption.NOFOLLOW_LINKS)).longValue();
+        long current = effectiveUserId();
+        if (owner != current) {
+            throw new IOException("Ship private state path is owned by another user: " + directory);
+        }
+        Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(
+                directory, LinkOption.NOFOLLOW_LINKS);
+        if (!permissions.equals(PosixFilePermissions.fromString("rwx------"))) {
+            throw new IOException("Ship private state path is not private: " + directory);
+        }
+    }
+
+    private static long effectiveUserId() throws IOException {
+        Path status = Path.of("/proc/self/status");
+        byte[] encoded;
+        try (InputStream input = Files.newInputStream(status)) {
+            encoded = input.readNBytes(MAX_PROCESS_STATUS_BYTES + 1);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_PROCESS_STATUS_BYTES) {
+            throw new IOException("Linux process status has an invalid size");
+        }
+        for (String line : new String(encoded, StandardCharsets.UTF_8).split("\\R")) {
+            if (!line.startsWith("Uid:")) {
+                continue;
+            }
+            String[] fields = line.trim().split("\\s+");
+            if (fields.length != 5) {
+                break;
+            }
+            try {
+                long uid = Long.parseLong(fields[2]);
+                if (uid >= 0) {
+                    return uid;
+                }
+            } catch (NumberFormatException ignored) {
+                // Report one stable error below.
+            }
+            break;
+        }
+        throw new IOException("Linux process status does not contain an effective user ID");
+    }
+
     private static Path canonicalize(Path path) throws IOException {
         if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
             return path.toRealPath();
@@ -465,6 +612,163 @@ final class ShipRunStore {
         return cause == null
                 ? new StoreException("operation-in-progress", message)
                 : new StoreException("operation-in-progress", message, cause);
+    }
+
+    private static StoreException projectBusy(Path project, Throwable cause) {
+        String message = "Ship project already has an in-progress publication: " + project;
+        return cause == null
+                ? new StoreException("operation-in-progress", message)
+                : new StoreException("operation-in-progress", message, cause);
+    }
+
+    private static StoreException projectOwned(ProjectOwner owner, Throwable cause) {
+        String message = "Ship run " + owner.runId()
+                         + " has an unfinished publication for this project in "
+                         + owner.stateRoot() + "; resume or abort it first";
+        return cause == null
+                ? new StoreException("project-publication-in-progress", message)
+                : new StoreException("project-publication-in-progress", message, cause);
+    }
+
+    private ProjectOwner readProjectOwner(Path ownerFile) throws IOException {
+        if (Files.notExists(ownerFile, LinkOption.NOFOLLOW_LINKS)) {
+            return null;
+        }
+        if (Files.isSymbolicLink(ownerFile)
+                || !Files.isRegularFile(ownerFile, LinkOption.NOFOLLOW_LINKS)
+                || Files.size(ownerFile) > MAX_PROJECT_OWNER_BYTES) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication owner is invalid: " + ownerFile);
+        }
+        byte[] encoded;
+        try (InputStream input = Files.newInputStream(ownerFile)) {
+            encoded = input.readNBytes(MAX_PROJECT_OWNER_BYTES + 1);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_PROJECT_OWNER_BYTES) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication owner is invalid: " + ownerFile);
+        }
+        try {
+            return JSON.readValue(encoded, ProjectOwner.class);
+        } catch (IOException | RuntimeException e) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication owner is corrupt: " + ownerFile, e);
+        }
+    }
+
+    private void writeProjectOwner(Path ownerFile, ProjectOwner owner) throws IOException {
+        final byte[] encoded;
+        try {
+            encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(owner);
+        } catch (JsonProcessingException e) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication owner cannot be encoded", e);
+        }
+        if (encoded.length == 0 || encoded.length > MAX_PROJECT_OWNER_BYTES) {
+            throw new StoreException(
+                    "state-corrupt", "Ship project publication owner exceeds its size limit");
+        }
+        Path temporary = Files.createTempFile(
+                ownerFile.getParent(), ".project-owner-", ".tmp",
+                PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------")));
+        boolean moved = false;
+        try {
+            Files.setPosixFilePermissions(
+                    temporary, PosixFilePermissions.fromString("rw-------"));
+            try (FileChannel output = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                ByteBuffer content = ByteBuffer.wrap(encoded);
+                while (content.hasRemaining()) {
+                    output.write(content);
+                }
+                output.force(true);
+            }
+            try {
+                Files.move(
+                        temporary,
+                        ownerFile,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw new StoreException(
+                        "atomic-write-unsupported",
+                        "Filesystem does not support atomic Ship project ownership",
+                        e);
+            }
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private boolean foreignOwnerBlocks(ProjectOwner owner) throws IOException {
+        final Path ownerRoot;
+        final Path ownerRun;
+        try {
+            Path suppliedRoot = Path.of(owner.stateRoot());
+            ownerRoot = canonicalize(suppliedRoot);
+            if (!ownerRoot.toString().equals(owner.stateRoot())) {
+                throw new IOException("Ship publication owner state root was rebound");
+            }
+            ownerRun = runRoot(ownerRoot, owner.runId());
+            if (Files.isSymbolicLink(ownerRun)
+                    || !Files.isDirectory(ownerRun, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Ship publication owner run directory is unavailable");
+            }
+        } catch (IOException | RuntimeException e) {
+            throw projectOwned(owner, e);
+        }
+        if (!ShipPublicationService.journalExists(ownerRun)) {
+            return false;
+        }
+        final ShipRun run;
+        try {
+            run = new ShipRunStore(ownerRoot, projectRegistryRoot).read(owner.runId());
+        } catch (IOException | RuntimeException e) {
+            throw projectOwned(owner, e);
+        }
+        final String runProjectIdentity;
+        try {
+            runProjectIdentity = ProjectEvidenceFiles.projectIdentity(
+                    Path.of(run.projectDirectory()));
+        } catch (IOException | RuntimeException e) {
+            throw projectOwned(owner, e);
+        }
+        if (!owner.projectIdentity().equals(runProjectIdentity)) {
+            throw projectOwned(owner, null);
+        }
+        if (run.publication() == null) {
+            return true;
+        }
+        try {
+            ShipPublicationService.readVerifiedRecord(
+                    ownerRun, run.publication(), run.id());
+        } catch (IOException | RuntimeException e) {
+            throw projectOwned(owner, e);
+        }
+        return false;
+    }
+
+    private ProjectOwner currentProjectOwner(
+            String projectIdentity, String runId)
+            throws IOException {
+        Path root = resolvedStateRoot("state-corrupt");
+        Path run = runRoot(root, runId);
+        if (Files.isSymbolicLink(run)
+                || !Files.isDirectory(run, LinkOption.NOFOLLOW_LINKS)) {
+            throw new StoreException(
+                    "state-corrupt", "Ship publication owner run directory is unavailable");
+        }
+        return new ProjectOwner(
+                PROJECT_OWNER_SCHEMA_VERSION,
+                projectIdentity,
+                root.toString(),
+                runId);
     }
 
     private static void closeAfterFailure(FileChannel channel, Throwable failure) {
@@ -542,6 +846,153 @@ final class ShipRunStore {
         private void requireOpen() throws StoreException {
             if (fileLock == null) {
                 throw new StoreException("lock-closed", "Ship run lock is already closed: " + runId);
+            }
+        }
+    }
+
+    final class LockedProject implements AutoCloseable {
+
+        private final Path project;
+        private final String projectIdentity;
+        private final Path ownerFile;
+        private FileChannel channel;
+        private FileLock fileLock;
+        private String claimedRunId;
+
+        private LockedProject(
+                              Path project,
+                              String projectIdentity,
+                              Path ownerFile,
+                              FileChannel channel,
+                              FileLock fileLock) {
+            this.project = project;
+            this.projectIdentity = projectIdentity;
+            this.ownerFile = ownerFile;
+            this.channel = channel;
+            this.fileLock = fileLock;
+        }
+
+        void requireNoForeignTornPublication(String runId) throws IOException {
+            requireOpen();
+            if (claimedRunId != null && !claimedRunId.equals(runId)) {
+                throw new StoreException(
+                        "state-corrupt", "Ship project lease already belongs to " + claimedRunId);
+            }
+            ProjectOwner current = currentProjectOwner(
+                    projectIdentity, runId);
+            ProjectOwner prior = readProjectOwner(ownerFile);
+            if (prior != null) {
+                if (!projectIdentity.equals(prior.projectIdentity())) {
+                    throw new StoreException(
+                            "state-corrupt",
+                            "Ship project publication owner does not match its registry key");
+                }
+                if (!prior.equals(current) && foreignOwnerBlocks(prior)) {
+                    throw projectOwned(prior, null);
+                }
+            }
+            writeProjectOwner(ownerFile, current);
+            claimedRunId = runId;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (fileLock == null) {
+                return;
+            }
+            IOException failure = null;
+            try {
+                clearResolvedClaim();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                fileLock.release();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            try {
+                channel.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            } finally {
+                fileLock = null;
+                channel = null;
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        private void clearResolvedClaim() throws IOException {
+            if (claimedRunId == null) {
+                return;
+            }
+            ProjectOwner expected = currentProjectOwner(
+                    projectIdentity, claimedRunId);
+            ProjectOwner recorded = readProjectOwner(ownerFile);
+            if (recorded == null) {
+                return;
+            }
+            if (!expected.equals(recorded)) {
+                throw new StoreException(
+                        "state-corrupt", "Ship project publication owner changed while locked");
+            }
+            Path root = Path.of(expected.stateRoot());
+            Path runDirectory = runRoot(root, claimedRunId);
+            boolean resolved = !ShipPublicationService.journalExists(runDirectory);
+            if (!resolved) {
+                try {
+                    ShipRun run = ShipRunStore.this.read(claimedRunId);
+                    if (run.publication() != null) {
+                        ShipPublicationService.readVerifiedRecord(
+                                runDirectory, run.publication(), run.id());
+                        resolved = true;
+                    }
+                } catch (IOException | RuntimeException ignored) {
+                    // An unreadable commit marker cannot authorize clearing a live owner.
+                }
+            }
+            if (resolved) {
+                Files.delete(ownerFile);
+            }
+        }
+
+        private void requireOpen() throws StoreException {
+            if (fileLock == null) {
+                throw new StoreException(
+                        "lock-closed", "Ship project lock is already closed: " + project);
+            }
+        }
+    }
+
+    private record ProjectOwner(
+            int schemaVersion,
+            String projectIdentity,
+            String stateRoot,
+            String runId) {
+
+        private ProjectOwner {
+            if (schemaVersion != PROJECT_OWNER_SCHEMA_VERSION
+                    || !ShipDigest.isSha256(projectIdentity)
+                    || !ShipRun.isRunId(runId)) {
+                throw new IllegalArgumentException("Invalid Ship project publication owner");
+            }
+            requireCanonicalAbsolute(stateRoot);
+        }
+
+        private static void requireCanonicalAbsolute(String value) {
+            Path path = Path.of(Objects.requireNonNull(value, "owner path"));
+            if (!path.isAbsolute() || !path.normalize().equals(path)) {
+                throw new IllegalArgumentException("Invalid Ship project publication owner path");
             }
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -151,6 +151,7 @@ final class ShipRunStore {
         requireDisjoint(runRoot, run, "state-corrupt");
         requireWorkspaceEvidence(runRoot, run, "state-corrupt");
         requireLocalStampEvidence(runRoot, run, "state-corrupt");
+        requirePublicationEvidence(runRoot, run, "state-corrupt");
         return run;
     }
 
@@ -189,6 +190,7 @@ final class ShipRunStore {
         requireDisjoint(runRoot, run, "state-invalid");
         requireWorkspaceEvidence(runRoot, run, "state-invalid");
         requireLocalStampEvidence(runRoot, run, "state-invalid");
+        requirePublicationEvidence(runRoot, run, "state-invalid");
         byte[] encoded;
         try {
             encoded = JSON.writerWithDefaultPrettyPrinter().writeValueAsBytes(run);
@@ -293,6 +295,24 @@ final class ShipRunStore {
         throw new StoreException(
                 code,
                 "Completed Ship validation evidence is invalid for run " + run.id());
+    }
+
+    private static void requirePublicationEvidence(
+            Path runRoot, ShipRun run, String code)
+            throws StoreException {
+        if (run.publication() == null) {
+            return;
+        }
+        Path expected = runRoot
+                .resolve(ShipPublicationService.DIRECTORY)
+                .resolve(ShipPublicationService.RECORD)
+                .toAbsolutePath()
+                .normalize();
+        if (!expected.toString().equals(run.publication().path())) {
+            throw new StoreException(
+                    code,
+                    "Ship publication evidence is invalid for run " + run.id());
+        }
     }
 
     private static void requireImportedEvidence(ShipRun run, String code)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
@@ -13,6 +13,16 @@ public final class ProjectEvidenceFiles {
         return new ProjectSnapshotService().capture(projectRoot);
     }
 
+    /** Returns the descriptor-bound identity of one project root without scanning its entries. */
+    public static String rootIdentity(Path projectRoot) throws IOException {
+        return new ProjectSnapshotService().rootIdentity(projectRoot);
+    }
+
+    /** Returns the path-independent device/inode identity used to coordinate one live project. */
+    public static String projectIdentity(Path projectRoot) throws IOException {
+        return new ProjectSnapshotService().projectIdentity(projectRoot);
+    }
+
     public static ProjectSnapshot captureSealed(Path sealedRoot) throws IOException {
         return new ProjectSnapshotService().captureSealed(sealedRoot);
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
@@ -40,6 +40,18 @@ final class ProjectSnapshotService {
         }
     }
 
+    String rootIdentity(Path projectRoot) throws IOException {
+        try (SecureRoot root = ShipSecureFilesystem.open(projectRoot, "Ship project", policy)) {
+            return root.rootIdentity();
+        }
+    }
+
+    String projectIdentity(Path projectRoot) throws IOException {
+        try (SecureRoot root = ShipSecureFilesystem.open(projectRoot, "Ship project", policy)) {
+            return root.projectIdentity();
+        }
+    }
+
     ProjectSnapshot captureStaged(Path stagedRoot) throws IOException {
         try (SecureRoot root = ShipSecureFilesystem.open(stagedRoot, "Staged Ship tree", policy)) {
             return root.snapshotStaged();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
@@ -265,6 +265,13 @@ final class ShipSecureFilesystem {
                 .getBytes(StandardCharsets.UTF_8));
     }
 
+    private static String projectIdentity(UnixIdentity identity) {
+        return digestBytes(("camel-kit.ship.project.v1\0"
+                            + Long.toUnsignedString(identity.device()) + "\0"
+                            + Long.toUnsignedString(identity.inode()))
+                .getBytes(StandardCharsets.UTF_8));
+    }
+
     private static String digestBytes(byte[] value) {
         return "sha256:" + HexFormat.of().formatHex(messageDigest().digest(value));
     }
@@ -338,6 +345,16 @@ final class ShipSecureFilesystem {
 
         void validateBinding() throws IOException {
             assertRootBinding();
+        }
+
+        String rootIdentity() throws IOException {
+            assertRootBinding();
+            return identity;
+        }
+
+        String projectIdentity() throws IOException {
+            assertRootBinding();
+            return ShipSecureFilesystem.projectIdentity(rootMetadata);
         }
 
         ProjectSnapshot snapshot() throws IOException {
@@ -606,7 +623,7 @@ final class ShipSecureFilesystem {
         private void assertLexicalRootStillNamesHandle() throws IOException {
             UnixIdentity named = sampleUnixIdentity(path, rootMetadata.fileKey(), label + " root");
             if (!rootMetadata.equals(named)
-                    || !identity.equals(rootIdentity(path, named))) {
+                    || !identity.equals(ShipSecureFilesystem.rootIdentity(path, named))) {
                 throw concurrentMutation(
                         label + " root path no longer names its original directory: " + path);
             }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/ShipWorkspace.java
@@ -147,6 +147,22 @@ public final class ShipWorkspace {
             int attempt,
             String inputDigest)
             throws IOException {
+        return verify(liveProject, suppliedCandidate, runId, attempt, inputDigest, null);
+    }
+
+    /**
+     * Verifies one published candidate, additionally accepting a live project whose material identity equals
+     * {@code publishedIdentity} — the recorded identity of an already-published candidate, which legitimately replaced
+     * the prepare-time baseline.
+     */
+    public static Verification verify(
+            Path liveProject,
+            Path suppliedCandidate,
+            String runId,
+            int attempt,
+            String inputDigest,
+            String publishedIdentity)
+            throws IOException {
         Path project = realProject(liveProject);
         requireBindingFields(runId, attempt, inputDigest);
         Path candidate = realDirectory(suppliedCandidate, "Ship workspace candidate");
@@ -165,7 +181,9 @@ public final class ShipWorkspace {
         }
         ProjectSnapshot candidateSnapshot = ProjectEvidenceFiles.captureStaged(candidate);
         ProjectSnapshot baseline = ProjectEvidenceFiles.capture(project);
-        if (!materialIdentity(baseline).equals(binding.baselineDigest())) {
+        String liveIdentity = materialIdentity(baseline);
+        if (!liveIdentity.equals(binding.baselineDigest())
+                && (publishedIdentity == null || !liveIdentity.equals(publishedIdentity))) {
             throw new StaleBaselineException(
                     "Ship workspace baseline no longer matches the live project");
         }
@@ -446,7 +464,8 @@ public final class ShipWorkspace {
                 : new FileAttribute<?>[0];
     }
 
-    private static String materialIdentity(ProjectSnapshot snapshot) {
+    /** Framed identity of one material tree; shared by workspace baselines and publication records. */
+    public static String materialIdentity(ProjectSnapshot snapshot) {
         ByteArrayOutputStream framed = new ByteArrayOutputStream();
         field(framed, "camel-kit.ship.workspace-material.v1");
         field(framed, snapshot.policyDigest());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -382,7 +382,11 @@ class ShipControllerTest {
                 never = complete(controller, never, "never-" + stage);
             }
         }
+        assertEquals(RunStatus.RUNNING, never.status());
+        assertTrue(never.publicationPending());
+        never = controller.publish(never.id());
         assertEquals(RunStatus.COMPLETED, never.status());
+        assertNotNull(never.publication());
         assertEquals(Stage.VALIDATE, never.currentStage());
         assertTrue(never.stages().stream().allMatch(record -> record.status() == StageStatus.COMPLETED));
     }
@@ -534,8 +538,13 @@ class ShipControllerTest {
         ShipController reloaded = new ShipController(state);
         assertEquals(paused, reloaded.status(paused.id()));
 
-        ShipRun completed = reloaded.resume(paused.id());
+        ShipRun pending = reloaded.resume(paused.id());
+        assertEquals(RunStatus.RUNNING, pending.status());
+        assertTrue(pending.publicationPending());
+
+        ShipRun completed = reloaded.publish(pending.id());
         assertEquals(RunStatus.COMPLETED, completed.status());
+        assertNotNull(completed.publication());
         assertEquals(validation, completed.stage(Stage.VALIDATE));
     }
 
@@ -602,11 +611,11 @@ class ShipControllerTest {
                     : localStamp(validating.id(), Outcome.PASS);
             Path stampPath = ShipLocalStampStore.write(
                     attempt.evidenceDirectory(), validating.id(), stamp);
-            ShipRun completed = controller.completeValidationStage(
+            ShipRun completed = controller.publish(controller.completeValidationStage(
                     validating.id(),
                     validating.stage(Stage.VALIDATE).attempts(),
                     validating.stage(Stage.VALIDATE).inputDigest(),
-                    stamp);
+                    stamp).id());
             assertEquals(RunStatus.COMPLETED, completed.status(), condition);
 
             if ("intact".equals(condition)) {
@@ -657,11 +666,11 @@ class ShipControllerTest {
         ShipController.StageAttempt attempt = controller.prepareAttempt(run.id());
         ShipLocalStamp stamp = localStamp(run.id(), Outcome.PASS);
         ShipLocalStampStore.write(attempt.evidenceDirectory(), run.id(), stamp);
-        ShipRun completed = controller.completeValidationStage(
+        ShipRun completed = controller.publish(controller.completeValidationStage(
                 run.id(),
                 run.stage(Stage.VALIDATE).attempts(),
                 run.stage(Stage.VALIDATE).inputDigest(),
-                stamp);
+                stamp).id());
         assertEquals(RunStatus.COMPLETED, completed.status());
 
         Files.writeString(document, "requirements-v2");
@@ -689,11 +698,11 @@ class ShipControllerTest {
         ShipController.StageAttempt attempt = controller.prepareAttempt(run.id());
         ShipLocalStamp stamp = localStamp(run.id(), Outcome.PASS);
         ShipLocalStampStore.write(attempt.evidenceDirectory(), run.id(), stamp);
-        ShipRun completed = controller.completeValidationStage(
+        ShipRun completed = controller.publish(controller.completeValidationStage(
                 run.id(),
                 run.stage(Stage.VALIDATE).attempts(),
                 run.stage(Stage.VALIDATE).inputDigest(),
-                stamp);
+                stamp).id());
         assertEquals(RunStatus.COMPLETED, completed.status());
 
         Files.writeString(design, "design-v2");
@@ -1516,6 +1525,363 @@ class ShipControllerTest {
                         shipStateProject, Oversight.SMART, List.of()));
         assertEquals("pre-release-ship-state", shipStateFailure.code());
         assertArrayEquals(shipState, Files.readAllBytes(shipStateFile));
+    }
+
+    @Test
+    void publishesTheValidatedCandidateIntoTheLiveProject() throws Exception {
+        Path project = publishableProject("publish-project");
+        ShipController controller = controller("publish-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+        assertTrue(pending.publicationPending());
+        assertEquals("old", Files.readString(project.resolve("old.txt")));
+
+        ShipRun published = controller.publish(pending.id());
+
+        assertEquals(RunStatus.COMPLETED, published.status());
+        assertNotNull(published.publication());
+        assertEquals("route: order", Files.readString(project.resolve("routes/order-route.yaml")));
+        assertEquals("replaced", Files.readString(project.resolve("src/replace.txt")));
+        assertEquals("keep", Files.readString(project.resolve("keep.txt")));
+        assertFalse(Files.exists(project.resolve("old.txt")));
+        Path record = Path.of(published.publication().path());
+        assertTrue(Files.isRegularFile(record));
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(record)),
+                published.publication().digest());
+        assertTrue(Files.isRegularFile(record.resolveSibling("journal.json")),
+                "the committed journal is retained as evidence");
+        assertFailure("stale-stage-attempt", () -> controller.publish(published.id()));
+    }
+
+    @Test
+    void refusesToPublishOverALiveProjectThatDrifted() throws Exception {
+        Path project = publishableProject("drift-project");
+        ShipController controller = controller("drift-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+        Files.writeString(project.resolve("keep.txt"), "user edit");
+
+        assertFailure("stale-stage-input", () -> controller.publish(pending.id()));
+
+        assertEquals("user edit", Files.readString(project.resolve("keep.txt")));
+        assertEquals("old", Files.readString(project.resolve("old.txt")));
+        assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
+        assertFalse(Files.exists(project.resolve("routes")));
+        ShipRun resumed = controller.resume(pending.id());
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(Stage.EXECUTE, resumed.currentStage());
+    }
+
+    @Test
+    void abortsAPendingRunWithoutTouchingTheLiveProject() throws Exception {
+        Path project = publishableProject("abort-pending-project");
+        ShipController controller = controller("abort-pending-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+
+        ShipRun aborted = controller.abort(pending.id());
+
+        assertEquals(RunStatus.ABORTED, aborted.status());
+        assertNull(aborted.publication());
+        assertEquals("old", Files.readString(project.resolve("old.txt")));
+        assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
+        assertFalse(Files.exists(project.resolve("routes")));
+    }
+
+    @Test
+    void recoversATornPublicationBeforeAnyLockedMutation() throws Exception {
+        Path project = publishableProject("torn-project");
+        ShipController controller = controller("torn-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+        Path runDirectory = directory.resolve("torn-state").resolve(pending.id());
+        ShipPublicationService.Journal journal = tornJournal(project, pending, runDirectory);
+        Path backup = runDirectory.resolve("publication/backup/src/replace.txt");
+        Files.createDirectories(backup.getParent());
+        Files.copy(project.resolve("src/replace.txt"), backup);
+        Files.writeString(project.resolve("src/replace.txt"), "replaced");
+
+        ShipRun resumed = controller.resume(pending.id());
+
+        assertEquals("original", Files.readString(project.resolve("src/replace.txt")),
+                "recovery restored the exact baseline");
+        assertFalse(Files.exists(runDirectory.resolve("publication/journal.json")));
+        assertTrue(resumed.publicationPending());
+        assertEquals(journal.runId(), pending.id());
+
+        ShipRun published = controller.publish(resumed.id());
+        assertEquals(RunStatus.COMPLETED, published.status());
+        assertEquals("replaced", Files.readString(project.resolve("src/replace.txt")));
+    }
+
+    @Test
+    void blocksRecoveryWhenTheLiveTreeMatchesNeitherSide() throws Exception {
+        Path project = publishableProject("blocked-project");
+        ShipController controller = controller("blocked-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+        Path runDirectory = directory.resolve("blocked-state").resolve(pending.id());
+        tornJournal(project, pending, runDirectory);
+        Files.writeString(project.resolve("src/replace.txt"), "foreign edit");
+
+        assertFailure(
+                "publication-recovery-blocked", () -> controller.resume(pending.id()));
+
+        assertEquals("foreign edit", Files.readString(project.resolve("src/replace.txt")),
+                "blocked recovery must not touch the live tree");
+        assertTrue(Files.isRegularFile(runDirectory.resolve("publication/journal.json")),
+                "the journal is retained for manual resolution");
+        assertFailure(
+                "publication-recovery-blocked", () -> controller.abort(pending.id()));
+    }
+
+    @Test
+    void resumeOfAPublishedRunKeepsThePublishedBaseline() throws Exception {
+        Path project = publishableProject("published-project");
+        ShipController controller = controller("published-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+        ShipRun published = controller.publish(pending.id());
+        assertEquals(RunStatus.COMPLETED, published.status());
+
+        assertFailure("run-completed", () -> controller.resume(published.id()));
+
+        Path stampPath = Path.of(published.stage(Stage.VALIDATE).artifacts().get(0).path());
+        Files.writeString(stampPath, Files.readString(stampPath) + "\n");
+        ShipRun revalidating = controller.resume(published.id());
+        assertEquals(RunStatus.RUNNING, revalidating.status());
+        assertEquals(Stage.VALIDATE, revalidating.currentStage());
+        assertEquals(2, revalidating.stage(Stage.VALIDATE).attempts());
+        assertNotNull(revalidating.publication());
+
+        ShipController.StageAttempt attempt = controller.prepareAttempt(revalidating.id());
+        ShipLocalStamp stamp = localStamp(revalidating.id(), Outcome.PASS);
+        ShipLocalStampStore.write(attempt.evidenceDirectory(), revalidating.id(), stamp);
+        ShipRun again = controller.completeValidationStage(
+                revalidating.id(),
+                revalidating.stage(Stage.VALIDATE).attempts(),
+                revalidating.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
+        assertEquals(RunStatus.COMPLETED, again.status());
+        assertEquals(published.publication(), again.publication());
+        assertEquals("replaced", Files.readString(project.resolve("src/replace.txt")));
+
+        Files.writeString(project.resolve("keep.txt"), "post-publish edit");
+        ShipRun restarted = controller.resume(again.id());
+        assertEquals(RunStatus.RUNNING, restarted.status());
+        assertEquals(Stage.EXECUTE, restarted.currentStage());
+        assertNull(restarted.publication());
+
+        // Voiding the published claim must also retire its journal: a later locked operation
+        // may never mistake a committed publication for a torn write-ahead log and roll it back.
+        Path runDirectory = directory.resolve("published-state").resolve(published.id());
+        assertFalse(Files.exists(runDirectory.resolve("publication/journal.json")));
+        ShipRun aborted = controller.abort(restarted.id());
+        assertEquals(RunStatus.ABORTED, aborted.status());
+        assertEquals("replaced", Files.readString(project.resolve("src/replace.txt")),
+                "the published content survives the voided claim");
+        assertEquals("route: order",
+                Files.readString(project.resolve("routes/order-route.yaml")));
+        assertFalse(Files.exists(project.resolve("old.txt")));
+        assertEquals("post-publish edit", Files.readString(project.resolve("keep.txt")));
+    }
+
+    @Test
+    void discardsAJournalLeftBySupersededExecuteAttempt() throws Exception {
+        Path project = publishableProject("superseded-project");
+        ShipController controller = controller("superseded-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project);
+        Path runDirectory = directory.resolve("superseded-state").resolve(pending.id());
+        int attempt = pending.stage(Stage.EXECUTE).attempts();
+
+        // A journal whose Execute attempt no longer exists cannot describe the live project, so
+        // rolling it back would revert content that belongs to a different candidate.
+        ShipRun.StageRecord execute = pending.stage(Stage.EXECUTE);
+        ShipPublicationService.Journal superseded = ShipPublicationService.plan(
+                pending.id(),
+                attempt - 1,
+                "2026-07-31T12:00:00Z",
+                io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.verify(
+                        project,
+                        runDirectory.resolve("workspace/candidate"),
+                        pending.id(),
+                        execute.attempts(),
+                        execute.inputDigest()));
+        ShipPublicationService.begin(runDirectory, superseded);
+        Files.writeString(project.resolve("src/replace.txt"), "replaced");
+
+        ShipRun resumed = controller.resume(pending.id());
+
+        assertEquals("replaced", Files.readString(project.resolve("src/replace.txt")),
+                "a superseded journal is discarded, never applied");
+        assertFalse(Files.exists(runDirectory.resolve("publication/journal.json")));
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(Stage.EXECUTE, resumed.currentStage());
+    }
+
+    @Test
+    void gatesAWaivedValidationBeforePublication() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("waiver-project"));
+        ShipController smartController = controller("waiver-smart-state");
+        ShipRun smart = advanceToValidation(smartController, project, Oversight.SMART);
+        ShipController.StageAttempt smartAttempt = smartController.prepareAttempt(smart.id());
+        ShipLocalStamp waived = waivedStamp(smart.id());
+        ShipLocalStampStore.write(smartAttempt.evidenceDirectory(), smart.id(), waived);
+        ShipRun gated = smartController.completeValidationStage(
+                smart.id(),
+                smart.stage(Stage.VALIDATE).attempts(),
+                smart.stage(Stage.VALIDATE).inputDigest(),
+                waived);
+        assertEquals(RunStatus.PAUSED, gated.status(),
+                "SMART pauses before publishing a waived validation");
+
+        ShipController neverController = controller("waiver-never-state");
+        ShipRun never = advanceToValidation(neverController, project, Oversight.NEVER);
+        ShipController.StageAttempt neverAttempt = neverController.prepareAttempt(never.id());
+        ShipLocalStamp neverWaived = waivedStamp(never.id());
+        ShipLocalStampStore.write(neverAttempt.evidenceDirectory(), never.id(), neverWaived);
+        ShipRun proceeding = neverController.completeValidationStage(
+                never.id(),
+                never.stage(Stage.VALIDATE).attempts(),
+                never.stage(Stage.VALIDATE).inputDigest(),
+                neverWaived);
+        assertEquals(RunStatus.RUNNING, proceeding.status());
+        assertTrue(proceeding.publicationPending());
+    }
+
+    private static ShipLocalStamp waivedStamp(String runId) {
+        return ShipLocalStamp.create(
+                runId,
+                List.of(new ShipLocalStamp.ToolVersion(
+                        "pi",
+                        null,
+                        "0.83.0",
+                        ShipLocalStamp.Support.SUPPORTED,
+                        null)),
+                List.of(new ShipLocalStamp.Check(
+                        "artifact-policy",
+                        true,
+                        Outcome.WAIVED,
+                        "Artifact policy result",
+                        "Waived to exercise the pre-publication gate",
+                        null)),
+                Instant.parse("2026-07-29T12:00:00Z"));
+    }
+
+    @Test
+    void failsOnceWhenTheCandidateChangesAPathBetweenFileAndDirectory() throws Exception {
+        Path project = publishableProject("kind-change-project");
+        Files.createDirectory(project.resolve("config"));
+        Files.writeString(project.resolve("config/app.properties"), "key=value");
+        ShipController controller = controller("kind-change-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project, candidate -> {
+            Files.delete(candidate.resolve("config/app.properties"));
+            Files.delete(candidate.resolve("config"));
+            Files.writeString(candidate.resolve("config"), "now a file");
+        });
+
+        ShipRun failed = controller.publish(pending.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertTrue(failed.message().contains("changes between a file and a directory"),
+                failed.message());
+        assertTrue(failed.message().contains("live project is unchanged"), failed.message());
+        assertTrue(Files.isDirectory(project.resolve("config")));
+        assertEquals("key=value", Files.readString(project.resolve("config/app.properties")));
+    }
+
+    @Test
+    void explainsADirectoryItCannotRemoveInsteadOfLoopingOnRetry() throws Exception {
+        Path project = publishableProject("occupied-project");
+        Files.createDirectory(project.resolve("legacy"));
+        Files.writeString(project.resolve("legacy/Old.java"), "class Old {}");
+        ShipController controller = controller("occupied-state");
+        ShipRun pending = pendingWithCandidateChanges(controller, project, candidate -> {
+            Files.delete(candidate.resolve("legacy/Old.java"));
+            Files.delete(candidate.resolve("legacy"));
+        });
+        // Build output is invisible to the snapshots, so the directory cannot simply be removed.
+        Files.createDirectories(project.resolve("legacy/target/classes"));
+
+        ShipRun failed = controller.publish(pending.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertTrue(failed.message().contains("legacy"), failed.message());
+        assertTrue(failed.message().contains("build output"), failed.message());
+        assertEquals("class Old {}", Files.readString(project.resolve("legacy/Old.java")),
+                "the rollback restored the removed sources");
+        assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
+        assertFalse(Files.exists(project.resolve("routes/order-route.yaml")));
+    }
+
+    private Path publishableProject(String name) throws Exception {
+        Path project = Files.createDirectory(directory.resolve(name));
+        Files.writeString(project.resolve("keep.txt"), "keep");
+        Files.writeString(project.resolve("old.txt"), "old");
+        Files.createDirectory(project.resolve("src"));
+        Files.writeString(project.resolve("src/replace.txt"), "original");
+        return project;
+    }
+
+    private ShipRun pendingWithCandidateChanges(
+            ShipController controller, Path project)
+            throws Exception {
+        return pendingWithCandidateChanges(controller, project, candidate -> {
+        });
+    }
+
+    private ShipRun pendingWithCandidateChanges(
+            ShipController controller, Path project, CandidateEdit extraEdits)
+            throws Exception {
+        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
+        while (run.currentStage() != Stage.EXECUTE) {
+            run = complete(
+                    controller, run, run.currentStage().name().toLowerCase(Locale.ROOT));
+        }
+        Path candidate = controller.prepareWorkspace(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest());
+        Files.createDirectory(candidate.resolve("routes"));
+        Files.writeString(candidate.resolve("routes/order-route.yaml"), "route: order");
+        Files.writeString(candidate.resolve("src/replace.txt"), "replaced");
+        Files.delete(candidate.resolve("old.txt"));
+        extraEdits.apply(candidate);
+        run = controller.completeExecuteStage(
+                run.id(),
+                run.stage(Stage.EXECUTE).attempts(),
+                run.stage(Stage.EXECUTE).inputDigest(),
+                List.of(candidate.resolve("routes/order-route.yaml")),
+                false);
+        ShipController.StageAttempt attempt = controller.prepareAttempt(run.id());
+        ShipLocalStamp stamp = localStamp(run.id(), Outcome.PASS);
+        ShipLocalStampStore.write(attempt.evidenceDirectory(), run.id(), stamp);
+        return controller.completeValidationStage(
+                run.id(),
+                run.stage(Stage.VALIDATE).attempts(),
+                run.stage(Stage.VALIDATE).inputDigest(),
+                stamp);
+    }
+
+    /** Forges the journal of a publication torn right after its backup phase. */
+    private ShipPublicationService.Journal tornJournal(
+            Path project, ShipRun pending, Path runDirectory)
+            throws Exception {
+        ShipRun.StageRecord execute = pending.stage(Stage.EXECUTE);
+        io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.Verification verification
+                = io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace.verify(
+                        project,
+                        runDirectory.resolve("workspace/candidate"),
+                        pending.id(),
+                        execute.attempts(),
+                        execute.inputDigest());
+        ShipPublicationService.Journal journal = ShipPublicationService.plan(
+                pending.id(),
+                execute.attempts(),
+                "2026-07-31T12:00:00Z",
+                verification);
+        ShipPublicationService.begin(runDirectory, journal);
+        return journal;
+    }
+
+    @FunctionalInterface
+    private interface CandidateEdit {
+        void apply(Path candidate) throws Exception;
     }
 
     private ShipController controller(String stateDirectory) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -1572,6 +1572,91 @@ class ShipControllerTest {
     }
 
     @Test
+    void foreignUncommittedJournalBlocksPublication() throws Exception {
+        Path project = publishableProject("foreign-journal-project");
+        Path registry = directory.resolve("foreign-journal-registry/projects");
+        Path state = directory.resolve("foreign-journal-state");
+        ShipController controller = new ShipController(
+                state, registry, Clock.systemUTC(), System.getenv());
+        ShipRun interrupted = pendingWithCandidateChanges(controller, project);
+        ShipRun competing = pendingWithCandidateChanges(controller, project);
+        Path interruptedDirectory = state.resolve(interrupted.id());
+        ShipRunStore store = new ShipRunStore(state, registry);
+        try (ShipRunStore.LockedProject owner = store.lockProject(project)) {
+            owner.requireNoForeignTornPublication(interrupted.id());
+            tornJournal(project, interrupted, interruptedDirectory);
+        }
+
+        assertFailure(
+                "project-publication-in-progress",
+                () -> controller.publish(competing.id()));
+
+        assertEquals(competing, controller.status(competing.id()));
+        assertTrue(Files.isRegularFile(
+                interruptedDirectory.resolve("publication/journal.json")));
+        assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
+        assertTrue(Files.exists(project.resolve("old.txt")));
+        assertFalse(Files.exists(project.resolve("routes")));
+    }
+
+    @Test
+    void foreignUncommittedJournalBlocksPublicationAcrossStateRoots() throws Exception {
+        Path project = publishableProject("cross-root-foreign-journal-project");
+        Path registry = directory.resolve("project-registry/projects");
+        Path firstState = directory.resolve("cross-root-state-one");
+        Path secondState = directory.resolve("cross-root-state-two");
+        ShipController first = new ShipController(
+                firstState, registry, Clock.systemUTC(), System.getenv());
+        ShipController second = new ShipController(
+                secondState, registry, Clock.systemUTC(), System.getenv());
+        ShipRun interrupted = pendingWithCandidateChanges(first, project);
+        ShipRun competing = pendingWithCandidateChanges(second, project);
+        Path interruptedDirectory = firstState.resolve(interrupted.id());
+
+        ShipRunStore firstStore = new ShipRunStore(firstState, registry);
+        try (ShipRunStore.LockedProject owner = firstStore.lockProject(project)) {
+            owner.requireNoForeignTornPublication(interrupted.id());
+            tornJournal(project, interrupted, interruptedDirectory);
+        }
+
+        assertFailure(
+                "project-publication-in-progress",
+                () -> second.publish(competing.id()));
+
+        assertEquals(competing, second.status(competing.id()));
+        assertTrue(Files.isRegularFile(
+                interruptedDirectory.resolve("publication/journal.json")));
+        assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
+        assertTrue(Files.exists(project.resolve("old.txt")));
+        assertFalse(Files.exists(project.resolve("routes")));
+    }
+
+    @Test
+    void committedJournalDoesNotHideAStaleBaselineFromALaterRun() throws Exception {
+        Path project = publishableProject("committed-journal-project");
+        ShipController controller = controller("committed-journal-state");
+        ShipRun first = pendingWithCandidateChanges(controller, project);
+        ShipRun later = pendingWithCandidateChanges(controller, project);
+
+        ShipRun published = controller.publish(first.id());
+        Path committedJournal = directory.resolve("committed-journal-state")
+                .resolve(first.id())
+                .resolve("publication/journal.json");
+        assertTrue(Files.isRegularFile(committedJournal));
+
+        assertFailure("stale-stage-input", () -> controller.publish(later.id()));
+
+        assertEquals(RunStatus.COMPLETED, published.status());
+        assertEquals(later, controller.status(later.id()));
+        assertTrue(Files.isRegularFile(committedJournal));
+        assertEquals("replaced", Files.readString(project.resolve("src/replace.txt")));
+        assertFalse(Files.exists(project.resolve("old.txt")));
+        assertEquals(
+                "route: order",
+                Files.readString(project.resolve("routes/order-route.yaml")));
+    }
+
+    @Test
     void abortsAPendingRunWithoutTouchingTheLiveProject() throws Exception {
         Path project = publishableProject("abort-pending-project");
         ShipController controller = controller("abort-pending-state");
@@ -1876,6 +1961,7 @@ class ShipControllerTest {
                 "2026-07-31T12:00:00Z",
                 verification);
         ShipPublicationService.begin(runDirectory, journal);
+        ShipPublicationService.startApplication(runDirectory, journal);
         return journal;
     }
 
@@ -1885,7 +1971,11 @@ class ShipControllerTest {
     }
 
     private ShipController controller(String stateDirectory) {
-        return new ShipController(directory.resolve(stateDirectory));
+        return new ShipController(
+                directory.resolve(stateDirectory),
+                directory.resolve("project-registry/projects"),
+                Clock.systemUTC(),
+                System.getenv());
     }
 
     private ShipRun advanceToValidation(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorLiveIT.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorLiveIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Opt-in authenticated Pi/Linux certification for the complete local Ship workflow. */
@@ -121,6 +122,23 @@ class ShipCoordinatorLiveIT {
             assertTrue(Files.isRegularFile(candidate.resolve(relative)), relative);
         }
         ArtifactManifestReader.read(candidate, manifest);
+
+        assertNotNull(completed.publication());
+        Path publicationRecord = Path.of(completed.publication().path());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(publicationRecord)),
+                completed.publication().digest());
+        for (String relative : List.of(
+                "src/main/resources/routes/orders.camel.yaml",
+                "test/orders.camel.it.yaml",
+                ".camel-kit/config.properties",
+                "pom.xml",
+                "docs/camel-kit/" + PIPELINE + "/artifact-manifest.json")) {
+            assertEquals(
+                    Files.readString(candidate.resolve(relative)),
+                    Files.readString(project.resolve(relative)),
+                    "published " + relative);
+        }
 
         Path evidence = state.resolve(completed.id())
                 .resolve("evidence/validate-1");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -116,7 +116,11 @@ class ShipCoordinatorTest {
         state = directory.resolve("state");
         Map<String, String> environment = Map.of();
         distribution = DistributionConfig.load(new Properties());
-        controller = new ShipController(state, environment);
+        controller = new ShipController(
+                state,
+                directory.resolve("project-registry/projects"),
+                Clock.systemUTC(),
+                environment);
         worker = new PiWorker(
                 fixture.resolve("pi-rpc"),
                 distribution.piVersion(),
@@ -416,7 +420,11 @@ class ShipCoordinatorTest {
                         stateFile,
                         StandardCopyOption.ATOMIC_MOVE);
             }
-            ShipRun aborted = new ShipController(state, Map.of())
+            ShipRun aborted = new ShipController(
+                    state,
+                    directory.resolve("project-registry/projects"),
+                    Clock.systemUTC(),
+                    Map.of())
                     .abort(run.id());
             invocation.join(Duration.ofSeconds(10).toMillis());
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -799,6 +800,31 @@ class ShipCoordinatorTest {
                 ShipDigest.sha256(Files.readAllBytes(stampPath)),
                 completed.stage(Stage.VALIDATE)
                         .artifacts().get(0).digest());
+
+        assertNotNull(completed.publication());
+        Path publicationRecord = Path.of(completed.publication().path());
+        assertEquals(
+                state.resolve(run.id()).resolve("publication/publication.json").toRealPath(),
+                publicationRecord.toRealPath());
+        assertEquals(
+                ShipDigest.sha256(Files.readAllBytes(publicationRecord)),
+                completed.publication().digest());
+        assertTrue(Files.isRegularFile(
+                state.resolve(run.id()).resolve("publication/journal.json")),
+                "the committed journal is retained as evidence");
+        Path candidateRoot = Path.of(
+                completed.stage(Stage.EXECUTE).artifacts().get(0).path());
+        for (String relative : List.of(
+                "src/main/resources/routes/orders.camel.yaml",
+                "test/orders.camel.it.yaml",
+                ".camel-kit/config.properties",
+                "pom.xml",
+                "docs/camel-kit/149-coordinator/artifact-manifest.json")) {
+            assertEquals(
+                    Files.readString(candidateRoot.resolve(relative)),
+                    Files.readString(project.resolve(relative)),
+                    "published " + relative);
+        }
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
@@ -1,0 +1,587 @@
+package io.github.luigidemasi.camelkit.ship.controller;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
+import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot;
+import io.github.luigidemasi.camelkit.ship.worker.ShipWorkspace;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class ShipPublicationServiceTest {
+
+    private static final String RUN_ID = "ship-00000000000000000000000000000001";
+    private static final int ATTEMPT = 1;
+    private static final String CREATED_AT = "2026-08-17T12:00:00Z";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void preservesLegacyMaterialAndDeniedTemporaryNames() throws Exception {
+        String materialTemporary = ".foo.camel-kit-publish.tmp";
+        String deniedTemporary = ".env.camel-kit-publish.tmp";
+        Fixture fixture = fixture("legacy-temporary", project -> {
+            write(project.resolve("foo"), "old");
+            write(project.resolve("env"), "old environment");
+            write(project.resolve(materialTemporary), "material sentinel");
+            setMode(project.resolve(materialTemporary), "rw-r-----");
+            write(project.resolve(deniedTemporary), "denied sentinel");
+            setMode(project.resolve(deniedTemporary), "rw-------");
+        }, candidate -> {
+            write(candidate.resolve("foo"), "new");
+            write(candidate.resolve("env"), "new environment");
+        });
+        byte[] material = Files.readAllBytes(fixture.live(materialTemporary));
+        byte[] denied = Files.readAllBytes(fixture.live(deniedTemporary));
+        Set<PosixFilePermission> materialMode = mode(fixture.live(materialTemporary));
+        Set<PosixFilePermission> deniedMode = mode(fixture.live(deniedTemporary));
+        fixture.begin();
+
+        ShipPublicationService.apply(
+                fixture.project(), fixture.candidate(), fixture.run(), fixture.journal());
+
+        assertEquals("new", Files.readString(fixture.live("foo")));
+        assertEquals("new environment", Files.readString(fixture.live("env")));
+        assertArrayEquals(material, Files.readAllBytes(fixture.live(materialTemporary)));
+        assertArrayEquals(denied, Files.readAllBytes(fixture.live(deniedTemporary)));
+        assertEquals(materialMode, mode(fixture.live(materialTemporary)));
+        assertEquals(deniedMode, mode(fixture.live(deniedTemporary)));
+        assertMaterialTree(fixture.candidateSnapshot(), fixture.project());
+    }
+
+    @Test
+    void publishesAndRecoversAValidTwoHundredFortyByteLeaf() throws Exception {
+        String leaf = "x".repeat(240);
+        Fixture fixture = fixture("long-leaf", project -> {
+            write(project.resolve(leaf), "old");
+        }, candidate -> {
+            write(candidate.resolve(leaf), "new");
+        });
+        fixture.begin();
+
+        ShipPublicationService.apply(
+                fixture.project(), fixture.candidate(), fixture.run(), fixture.journal());
+
+        assertEquals("new", Files.readString(fixture.live(leaf)));
+        assertMaterialTree(fixture.candidateSnapshot(), fixture.project());
+
+        ShipPublicationService.recover(
+                fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
+
+        assertEquals("old", Files.readString(fixture.live(leaf)));
+        assertMaterialTree(fixture.baseline(), fixture.project());
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void blocksRecoveryOfAThirdFileModeWithoutMutation() throws Exception {
+        Fixture fixture = fixture("third-file-mode", project -> {
+            write(project.resolve("mode.txt"), "same bytes");
+            setMode(project.resolve("mode.txt"), "rw-r--r--");
+        }, candidate -> {
+            setMode(candidate.resolve("mode.txt"), "rw-------");
+        });
+        fixture.begin();
+        backup(fixture, "mode.txt");
+        setMode(fixture.live("mode.txt"), "rw-rw----");
+        ProjectSnapshot thirdState = ProjectEvidenceFiles.capture(fixture.project());
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertMaterialTree(thirdState, fixture.project());
+        assertEquals("same bytes", Files.readString(fixture.live("mode.txt")));
+        assertMode(fixture.live("mode.txt"), "rw-rw----");
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void blocksRecoveryOfAThirdDirectoryModeWithoutMutation() throws Exception {
+        Fixture fixture = fixture("third-directory-mode", project -> {
+            Path config = Files.createDirectory(project.resolve("config"));
+            setMode(config, "rwxr-xr-x");
+        }, candidate -> {
+            setMode(candidate.resolve("config"), "rwx------");
+        });
+        fixture.begin();
+        setMode(fixture.live("config"), "rwxr-x---");
+        ProjectSnapshot thirdState = ProjectEvidenceFiles.capture(fixture.project());
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertMaterialTree(thirdState, fixture.project());
+        assertMode(fixture.live("config"), "rwxr-x---");
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void blocksAThirdReplacementDirectoryModeAfterRecoveryStarted() throws Exception {
+        Fixture fixture = fixture("third-recovery-directory-mode", project -> {
+            Path config = Files.createDirectory(project.resolve("config"));
+            setMode(config, "rwxr-xr-x");
+        }, candidate -> {
+            setMode(candidate.resolve("config"), "rwx------");
+        });
+        fixture.begin();
+        ShipPublicationService.startRecovery(fixture.run(), fixture.journal(), false);
+        setMode(fixture.live("config"), "rwxr-x---");
+        ProjectSnapshot thirdState = ProjectEvidenceFiles.capture(fixture.project());
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertMaterialTree(thirdState, fixture.project());
+        assertMode(fixture.live("config"), "rwxr-x---");
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void blocksOnAStableDescendantSymlinkWithoutTouchingItOrItsTarget()
+            throws Exception {
+        Fixture fixture = fixture("descendant-symlink", project -> {
+            write(project.resolve("replace.txt"), "old");
+        }, candidate -> {
+            write(candidate.resolve("replace.txt"), "new");
+        });
+        Path outside = temporaryDirectory.resolve("outside.txt");
+        write(outside, "outside content");
+        setMode(outside, "rw-r-----");
+        byte[] outsideContent = Files.readAllBytes(outside);
+        Set<PosixFilePermission> outsideMode = mode(outside);
+        fixture.begin();
+        Files.delete(fixture.live("replace.txt"));
+        Files.createSymbolicLink(fixture.live("replace.txt"), outside);
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertTrue(Files.isSymbolicLink(fixture.live("replace.txt")));
+        assertEquals(outside, Files.readSymbolicLink(fixture.live("replace.txt")));
+        assertArrayEquals(outsideContent, Files.readAllBytes(outside));
+        assertEquals(outsideMode, mode(outside));
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void blocksOnAStableSymlinkedParentWithoutDeletingOutsideTheProject()
+            throws Exception {
+        Fixture fixture = fixture("symlinked-parent", project -> {
+        }, candidate -> {
+            Path generated = Files.createDirectory(candidate.resolve("generated"));
+            write(generated.resolve("result.txt"), "candidate content");
+        });
+        Path outside = Files.createDirectory(temporaryDirectory.resolve("outside-directory"));
+        write(outside.resolve("result.txt"), "candidate content");
+        setMode(
+                outside.resolve("result.txt"),
+                PosixFilePermissions.toString(mode(fixture.candidate().resolve(
+                        "generated/result.txt"))));
+        fixture.begin();
+        Files.createSymbolicLink(fixture.live("generated"), outside);
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertTrue(Files.isSymbolicLink(fixture.live("generated")));
+        assertEquals("candidate content", Files.readString(outside.resolve("result.txt")));
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void publishesAndRecoversAReadOnlyAddedDirectoryWithAChild() throws Exception {
+        Fixture fixture = fixture("read-only-directory", project -> {
+        }, candidate -> {
+            Path generated = Files.createDirectory(candidate.resolve("generated"));
+            write(generated.resolve("result.txt"), "candidate content");
+            setMode(generated, "r-xr-xr-x");
+        });
+        fixture.begin();
+
+        ShipPublicationService.apply(
+                fixture.project(), fixture.candidate(), fixture.run(), fixture.journal());
+
+        assertEquals("candidate content", Files.readString(fixture.live("generated/result.txt")));
+        assertMode(fixture.live("generated"), "r-xr-xr-x");
+
+        ShipPublicationService.recover(
+                fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
+
+        assertFalse(Files.exists(fixture.live("generated"), LinkOption.NOFOLLOW_LINKS));
+        assertMaterialTree(fixture.baseline(), fixture.project());
+    }
+
+    @Test
+    void blocksRecoveryWhenTheProjectRootWasReplaced() throws Exception {
+        Fixture fixture = fixture("replaced-root", project -> {
+            write(project.resolve("replace.txt"), "old");
+            setMode(project.resolve("replace.txt"), "rw-r-----");
+        }, candidate -> {
+            write(candidate.resolve("replace.txt"), "new");
+        });
+        fixture.begin();
+        Path original = temporaryDirectory.resolve("replaced-root-original");
+        Files.move(fixture.project(), original, StandardCopyOption.ATOMIC_MOVE);
+        Files.createDirectory(fixture.project());
+        write(fixture.live("replace.txt"), "old");
+        setMode(fixture.live("replace.txt"), "rw-r-----");
+        assertMaterialTree(fixture.baseline(), fixture.project());
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertEquals("old", Files.readString(fixture.live("replace.txt")));
+        assertEquals("old", Files.readString(original.resolve("replace.txt")));
+        assertMaterialTree(fixture.baseline(), fixture.project());
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void blocksRecoveryOfACandidateOnlyDirectoryContainingDeniedContent()
+            throws Exception {
+        Fixture fixture = fixture("foreign-denied-child", project -> {
+        }, candidate -> {
+            Path generated = Files.createDirectory(candidate.resolve("generated"));
+            setMode(generated, "rwxr-x---");
+        });
+        fixture.begin();
+        Path generated = Files.createDirectory(fixture.live("generated"));
+        setMode(generated, "rwxr-x---");
+        Path denied = generated.resolve(".env");
+        write(denied, "foreign secret");
+        setMode(denied, "rw-------");
+        byte[] deniedContent = Files.readAllBytes(denied);
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertTrue(Files.isDirectory(generated, LinkOption.NOFOLLOW_LINKS));
+        assertMode(generated, "rwxr-x---");
+        assertArrayEquals(deniedContent, Files.readAllBytes(denied));
+        assertMode(denied, "rw-------");
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void rejectsAndPreservesAForeignScratchCollisionCreatedAfterBegin() throws Exception {
+        Fixture fixture = fixture("scratch-collision", project -> {
+            write(project.resolve("replace.txt"), "old");
+        }, candidate -> {
+            write(candidate.resolve("replace.txt"), "new");
+        });
+        fixture.begin();
+        Path scratch = fixture.staging("replace.txt");
+        Files.write(
+                scratch,
+                new byte[0],
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE);
+        setMode(scratch, "rw-------");
+        byte[] scratchContent = Files.readAllBytes(scratch);
+        Set<PosixFilePermission> scratchMode = mode(scratch);
+
+        assertThrows(
+                ShipPublicationService.StaleLiveTreeException.class,
+                () -> ShipPublicationService.apply(
+                        fixture.project(), fixture.candidate(), fixture.run(), fixture.journal()));
+
+        assertEquals("old", Files.readString(fixture.live("replace.txt")));
+        assertArrayEquals(scratchContent, Files.readAllBytes(scratch));
+        assertEquals(scratchMode, mode(scratch));
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void recoveryBeforeApplicationPreservesAnExactScratchLookalike() throws Exception {
+        Fixture fixture = fixture("pre-application-scratch", project -> {
+            write(project.resolve("replace.txt"), "old");
+        }, candidate -> {
+            write(candidate.resolve("replace.txt"), "new");
+        });
+        fixture.begin();
+        Path scratch = fixture.staging("replace.txt");
+        Files.write(
+                scratch,
+                new byte[0],
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE);
+        setMode(scratch, "rw-------");
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertEquals("old", Files.readString(fixture.live("replace.txt")));
+        assertEquals(0, Files.size(scratch));
+        assertMode(scratch, "rw-------");
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void recoveryRecognizesAnInterruptedDeleteProbeAfterApplicationStarted() throws Exception {
+        Fixture fixture = fixture("delete-probe", project -> {
+            write(project.resolve("deleted.txt"), "baseline");
+        }, candidate -> {
+            Files.delete(candidate.resolve("deleted.txt"));
+        });
+        fixture.begin();
+        backup(fixture, "deleted.txt");
+        ShipPublicationService.startApplication(fixture.run(), fixture.journal());
+        Path scratch = fixture.staging("deleted.txt");
+        Files.write(
+                scratch,
+                new byte[0],
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE);
+        setMode(scratch, "rw-------");
+
+        ShipPublicationService.recover(
+                fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
+
+        assertEquals("baseline", Files.readString(fixture.live("deleted.txt")));
+        assertFalse(Files.exists(scratch, LinkOption.NOFOLLOW_LINKS));
+        assertMaterialTree(fixture.baseline(), fixture.project());
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void recoveryRecognizesAnInterruptedBaselineRestore() throws Exception {
+        Fixture fixture = fixture("interrupted-baseline-restore", project -> {
+            write(project.resolve("first.txt"), "old first");
+            write(project.resolve("second.txt"), "old second");
+        }, candidate -> {
+            write(candidate.resolve("first.txt"), "new first");
+            write(candidate.resolve("second.txt"), "new second");
+        });
+        fixture.begin();
+        backup(fixture, "first.txt");
+        backup(fixture, "second.txt");
+        ShipPublicationService.startApplication(fixture.run(), fixture.journal());
+        Files.write(
+                fixture.live("first.txt"),
+                Files.readAllBytes(fixture.candidate().resolve("first.txt")),
+                StandardOpenOption.TRUNCATE_EXISTING);
+        Files.setPosixFilePermissions(
+                fixture.live("first.txt"), mode(fixture.candidate().resolve("first.txt")));
+        ShipPublicationService.startRecovery(fixture.run(), fixture.journal(), false);
+        Path scratch = fixture.staging("first.txt");
+        Files.writeString(scratch, "old", StandardOpenOption.CREATE_NEW);
+        setMode(scratch, "rw-------");
+
+        ShipPublicationService.recover(
+                fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
+
+        assertMaterialTree(fixture.baseline(), fixture.project());
+        assertEquals("old first", Files.readString(fixture.live("first.txt")));
+        assertEquals("old second", Files.readString(fixture.live("second.txt")));
+        assertFalse(Files.exists(scratch, LinkOption.NOFOLLOW_LINKS));
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void publishesAndRecoversReplacementsToAndFromEmptyFiles() throws Exception {
+        Fixture fixture = fixture("empty-files", project -> {
+            write(project.resolve("from-empty.txt"), "");
+            write(project.resolve("to-empty.txt"), "non-empty");
+        }, candidate -> {
+            write(candidate.resolve("from-empty.txt"), "now populated");
+            write(candidate.resolve("to-empty.txt"), "");
+        });
+        fixture.begin();
+
+        ShipPublicationService.apply(
+                fixture.project(), fixture.candidate(), fixture.run(), fixture.journal());
+
+        assertEquals("now populated", Files.readString(fixture.live("from-empty.txt")));
+        assertEquals(0, Files.size(fixture.live("to-empty.txt")));
+        assertMaterialTree(fixture.candidateSnapshot(), fixture.project());
+
+        ShipPublicationService.recover(
+                fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
+
+        assertEquals(0, Files.size(fixture.live("from-empty.txt")));
+        assertEquals("non-empty", Files.readString(fixture.live("to-empty.txt")));
+        assertMaterialTree(fixture.baseline(), fixture.project());
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void recoveryPreflightsAnEditedUnchangedPathBeforeRestoringAnything() throws Exception {
+        Fixture fixture = fixture("edited-unchanged-path", project -> {
+            write(project.resolve("keep.txt"), "keep");
+            write(project.resolve("replace.txt"), "old");
+        }, candidate -> {
+            write(candidate.resolve("replace.txt"), "new");
+        });
+        fixture.begin();
+        ShipPublicationService.apply(
+                fixture.project(), fixture.candidate(), fixture.run(), fixture.journal());
+        write(fixture.live("keep.txt"), "user edit");
+        ProjectSnapshot beforeRecovery = ProjectEvidenceFiles.capture(fixture.project());
+
+        assertThrows(
+                ShipPublicationService.RecoveryBlockedException.class,
+                () -> ShipPublicationService.recover(
+                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+
+        assertMaterialTree(beforeRecovery, fixture.project());
+        assertEquals("new", Files.readString(fixture.live("replace.txt")));
+        assertEquals("user edit", Files.readString(fixture.live("keep.txt")));
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
+    void treatsAnIndeterminateJournalLookupAsPresent() throws Exception {
+        Path run = Files.createDirectory(temporaryDirectory.resolve("indeterminate-journal-run"));
+        Path publication = Files.createDirectory(
+                ShipPublicationService.publicationDirectory(run));
+        Files.writeString(publication.resolve(ShipPublicationService.JOURNAL), "{}");
+        setMode(publication, "---------");
+        try {
+            assertTrue(ShipPublicationService.journalExists(run));
+        } finally {
+            setMode(publication, "rwx------");
+        }
+    }
+
+    @Test
+    void beginCleansAnInterruptedPermissionProbeBeforeWritingTheJournal() throws Exception {
+        Fixture fixture = fixture("interrupted-permission-probe", project -> {
+            write(project.resolve("replace.txt"), "old");
+        }, candidate -> {
+            write(candidate.resolve("replace.txt"), "new");
+        });
+        Path publication = Files.createDirectory(
+                ShipPublicationService.publicationDirectory(fixture.run()));
+        Path fileProbe = Files.writeString(publication.resolve(".permission-probe-file"), "");
+        Path directoryProbe = Files.createDirectory(
+                publication.resolve(".permission-probe-directory"));
+
+        fixture.begin();
+
+        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+        assertFalse(Files.exists(fileProbe, LinkOption.NOFOLLOW_LINKS));
+        assertFalse(Files.exists(directoryProbe, LinkOption.NOFOLLOW_LINKS));
+    }
+
+    private Fixture fixture(
+            String name, Edit baselineEdit, Edit candidateEdit)
+            throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve(name + "-project"));
+        baselineEdit.apply(project);
+        ProjectSnapshot baseline = ProjectEvidenceFiles.capture(project);
+        Path run = Files.createDirectory(temporaryDirectory.resolve(name + "-run"));
+        Path candidate = Files.createDirectories(run.resolve("workspace/candidate"));
+        ProjectEvidenceFiles.materializeMaterial(project, candidate);
+        candidateEdit.apply(candidate);
+        ProjectSnapshot candidateSnapshot = ProjectEvidenceFiles.captureStaged(candidate);
+        ShipPublicationService.Journal journal = ShipPublicationService.plan(
+                RUN_ID,
+                ATTEMPT,
+                CREATED_AT,
+                new ShipWorkspace.Verification(baseline, candidateSnapshot));
+        return new Fixture(project, candidate, run, baseline, candidateSnapshot, journal);
+    }
+
+    private static Path backup(Fixture fixture, String relative) throws IOException {
+        Path destination = ShipPublicationService.publicationDirectory(fixture.run())
+                .resolve(ShipPublicationService.BACKUP)
+                .resolve(relative);
+        Files.createDirectories(destination.getParent());
+        return Files.copy(fixture.live(relative), destination);
+    }
+
+    private static Path write(Path path, String content) throws IOException {
+        return Files.writeString(path, content);
+    }
+
+    private static void setMode(Path path, String permissions) throws IOException {
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(permissions));
+    }
+
+    private static Set<PosixFilePermission> mode(Path path) throws IOException {
+        return Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static void assertMode(Path path, String expected) throws IOException {
+        assertEquals(PosixFilePermissions.fromString(expected), mode(path));
+    }
+
+    private static void assertMaterialTree(ProjectSnapshot expected, Path actual)
+            throws IOException {
+        assertTrue(
+                ProjectEvidenceFiles.unchangedMaterialTree(
+                        expected, ProjectEvidenceFiles.capture(actual)),
+                "material tree differs from the expected snapshot");
+    }
+
+    @FunctionalInterface
+    private interface Edit {
+        void apply(Path root) throws Exception;
+    }
+
+    private record Fixture(
+            Path project,
+            Path candidate,
+            Path run,
+            ProjectSnapshot baseline,
+            ProjectSnapshot candidateSnapshot,
+            ShipPublicationService.Journal journal) {
+
+        void begin() throws IOException {
+            ShipPublicationService.begin(run, journal);
+        }
+
+        Path live(String relative) {
+            return project.resolve(relative);
+        }
+
+        int index(String relative) {
+            for (int index = 0; index < journal.entries().size(); index++) {
+                if (relative.equals(journal.entries().get(index).path())) {
+                    return index;
+                }
+            }
+            throw new AssertionError("Missing publication entry: " + relative);
+        }
+
+        Path staging(String relative) {
+            return ShipPublicationService.stagingPath(
+                    journal, index(relative), live(relative));
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -304,11 +304,28 @@ class ShipRunStoreTest {
                 ShipRun.Stage.EXECUTE,
                 context,
                 stages,
+                null,
                 CREATED_AT,
                 UPDATED_AT,
                 null);
 
         assertCode("state-invalid", () -> store().create(legacy));
+    }
+
+    @Test
+    void rejectsAPublicationRecordOutsideItsRunDirectory() throws Exception {
+        ShipRunStore store = store();
+        ShipRun completed = completedRun(RUN_ID);
+        store.create(completed);
+        Path state = stateRoot().resolve(RUN_ID).resolve("state.json");
+        ObjectMapper json = new ObjectMapper();
+
+        ObjectNode document = (ObjectNode) json.readTree(Files.readAllBytes(state));
+        ((ObjectNode) document.get("publication")).put(
+                "path", temporaryDirectory.resolve("external-publication.json").toString());
+        Files.write(state, json.writeValueAsBytes(document));
+
+        assertCode("state-corrupt", () -> store.read(RUN_ID));
     }
 
     @Test
@@ -459,6 +476,7 @@ class ShipRunStoreTest {
                 ShipRun.Stage.DISCOVERY,
                 ShipContext.none(),
                 ShipRun.pendingStages(),
+                null,
                 CREATED_AT,
                 CREATED_AT,
                 null);
@@ -505,6 +523,11 @@ class ShipRunStoreTest {
                 ShipRun.Stage.VALIDATE,
                 context,
                 stages,
+                new ShipRun.ArtifactRef(
+                        stateRoot().resolve(runId).resolve("publication/publication.json")
+                                .toAbsolutePath().normalize().toString(),
+                        ShipDigest.sha256(
+                                "publication".getBytes(java.nio.charset.StandardCharsets.UTF_8))),
                 CREATED_AT,
                 UPDATED_AT,
                 null);
@@ -521,6 +544,7 @@ class ShipRunStoreTest {
                 run.currentStage(),
                 run.context(),
                 run.stages(),
+                run.publication(),
                 run.createdAt(),
                 UPDATED_AT,
                 run.message());
@@ -537,6 +561,7 @@ class ShipRunStoreTest {
                 run.currentStage(),
                 run.context(),
                 run.stages(),
+                run.publication(),
                 run.createdAt(),
                 run.updatedAt(),
                 run.message());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -140,6 +140,175 @@ class ShipRunStoreTest {
     }
 
     @Test
+    void excludesConcurrentProjectPublicationAndReleasesTheLock() throws Exception {
+        Files.createDirectory(temporaryDirectory.resolve("project"));
+        ShipRunStore first = store();
+        ShipRun initial = run(RUN_ID);
+        first.create(initial);
+        ShipRunStore second = store();
+        Path project = Path.of(initial.projectDirectory());
+
+        try (ShipRunStore.LockedProject ignored = first.lockProject(project)) {
+            assertCode("operation-in-progress", () -> {
+                try (ShipRunStore.LockedProject competing = second.lockProject(project)) {
+                    // A competing publication must not enter.
+                }
+            });
+        }
+
+        try (ShipRunStore.LockedProject ignored = second.lockProject(project)) {
+            // Closing the first lease makes the project immediately available again.
+        }
+    }
+
+    @Test
+    void excludesConcurrentProjectPublicationAcrossStateRoots() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
+        Path registry = projectRegistryRoot();
+        ShipRunStore first = new ShipRunStore(
+                temporaryDirectory.resolve("state-one"), registry);
+        ShipRunStore second = new ShipRunStore(
+                temporaryDirectory.resolve("state-two"), registry);
+
+        try (ShipRunStore.LockedProject ignored = first.lockProject(project)) {
+            assertCode("operation-in-progress", () -> {
+                try (ShipRunStore.LockedProject competing = second.lockProject(project)) {
+                    // The project rendezvous is independent of either run-state root.
+                }
+            });
+        }
+    }
+
+    @Test
+    void rejectsANonPrivateProjectRegistryWithoutChangingItsPermissions() throws Exception {
+        Assumptions.assumeTrue(
+                temporaryDirectory.getFileSystem().supportedFileAttributeViews().contains("posix"));
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
+        Path parent = Files.createDirectory(temporaryDirectory.resolve("project-registry"));
+        Files.setPosixFilePermissions(parent, PosixFilePermissions.fromString("rwx------"));
+        Path registry = Files.createDirectory(parent.resolve("projects"));
+        var publicPermissions = PosixFilePermissions.fromString("rwxr-xr-x");
+        Files.setPosixFilePermissions(registry, publicPermissions);
+        ShipRunStore store = new ShipRunStore(
+                temporaryDirectory.resolve("state"), registry);
+
+        assertCode("state-corrupt", () -> {
+            try (ShipRunStore.LockedProject ignored = store.lockProject(project)) {
+                // An unsafe rendezvous must not be used.
+            }
+        });
+        assertEquals(publicPermissions, Files.getPosixFilePermissions(registry));
+    }
+
+    @Test
+    void retainsAndFindsADormantPublicationOwnerAcrossStateRoots() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
+        Path registry = projectRegistryRoot();
+        Path firstState = temporaryDirectory.resolve("state-one");
+        Path secondState = temporaryDirectory.resolve("state-two");
+        ShipRunStore first = new ShipRunStore(firstState, registry);
+        ShipRunStore second = new ShipRunStore(secondState, registry);
+        first.create(withProject(run(RUN_ID), project));
+        second.create(withProject(run(OTHER_RUN_ID), project));
+        Path journal = firstState.resolve(RUN_ID).resolve("publication/journal.json");
+
+        try (ShipRunStore.LockedProject owner = first.lockProject(project)) {
+            owner.requireNoForeignTornPublication(RUN_ID);
+            Files.createDirectories(journal.getParent());
+            Files.writeString(journal, "{}");
+        }
+
+        try (ShipRunStore.LockedProject competing = second.lockProject(project)) {
+            assertCode(
+                    "project-publication-in-progress",
+                    () -> competing.requireNoForeignTornPublication(OTHER_RUN_ID));
+        }
+
+        try (ShipRunStore.LockedProject owner = first.lockProject(project)) {
+            owner.requireNoForeignTornPublication(RUN_ID);
+            Files.delete(journal);
+        }
+        try (ShipRunStore.LockedProject competing = second.lockProject(project)) {
+            competing.requireNoForeignTornPublication(OTHER_RUN_ID);
+        }
+    }
+
+    @Test
+    void keepsTheProjectLeaseAcrossAnAncestorRename() throws Exception {
+        Path oldParent = Files.createDirectory(temporaryDirectory.resolve("old-parent"));
+        Path project = Files.createDirectory(oldParent.resolve("project"));
+        Path registry = projectRegistryRoot();
+        ShipRunStore first = new ShipRunStore(
+                temporaryDirectory.resolve("state-one"), registry);
+        ShipRunStore second = new ShipRunStore(
+                temporaryDirectory.resolve("state-two"), registry);
+
+        try (ShipRunStore.LockedProject ignored = first.lockProject(project)) {
+            Path newParent = temporaryDirectory.resolve("new-parent");
+            Files.move(oldParent, newParent);
+            Files.createSymbolicLink(oldParent, newParent);
+            Path renamedProject = newParent.resolve("project");
+            assertCode("operation-in-progress", () -> {
+                try (ShipRunStore.LockedProject competing = second.lockProject(renamedProject)) {
+                    // Device/inode identity remains stable when lexical ancestors move.
+                }
+            });
+        }
+    }
+
+    @Test
+    void recognizesADormantOwnerAfterAnAncestorRename() throws Exception {
+        Path oldParent = Files.createDirectory(temporaryDirectory.resolve("old-parent"));
+        Path project = Files.createDirectory(oldParent.resolve("project"));
+        Path registry = projectRegistryRoot();
+        Path state = temporaryDirectory.resolve("state");
+        ShipRunStore store = new ShipRunStore(state, registry);
+        store.create(withProject(run(RUN_ID), project));
+        Path journal = state.resolve(RUN_ID).resolve("publication/journal.json");
+
+        try (ShipRunStore.LockedProject owner = store.lockProject(project)) {
+            owner.requireNoForeignTornPublication(RUN_ID);
+            Files.createDirectories(journal.getParent());
+            Files.writeString(journal, "{}");
+        }
+
+        Path newParent = temporaryDirectory.resolve("new-parent");
+        Files.move(oldParent, newParent);
+        Files.createSymbolicLink(oldParent, newParent);
+        Path renamedProject = newParent.resolve("project");
+        try (ShipRunStore.LockedProject owner = store.lockProject(renamedProject)) {
+            owner.requireNoForeignTornPublication(RUN_ID);
+            Files.delete(journal);
+        }
+    }
+
+    @Test
+    void doesNotReclaimAnOwnerFromAnUnverifiedPublicationReference() throws Exception {
+        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
+        ShipRunStore store = store();
+        store.create(withProject(completedRun(RUN_ID), project));
+        store.create(withProject(run(OTHER_RUN_ID), project));
+        Path journal = stateRoot().resolve(RUN_ID).resolve("publication/journal.json");
+
+        try (ShipRunStore.LockedProject owner = store.lockProject(project)) {
+            owner.requireNoForeignTornPublication(RUN_ID);
+            Files.createDirectories(journal.getParent());
+            Files.writeString(journal, "{}");
+        }
+
+        try (ShipRunStore.LockedProject competing = store.lockProject(project)) {
+            assertCode(
+                    "project-publication-in-progress",
+                    () -> competing.requireNoForeignTornPublication(OTHER_RUN_ID));
+        }
+
+        Files.delete(journal);
+        try (ShipRunStore.LockedProject competing = store.lockProject(project)) {
+            competing.requireNoForeignTornPublication(OTHER_RUN_ID);
+        }
+    }
+
+    @Test
     void distinguishesMissingInvalidAndCorruptState() throws Exception {
         ShipRunStore store = store();
         assertCode("run-not-found", () -> store.read(RUN_ID));
@@ -458,11 +627,15 @@ class ShipRunStoreTest {
     }
 
     private ShipRunStore store() {
-        return new ShipRunStore(stateRoot());
+        return new ShipRunStore(stateRoot(), projectRegistryRoot());
     }
 
     private Path stateRoot() {
         return temporaryDirectory.resolve("state");
+    }
+
+    private Path projectRegistryRoot() {
+        return temporaryDirectory.resolve("project-registry/projects");
     }
 
     private ShipRun run(String runId) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
@@ -41,6 +41,8 @@ class ShipRunTest {
     private static final String UPDATED_AT = "2026-07-23T08:00:01Z";
     private static final String INPUT = digest("input");
     private static final String OUTPUT = digest("output");
+    private static final ShipRun.ArtifactRef PUBLICATION = new ShipRun.ArtifactRef(
+            "/tmp/camel-kit-state/publication/publication.json", digest("publication"));
 
     @Test
     void parsesCanonicalEnumsAndAdvancesStages() {
@@ -101,11 +103,32 @@ class ShipRunTest {
                 () -> assertDoesNotThrow(() -> run(FAILED, DISCOVERY, failedStages, "stage failed")),
                 () -> assertDoesNotThrow(() -> run(ABORTED, DISCOVERY, abortedStages, "cancelled")),
                 () -> assertDoesNotThrow(() -> run(COMPLETED, VALIDATE,
-                        completedThrough(VALIDATE), null)),
+                        completedThrough(VALIDATE), null, PUBLICATION)),
                 () -> assertDoesNotThrow(() -> run(PAUSED, VALIDATE,
                         completedThrough(VALIDATE), null)),
+                () -> assertDoesNotThrow(() -> run(RUNNING, VALIDATE,
+                        completedThrough(VALIDATE), null)),
+                () -> assertDoesNotThrow(() -> run(FAILED, VALIDATE,
+                        completedThrough(VALIDATE), "publication rolled back")),
                 () -> assertDoesNotThrow(() -> run(ABORTED, VALIDATE,
                         completedThrough(VALIDATE), "cancelled after final approval")));
+    }
+
+    @Test
+    void publicationPendingCoversExactlyTheValidatedUnpublishedRun() {
+        List<ShipRun.StageRecord> running = ShipRun.pendingStages();
+        List<ShipRun.StageRecord> runningStages = replace(
+                running, DISCOVERY, running.get(0).start(INPUT));
+
+        assertAll(
+                () -> assertTrue(run(RUNNING, VALIDATE, completedThrough(VALIDATE), null)
+                        .publicationPending()),
+                () -> assertFalse(run(RUNNING, DISCOVERY, runningStages, null)
+                        .publicationPending()),
+                () -> assertFalse(run(PAUSED, VALIDATE, completedThrough(VALIDATE), null)
+                        .publicationPending()),
+                () -> assertFalse(run(COMPLETED, VALIDATE, completedThrough(VALIDATE), null, PUBLICATION)
+                        .publicationPending()));
     }
 
     @Test
@@ -193,6 +216,33 @@ class ShipRunTest {
     }
 
     @Test
+    void bindsThePublicationRecordToItsCompletedPublishedRun() {
+        List<ShipRun.StageRecord> allComplete = completedThrough(VALIDATE);
+        List<ShipRun.StageRecord> revalidating = replace(
+                allComplete, VALIDATE,
+                allComplete.get(VALIDATE.ordinal()).reset().start(INPUT));
+        List<ShipRun.StageRecord> discovering = ShipRun.pendingStages();
+
+        assertAll(
+                () -> assertRejected(
+                        "Completed Ship run has no publication record",
+                        () -> run(COMPLETED, VALIDATE, allComplete, null)),
+                () -> assertRejected(
+                        "Only a completed Ship run retains a publication record with all stages complete",
+                        () -> run(RUNNING, VALIDATE, allComplete, null, PUBLICATION)),
+                () -> assertRejected(
+                        "Only a completed Ship run retains a publication record with all stages complete",
+                        () -> run(PAUSED, VALIDATE, allComplete, null, PUBLICATION)),
+                () -> assertDoesNotThrow(
+                        () -> run(RUNNING, VALIDATE, revalidating, null, PUBLICATION)),
+                () -> assertRejected(
+                        "A Ship publication record requires its published EXECUTE candidate",
+                        () -> run(RUNNING, DISCOVERY,
+                                replace(discovering, DISCOVERY, discovering.get(0).start(INPUT)),
+                                null, PUBLICATION)));
+    }
+
+    @Test
     void rejectsUnsafePipelineMessagesAndTimestamps() {
         assertRejected(
                 "Ship pipeline ID is invalid",
@@ -233,6 +283,28 @@ class ShipRunTest {
             ShipRun.Stage currentStage,
             List<ShipRun.StageRecord> stages,
             String message,
+            ShipRun.ArtifactRef publication) {
+        return new ShipRun(
+                ShipRun.SCHEMA_VERSION,
+                RUN_ID,
+                "/tmp/camel-kit-project",
+                null,
+                SMART,
+                status,
+                currentStage,
+                ShipContext.none(),
+                stages,
+                publication,
+                CREATED_AT,
+                UPDATED_AT,
+                message);
+    }
+
+    private static ShipRun run(
+            ShipRun.RunStatus status,
+            ShipRun.Stage currentStage,
+            List<ShipRun.StageRecord> stages,
+            String message,
             String id) {
         return new ShipRun(
                 ShipRun.SCHEMA_VERSION,
@@ -244,6 +316,7 @@ class ShipRunTest {
                 currentStage,
                 ShipContext.none(),
                 stages,
+                null,
                 CREATED_AT,
                 UPDATED_AT,
                 message);
@@ -263,6 +336,7 @@ class ShipRunTest {
                 DISCOVERY,
                 ShipContext.none(),
                 stages,
+                null,
                 createdAt,
                 updatedAt,
                 message);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -724,7 +724,7 @@ class ProjectSnapshotServiceTest {
         assertEquals(
                 Set.of("capture", "captureStaged", "captureSealed", "unchanged",
                         "unchangedMaterialTree", "materializeMaterial", "readMaterial",
-                        "readVolatile"),
+                        "readVolatile", "rootIdentity", "projectIdentity"),
                 Arrays.stream(ProjectEvidenceFiles.class.getDeclaredMethods())
                         .filter(method -> Modifier.isPublic(method.getModifiers()))
                         .map(method -> method.getName())


### PR DESCRIPTION
## Summary

Publishes the validated workspace candidate into the live project, closing the last gap between a Ship run that validates and one that actually changes the user's project. Until now a successful run ended with generated code retained under `<stateRoot>/<runId>/workspace/candidate` and the project untouched.

Publication is a controller-owned operation between VALIDATE and COMPLETED, not a sixth stage: ADR-0052 pins the stage order `DISCOVERY -> DESIGN -> PLAN -> EXECUTE -> VALIDATE -> COMPLETED`, so `COMPLETED` now means validated **and** published.

## Protocol

`ShipPublicationService` applies one validated candidate with a write-ahead journal:

1. acquire the run lock and a project-global publication lease keyed by the secure device/inode identity of the live project;
2. reconcile any durable owner left by another state root, then re-verify every completed stage, the refreshed context, the workspace binding, and the exact live root identity;
3. plan the material publication set from the baseline and candidate snapshots, including files, directories, and modes;
4. derive bounded journal-owned sibling staging names (`.ckp-<run>-<attempt>-<entry>.tmp`), reject collisions before mutation, and write `publication/journal.json`;
5. back up every file the set overwrites or deletes, requiring exact baseline bytes and mode before anything is mutated and forcing each normalized `0600` backup to disk;
6. write an application marker, probe the actual sibling staging paths with `CREATE_NEW`, and apply quota-releasing deletes/shrinks before additions and growing replacements;
7. replace files through one forced same-directory staging channel plus `ATOMIC_MOVE`, and apply exact candidate directory modes after their children;
8. post-verify the descriptor-bound root and complete material identity against the validated candidate;
9. write `publication/publication.json` and atomically commit `ShipRun.publication` with status COMPLETED — the commit point.

The project lease uses a private per-effective-user registry at `/var/tmp/camel-kit-ship-<uid>/projects`, independent of `CAMEL_KIT_SHIP_STATE_HOME` and XDG overrides. Its durable owner survives only while an uncommitted journal may still mutate the project. A competing run in the same or a different state root blocks until the owning run resumes or aborts; a committed owner is reclaimed only after its referenced publication record is verified.

Any apply failure rolls the live project back to the exact baseline or retains the journal and fails closed. Recovery first authenticates phase-bound scratch, then securely captures the root, candidate, and complete material tree before any target mutation. It classifies every changed file and directory by exact kind, digest, size, and mode; verifies unchanged material paths too; validates every required backup; rejects stable symlinks and rebound roots; and refuses any third state with `publication-recovery-blocked`. Application and recovery markers make Ship-created intermediate modes and partial staging files replayable after process death without treating arbitrary pre-application files as owned scratch.

A POSIX mask that strips required owner permissions is rejected before the journal is written or the live project is touched. A torn private permission probe is removed by the next `begin` before retry.

## State model

`ShipRun` schema 3 -> 4 adds a nullable `publication` artifact reference:

- COMPLETED requires it, and the store binds it structurally to `<runDir>/publication/publication.json`.
- RUNNING with every stage complete is the new publication-pending state; FAILED with every stage complete is a rolled-back publication; PAUSED stays the pre-publication oversight gate.
- A resume that restarts EXECUTE or earlier voids the claim and discards its journal because the next candidate supersedes it.
- The published candidate identity is accepted as a legitimate live baseline, so resuming a published run no longer looks stale and reruns the whole implementation.

Oversight is unchanged: ALWAYS pauses after VALIDATE as the explicit pre-publication gate, SMART's pause after EXECUTE is the human gate before publishing, and NEVER publishes automatically because the invocation is the authority grant. A waivered stamp now pauses SMART before publishing.

## Verification

- Dedicated publication service suite: 18 Linux tests covering legacy staging-name preservation, denied files, 240-byte leaves, exact file/directory modes, stable symlinks and root replacement, foreign directory content, scratch collisions, application/recovery crash states, empty files, unchanged-path edits, and interrupted permission probes.
- Focused publication/lifecycle/security suites: 155 tests.
- The deterministic coordinator end-to-end test asserts generated route, test, config, pom, and manifest content in the live project, not only in the candidate.
- `ShipCoordinatorLiveIT` asserts the same published content on the real Pi/Linux path.
- `./mvnw -B -Psourcecheck validate`.
- `./mvnw -B clean install`.

## Adversarial review disposition

The follow-up review found and fixed four publication-safety gaps on the earlier head:

1. **Deterministic staging-name data loss.** A legitimate sibling such as `.foo.camel-kit-publish.tmp` — including a denied `.env.*` file invisible to material verification — could be deleted as scratch. Staging is now bounded, journal-derived, collision-checked, created with `CREATE_NEW`, and phase-bound during recovery.
2. **Cross-run publication races.** Per-run locks allowed two runs, including runs under different state roots, to back up the same baseline and both commit or roll one another back. A project-global lease and durable owner now cover verify through state commit and block dormant foreign journals.
3. **Incomplete recovery classification.** Directory modes and candidate file modes were not classified, so a post-tear chmod or other third state could be overwritten. Recovery now preflights exact file/directory identity, unchanged material paths, backups, and foreign directory contents before the first target mutation.
4. **Unbound recovery paths.** Stable parent symlinks or a replaced project root could redirect lexical rollback outside the verified tree. Descriptor-bound snapshots, journalled root identity, and path-independent project identity now fail closed before mutation.

The owner registry also treats indeterminate journal/owner lookup as present and verifies a committed publication record before releasing or stealing an owner.

Two earlier residuals remain deliberate: publication applies candidate file modes verbatim because modes are part of the validated identity, and an existing material directory that is not owner-writable fails deterministically rather than being forced writable. Both surface the concrete cause in the run message.

Ship remains unregistered; publication has no separate CLI option because it is part of the run. Website impact for #149 remains required for the later public cutover, but no website change belongs in this internal slice.

Refs #149
