### PR TITLE
Make Ship pauses interactive and status actionable

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -123,7 +123,9 @@ public final class ShipCommand implements Callable<Integer> {
         }
         Workflow workflow = launchWorkflow();
         if (operation != null && operation.resume != null) {
-            return awaitWorkflow(workflow::resume, operation.resume);
+            List<ShipContext.Input> additions = inputs();
+            return awaitWorkflow(
+                    runId -> workflow.resume(runId, additions), operation.resume);
         }
         ShipRun run = operation == null
                 ? controller.start(projectDirectory, selectedOversight(), inputs())
@@ -190,11 +192,16 @@ public final class ShipCommand implements Callable<Integer> {
     }
 
     private void validateArguments() {
-        if (operation != null && operation.startFrom == null
-                && (oversight != null || !contextArguments.isEmpty())) {
+        if (operation != null && operation.startFrom == null && oversight != null) {
             throw new ParameterException(
                     spec.commandLine(),
-                    "--ask, --text, and --document are only valid when starting a run");
+                    "--ask is only valid when starting a run");
+        }
+        if (operation != null && (operation.status != null || operation.abort != null)
+                && !contextArguments.isEmpty()) {
+            throw new ParameterException(
+                    spec.commandLine(),
+                    "--text and --document are only valid when starting or resuming a run");
         }
         if (operation != null && (operation.status != null || operation.abort != null)
                 && (piExecutable != null || nodeExecutable != null || mavenRepository != null
@@ -220,12 +227,70 @@ public final class ShipCommand implements Callable<Integer> {
         writer.println("Status: " + run.status());
         writer.println("Stage: " + run.currentStage());
         writer.println("Oversight: " + run.oversight());
+        if (run.status() == ShipRun.RunStatus.PAUSED) {
+            writer.println("Paused after: " + pausedAfter(run));
+            if (run.message() != null) {
+                writer.println("Report:");
+                for (String line : safeDisplay(run.message(), true).split("\n", -1)) {
+                    writer.println("  " + line);
+                }
+            }
+        } else if (run.message() != null) {
+            writer.println("Message: " + safeDisplay(run.message(), false));
+        }
+        List<ShipRun.ArtifactRef> validation = run.stage(Stage.VALIDATE).artifacts();
+        if (!validation.isEmpty()) {
+            writer.println("Stamp: " + safeDisplay(validation.get(0).path(), false));
+        }
+        if (run.publication() != null) {
+            writer.println("Publication: " + safeDisplay(run.publication().path(), false));
+        }
+        if (run.status() == ShipRun.RunStatus.PAUSED) {
+            writer.println("Next: camel-kit ship --resume " + run.id()
+                           + " [--text TEXT | --document PATH]");
+        } else if (run.status() == ShipRun.RunStatus.RUNNING
+                || run.status() == ShipRun.RunStatus.FAILED) {
+            writer.println("Next: camel-kit ship --resume " + run.id());
+        }
         writer.flush();
+    }
+
+    private static Stage pausedAfter(ShipRun run) {
+        Stage completed = run.currentStage();
+        for (ShipRun.StageRecord stage : run.stages()) {
+            if (stage.status() == ShipRun.StageStatus.COMPLETED) {
+                completed = stage.stage();
+            }
+        }
+        return completed;
+    }
+
+    private static String safeDisplay(String value, boolean multiline) {
+        StringBuilder safe = new StringBuilder(value.length());
+        for (int offset = 0; offset < value.length();) {
+            int codePoint = value.codePointAt(offset);
+            int type = Character.getType(codePoint);
+            if (codePoint == '\n' && multiline) {
+                safe.append('\n');
+            } else if (Character.isISOControl(codePoint)
+                    || type == Character.FORMAT
+                    || type == Character.LINE_SEPARATOR
+                    || type == Character.PARAGRAPH_SEPARATOR
+                    || type == Character.SURROGATE) {
+                safe.append(' ');
+            } else {
+                safe.appendCodePoint(codePoint);
+            }
+            offset += Character.charCount(codePoint);
+        }
+        String display = safe.toString().strip();
+        return display.isEmpty() ? "[unprintable]" : display;
     }
 
     private Integer failure(String code, String message) {
         PrintWriter writer = spec.commandLine().getErr();
-        writer.println("Error [" + code + "]: " + message);
+        writer.println("Error [" + code + "]: "
+                       + (message == null ? "[unprintable]" : safeDisplay(message, false)));
         writer.flush();
         return 1;
     }
@@ -235,7 +300,8 @@ public final class ShipCommand implements Callable<Integer> {
 
         ShipRun run(String runId) throws IOException, InterruptedException;
 
-        ShipRun resume(String runId) throws IOException, InterruptedException;
+        ShipRun resume(String runId, List<? extends ShipContext.Input> additions)
+                throws IOException, InterruptedException;
     }
 
     /** Builds the runtime-backed workflow, failing fast before any run state exists. */

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -246,6 +246,9 @@ public final class ShipCommand implements Callable<Integer> {
             writer.println("Publication: " + safeDisplay(run.publication().path(), false));
         }
         if (run.status() == ShipRun.RunStatus.PAUSED) {
+            if (pausedAfter(run) == Stage.VALIDATE) {
+                writer.println("Warning: Adding context restarts from DISCOVERY and discards the validation Stamp.");
+            }
             writer.println("Next: camel-kit ship --resume " + run.id()
                            + " [--text TEXT | --document PATH]");
         } else if (run.status() == ShipRun.RunStatus.RUNNING

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
@@ -5,11 +5,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
 import io.github.luigidemasi.camelkit.config.DistributionConfig;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
 import io.github.luigidemasi.camelkit.ship.controller.ShipCoordinator;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
 
@@ -64,8 +66,10 @@ final class ShipRuntime implements ShipCommand.WorkflowLauncher {
             }
 
             @Override
-            public ShipRun resume(String runId) throws IOException, InterruptedException {
-                return coordinator.resume(runId);
+            public ShipRun resume(
+                    String runId, List<? extends ShipContext.Input> additions)
+                    throws IOException, InterruptedException {
+                return coordinator.resume(runId, additions);
             }
         };
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -756,7 +756,9 @@ public final class ShipController {
     }
 
     private static String pauseMessage(Stage stage, String report) {
-        String message = report == null ? "" : report.replace('\0', ' ').strip();
+        String message = report == null
+                ? ""
+                : report.replaceAll("[\\p{Cntrl}&&[^\\n]]", " ").strip();
         if (message.isBlank()) {
             message = "Approval required after " + stage;
         }
@@ -2077,6 +2079,10 @@ public final class ShipController {
 
         public String code() {
             return code;
+        }
+
+        Failure withMessage(String message) {
+            return new Failure(code, message, this);
         }
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -219,10 +219,23 @@ public final class ShipController {
      * Re-reads mutable inputs and restarts the earliest stale or incomplete stage with a fresh attempt.
      */
     public ShipRun resume(String runId) {
+        return resume(runId, List.of());
+    }
+
+    /**
+     * Appends context to a paused run, then applies the same stale-input restart used by ordinary resume.
+     */
+    public ShipRun resume(String runId, List<? extends Input> additions) {
+        List<Input> added = new ArrayList<>(Objects.requireNonNull(additions, "context additions"));
         try (ShipRunStore.LockedRun locked = store.lock(runId)) {
             ShipRun current = locked.read();
             if (current.status() == RunStatus.ABORTED) {
                 throw failure("run-aborted", "Ship run is aborted and cannot resume: " + runId);
+            }
+            if (!added.isEmpty() && current.status() != RunStatus.PAUSED) {
+                throw failure(
+                        "run-not-paused",
+                        "Ship context can only be added while a run is paused: " + runId);
             }
             boolean completedWithLocalStamp = current.status() == RunStatus.COMPLETED;
             if (completedWithLocalStamp) {
@@ -241,7 +254,7 @@ public final class ShipController {
             }
             String publishedIdentity = publishedCandidateIdentity(
                     current, locked.directory());
-            ShipContext refreshed = refreshContext(current.context());
+            ShipContext refreshed = resumeContext(project, current.context(), added);
             rejectContextSecrets(refreshed);
             List<StageRecord> stages = new ArrayList<>(current.stages());
             int restart = stages.size();
@@ -737,7 +750,25 @@ public final class ShipController {
             return outcome;
         }
         String combined = outcome + ": " + detail.replaceAll("\\p{Cntrl}", " ").trim();
-        return combined.length() > 1024 ? combined.substring(0, 1024) : combined;
+        return combined.length() > ShipRun.MAX_MESSAGE_LENGTH
+                ? combined.substring(0, ShipRun.MAX_MESSAGE_LENGTH)
+                : combined;
+    }
+
+    private static String pauseMessage(Stage stage, String report) {
+        String message = report == null ? "" : report.replace('\0', ' ').strip();
+        if (message.isBlank()) {
+            message = "Approval required after " + stage;
+        }
+        if (message.length() <= ShipRun.MAX_MESSAGE_LENGTH) {
+            return message;
+        }
+        int start = message.length() - (ShipRun.MAX_MESSAGE_LENGTH - 4);
+        if (Character.isLowSurrogate(message.charAt(start))
+                && Character.isHighSurrogate(message.charAt(start - 1))) {
+            start++;
+        }
+        return "...\n" + message.substring(start);
     }
 
     /**
@@ -751,6 +782,26 @@ public final class ShipController {
             String outputDigest,
             List<Path> artifacts,
             boolean materialAmbiguity) {
+        return completeStage(
+                runId,
+                stage,
+                attempt,
+                inputDigest,
+                outputDigest,
+                artifacts,
+                materialAmbiguity,
+                null);
+    }
+
+    ShipRun completeStage(
+            String runId,
+            Stage stage,
+            int attempt,
+            String inputDigest,
+            String outputDigest,
+            List<Path> artifacts,
+            boolean materialAmbiguity,
+            String report) {
         if (stage == Stage.EXECUTE) {
             throw failure(
                     "workspace-required",
@@ -770,6 +821,7 @@ public final class ShipController {
                 artifacts,
                 false,
                 materialAmbiguity,
+                report,
                 null);
     }
 
@@ -780,7 +832,8 @@ public final class ShipController {
             String inputDigest,
             String outputDigest,
             String pipelineId,
-            boolean materialAmbiguity) {
+            boolean materialAmbiguity,
+            String report) {
         if (!ShipRun.isPipelineId(pipelineId)) {
             throw failure(
                     "stage-result-invalid",
@@ -795,6 +848,7 @@ public final class ShipController {
                 List.of(),
                 false,
                 materialAmbiguity,
+                report,
                 pipelineId);
     }
 
@@ -808,6 +862,22 @@ public final class ShipController {
             String inputDigest,
             List<Path> artifacts,
             boolean materialAmbiguity) {
+        return completeExecuteStage(
+                runId,
+                attempt,
+                inputDigest,
+                artifacts,
+                materialAmbiguity,
+                null);
+    }
+
+    ShipRun completeExecuteStage(
+            String runId,
+            int attempt,
+            String inputDigest,
+            List<Path> artifacts,
+            boolean materialAmbiguity,
+            String report) {
         return completeStage(
                 runId,
                 Stage.EXECUTE,
@@ -817,6 +887,7 @@ public final class ShipController {
                 artifacts,
                 true,
                 materialAmbiguity,
+                report,
                 null);
     }
 
@@ -909,6 +980,7 @@ public final class ShipController {
             List<Path> artifacts,
             boolean execute,
             boolean materialAmbiguity,
+            String report,
             String discoveredPipelineId) {
         Objects.requireNonNull(stage, "stage");
         Objects.requireNonNull(artifacts, "artifacts");
@@ -977,6 +1049,7 @@ public final class ShipController {
             Stage next = stage.next();
             RunStatus status;
             Stage currentStage;
+            String message = null;
             if (next == null) {
                 // VALIDATE completes through completeValidationStage, which owns the publication gate.
                 throw new IllegalStateException(
@@ -984,6 +1057,7 @@ public final class ShipController {
             } else if (current.oversight().pausesAfter(stage, materialAmbiguity)) {
                 status = RunStatus.PAUSED;
                 currentStage = next;
+                message = pauseMessage(stage, report);
             } else {
                 stages.set(
                         next.ordinal(),
@@ -1003,7 +1077,7 @@ public final class ShipController {
                     currentStage,
                     current.context(),
                     stages,
-                    null);
+                    message);
             locked.write(completed);
             return completed;
         } catch (ShipRunStore.StoreException e) {
@@ -1017,7 +1091,8 @@ public final class ShipController {
     public ShipRun failStage(
             String runId, Stage stage, int attempt, String inputDigest, String message) {
         Objects.requireNonNull(stage, "stage");
-        if (message == null || message.isBlank() || message.length() > 1024
+        if (message == null || message.isBlank()
+                || message.length() > ShipRun.MAX_MESSAGE_LENGTH
                 || message.indexOf('\0') >= 0) {
             throw failure("stage-result-invalid", "Ship stage failure message is invalid");
         }
@@ -1088,6 +1163,11 @@ public final class ShipController {
                     status = current.oversight().pausesAfter(Stage.VALIDATE, waived)
                             ? RunStatus.PAUSED
                             : RunStatus.RUNNING;
+                    if (status == RunStatus.PAUSED) {
+                        message = waived
+                                ? "Validation completed with a waiver; approval is required before publication"
+                                : "Validation passed; approval is required before publication";
+                    }
                 }
             }
             ShipRun completed = copy(
@@ -1680,6 +1760,21 @@ public final class ShipController {
         } catch (ShipContext.Failure e) {
             throw failure(contextCode(e), e.getMessage(), e);
         }
+    }
+
+    private static ShipContext resumeContext(
+            Path project, ShipContext existing, List<? extends Input> additions) {
+        if (additions.isEmpty()) {
+            return refreshContext(existing);
+        }
+        List<Input> combined = new ArrayList<>(existing.sources().size() + additions.size());
+        for (ShipContext.Source source : existing.sources()) {
+            combined.add(source.kind() == ShipContext.Kind.TEXT
+                    ? new ShipContext.TextInput(source.value())
+                    : new ShipContext.DocumentInput(source.value()));
+        }
+        combined.addAll(additions);
+        return resolveContext(project, combined);
     }
 
     private static String contextCode(ShipContext.Failure failure) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -213,33 +213,54 @@ public final class ShipCoordinator {
      * Recovers an exact durable Pi result before retrying; deterministic validation restarts in a fresh attempt.
      */
     public ShipRun resume(String runId) throws IOException, InterruptedException {
+        return resume(runId, List.of());
+    }
+
+    /** Appends context to a paused run before restarting stale work. */
+    public ShipRun resume(
+            String runId, List<? extends ShipContext.Input> additions)
+            throws IOException, InterruptedException {
+        List<ShipContext.Input> added = List.copyOf(
+                Objects.requireNonNull(additions, "context additions"));
         try {
             ShipRun initial = controller.status(runId);
             try (AttemptLease lease = tryCoordinatorLease(runId)) {
                 if (lease == null) {
+                    if (!added.isEmpty()) {
+                        throw new IOException(
+                                "Ship run is already active; context was not added");
+                    }
                     return controller.status(runId);
                 }
                 if (initial.status() == RunStatus.ABORTED) {
-                    return resumeAvailable(runId);
+                    return resumeAvailable(runId, added);
                 }
                 try (AbortWatcher ignored = new AbortWatcher(
                         controller, runId)) {
-                    return resumeAvailable(runId);
+                    return resumeAvailable(runId, added);
                 }
             }
         } catch (SessionBusyException e) {
+            if (!added.isEmpty()) {
+                throw e;
+            }
             return controller.status(runId);
         } catch (ShipController.Failure e) {
-            if (concurrentTransition(e)) {
+            if (added.isEmpty() && concurrentTransition(e)) {
                 return controller.status(runId);
             }
             throw e;
         }
     }
 
-    private ShipRun resumeAvailable(String runId)
+    private ShipRun resumeAvailable(
+            String runId, List<? extends ShipContext.Input> additions)
             throws IOException, InterruptedException {
         requireNotInterrupted();
+        if (!additions.isEmpty()) {
+            return continueAvailable(
+                    runId, controller.resume(runId, additions));
+        }
         ShipRun current = controller.status(runId);
         if (current.status() == RunStatus.RUNNING) {
             if (current.publicationPending()) {
@@ -435,7 +456,8 @@ public final class ShipCoordinator {
                         stage.inputDigest(),
                         outputDigest,
                         typed.pipelineId(),
-                        typed.materialAmbiguity());
+                        typed.materialAmbiguity(),
+                        typed.report());
             } else if (stage.stage() == Stage.EXECUTE) {
                 Path manifest;
                 try {
@@ -453,7 +475,8 @@ public final class ShipCoordinator {
                         stage.attempts(),
                         stage.inputDigest(),
                         List.of(manifest),
-                        typed.materialAmbiguity());
+                        typed.materialAmbiguity(),
+                        typed.report());
             } else {
                 committed = controller.completeStage(
                         attempt.run().id(),
@@ -462,7 +485,8 @@ public final class ShipCoordinator {
                         stage.inputDigest(),
                         outputDigest,
                         List.of(),
-                        typed.materialAmbiguity());
+                        typed.materialAmbiguity(),
+                        typed.report());
             }
             return new Step(committed, true);
         } catch (ShipController.Failure e) {
@@ -532,7 +556,7 @@ public final class ShipCoordinator {
             return new Step(
                     optimisticFailure(
                             attempt,
-                            "Ship validation could not run"),
+                            "Ship validation could not run: " + safeMessage(e)),
                     true);
         }
     }
@@ -809,11 +833,13 @@ public final class ShipCoordinator {
                 .append("The authoritative input digest is ")
                 .append(attempt.stage().inputDigest()).append(".\n")
                 .append("The bounded worker input identity is ")
-                .append(workerInputDigest).append(".\n");
+                .append(workerInputDigest).append(".\n")
+                .append("Do not ask for information already resolved by any context source. ")
+                .append("If material ambiguity remains, group concrete questions at the end of report ")
+                .append("and set materialAmbiguity to true.\n");
         switch (attempt.stage().stage()) {
             case DISCOVERY -> {
-                prompt.append(
-                        "Analyze supplied material before unresolved requirements. ");
+                prompt.append("Analyze every context source before unresolved requirements. ");
                 if (attempt.run().pipelineId() == null) {
                     prompt.append(
                             "Choose one unused pipeline ID matching "
@@ -1121,9 +1147,9 @@ public final class ShipCoordinator {
                 message.getBytes(StandardCharsets.UTF_8), environment)) {
             return "Failed";
         }
-        return message.length() <= 1024
+        return message.length() <= ShipRun.MAX_MESSAGE_LENGTH
                 ? message
-                : message.substring(0, 1024);
+                : message.substring(0, ShipRun.MAX_MESSAGE_LENGTH);
     }
 
     private static String safeMessage(IOException failure) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -3,6 +3,7 @@ package io.github.luigidemasi.camelkit.ship.controller;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
@@ -258,8 +259,21 @@ public final class ShipCoordinator {
             throws IOException, InterruptedException {
         requireNotInterrupted();
         if (!additions.isEmpty()) {
-            return continueAvailable(
-                    runId, controller.resume(runId, additions));
+            ShipRun committed = controller.resume(runId, additions);
+            try {
+                return continueAvailable(runId, committed);
+            } catch (ClosedByInterruptException e) {
+                throw e;
+            } catch (IOException e) {
+                throw new IOException(
+                        "Ship context was recorded, but the run could not continue: "
+                                      + safeMessage(e),
+                        e);
+            } catch (ShipController.Failure e) {
+                throw e.withMessage(
+                        "Ship context was recorded, but the run could not continue: "
+                                    + safeMessage(e));
+            }
         }
         ShipRun current = controller.status(runId);
         if (current.status() == RunStatus.RUNNING) {
@@ -1152,7 +1166,7 @@ public final class ShipCoordinator {
                 : message.substring(0, ShipRun.MAX_MESSAGE_LENGTH);
     }
 
-    private static String safeMessage(IOException failure) {
+    private static String safeMessage(Exception failure) {
         String message = failure.getMessage();
         return message == null || message.isBlank()
                 ? failure.getClass().getSimpleName()

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRun.java
@@ -31,6 +31,7 @@ public record ShipRun(
         String message) {
 
     public static final int SCHEMA_VERSION = 4;
+    static final int MAX_MESSAGE_LENGTH = 1024;
 
     private static final Pattern RUN_ID = Pattern.compile("ship-[0-9a-f]{32}");
     private static final Pattern PIPELINE_ID = Pattern.compile("[0-9]{3,}-[a-z0-9]+(?:-[a-z0-9]+)*");
@@ -57,11 +58,16 @@ public record ShipRun(
         if (Instant.parse(updatedAt).isBefore(Instant.parse(createdAt))) {
             throw new IllegalArgumentException("Ship run update precedes its creation");
         }
-        if (message != null && (message.isBlank() || message.length() > 1024 || message.indexOf('\0') >= 0)) {
+        if (message != null
+                && (message.isBlank()
+                        || message.length() > MAX_MESSAGE_LENGTH
+                        || message.indexOf('\0') >= 0)) {
             throw new IllegalArgumentException("Ship run message is invalid");
         }
-        if ((status == RunStatus.FAILED || status == RunStatus.ABORTED) != (message != null)) {
-            throw new IllegalArgumentException("Only failed or aborted runs carry a message");
+        if (status != RunStatus.PAUSED
+                && ((status == RunStatus.FAILED || status == RunStatus.ABORTED)
+                    != (message != null))) {
+            throw new IllegalArgumentException("Only paused, failed, or aborted runs carry a message");
         }
         requireConsistentProgress(status, currentStage, stages, publication);
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import io.github.luigidemasi.camelkit.ship.ShipDigest;
+import io.github.luigidemasi.camelkit.ship.context.ShipContext;
 import io.github.luigidemasi.camelkit.ship.context.ShipContext.Kind;
 import io.github.luigidemasi.camelkit.ship.controller.ShipController;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
@@ -67,7 +69,7 @@ class ShipCommandTest {
                     "--ask", policy);
 
             assertEquals(0, result.exitCode(), result.error());
-            assertTrue(result.output().endsWith(
+            assertTrue(result.output().contains(
                     "Oversight: " + policy.toUpperCase(Locale.ROOT) + System.lineSeparator()));
         }
     }
@@ -94,6 +96,46 @@ class ShipCommandTest {
         assertEquals(document.toAbsolutePath().normalize().toString(),
                 run.context().sources().get(1).value());
         assertEquals("last", run.context().sources().get(2).value());
+    }
+
+    @Test
+    void resumeAppendsMixedContextAgainstThePersistedProject() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path document = Files.writeString(project.resolve("answer.md"), "document answer");
+        ShipController controller = controller("state");
+        ShipRun started = controller.start(
+                project,
+                ShipRun.Oversight.SMART,
+                List.of(new ShipContext.TextInput("original context")));
+        ShipRun paused = controller.completeStage(
+                started.id(),
+                ShipRun.Stage.DISCOVERY,
+                started.stage(ShipRun.Stage.DISCOVERY).attempts(),
+                started.stage(ShipRun.Stage.DISCOVERY).inputDigest(),
+                ShipDigest.sha256("discovery result".getBytes(StandardCharsets.UTF_8)),
+                List.of(),
+                true);
+        RecordingLauncher launcher = RecordingLauncher.passThrough(controller);
+
+        RunResult result = run(
+                controller,
+                launcher,
+                "--resume", paused.id(),
+                "--text", "inline answer",
+                "--document", document.getFileName().toString());
+
+        assertEquals(0, result.exitCode(), result.error());
+        ShipRun resumed = controller.status(paused.id());
+        assertEquals(List.of(Kind.TEXT, Kind.TEXT, Kind.DOCUMENT),
+                resumed.context().sources().stream().map(source -> source.kind()).toList());
+        assertEquals("original context", resumed.context().sources().get(0).value());
+        assertEquals("inline answer", resumed.context().sources().get(1).value());
+        assertEquals(document.toAbsolutePath().normalize().toString(),
+                resumed.context().sources().get(2).value());
+        assertEquals(2, resumed.stage(ShipRun.Stage.DISCOVERY).attempts(),
+                "adding context must restart the stage exactly once");
+        assertEquals(List.of("resume:" + paused.id()), launcher.invocations);
+        assertEquals(summary(paused.id(), "RUNNING", "DISCOVERY", "SMART"), result.output());
     }
 
     @Test
@@ -129,7 +171,9 @@ class ShipCommandTest {
 
         RunResult aborted = run(controller, launcher, "--abort", id);
         assertEquals(0, aborted.exitCode(), aborted.error());
-        assertEquals(summary(id, "ABORTED", "DESIGN", "SMART"), aborted.output());
+        assertEquals(summary(
+                id, "ABORTED", "DESIGN", "SMART", "Message: Run aborted by user"),
+                aborted.output());
         assertEquals(List.of("run:" + id, "resume:" + id), launcher.invocations);
 
         RunResult rejected = run(controller, launcher, "--resume", id);
@@ -155,6 +199,127 @@ class ShipCommandTest {
 
         RunResult aborted = run(controller, rejecting, "--abort", id);
         assertEquals(0, aborted.exitCode(), aborted.error());
+    }
+
+    @Test
+    void pausedStatusShowsTheDurableReportAndResumeChoicesWithoutLaunchingRuntime()
+            throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun started = controller.start(project, ShipRun.Oversight.SMART, List.of());
+        ShipRun paused = controller.completeStage(
+                started.id(),
+                ShipRun.Stage.DISCOVERY,
+                started.stage(ShipRun.Stage.DISCOVERY).attempts(),
+                started.stage(ShipRun.Stage.DISCOVERY).inputDigest(),
+                ShipDigest.sha256("discovery result".getBytes(StandardCharsets.UTF_8)),
+                List.of(),
+                true);
+        ShipCommand.WorkflowLauncher rejecting = settings -> {
+            throw new AssertionError("status must not launch the runtime");
+        };
+
+        RunResult status = run(controller, rejecting, "--status", paused.id());
+
+        assertEquals(0, status.exitCode(), status.error());
+        assertEquals(summary(
+                paused.id(),
+                "PAUSED",
+                "DESIGN",
+                "SMART",
+                "Paused after: DISCOVERY",
+                "Report:",
+                "  Approval required after DISCOVERY"), status.output());
+    }
+
+    @Test
+    void pausedReportKeepsSafeLinesIndentedAndCannotSpoofTheSummary()
+            throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        ShipController controller = controller("state");
+        String report = "Question one?\n\u001b[31mStatus: SPOOFED\u202e\r\nQuestion two?";
+        RecordingLauncher launcher = new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) {
+                ShipRun running = controller.status(runId);
+                ShipRun paused = controller.completeStage(
+                        runId,
+                        ShipRun.Stage.DISCOVERY,
+                        running.stage(ShipRun.Stage.DISCOVERY).attempts(),
+                        running.stage(ShipRun.Stage.DISCOVERY).inputDigest(),
+                        ShipDigest.sha256("discovery result".getBytes(StandardCharsets.UTF_8)),
+                        List.of(),
+                        true);
+                return withMessage(paused, report);
+            }
+
+            @Override
+            public ShipRun resume(
+                    String runId, List<? extends ShipContext.Input> additions) {
+                throw new AssertionError("not resumed");
+            }
+        });
+
+        RunResult result = run(
+                controller, launcher, "--project-dir", project.toString());
+
+        assertEquals(0, result.exitCode(), result.error());
+        assertFalse(result.output().contains("\u001b"), result.output());
+        assertFalse(result.output().contains("\u202e"), result.output());
+        assertFalse(result.output().contains("\r"), result.output());
+        assertFalse(result.output().contains("\nStatus: SPOOFED"), result.output());
+        List<String> lines = result.output().lines().toList();
+        int reportLine = lines.indexOf("Report:");
+        int nextLine = lines.indexOf("Next: camel-kit ship --resume "
+                                     + runId(result.output())
+                                     + " [--text TEXT | --document PATH]");
+        assertEquals(3, nextLine - reportLine - 1);
+        assertTrue(lines.subList(reportLine + 1, nextLine).stream()
+                .allMatch(line -> line.startsWith("  ")),
+                result.output());
+        assertTrue(lines.stream().anyMatch(line -> line.contains("Status: SPOOFED")),
+                result.output());
+    }
+
+    @Test
+    void summaryNamesRetainedValidationAndPublicationEvidence()
+            throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("project"));
+        Path stamp = project.resolve("stamp.json");
+        Path publication = project.resolve("publication.json");
+        ShipController controller = controller("state");
+
+        RunResult failed = run(
+                controller,
+                evidenceLauncher(
+                        controller, ShipRun.RunStatus.FAILED, stamp, publication),
+                "--project-dir", project.toString());
+
+        String id = runId(failed.output());
+        assertEquals(1, failed.exitCode(), failed.error());
+        assertEquals(summary(
+                id,
+                "FAILED",
+                "VALIDATE",
+                "SMART",
+                "Message: Validation failed",
+                "Stamp: " + stamp), failed.output());
+
+        RunResult completed = run(
+                controller,
+                evidenceLauncher(
+                        controller, ShipRun.RunStatus.COMPLETED, stamp, publication),
+                "--resume", id);
+
+        assertEquals(0, completed.exitCode(), completed.error());
+        assertEquals(summary(
+                id,
+                "COMPLETED",
+                "VALIDATE",
+                "SMART",
+                "Stamp: " + stamp,
+                "Publication: " + publication), completed.output());
     }
 
     @Test
@@ -219,13 +384,11 @@ class ShipCommandTest {
 
             @Override
             public ShipRun run(String runId) throws IOException {
-                throw new IOException(
-                        "Node is installed but `node --version` failed;"
-                                      + " reinstall Node and verify the configured executable");
+                throw new IOException("Node failed\u001b[31m\nStatus: SPOOFED\u202e");
             }
 
             @Override
-            public ShipRun resume(String runId) {
+            public ShipRun resume(String runId, List<? extends ShipContext.Input> additions) {
                 throw new AssertionError("not resumed");
             }
         });
@@ -234,8 +397,13 @@ class ShipCommandTest {
 
         assertEquals(1, result.exitCode());
         assertEquals("", result.output());
+        assertEquals(1, result.error().lines().count(), result.error());
+        assertFalse(result.error().contains("\u001b"), result.error());
+        assertFalse(result.error().contains("\u202e"), result.error());
+        assertFalse(result.error().contains("\nStatus: SPOOFED"), result.error());
         assertTrue(result.error().matches(
-                "(?s)Error \\[workflow-failed]: Node is installed.*\\(run ship-[0-9a-f]{32}\\)\\R"),
+                "Error \\[workflow-failed]: Node failed \\[31m Status: SPOOFED +"
+                                          + "\\(run ship-[0-9a-f]{32}\\)\\R"),
                 result.error());
         String id = result.error().replaceAll("(?s).*\\(run (ship-[0-9a-f]{32})\\).*", "$1");
         assertEquals(id, controller.status(id).id(), "the reported run must be recoverable");
@@ -253,7 +421,7 @@ class ShipCommandTest {
             }
 
             @Override
-            public ShipRun resume(String runId) {
+            public ShipRun resume(String runId, List<? extends ShipContext.Input> additions) {
                 throw new AssertionError("not resumed");
             }
         });
@@ -277,7 +445,7 @@ class ShipCommandTest {
             }
 
             @Override
-            public ShipRun resume(String runId) {
+            public ShipRun resume(String runId, List<? extends ShipContext.Input> additions) {
                 throw new AssertionError("not resumed");
             }
         });
@@ -310,7 +478,9 @@ class ShipCommandTest {
             }
 
             @Override
-            public ShipRun resume(String runId) throws IOException {
+            public ShipRun resume(
+                    String runId, List<? extends ShipContext.Input> additions)
+                    throws IOException {
                 throw new IOException("Pi stage session is already running");
             }
         });
@@ -335,7 +505,7 @@ class ShipCommandTest {
             }
 
             @Override
-            public ShipRun resume(String runId) {
+            public ShipRun resume(String runId, List<? extends ShipContext.Input> additions) {
                 throw new AssertionError("not resumed");
             }
         });
@@ -475,7 +645,7 @@ class ShipCommandTest {
     }
 
     @Test
-    void rejectsExclusiveOperationsAndContextOnNonStartingOperations() throws Exception {
+    void rejectsExclusiveOperationsAndArgumentsOutsideTheirLifecycle() throws Exception {
         ShipController controller = controller("state");
         String id = "ship-0123456789abcdef0123456789abcdef";
 
@@ -486,14 +656,20 @@ class ShipCommandTest {
         RunResult context = run(controller, rejectingLauncher(), "--status", id, "--text", "not allowed");
         assertEquals(CommandLine.ExitCode.USAGE, context.exitCode());
         assertTrue(context.error().contains(
-                "--ask, --text, and --document are only valid when starting a run"),
+                "--text and --document are only valid when starting or resuming a run"),
                 context.error());
 
         RunResult oversight = run(controller, rejectingLauncher(), "--abort", id, "--ask", "never");
         assertEquals(CommandLine.ExitCode.USAGE, oversight.exitCode());
         assertTrue(oversight.error().contains(
-                "--ask, --text, and --document are only valid when starting a run"),
+                "--ask is only valid when starting a run"),
                 oversight.error());
+
+        RunResult resumedOversight = run(
+                controller, rejectingLauncher(), "--resume", id, "--ask", "always");
+        assertEquals(CommandLine.ExitCode.USAGE, resumedOversight.exitCode());
+        assertTrue(resumedOversight.error().contains(
+                "--ask is only valid when starting a run"), resumedOversight.error());
     }
 
     @Test
@@ -572,13 +748,17 @@ class ShipCommandTest {
 
         assertEquals(1, result.exitCode(), result.error());
         String id = runId(result.output());
-        assertEquals(summary(id, "FAILED", "DISCOVERY", "SMART"), result.output());
+        String message = "Pi stage could not run: Pi 0.81.1 is unverified; "
+                         + "install maintained Pi 0.83.0; explicitly accept experimental Pi "
+                         + "or Node before starting the stage";
+        assertEquals(summary(
+                id, "FAILED", "DISCOVERY", "SMART", "Message: " + message),
+                result.output());
         RunResult failedStatus = run(controller, new ShipRuntime(state), "--status", id);
         assertEquals(0, failedStatus.exitCode(),
                 "status queries report failed runs without a failing exit code");
-        assertTrue(controller.status(id).message().contains(
-                "Pi 0.81.1 is unverified; install maintained Pi"),
-                controller.status(id).message());
+        assertEquals(result.output(), failedStatus.output());
+        assertEquals(message, controller.status(id).message());
         assertFalse(Files.exists(fixture.resolve("args")),
                 "the gate must fire before any Pi process starts");
     }
@@ -632,13 +812,109 @@ class ShipCommandTest {
         return output.lines().findFirst().orElseThrow().substring("Run: ".length());
     }
 
-    private static String summary(String id, String status, String stage, String oversight) {
-        return String.join(System.lineSeparator(),
-                "Run: " + id,
-                "Status: " + status,
-                "Stage: " + stage,
-                "Oversight: " + oversight,
-                "");
+    private static ShipRun withMessage(ShipRun run, String message) {
+        return new ShipRun(
+                run.schemaVersion(),
+                run.id(),
+                run.projectDirectory(),
+                run.pipelineId(),
+                run.oversight(),
+                run.status(),
+                run.currentStage(),
+                run.context(),
+                run.stages(),
+                run.publication(),
+                run.createdAt(),
+                run.updatedAt(),
+                message);
+    }
+
+    private static RecordingLauncher evidenceLauncher(
+            ShipController controller,
+            ShipRun.RunStatus status,
+            Path stamp,
+            Path publication) {
+        return new RecordingLauncher(new ShipCommand.Workflow() {
+
+            @Override
+            public ShipRun run(String runId) {
+                return evidenceSnapshot(
+                        controller.status(runId), status, stamp, publication);
+            }
+
+            @Override
+            public ShipRun resume(
+                    String runId, List<? extends ShipContext.Input> additions) {
+                return evidenceSnapshot(
+                        controller.status(runId), status, stamp, publication);
+            }
+        });
+    }
+
+    private static ShipRun evidenceSnapshot(
+            ShipRun run,
+            ShipRun.RunStatus status,
+            Path stamp,
+            Path publication) {
+        String stampDigest = ShipDigest.sha256("stamp".getBytes(StandardCharsets.UTF_8));
+        List<ShipRun.StageRecord> stages = java.util.Arrays.stream(ShipRun.Stage.values())
+                .map(stage -> {
+                    boolean validation = stage == ShipRun.Stage.VALIDATE;
+                    return new ShipRun.StageRecord(
+                            stage,
+                            validation && status == ShipRun.RunStatus.FAILED
+                                    ? ShipRun.StageStatus.FAILED
+                                    : ShipRun.StageStatus.COMPLETED,
+                            1,
+                            ShipDigest.sha256(
+                                    (stage + " input").getBytes(StandardCharsets.UTF_8)),
+                            validation
+                                    ? stampDigest
+                                    : ShipDigest.sha256(
+                                            (stage + " output")
+                                                    .getBytes(StandardCharsets.UTF_8)),
+                            validation
+                                    ? List.of(new ShipRun.ArtifactRef(
+                                            stamp.toString(), stampDigest))
+                                    : List.of());
+                })
+                .toList();
+        ShipRun.ArtifactRef publicationRef = status == ShipRun.RunStatus.COMPLETED
+                ? new ShipRun.ArtifactRef(publication.toString(), stampDigest)
+                : null;
+        return new ShipRun(
+                run.schemaVersion(),
+                run.id(),
+                run.projectDirectory(),
+                run.pipelineId(),
+                run.oversight(),
+                status,
+                ShipRun.Stage.VALIDATE,
+                run.context(),
+                stages,
+                publicationRef,
+                run.createdAt(),
+                run.updatedAt(),
+                status == ShipRun.RunStatus.FAILED ? "Validation failed" : null);
+    }
+
+    private static String summary(
+            String id, String status, String stage, String oversight, String... details) {
+        List<String> lines = new ArrayList<>(
+                List.of(
+                        "Run: " + id,
+                        "Status: " + status,
+                        "Stage: " + stage,
+                        "Oversight: " + oversight));
+        lines.addAll(List.of(details));
+        if ("PAUSED".equals(status)) {
+            lines.add("Next: camel-kit ship --resume " + id
+                      + " [--text TEXT | --document PATH]");
+        } else if ("RUNNING".equals(status) || "FAILED".equals(status)) {
+            lines.add("Next: camel-kit ship --resume " + id);
+        }
+        lines.add("");
+        return String.join(System.lineSeparator(), lines);
     }
 
     /** Records launches and workflow invocations; the pass-through variant mirrors today's state. */
@@ -662,8 +938,9 @@ class ShipCommandTest {
                 }
 
                 @Override
-                public ShipRun resume(String runId) {
-                    return controller.resume(runId);
+                public ShipRun resume(
+                        String runId, List<? extends ShipContext.Input> additions) {
+                    return controller.resume(runId, additions);
                 }
             });
         }
@@ -681,9 +958,11 @@ class ShipCommandTest {
                 }
 
                 @Override
-                public ShipRun resume(String runId) throws IOException, InterruptedException {
+                public ShipRun resume(
+                        String runId, List<? extends ShipContext.Input> additions)
+                        throws IOException, InterruptedException {
                     invocations.add("resume:" + runId);
-                    return delegate.resume(runId);
+                    return delegate.resume(runId, additions);
                 }
             };
         }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -306,6 +306,22 @@ class ShipCommandTest {
                 "Message: Validation failed",
                 "Stamp: " + stamp), failed.output());
 
+        RunResult paused = run(
+                controller,
+                evidenceLauncher(
+                        controller, ShipRun.RunStatus.PAUSED, stamp, publication),
+                "--resume", id);
+
+        assertEquals(0, paused.exitCode(), paused.error());
+        assertEquals(summary(
+                id,
+                "PAUSED",
+                "VALIDATE",
+                "SMART",
+                "Paused after: VALIDATE",
+                "Stamp: " + stamp,
+                "Warning: Adding context restarts from DISCOVERY and discards the validation Stamp."), paused.output());
+
         RunResult completed = run(
                 controller,
                 evidenceLauncher(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -192,6 +192,112 @@ class ShipControllerTest {
     }
 
     @Test
+    void addedResumeContextIsAtomicAndRestartsTheEarliestStage() throws Exception {
+        String secret = "resume-context-secret-12345678";
+        Path project = Files.createDirectory(directory.resolve("project"));
+        Path document = Files.writeString(project.resolve("answer.md"), "document answer");
+        Path state = directory.resolve("state");
+        ShipController controller = new ShipController(
+                state, Map.of("SHIP_TEST_TOKEN", secret));
+        ShipRun started = controller.start(
+                project,
+                Oversight.SMART,
+                List.of(new ShipContext.TextInput("original context")));
+        ShipRun paused = controller.completeStage(
+                started.id(),
+                Stage.DISCOVERY,
+                started.stage(Stage.DISCOVERY).attempts(),
+                started.stage(Stage.DISCOVERY).inputDigest(),
+                digest("discovery result"),
+                List.of(),
+                true,
+                "Which deployment region should be used?");
+        assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals("Which deployment region should be used?", paused.message());
+
+        ShipController.Failure rejected = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.resume(
+                        paused.id(),
+                        List.of(new ShipContext.TextInput("answer: " + secret))));
+
+        assertEquals("context-secret-detected", rejected.code());
+        assertFalse(rejected.toString().contains(secret));
+        assertEquals(paused, controller.status(paused.id()));
+        assertFalse(Files.readString(state.resolve(paused.id()).resolve("state.json"))
+                .contains(secret));
+
+        ShipRun resumed = controller.resume(
+                paused.id(),
+                List.of(
+                        new ShipContext.TextInput("Use eu-west"),
+                        new ShipContext.DocumentInput(document.getFileName())));
+
+        assertEquals(RunStatus.RUNNING, resumed.status());
+        assertEquals(Stage.DISCOVERY, resumed.currentStage());
+        assertEquals(2, resumed.stage(Stage.DISCOVERY).attempts());
+        assertNotEquals(
+                paused.stage(Stage.DISCOVERY).inputDigest(),
+                resumed.stage(Stage.DISCOVERY).inputDigest());
+        assertEquals(StageStatus.PENDING, resumed.stage(Stage.DESIGN).status());
+        assertEquals(
+                List.of(
+                        ShipContext.Kind.TEXT,
+                        ShipContext.Kind.TEXT,
+                        ShipContext.Kind.DOCUMENT),
+                resumed.context().sources().stream().map(ShipContext.Source::kind).toList());
+        assertEquals(document.toAbsolutePath().normalize().toString(),
+                resumed.context().sources().get(2).value());
+        assertNull(resumed.message());
+        assertEquals(resumed, controller.status(resumed.id()));
+
+        ShipController.Failure duplicate = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.resume(
+                        resumed.id(),
+                        List.of(new ShipContext.TextInput("duplicate answer"))));
+        assertEquals("run-not-paused", duplicate.code());
+        assertEquals(resumed, controller.status(resumed.id()));
+
+        ShipController.Failure stale = assertThrows(
+                ShipController.Failure.class,
+                () -> controller.completeStage(
+                        paused.id(),
+                        Stage.DISCOVERY,
+                        paused.stage(Stage.DISCOVERY).attempts(),
+                        paused.stage(Stage.DISCOVERY).inputDigest(),
+                        digest("late result"),
+                        List.of(),
+                        false));
+        assertEquals("stale-stage-attempt", stale.code());
+    }
+
+    @Test
+    void pauseReportsKeepTheirQuestionTailWithinTheRunMessageBound() throws Exception {
+        Path project = Files.createDirectory(directory.resolve("project"));
+        ShipController controller = controller("state");
+        ShipRun started = controller.start(project, Oversight.SMART, List.of());
+        String question = "Question: Which deployment region should be used?";
+        String report = "Analysis:\n" + "x".repeat(ShipRun.MAX_MESSAGE_LENGTH) + '\n' + question;
+
+        ShipRun paused = controller.completeStage(
+                started.id(),
+                Stage.DISCOVERY,
+                started.stage(Stage.DISCOVERY).attempts(),
+                started.stage(Stage.DISCOVERY).inputDigest(),
+                digest("discovery result"),
+                List.of(),
+                true,
+                report);
+
+        assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals(ShipRun.MAX_MESSAGE_LENGTH, paused.message().length());
+        assertTrue(paused.message().startsWith("...\n"), paused.message());
+        assertTrue(paused.message().endsWith(question), paused.message());
+        assertEquals(paused, controller.status(paused.id()));
+    }
+
+    @Test
     void rejectsControllerStateInsideTheProjectBeforeCreatingIt() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         Path state = project.resolve("ship-state");
@@ -529,6 +635,9 @@ class ShipControllerTest {
 
         ShipRun.StageRecord validation = paused.stage(Stage.VALIDATE);
         assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals(
+                "Validation passed; approval is required before publication",
+                paused.message());
         assertEquals(StageStatus.COMPLETED, validation.status());
         assertEquals(List.of(stampPath.toRealPath().toString()),
                 validation.artifacts().stream().map(ShipRun.ArtifactRef::path).toList());
@@ -540,6 +649,7 @@ class ShipControllerTest {
 
         ShipRun pending = reloaded.resume(paused.id());
         assertEquals(RunStatus.RUNNING, pending.status());
+        assertNull(pending.message());
         assertTrue(pending.publicationPending());
 
         ShipRun completed = reloaded.publish(pending.id());
@@ -1814,6 +1924,9 @@ class ShipControllerTest {
                 waived);
         assertEquals(RunStatus.PAUSED, gated.status(),
                 "SMART pauses before publishing a waived validation");
+        assertEquals(
+                "Validation completed with a waiver; approval is required before publication",
+                gated.message());
 
         ShipController neverController = controller("waiver-never-state");
         ShipRun never = advanceToValidation(neverController, project, Oversight.NEVER);
@@ -1826,6 +1939,7 @@ class ShipControllerTest {
                 never.stage(Stage.VALIDATE).inputDigest(),
                 neverWaived);
         assertEquals(RunStatus.RUNNING, proceeding.status());
+        assertNull(proceeding.message());
         assertTrue(proceeding.publicationPending());
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -277,8 +277,9 @@ class ShipControllerTest {
         Path project = Files.createDirectory(directory.resolve("project"));
         ShipController controller = controller("state");
         ShipRun started = controller.start(project, Oversight.SMART, List.of());
-        String question = "Question: Which deployment region should be used?";
-        String report = "Analysis:\n" + "x".repeat(ShipRun.MAX_MESSAGE_LENGTH) + '\n' + question;
+        String unsafeQuestion = "Question:\tWhich deployment\rregion\u001bshould be used\u007f?";
+        String question = "Question: Which deployment region should be used ?";
+        String report = "Analysis:\n" + "x".repeat(ShipRun.MAX_MESSAGE_LENGTH) + '\n' + unsafeQuestion;
 
         ShipRun paused = controller.completeStage(
                 started.id(),
@@ -293,7 +294,7 @@ class ShipControllerTest {
         assertEquals(RunStatus.PAUSED, paused.status());
         assertEquals(ShipRun.MAX_MESSAGE_LENGTH, paused.message().length());
         assertTrue(paused.message().startsWith("...\n"), paused.message());
-        assertTrue(paused.message().endsWith(question), paused.message());
+        assertTrue(paused.message().endsWith("\n" + question), paused.message());
         assertEquals(paused, controller.status(paused.id()));
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -520,6 +520,14 @@ class ShipCoordinatorTest {
              FileLock ignored = channel.lock()) {
             assertEquals(run, coordinator.run(run.id()));
             assertEquals(run, coordinator.resume(run.id()));
+            IOException rejected = assertThrows(
+                    IOException.class,
+                    () -> coordinator.resume(
+                            run.id(),
+                            List.of(new ShipContext.TextInput("must not be dropped"))));
+            assertEquals(
+                    "Ship run is already active; context was not added",
+                    rejected.getMessage());
             assertEquals(run, controller.status(run.id()));
             assertFalse(Files.exists(fixture.resolve("session-ids")));
         }
@@ -584,6 +592,62 @@ class ShipCoordinatorTest {
                 List.of(
                         sessionId(run, Stage.DISCOVERY),
                         sessionId(completed, Stage.DISCOVERY)),
+                Files.readAllLines(fixture.resolve("session-ids")));
+        assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void resumeWithAddedContextRunsAFreshAttemptAndRetainsItsReport()
+            throws Exception {
+        writeDiscoveryResult(
+                "Question: Which deployment region should be used?");
+        ShipRun run = controller.start(
+                project,
+                Oversight.SMART,
+                List.of(new ShipContext.TextInput("Deploy the integration")));
+
+        ShipRun paused = coordinator.run(run.id());
+
+        assertEquals(RunStatus.PAUSED, paused.status());
+        assertEquals(
+                "Question: Which deployment region should be used?",
+                paused.message());
+        String firstDigest = paused.stage(Stage.DISCOVERY).inputDigest();
+
+        writeDiscoveryResult(
+                "Region accepted. Question: Which deployment window should be used?");
+        ShipRun resumed = coordinator.resume(
+                run.id(),
+                List.of(new ShipContext.TextInput("Use eu-west")));
+
+        assertEquals(RunStatus.PAUSED, resumed.status());
+        assertEquals(Stage.DESIGN, resumed.currentStage());
+        assertEquals(StageStatus.COMPLETED,
+                resumed.stage(Stage.DISCOVERY).status());
+        assertEquals(2, resumed.stage(Stage.DISCOVERY).attempts());
+        assertNotEquals(
+                firstDigest,
+                resumed.stage(Stage.DISCOVERY).inputDigest());
+        assertEquals(2, resumed.context().sources().size());
+        assertEquals(
+                "Use eu-west",
+                resumed.context().sources().get(1).value());
+        assertEquals(
+                "Region accepted. Question: Which deployment window should be used?",
+                resumed.message());
+
+        String secondDigest = resumed.stage(Stage.DISCOVERY).inputDigest();
+        Path briefing = state.resolve(run.id())
+                .resolve("inputs")
+                .resolve("discovery-"
+                         + secondDigest.substring("sha256:".length()) + ".md");
+        assertTrue(Files.readString(briefing).contains("Use eu-west"));
+        assertTrue(Files.readString(fixture.resolve("prompt")).contains(
+                "Do not ask for information already resolved by any context source."));
+        assertEquals(
+                List.of(
+                        sessionId(paused, Stage.DISCOVERY),
+                        sessionId(resumed, Stage.DISCOVERY)),
                 Files.readAllLines(fixture.resolve("session-ids")));
         assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
     }
@@ -766,7 +830,9 @@ class ShipCoordinatorTest {
         assertEquals(StageStatus.FAILED,
                 failed.stage(Stage.VALIDATE).status());
         assertEquals(1, failed.stage(Stage.VALIDATE).attempts());
-        assertEquals("Ship validation could not run", failed.message());
+        assertEquals(
+                "Ship validation could not run: Catalog unavailable",
+                failed.message());
         assertFalse(Files.exists(
                 state.resolve(run.id())
                         .resolve("evidence/validate-1/stamp.json")));
@@ -1005,7 +1071,9 @@ class ShipCoordinatorTest {
         assertEquals(StageStatus.FAILED,
                 failed.stage(Stage.VALIDATE).status());
         assertEquals(2, failed.stage(Stage.VALIDATE).attempts());
-        assertEquals("Ship validation could not run", failed.message());
+        assertEquals(
+                "Ship validation could not run: Catalog unavailable",
+                failed.message());
         assertTrue(failed.stage(Stage.VALIDATE).artifacts().isEmpty());
         assertEquals(stamp, ShipLocalStampStore.read(
                 attempt.evidenceDirectory(), run.id()));
@@ -1307,11 +1375,15 @@ class ShipCoordinatorTest {
     }
 
     private void writeDiscoveryResult() throws IOException {
+        writeDiscoveryResult("Discovery report");
+    }
+
+    private void writeDiscoveryResult(String report) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         var result = mapper.createObjectNode();
         result.put("schemaVersion", 1);
         result.put("pipelineId", "149-coordinator");
-        result.put("report", "Discovery report");
+        result.put("report", report);
         result.putNull("artifactPolicy");
         result.put("materialAmbiguity", true);
         Files.writeString(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -653,6 +653,45 @@ class ShipCoordinatorTest {
     }
 
     @Test
+    void reportsWhenContextWasRecordedBeforeContinuationFailed()
+            throws Exception {
+        writeDiscoveryResult(
+                "Question: Which deployment region should be used?");
+        ShipRun run = controller.start(
+                project,
+                Oversight.SMART,
+                List.of(new ShipContext.TextInput("Deploy the integration")));
+        ShipRun paused = coordinator.run(run.id());
+        assertEquals(RunStatus.PAUSED, paused.status());
+        Path inputs = state.resolve(run.id()).resolve("inputs");
+        Files.setPosixFilePermissions(
+                inputs, PosixFilePermissions.fromString("rwxr-xr-x"));
+        try {
+            ShipController.Failure failure = assertThrows(
+                    ShipController.Failure.class,
+                    () -> coordinator.resume(
+                            run.id(),
+                            List.of(new ShipContext.TextInput("Use eu-west"))));
+
+            assertEquals("worker-preparation-failed", failure.code());
+            assertEquals(
+                    "Ship context was recorded, but the run could not continue: "
+                         + "Could not prepare the Ship worker attempt for " + run.id(),
+                    failure.getMessage());
+            assertTrue(failure.getCause() instanceof ShipController.Failure);
+            ShipRun committed = controller.status(run.id());
+            assertEquals(RunStatus.RUNNING, committed.status());
+            assertEquals(2, committed.context().sources().size());
+            assertEquals(
+                    "Use eu-west",
+                    committed.context().sources().get(1).value());
+        } finally {
+            Files.setPosixFilePermissions(
+                    inputs, PosixFilePermissions.fromString("rwx------"));
+        }
+    }
+
+    @Test
     void invalidTypedResultCanResumeWithADistinctAttemptPrompt()
             throws Exception {
         ShipRun run = designRun(List.of(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunTest.java
@@ -100,6 +100,8 @@ class ShipRunTest {
         assertAll(
                 () -> assertDoesNotThrow(() -> run(RUNNING, DISCOVERY, runningStages, null)),
                 () -> assertDoesNotThrow(() -> run(PAUSED, DESIGN, pausedStages, null)),
+                () -> assertDoesNotThrow(() -> run(PAUSED, DESIGN, pausedStages,
+                        "Which database should the route use?")),
                 () -> assertDoesNotThrow(() -> run(FAILED, DISCOVERY, failedStages, "stage failed")),
                 () -> assertDoesNotThrow(() -> run(ABORTED, DISCOVERY, abortedStages, "cancelled")),
                 () -> assertDoesNotThrow(() -> run(COMPLETED, VALIDATE,
@@ -204,6 +206,11 @@ class ShipRunTest {
                                 "not-a-digest", null, List.of())),
                 () -> assertThrows(IllegalArgumentException.class,
                         () -> run(RUNNING, DISCOVERY, stages, null, "ship-ABC")),
+                () -> assertRejected(
+                        "Only paused, failed, or aborted runs carry a message",
+                        () -> run(RUNNING, DISCOVERY,
+                                replace(stages, DISCOVERY, stages.get(0).start(INPUT)),
+                                "not a running-state message")),
                 () -> assertThrows(IllegalArgumentException.class,
                         () -> run(RUNNING, DESIGN, stages, null)),
                 () -> assertThrows(IllegalArgumentException.class,
@@ -227,6 +234,10 @@ class ShipRunTest {
                 () -> assertRejected(
                         "Completed Ship run has no publication record",
                         () -> run(COMPLETED, VALIDATE, allComplete, null)),
+                () -> assertRejected(
+                        "Only paused, failed, or aborted runs carry a message",
+                        () -> run(COMPLETED, VALIDATE, allComplete,
+                                "not a completed-state message", PUBLICATION)),
                 () -> assertRejected(
                         "Only a completed Ship run retains a publication record with all stages complete",
                         () -> run(RUNNING, VALIDATE, allComplete, null, PUBLICATION)),


### PR DESCRIPTION
## Summary

- allow a paused Ship run to accept ordered `--text` and `--document` context during `--resume`, resolve it against the persisted project, and atomically restart the earliest stale stage
- retain a bounded, question-bearing pause report or validation approval reason while preserving exact-attempt recovery for plain resume
- make command summaries actionable and terminal-safe by showing pause details, failure and abort messages, retained Stamp and publication paths, safe resume commands, and concrete validation failures

## Design

This deliberately reuses `ShipContext`, existing stage-input digests, and the bounded `ShipRun.message` field. It does not add question IDs, answer history, or a separate Pi result-marker reader. A busy coordinator rejects added context instead of silently dropping it, and a committed answer cannot be appended twice.

The full Pi result remains in its existing durable marker; status retains only the actionable report tail. Prompts require unresolved questions to be grouped at the end of that report.

## Verification

- `./mvnw -B -pl camel-kit-core test` — 924 tests passed
- `./mvnw -B -Psourcecheck validate`
- `./mvnw -B clean install`

Website impact is required for the eventual public Ship cutover. It remains deferred within #149 because `ship` is still unregistered; registration, migration guidance, and website documentation belong to the later public-cutover slice.

Refs #149

## Summary by Sourcery

Make paused Ship runs recoverable with additional context and expose safe, actionable status information.

New Features:
- Allow paused Ship runs to accept ordered text and document context when resumed.
- Retain actionable pause reports and validation approval reasons for recovery and status inspection.
- Display actionable, terminal-safe run summaries with pause details, errors, artifacts, publication paths, and resume commands.

Bug Fixes:
- Prevent context from being silently discarded when a run or coordinator is already active.
- Preserve atomic recovery semantics when recording resume context or restarting stale stages.
- Sanitize persisted reports and failure messages before displaying them in the terminal.

Enhancements:
- Restart the earliest affected stage exactly once when new resume context changes its inputs.
- Improve validation failure reporting and preserve validation and publication evidence in run summaries.
- Bound retained run messages while preserving the actionable question tail.

Tests:
- Add coverage for contextual resume, atomic state updates, pause reports, actionable summaries, evidence retention, and terminal sanitization.