### PR TITLE
Register Ship with user configuration

### DIFF
--- a/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
+++ b/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
@@ -28,6 +28,8 @@ public class CamelKitPlugin implements Plugin {
                 .addSubcommand("doctor", new CommandLine(new DoctorCommand(camelKitMain)))
                 .addSubcommand("graph", new CommandLine(new GraphCommand()))
                 .addSubcommand("plan", new CommandLine(new PlanCommand()))
+                // The Camel root expands @files before dispatch and customize() has no argv. Disabling it here
+                // would affect every camel kit command, so Ship help documents attached and escaped literal forms.
                 .addSubcommand("ship", new CommandLine(new ShipCommand()));
 
         commandLine.addSubcommand("kit", kitCommand);

--- a/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
+++ b/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
@@ -8,6 +8,7 @@ import io.github.luigidemasi.camelkit.CamelKitMain;
 import io.github.luigidemasi.camelkit.command.DoctorCommand;
 import io.github.luigidemasi.camelkit.command.graph.GraphCommand;
 import io.github.luigidemasi.camelkit.command.plan.PlanCommand;
+import io.github.luigidemasi.camelkit.command.ship.ShipCommand;
 
 import picocli.CommandLine;
 
@@ -26,7 +27,8 @@ public class CamelKitPlugin implements Plugin {
                 .addSubcommand("init", new CommandLine(new KitInitCommand(main, camelKitMain)))
                 .addSubcommand("doctor", new CommandLine(new DoctorCommand(camelKitMain)))
                 .addSubcommand("graph", new CommandLine(new GraphCommand()))
-                .addSubcommand("plan", new CommandLine(new PlanCommand()));
+                .addSubcommand("plan", new CommandLine(new PlanCommand()))
+                .addSubcommand("ship", new CommandLine(new ShipCommand()));
 
         commandLine.addSubcommand("kit", kitCommand);
     }

--- a/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
+++ b/camel-jbang-plugin-kit/src/main/java/io/github/luigidemasi/camelkit/jbang/CamelKitPlugin.java
@@ -1,5 +1,10 @@
 package io.github.luigidemasi.camelkit.jbang;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Stack;
+
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CamelJBangPlugin;
 import org.apache.camel.dsl.jbang.core.common.Plugin;
@@ -28,10 +33,67 @@ public class CamelKitPlugin implements Plugin {
                 .addSubcommand("doctor", new CommandLine(new DoctorCommand(camelKitMain)))
                 .addSubcommand("graph", new CommandLine(new GraphCommand()))
                 .addSubcommand("plan", new CommandLine(new PlanCommand()))
-                // The Camel root expands @files before dispatch and customize() has no argv. Disabling it here
-                // would affect every camel kit command, so Ship help documents attached and escaped literal forms.
                 .addSubcommand("ship", new CommandLine(new ShipCommand()));
 
         commandLine.addSubcommand("kit", kitCommand);
+        preserveShipAtArguments(commandLine);
+    }
+
+    // Camel's plugin hook has no argv, while picocli expands @files before subcommand dispatch. Route expansion at the
+    // root so direct Ship context stays literal without changing argument-file behavior for sibling commands.
+    private static void preserveShipAtArguments(CommandLine commandLine) {
+        boolean expandAtFiles = commandLine.isExpandAtFiles();
+        CommandLine.IParameterPreprocessor inherited = commandLine.getCommandSpec().preprocessor();
+        commandLine.getCommandSpec().preprocessor((arguments, command, argument, info) -> {
+            if (expandAtFiles) {
+                if (isShipInvocation(arguments)) {
+                    arguments.replaceAll(value -> value.startsWith("@@") ? value.substring(1) : value);
+                } else if (hasArgumentFile(arguments)) {
+                    replace(arguments, expandArgumentFiles(commandLine, arguments));
+                }
+            }
+            return inherited.preprocess(arguments, command, argument, info);
+        });
+        commandLine.setExpandAtFiles(false);
+    }
+
+    private static boolean isShipInvocation(Stack<String> arguments) {
+        if (arguments.size() < 2 || !"kit".equals(arguments.peek())) {
+            return false;
+        }
+        int index = arguments.size() - 2;
+        while (index >= 0 && isKitVersionOption(arguments.get(index))) {
+            index--;
+        }
+        return index >= 0 && "ship".equals(arguments.get(index));
+    }
+
+    private static boolean isKitVersionOption(String argument) {
+        return "-V".equals(argument)
+                || argument.startsWith("-V=")
+                || "--version".equals(argument)
+                || argument.startsWith("--version=");
+    }
+
+    private static boolean hasArgumentFile(Stack<String> arguments) {
+        return arguments.stream().anyMatch(argument -> argument.length() > 1 && argument.charAt(0) == '@');
+    }
+
+    private static List<String> expandArgumentFiles(CommandLine commandLine, Stack<String> arguments) {
+        List<String> ordered = new ArrayList<>(arguments);
+        Collections.reverse(ordered);
+        return new CommandLine(CommandLine.Model.CommandSpec.create())
+                .setAtFileCommentChar(commandLine.getAtFileCommentChar())
+                .setUseSimplifiedAtFiles(commandLine.isUseSimplifiedAtFiles())
+                .setStopAtUnmatched(true)
+                .parseArgs(ordered.toArray(String[]::new))
+                .expandedArgs();
+    }
+
+    private static void replace(Stack<String> arguments, List<String> expanded) {
+        arguments.clear();
+        for (int index = expanded.size() - 1; index >= 0; index--) {
+            arguments.push(expanded.get(index));
+        }
     }
 }

--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
@@ -56,7 +56,7 @@ class CamelKitPluginTest {
     }
 
     @Test
-    void registersShipWithQualifiedHelpAndPreservesCamelArgumentFiles() throws Exception {
+    void registersShipWithQualifiedHelpAndDocumentsCamelArgumentFiles() throws Exception {
         Path arguments = Files.writeString(tempDir.resolve("ship-arguments"), "EXPANDED");
         String literal = "@" + arguments.toAbsolutePath();
         CamelJBangMain main = new CamelJBangMain();
@@ -72,7 +72,17 @@ class CamelKitPluginTest {
         CommandLine.ParseResult parsed = root.parseArgs("kit", "ship", "--text=" + literal);
         assertEquals(literal,
                 parsed.subcommand().subcommand().matchedOptionValue("--text", null));
+        CommandLine.ParseResult expanded = root.parseArgs("kit", "ship", "--text", literal);
+        assertEquals("EXPANDED",
+                expanded.subcommand().subcommand().matchedOptionValue("--text", null));
+        CommandLine.ParseResult escaped = root.parseArgs("kit", "ship", "--text", "@" + literal);
+        assertEquals(literal,
+                escaped.subcommand().subcommand().matchedOptionValue("--text", null));
         assertEquals(0, root.execute("kit", "ship", "--help"));
         assertTrue(output.toString().contains("Usage: camel kit ship"), output.toString());
+        assertTrue(output.toString().contains("--text=@value"), output.toString());
+        assertTrue(output.toString().contains("--text @@value"), output.toString());
+        assertTrue(output.toString().contains("--document=@path"), output.toString());
+        assertTrue(output.toString().contains("--document @@path"), output.toString());
     }
 }

--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
@@ -56,9 +56,11 @@ class CamelKitPluginTest {
     }
 
     @Test
-    void registersShipWithQualifiedHelpAndDocumentsCamelArgumentFiles() throws Exception {
-        Path arguments = Files.writeString(tempDir.resolve("ship-arguments"), "EXPANDED");
-        String literal = "@" + arguments.toAbsolutePath();
+    void preservesLiteralShipContextAndCamelArgumentFiles() throws Exception {
+        Path context = Files.writeString(tempDir.resolve("ship-context"), "EXPANDED VALUE");
+        Path arguments = Files.writeString(
+                tempDir.resolve("kit-arguments"), "kit init orders --ai codex");
+        String literal = "@" + context.toAbsolutePath();
         CamelJBangMain main = new CamelJBangMain();
         CommandLine root = new CommandLine(main);
         new CamelKitPlugin().customize(root, main);
@@ -66,23 +68,27 @@ class CamelKitPluginTest {
         StringWriter output = new StringWriter();
         root.setOut(new PrintWriter(output, true));
 
-        assertTrue(root.isExpandAtFiles());
         assertInstanceOf(ShipCommand.class, ship.getCommand());
         assertEquals("camel kit ship", ship.getCommandSpec().qualifiedName());
-        CommandLine.ParseResult parsed = root.parseArgs("kit", "ship", "--text=" + literal);
+        CommandLine.ParseResult parsed = root.parseArgs("kit", "ship", "--text", literal);
         assertEquals(literal,
                 parsed.subcommand().subcommand().matchedOptionValue("--text", null));
-        CommandLine.ParseResult expanded = root.parseArgs("kit", "ship", "--text", literal);
-        assertEquals("EXPANDED",
-                expanded.subcommand().subcommand().matchedOptionValue("--text", null));
+        CommandLine.ParseResult document = root.parseArgs("kit", "ship", "--document", literal);
+        assertEquals(Path.of(literal),
+                document.subcommand().subcommand().matchedOptionValue("--document", null));
         CommandLine.ParseResult escaped = root.parseArgs("kit", "ship", "--text", "@" + literal);
         assertEquals(literal,
                 escaped.subcommand().subcommand().matchedOptionValue("--text", null));
+        CommandLine.ParseResult parentOption = root.parseArgs("kit", "--version=true", "ship", "--text", literal);
+        assertEquals(literal,
+                parentOption.subcommand().subcommand().matchedOptionValue("--text", null));
+
+        CommandLine.ParseResult expanded = root.parseArgs("@" + arguments.toAbsolutePath());
+        CommandLine.ParseResult init = expanded.subcommand().subcommand();
+        assertEquals("orders", init.matchedPositionalValue(0, null));
+        assertEquals("codex", init.matchedOptionValue("--ai", null));
+
         assertEquals(0, root.execute("kit", "ship", "--help"));
         assertTrue(output.toString().contains("Usage: camel kit ship"), output.toString());
-        assertTrue(output.toString().contains("--text=@value"), output.toString());
-        assertTrue(output.toString().contains("--text @@value"), output.toString());
-        assertTrue(output.toString().contains("--document=@path"), output.toString());
-        assertTrue(output.toString().contains("--document @@path"), output.toString());
     }
 }

--- a/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
+++ b/camel-jbang-plugin-kit/src/test/java/io/github/luigidemasi/camelkit/jbang/CamelKitPluginTest.java
@@ -1,13 +1,24 @@
 package io.github.luigidemasi.camelkit.jbang;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 
+import io.github.luigidemasi.camelkit.command.ship.ShipCommand;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CamelKitPluginTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void kitInitDefaultsToBob2WhenAgentOptionIsOmitted() {
@@ -42,5 +53,26 @@ class CamelKitPluginTest {
         assertTrue(kit.getSubcommands().containsKey("doctor"));
         assertTrue(kit.getSubcommands().containsKey("graph"));
         assertTrue(kit.getSubcommands().containsKey("plan"));
+    }
+
+    @Test
+    void registersShipWithQualifiedHelpAndPreservesCamelArgumentFiles() throws Exception {
+        Path arguments = Files.writeString(tempDir.resolve("ship-arguments"), "EXPANDED");
+        String literal = "@" + arguments.toAbsolutePath();
+        CamelJBangMain main = new CamelJBangMain();
+        CommandLine root = new CommandLine(main);
+        new CamelKitPlugin().customize(root, main);
+        CommandLine ship = root.getSubcommands().get("kit").getSubcommands().get("ship");
+        StringWriter output = new StringWriter();
+        root.setOut(new PrintWriter(output, true));
+
+        assertTrue(root.isExpandAtFiles());
+        assertInstanceOf(ShipCommand.class, ship.getCommand());
+        assertEquals("camel kit ship", ship.getCommandSpec().qualifiedName());
+        CommandLine.ParseResult parsed = root.parseArgs("kit", "ship", "--text=" + literal);
+        assertEquals(literal,
+                parsed.subcommand().subcommand().matchedOptionValue("--text", null));
+        assertEquals(0, root.execute("kit", "ship", "--help"));
+        assertTrue(output.toString().contains("Usage: camel kit ship"), output.toString());
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/CamelKitMain.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/CamelKitMain.java
@@ -11,6 +11,7 @@ import io.github.luigidemasi.camelkit.command.doc.DocCommand;
 import io.github.luigidemasi.camelkit.command.graph.GraphCommand;
 import io.github.luigidemasi.camelkit.command.pipeline.NextIdCommand;
 import io.github.luigidemasi.camelkit.command.plan.PlanCommand;
+import io.github.luigidemasi.camelkit.command.ship.ShipCommand;
 import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.output.JLinePrinter;
 import io.github.luigidemasi.camelkit.output.Printer;
@@ -146,16 +147,25 @@ public class CamelKitMain implements Callable<Integer> {
     }
 
     public static void run(CamelKitMain main, String... args) {
+        int exitCode = commandLine(main, args).execute(args);
+        System.exit(exitCode);
+    }
+
+    static CommandLine commandLine(CamelKitMain main, String... args) {
         CommandLine commandLine = new CommandLine(main)
                 .addSubcommand("init", new InitCommand(main))
                 .addSubcommand("doctor", new DoctorCommand(main))
                 .addSubcommand("doc", new CommandLine(new DocCommand()))
                 .addSubcommand("graph", new CommandLine(new GraphCommand()))
                 .addSubcommand("plan", new CommandLine(new PlanCommand()))
-                .addSubcommand("nextId", new NextIdCommand());
+                .addSubcommand("nextId", new NextIdCommand())
+                .addSubcommand("ship", new CommandLine(new ShipCommand()));
 
-        int exitCode = commandLine.execute(args);
-        System.exit(exitCode);
+        // Picocli expands @files at the root before dispatching; only direct Ship invocations need literals.
+        if (args.length > 0 && "ship".equals(args[0])) {
+            commandLine.setExpandAtFiles(false);
+        }
+        return commandLine;
     }
 
     @Override

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -398,10 +398,18 @@ public final class ShipCommand implements Callable<Integer> {
 
     static final class ContextArgument {
 
-        @Option(names = "--text", paramLabel = "TEXT", description = "Add text context")
+        @Option(
+                names = "--text",
+                paramLabel = "TEXT",
+                description = "Add text context (camel kit ship: use --text=@value or --text @@value"
+                              + " for a leading @)")
         String text;
 
-        @Option(names = "--document", paramLabel = "PATH", description = "Add document context")
+        @Option(
+                names = "--document",
+                paramLabel = "PATH",
+                description = "Add document context (camel kit ship: use --document=@path or --document @@path"
+                              + " for a leading @)")
         Path document;
 
         ShipContext.Input input() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -29,7 +29,7 @@ import picocli.CommandLine.TypeConversionException;
 
 /**
  * Local Ship command. Starting or resuming a run drives the authoritative coordinator workflow; status and abort remain
- * pure controller operations. Kept unregistered until the publication, interaction, and documentation gates pass.
+ * pure controller operations.
  */
 @Command(
          name = "ship",
@@ -37,8 +37,8 @@ import picocli.CommandLine.TypeConversionException;
          description = "Start, inspect, resume, or abort a local Camel Ship run")
 public final class ShipCommand implements Callable<Integer> {
 
-    private final ShipController controller;
-    private final WorkflowLauncher launcher;
+    private ShipController controller;
+    private WorkflowLauncher launcher;
 
     @Spec
     CommandLine.Model.CommandSpec spec;
@@ -90,9 +90,20 @@ public final class ShipCommand implements Callable<Integer> {
             description = "Accept an experimental Pi or Node version after its warning")
     Boolean acceptExperimental;
 
+    @Option(
+            names = {"-c", "--config"},
+            paramLabel = "PATH",
+            description = "Config properties file (default: ~/.camel-kit/config.properties)")
+    Path configFile;
+
+    @Option(
+            names = {"-p", "--property"},
+            paramLabel = "KEY=VALUE",
+            description = "Override a config property (repeatable)")
+    List<String> configProperties = new ArrayList<>();
+
     public ShipCommand() {
-        this(new ShipController(ShipController.defaultStateRoot()),
-             new ShipRuntime(ShipController.defaultStateRoot()));
+        this(null, null);
     }
 
     ShipCommand(ShipController controller, WorkflowLauncher launcher) {
@@ -116,10 +127,10 @@ public final class ShipCommand implements Callable<Integer> {
 
     private ShipRun execute() {
         if (operation != null && operation.status != null) {
-            return controller.status(operation.status);
+            return controller().status(operation.status);
         }
         if (operation != null && operation.abort != null) {
-            return controller.abort(operation.abort);
+            return controller().abort(operation.abort);
         }
         Workflow workflow = launchWorkflow();
         if (operation != null && operation.resume != null) {
@@ -128,8 +139,8 @@ public final class ShipCommand implements Callable<Integer> {
                     runId -> workflow.resume(runId, additions), operation.resume);
         }
         ShipRun run = operation == null
-                ? controller.start(projectDirectory, selectedOversight(), inputs())
-                : controller.startFrom(projectDirectory, operation.startFrom, selectedOversight(), inputs());
+                ? controller().start(projectDirectory, selectedOversight(), inputs())
+                : controller().startFrom(projectDirectory, operation.startFrom, selectedOversight(), inputs());
         return awaitWorkflow(workflow::run, run.id());
     }
 
@@ -139,12 +150,14 @@ public final class ShipCommand implements Callable<Integer> {
 
     private Workflow launchWorkflow() {
         try {
-            return launcher.launch(new RuntimeSettings(
+            return launcher().launch(new RuntimeSettings(
                     piExecutable,
                     nodeExecutable,
                     mavenRepository,
                     stageTimeout,
-                    Boolean.TRUE.equals(acceptExperimental)));
+                    Boolean.TRUE.equals(acceptExperimental),
+                    configFile,
+                    configProperties));
         } catch (IllegalArgumentException e) {
             throw new CommandFailure("runtime-unavailable", e.getMessage(), e);
         } catch (IllegalStateException e) {
@@ -181,7 +194,7 @@ public final class ShipCommand implements Callable<Integer> {
     private ShipRun statusAfterInterrupt(String runId) {
         Thread.interrupted();
         try {
-            return controller.status(runId);
+            return controller().status(runId);
         } finally {
             Thread.currentThread().interrupt();
         }
@@ -189,6 +202,26 @@ public final class ShipCommand implements Callable<Integer> {
 
     private static String runReference(String runId) {
         return " (run " + runId + ")";
+    }
+
+    private ShipController controller() {
+        if (controller == null) {
+            try {
+                controller = new ShipController(ShipController.defaultStateRoot());
+            } catch (IllegalArgumentException e) {
+                throw new CommandFailure("runtime-unavailable", e.getMessage(), e);
+            } catch (IllegalStateException e) {
+                throw new CommandFailure("runtime-unsupported", e.getMessage(), e);
+            }
+        }
+        return controller;
+    }
+
+    private WorkflowLauncher launcher() {
+        if (launcher == null) {
+            launcher = new ShipRuntime(ShipController.defaultStateRoot());
+        }
+        return launcher;
     }
 
     private void validateArguments() {
@@ -205,11 +238,11 @@ public final class ShipCommand implements Callable<Integer> {
         }
         if (operation != null && (operation.status != null || operation.abort != null)
                 && (piExecutable != null || nodeExecutable != null || mavenRepository != null
-                        || stageTimeout != null || acceptExperimental != null)) {
+                        || stageTimeout != null || acceptExperimental != null || configFile != null
+                        || !configProperties.isEmpty())) {
             throw new ParameterException(
                     spec.commandLine(),
-                    "--pi, --node, --maven-repository, --stage-timeout, and --accept-experimental"
-                                        + " are only valid when starting or resuming a run");
+                    "Runtime and config options are only valid when starting or resuming a run");
         }
     }
 
@@ -245,15 +278,21 @@ public final class ShipCommand implements Callable<Integer> {
         if (run.publication() != null) {
             writer.println("Publication: " + safeDisplay(run.publication().path(), false));
         }
+        if ((run.status() == ShipRun.RunStatus.PAUSED
+                || run.status() == ShipRun.RunStatus.RUNNING
+                || run.status() == ShipRun.RunStatus.FAILED)
+                && (configFile != null || !configProperties.isEmpty())) {
+            writer.println("Config: Repeat the same -c/-p options when resuming this run.");
+        }
         if (run.status() == ShipRun.RunStatus.PAUSED) {
             if (pausedAfter(run) == Stage.VALIDATE) {
                 writer.println("Warning: Adding context restarts from DISCOVERY and discards the validation Stamp.");
             }
-            writer.println("Next: camel-kit ship --resume " + run.id()
+            writer.println("Next: " + spec.qualifiedName() + " --resume " + run.id()
                            + " [--text TEXT | --document PATH]");
         } else if (run.status() == ShipRun.RunStatus.RUNNING
                 || run.status() == ShipRun.RunStatus.FAILED) {
-            writer.println("Next: camel-kit ship --resume " + run.id());
+            writer.println("Next: " + spec.qualifiedName() + " --resume " + run.id());
         }
         writer.flush();
     }
@@ -316,7 +355,8 @@ public final class ShipCommand implements Callable<Integer> {
 
     /** Raw runtime option values; the launcher resolves defaults and discovery. */
     record RuntimeSettings(Path piExecutable, Path nodeExecutable, Path mavenRepository,
-            Duration stageTimeout, boolean acceptExperimental) {
+            Duration stageTimeout, boolean acceptExperimental, Path configFile,
+            List<String> configProperties) {
     }
 
     @FunctionalInterface

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipCommand.java
@@ -398,18 +398,10 @@ public final class ShipCommand implements Callable<Integer> {
 
     static final class ContextArgument {
 
-        @Option(
-                names = "--text",
-                paramLabel = "TEXT",
-                description = "Add text context (camel kit ship: use --text=@value or --text @@value"
-                              + " for a leading @)")
+        @Option(names = "--text", paramLabel = "TEXT", description = "Add text context")
         String text;
 
-        @Option(
-                names = "--document",
-                paramLabel = "PATH",
-                description = "Add document context (camel kit ship: use --document=@path or --document @@path"
-                              + " for a leading @)")
+        @Option(names = "--document", paramLabel = "PATH", description = "Add document context")
         Path document;
 
         ShipContext.Input input() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntime.java
@@ -21,9 +21,8 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
  * <p>
  * Executable paths come from explicit options or PATH discovery; the maintained Pi/Node support pins always come from
  * the bundled distribution inside {@link ShipCoordinator}, so no option here can promote an unmaintained version beyond
- * an experimental run. The bundled distribution also drives artifact policy for now: the user config cascade prints
- * progress to stdout while loading, which would corrupt the command's summary contract, so wiring it up belongs to the
- * registration slice.
+ * an experimental run. User configuration is loaded only when a start or resume operation launches the workflow and
+ * drives the Camel and Citrus artifact policy.
  * </p>
  */
 final class ShipRuntime implements ShipCommand.WorkflowLauncher {
@@ -55,7 +54,8 @@ final class ShipRuntime implements ShipCommand.WorkflowLauncher {
                 resolved.piExecutable(),
                 resolved.nodeExecutable(),
                 resolved.mavenRepository(),
-                DistributionConfig.loadBundled(),
+                DistributionConfig.loadWithOverridesStrict(
+                        resolved.configFile(), resolved.configProperties()),
                 resolved.stageTimeout(),
                 resolved.acceptExperimental());
         return new ShipCommand.Workflow() {
@@ -83,7 +83,9 @@ final class ShipRuntime implements ShipCommand.WorkflowLauncher {
                         ? stateRoot.resolve(CATALOG_REPOSITORY)
                         : settings.mavenRepository(),
                 settings.stageTimeout() == null ? DEFAULT_STAGE_TIMEOUT : settings.stageTimeout(),
-                settings.acceptExperimental());
+                settings.acceptExperimental(),
+                settings.configFile(),
+                settings.configProperties());
     }
 
     private Path resolveExecutable(Path configured, String name, String label) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -2,11 +2,11 @@ package io.github.luigidemasi.camelkit.config;
 
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -90,13 +90,34 @@ public class DistributionConfig {
      * @return               merged configuration
      */
     public static DistributionConfig loadWithOverrides(Path configFile, List<String> cliProperties) {
+        return loadWithOverrides(configFile, cliProperties, DEFAULT_USER_CONFIG, false);
+    }
+
+    /** Loads the same cascade but rejects a present configuration that cannot be applied exactly. */
+    public static DistributionConfig loadWithOverridesStrict(Path configFile, List<String> cliProperties) {
+        return loadWithOverrides(configFile, cliProperties, DEFAULT_USER_CONFIG, true);
+    }
+
+    static DistributionConfig loadWithOverridesStrict(
+            Path configFile, List<String> cliProperties, Path defaultConfig) {
+        return loadWithOverrides(configFile, cliProperties, defaultConfig, true);
+    }
+
+    private static DistributionConfig loadWithOverrides(
+            Path configFile, List<String> cliProperties, Path defaultConfig, boolean strict) {
         // Layer 1: built-in defaults from classpath
         Properties props = loadClasspathProperties();
 
         // Layer 2: user config file (-c or default location)
         int overrides = 0;
-        Path userConfig = configFile != null ? configFile : DEFAULT_USER_CONFIG;
-        if (Files.exists(userConfig)) {
+        Path userConfig = configFile != null ? configFile : defaultConfig;
+        boolean present = configFile != null || (strict
+                ? !Files.notExists(userConfig, LinkOption.NOFOLLOW_LINKS)
+                : Files.exists(userConfig));
+        if (strict && present && !Files.isRegularFile(userConfig)) {
+            throw new IllegalArgumentException("Config file is missing or not a regular file: " + userConfig);
+        }
+        if (present) {
             try (InputStream in = Files.newInputStream(userConfig)) {
                 Properties userProps = new Properties();
                 userProps.load(in);
@@ -104,23 +125,29 @@ public class DistributionConfig {
                     props.setProperty(key, userProps.getProperty(key));
                     overrides++;
                 }
-                System.out.printf(Locale.ROOT, "  Config: %s (%d overrides)%n", userConfig, userProps.size());
             } catch (Exception e) {
-                System.out.printf(Locale.ROOT, "  WARN: Failed to load config from %s: %s%n", userConfig,
-                        e.getMessage());
+                if (strict) {
+                    throw new IllegalArgumentException(
+                            "Failed to load config from " + userConfig, e);
+                }
             }
         }
 
         // Layer 3: CLI -p overrides (highest priority)
         if (cliProperties != null) {
             for (String prop : cliProperties) {
-                int eq = prop.indexOf('=');
-                if (eq > 0) {
-                    String key = prop.substring(0, eq).trim();
-                    String value = prop.substring(eq + 1).trim();
-                    props.setProperty(key, value);
-                    overrides++;
+                int eq = prop == null ? -1 : prop.indexOf('=');
+                String key = eq < 0 ? "" : prop.substring(0, eq).trim();
+                if (key.isEmpty()) {
+                    if (strict) {
+                        throw new IllegalArgumentException(
+                                "Invalid config property; expected key=value");
+                    }
+                    continue;
                 }
+                String value = prop.substring(eq + 1).trim();
+                props.setProperty(key, value);
+                overrides++;
             }
         }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -115,7 +116,8 @@ public class DistributionConfig {
                 ? !Files.notExists(userConfig, LinkOption.NOFOLLOW_LINKS)
                 : Files.exists(userConfig));
         if (strict && present && !Files.isRegularFile(userConfig)) {
-            throw new IllegalArgumentException("Config file is missing or not a regular file: " + userConfig);
+            throw new IllegalArgumentException(
+                    "Config file is missing, unreadable, or not a regular file: " + userConfig);
         }
         if (present) {
             try (InputStream in = Files.newInputStream(userConfig)) {
@@ -130,6 +132,8 @@ public class DistributionConfig {
                     throw new IllegalArgumentException(
                             "Failed to load config from " + userConfig, e);
                 }
+                System.err.printf(Locale.ROOT, "WARN: Failed to load config from %s: %s%n", userConfig,
+                        e.getMessage());
             }
         }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -52,12 +52,7 @@ import io.github.luigidemasi.camelkit.ship.worker.PiWorker.UntrustedResultExcept
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/**
- * Concrete local composition of the compact Ship controller, Pi worker, and deterministic Main validation.
- *
- * <p>
- * The command remains unregistered until the live Pi/Linux and publication gates pass.
- */
+/** Concrete local composition of the compact Ship controller, Pi worker, and deterministic Main validation. */
 public final class ShipCoordinator {
 
     private static final long ABORT_POLL_MILLIS = 50;

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/CamelKitMainShipTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/CamelKitMainShipTest.java
@@ -1,0 +1,72 @@
+package io.github.luigidemasi.camelkit;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelKitMainShipTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void registersShipWithQualifiedHelp() {
+        CamelKitMain main = new CamelKitMain();
+        try {
+            CommandLine root = CamelKitMain.commandLine(main, "ship", "--help");
+            CommandLine ship = root.getSubcommands().get("ship");
+            StringWriter output = new StringWriter();
+            root.setOut(new PrintWriter(output, true));
+
+            assertNotNull(ship);
+            assertEquals("camel-kit ship", ship.getCommandSpec().qualifiedName());
+            assertFalse(root.isExpandAtFiles());
+            assertEquals(0, root.execute("ship", "--help"));
+            assertTrue(output.toString().contains("Usage: camel-kit ship"), output.toString());
+            assertTrue(output.toString().contains("-c, --config"), output.toString());
+            assertTrue(output.toString().contains("-p, --property"), output.toString());
+        } finally {
+            main.closeTerminal();
+        }
+    }
+
+    @Test
+    void preservesLiteralAtContextForShip() throws Exception {
+        Path arguments = Files.writeString(tempDir.resolve("ship-arguments"), "EXPANDED");
+        String literal = "@" + arguments.toAbsolutePath();
+        CamelKitMain main = new CamelKitMain();
+        try {
+            CommandLine root = CamelKitMain.commandLine(main, "ship", "--text", literal);
+
+            CommandLine.ParseResult parsed = root.parseArgs("ship", "--text", literal);
+
+            assertEquals(literal, parsed.subcommand().matchedOptionValue("--text", null));
+        } finally {
+            main.closeTerminal();
+        }
+    }
+
+    @Test
+    void retainsArgumentFileExpansionForOtherStandaloneInvocations() throws Exception {
+        Path arguments = Files.writeString(tempDir.resolve("root-arguments"), "--version\n");
+        CamelKitMain main = new CamelKitMain();
+        try {
+            CommandLine root = CamelKitMain.commandLine(main, "@" + arguments.toAbsolutePath());
+
+            assertTrue(root.isExpandAtFiles());
+            assertTrue(root.parseArgs("@" + arguments.toAbsolutePath()).isVersionHelpRequested());
+        } finally {
+            main.closeTerminal();
+        }
+    }
+}

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/CamelKitMainShipTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/CamelKitMainShipTest.java
@@ -51,6 +51,8 @@ class CamelKitMainShipTest {
             CommandLine.ParseResult parsed = root.parseArgs("ship", "--text", literal);
 
             assertEquals(literal, parsed.subcommand().matchedOptionValue("--text", null));
+            CommandLine.ParseResult document = root.parseArgs("ship", "--document", literal);
+            assertEquals(Path.of(literal), document.subcommand().matchedOptionValue("--document", null));
         } finally {
             main.closeTerminal();
         }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -552,7 +552,10 @@ class ShipCommandTest {
                 "--node", "/opt/node/bin/node",
                 "--maven-repository", "/tmp/ship-repo",
                 "--stage-timeout", "90s",
-                "--accept-experimental");
+                "--accept-experimental",
+                "--config", "/tmp/ship.properties",
+                "--property", "camel.main.version=9.9.8",
+                "--property", "camel.main.version=9.9.9");
 
         assertEquals(0, result.exitCode(), result.error());
         ShipCommand.RuntimeSettings settings = launcher.settings;
@@ -561,6 +564,12 @@ class ShipCommandTest {
         assertEquals(Path.of("/tmp/ship-repo"), settings.mavenRepository());
         assertEquals(Duration.ofSeconds(90), settings.stageTimeout());
         assertTrue(settings.acceptExperimental());
+        assertEquals(Path.of("/tmp/ship.properties"), settings.configFile());
+        assertEquals(
+                List.of("camel.main.version=9.9.8", "camel.main.version=9.9.9"),
+                settings.configProperties());
+        assertTrue(result.output().contains(
+                "Config: Repeat the same -c/-p options when resuming this run."), result.output());
     }
 
     @Test
@@ -578,6 +587,8 @@ class ShipCommandTest {
         assertNull(settings.mavenRepository());
         assertNull(settings.stageTimeout());
         assertFalse(settings.acceptExperimental());
+        assertNull(settings.configFile());
+        assertTrue(settings.configProperties().isEmpty());
     }
 
     @Test
@@ -590,7 +601,9 @@ class ShipCommandTest {
                 new String[]{"--status", id, "--stage-timeout", "10m"},
                 new String[]{"--abort", id, "--accept-experimental"},
                 new String[]{"--abort", id, "--maven-repository", "/tmp/repo"},
-                new String[]{"--status", id, "--node", "/opt/node"})) {
+                new String[]{"--status", id, "--node", "/opt/node"},
+                new String[]{"--status", id, "--config", "/tmp/config"},
+                new String[]{"--abort", id, "--property", "camel.main.version=9.9.9"})) {
             RunResult result = run(controller, RecordingLauncher.passThrough(controller), arguments);
             assertEquals(CommandLine.ExitCode.USAGE, result.exitCode());
             assertTrue(result.error().contains(
@@ -700,6 +713,25 @@ class ShipCommandTest {
     }
 
     @Test
+    void resumeHintUsesTheRegisteredQualifiedCommandName() throws Exception {
+        Path project = Files.createDirectory(tempDir.resolve("qualified-project"));
+        ShipController controller = controller("qualified-state");
+        ShipRun started = controller.start(project, ShipRun.Oversight.SMART, List.of());
+
+        RunResult result = runAs(
+                "camel kit ship",
+                controller,
+                rejectingLauncher(),
+                "--status",
+                started.id());
+
+        assertEquals(0, result.exitCode(), result.error());
+        assertTrue(result.output().contains(
+                "Next: camel kit ship --resume " + started.id() + System.lineSeparator()),
+                result.output());
+    }
+
+    @Test
     void reportsDistinctDocumentFailuresAsOperationalErrors() throws Exception {
         Path project = Files.createDirectory(tempDir.resolve("project"));
         Path empty = Files.createFile(project.resolve("empty.txt"));
@@ -751,6 +783,7 @@ class ShipCommandTest {
         Files.writeString(fixture.resolve("version"), "0.81.1\n");
         Path project = Files.createDirectory(tempDir.resolve("project"));
         Path state = tempDir.resolve("state");
+        Path config = Files.createFile(tempDir.resolve("ship.properties"));
         ShipController controller = new ShipController(state);
 
         RunResult result = run(
@@ -759,6 +792,7 @@ class ShipCommandTest {
                 "--project-dir", project.toString(),
                 "--pi", fixture.resolve("pi-rpc").toString(),
                 "--node", node.toString(),
+                "--config", config.toString(),
                 "--stage-timeout", "30s",
                 "--text", "unverified Pi must fail the stage");
 
@@ -768,12 +802,19 @@ class ShipCommandTest {
                          + "install maintained Pi 0.83.0; explicitly accept experimental Pi "
                          + "or Node before starting the stage";
         assertEquals(summary(
-                id, "FAILED", "DISCOVERY", "SMART", "Message: " + message),
+                id,
+                "FAILED",
+                "DISCOVERY",
+                "SMART",
+                "Message: " + message,
+                "Config: Repeat the same -c/-p options when resuming this run."),
                 result.output());
         RunResult failedStatus = run(controller, new ShipRuntime(state), "--status", id);
         assertEquals(0, failedStatus.exitCode(),
                 "status queries report failed runs without a failing exit code");
-        assertEquals(result.output(), failedStatus.output());
+        assertEquals(summary(
+                id, "FAILED", "DISCOVERY", "SMART", "Message: " + message),
+                failedStatus.output());
         assertEquals(message, controller.status(id).message());
         assertFalse(Files.exists(fixture.resolve("args")),
                 "the gate must fire before any Pi process starts");
@@ -806,9 +847,18 @@ class ShipCommandTest {
 
     private static RunResult run(
             ShipController controller, ShipCommand.WorkflowLauncher launcher, String... args) {
+        return runAs("camel-kit ship", controller, launcher, args);
+    }
+
+    private static RunResult runAs(
+            String commandName,
+            ShipController controller,
+            ShipCommand.WorkflowLauncher launcher,
+            String... args) {
         StringWriter output = new StringWriter();
         StringWriter error = new StringWriter();
         CommandLine commandLine = new CommandLine(new ShipCommand(controller, launcher));
+        commandLine.setCommandName(commandName);
         commandLine.setExpandAtFiles(false);
         commandLine.setOut(new PrintWriter(output, true));
         commandLine.setErr(new PrintWriter(error, true));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntimeTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipRuntimeTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -83,7 +84,7 @@ class ShipRuntimeTest {
         ShipRuntime runtime = new ShipRuntime(state, binDirectory.toString());
 
         ShipCommand.RuntimeSettings defaults = runtime.resolve(new ShipCommand.RuntimeSettings(
-                null, null, null, null, false));
+                null, null, null, null, false, null, List.of()));
         assertEquals(binDirectory.resolve("pi"), defaults.piExecutable());
         assertEquals(binDirectory.resolve("node"), defaults.nodeExecutable());
         assertEquals(state.toAbsolutePath().normalize().resolve(ShipRuntime.CATALOG_REPOSITORY),
@@ -92,12 +93,15 @@ class ShipRuntimeTest {
         assertFalse(defaults.acceptExperimental());
 
         ShipCommand.RuntimeSettings explicit = runtime.resolve(new ShipCommand.RuntimeSettings(
-                explicitPi, explicitPi, tempDir.resolve("repo"), Duration.ofSeconds(90), true));
+                explicitPi, explicitPi, tempDir.resolve("repo"), Duration.ofSeconds(90), true,
+                tempDir.resolve("config"), List.of("camel.main.version=9.9.9")));
         assertEquals(explicitPi, explicit.piExecutable());
         assertEquals(explicitPi, explicit.nodeExecutable());
         assertEquals(tempDir.resolve("repo"), explicit.mavenRepository());
         assertEquals(Duration.ofSeconds(90), explicit.stageTimeout());
         assertTrue(explicit.acceptExperimental());
+        assertEquals(tempDir.resolve("config"), explicit.configFile());
+        assertEquals(List.of("camel.main.version=9.9.9"), explicit.configProperties());
     }
 
     @Test
@@ -107,7 +111,7 @@ class ShipRuntimeTest {
         IllegalArgumentException missing = assertThrows(
                 IllegalArgumentException.class,
                 () -> runtime.resolve(new ShipCommand.RuntimeSettings(
-                        null, null, null, null, false)));
+                        null, null, null, null, false, null, List.of())));
 
         assertEquals(
                 "Pi is missing or not executable; install Pi and configure its executable path",
@@ -124,7 +128,7 @@ class ShipRuntimeTest {
         IllegalArgumentException missing = assertThrows(
                 IllegalArgumentException.class,
                 () -> runtime.resolve(new ShipCommand.RuntimeSettings(
-                        null, null, null, null, false)));
+                        null, null, null, null, false, null, List.of())));
 
         assertEquals(
                 "Node is missing or not executable; install Node and configure its executable path",
@@ -140,7 +144,7 @@ class ShipRuntimeTest {
         IllegalArgumentException missing = assertThrows(
                 IllegalArgumentException.class,
                 () -> runtime.launch(new ShipCommand.RuntimeSettings(
-                        absent, absent, null, null, false)));
+                        absent, absent, null, null, false, null, List.of())));
 
         assertTrue(missing.getMessage().contains("install Pi"), missing.getMessage());
     }
@@ -151,13 +155,33 @@ class ShipRuntimeTest {
         Path binDirectory = Files.createDirectory(tempDir.resolve("bin"));
         writeExecutable(binDirectory.resolve("pi"));
         writeExecutable(binDirectory.resolve("node"));
+        Path configFile = Files.createFile(tempDir.resolve("config.properties"));
         ShipRuntime runtime = new ShipRuntime(
                 tempDir.resolve("state"), binDirectory.toString());
 
         ShipCommand.Workflow workflow = runtime.launch(new ShipCommand.RuntimeSettings(
-                null, null, null, Duration.ofSeconds(5), false));
+                null, null, null, Duration.ofSeconds(5), false, configFile, List.of()));
 
         assertNotNull(workflow);
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void loadsUserConfigurationOnlyWhenLaunchingTheWorkflow() throws Exception {
+        Path binDirectory = Files.createDirectory(tempDir.resolve("config-bin"));
+        writeExecutable(binDirectory.resolve("pi"));
+        writeExecutable(binDirectory.resolve("node"));
+        Path configFile = tempDir.resolve("missing-ship.properties");
+        ShipRuntime runtime = new ShipRuntime(
+                tempDir.resolve("config-state"), binDirectory.toString());
+        ShipCommand.RuntimeSettings settings = new ShipCommand.RuntimeSettings(
+                null, null, null, Duration.ofSeconds(5), false, configFile, List.of());
+
+        assertNotNull(runtime.resolve(settings), "resolving options must not load user config");
+
+        IllegalArgumentException failure = assertThrows(
+                IllegalArgumentException.class, () -> runtime.launch(settings));
+        assertTrue(failure.getMessage().contains(configFile.toString()), failure.getMessage());
     }
 
     private static void writeExecutable(Path path) throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -1,12 +1,20 @@
 package io.github.luigidemasi.camelkit.config;
 
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -158,6 +166,115 @@ class DistributionConfigTest {
         assertEquals("0.83.0", config.piVersion());
         assertEquals("22.22.2", config.nodeVersion());
         assertEquals(0, config.overrideCount());
+    }
+
+    @Test
+    @ResourceLock(Resources.SYSTEM_OUT)
+    void cascadingOverridesAreQuietAndCliPropertiesWin(@TempDir Path tempDir) throws Exception {
+        Path configFile = tempDir.resolve("config.properties");
+        Files.writeString(
+                configFile,
+                "camel.main.version=8.8.8\n"
+                            + "citrus.version=4.9.0\n");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        DistributionConfig config;
+        try {
+            System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+            config = DistributionConfig.loadWithOverrides(
+                    configFile,
+                    List.of(
+                            "camel.main.version=9.9.8",
+                            "camel.main.version=9.9.9",
+                            "knowledge.mcp.version="));
+        } finally {
+            System.setOut(original);
+        }
+
+        assertEquals("", output.toString(StandardCharsets.UTF_8));
+        assertEquals("9.9.9", config.camelMainVersion());
+        assertEquals("4.9.0", config.citrusVersion());
+        assertEquals("4.21.0", config.camelSpringbootVersion());
+        assertEquals("", config.knowledgeMcpVersion());
+        assertEquals(5, config.overrideCount());
+    }
+
+    @Test
+    void explicitConfigMustBeAReadablePropertiesFile(@TempDir Path tempDir) throws Exception {
+        Path missing = tempDir.resolve("missing.properties");
+        Path directory = Files.createDirectory(tempDir.resolve("directory.properties"));
+        Path malformed = Files.write(
+                tempDir.resolve("malformed.properties"),
+                "camel.main.version=\\u00ZZ\n".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        assertTrue(assertThrows(
+                IllegalArgumentException.class,
+                () -> DistributionConfig.loadWithOverridesStrict(missing, List.of()))
+                .getMessage().contains(missing.toString()));
+        assertTrue(assertThrows(
+                IllegalArgumentException.class,
+                () -> DistributionConfig.loadWithOverridesStrict(directory, List.of()))
+                .getMessage().contains(directory.toString()));
+        assertTrue(assertThrows(
+                IllegalArgumentException.class,
+                () -> DistributionConfig.loadWithOverridesStrict(malformed, List.of()))
+                .getMessage().contains(malformed.toString()));
+    }
+
+    @Test
+    void strictDefaultConfigMayBeAbsentButNotMalformed(@TempDir Path tempDir) throws Exception {
+        Path configFile = tempDir.resolve("config.properties");
+
+        assertEquals("4.21.0", DistributionConfig.loadWithOverridesStrict(
+                null, List.of(), configFile).camelMainVersion());
+
+        Files.writeString(configFile, "camel.main.version=9.9.9\n");
+        assertEquals("9.9.9", DistributionConfig.loadWithOverridesStrict(
+                null, List.of(), configFile).camelMainVersion());
+
+        Files.writeString(configFile, "camel.main.version=\\u00ZZ\n");
+        assertTrue(assertThrows(
+                IllegalArgumentException.class,
+                () -> DistributionConfig.loadWithOverridesStrict(null, List.of(), configFile))
+                .getMessage().contains(configFile.toString()));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void strictDefaultConfigRejectsADanglingLink(@TempDir Path tempDir) throws Exception {
+        Path configFile = tempDir.resolve("config.properties");
+        Files.createSymbolicLink(configFile, tempDir.resolve("missing.properties"));
+
+        assertTrue(assertThrows(
+                IllegalArgumentException.class,
+                () -> DistributionConfig.loadWithOverridesStrict(null, List.of(), configFile))
+                .getMessage().contains(configFile.toString()));
+    }
+
+    @Test
+    void legacyCascadeIgnoresInvalidOverrides(@TempDir Path tempDir) throws Exception {
+        Path malformed = Files.writeString(
+                tempDir.resolve("malformed.properties"), "camel.main.version=\\u00ZZ\n");
+
+        DistributionConfig config = DistributionConfig.loadWithOverrides(
+                malformed, List.of("missing-equals"));
+
+        assertEquals("4.21.0", config.camelMainVersion());
+        assertEquals(0, config.overrideCount());
+    }
+
+    @Test
+    void malformedCliPropertiesFailWithoutEchoingTheirValues(@TempDir Path tempDir) {
+        Path defaultConfig = tempDir.resolve("config.properties");
+        for (String property : List.of("missing-equals", " =secret-value")) {
+            IllegalArgumentException failure = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> DistributionConfig.loadWithOverridesStrict(
+                            null, List.of(property), defaultConfig));
+
+            assertEquals("Invalid config property; expected key=value", failure.getMessage());
+            assertFalse(failure.getMessage().contains(property));
+        }
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -207,10 +207,12 @@ class DistributionConfigTest {
                 tempDir.resolve("malformed.properties"),
                 "camel.main.version=\\u00ZZ\n".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
-        assertTrue(assertThrows(
-                IllegalArgumentException.class,
-                () -> DistributionConfig.loadWithOverridesStrict(missing, List.of()))
-                .getMessage().contains(missing.toString()));
+        assertEquals(
+                "Config file is missing, unreadable, or not a regular file: " + missing,
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> DistributionConfig.loadWithOverridesStrict(missing, List.of()))
+                        .getMessage());
         assertTrue(assertThrows(
                 IllegalArgumentException.class,
                 () -> DistributionConfig.loadWithOverridesStrict(directory, List.of()))
@@ -252,15 +254,25 @@ class DistributionConfigTest {
     }
 
     @Test
+    @ResourceLock(Resources.SYSTEM_ERR)
     void legacyCascadeIgnoresInvalidOverrides(@TempDir Path tempDir) throws Exception {
         Path malformed = Files.writeString(
                 tempDir.resolve("malformed.properties"), "camel.main.version=\\u00ZZ\n");
-
-        DistributionConfig config = DistributionConfig.loadWithOverrides(
-                malformed, List.of("missing-equals"));
+        ByteArrayOutputStream error = new ByteArrayOutputStream();
+        PrintStream original = System.err;
+        DistributionConfig config;
+        try {
+            System.setErr(new PrintStream(error, true, StandardCharsets.UTF_8));
+            config = DistributionConfig.loadWithOverrides(
+                    malformed, List.of("missing-equals"));
+        } finally {
+            System.setErr(original);
+        }
 
         assertEquals("4.21.0", config.camelMainVersion());
         assertEquals(0, config.overrideCount());
+        assertTrue(error.toString(StandardCharsets.UTF_8)
+                .contains("WARN: Failed to load config from " + malformed + ":"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- register the same `ship` command in the standalone `camel-kit` CLI and under `camel kit`
- load the user configuration cascade lazily and quietly for Ship start/resume operations, with strict errors for configuration that cannot be applied
- preserve separate-token leading-`@` Ship context in both entry points, native Camel argument-file expansion for sibling commands, bundled runtime pins, runtime-free help/status behavior, and entry-point-specific resume hints

Ship accepts repeatable `-p` overrides above `-c` or the default user config and the bundled distribution. Summaries remind users to repeat invocation-specific config options when resuming so a policy change is not accidental.

## Verification

- `./mvnw -B -Psourcecheck validate`
- `./mvnw -B clean install`
- `./mvnw -B -Plinux-ship-certification clean install`

The Linux certification profile ran the packaged-payload compatibility tests successfully. Its authenticated live Pi test skipped because `CAMEL_KIT_SHIP_LIVE_PI` was not configured.

## Website impact

Required. Issue #149 remains open for the thin harness delegates and the repository, migration, and website documentation/certification cutover that follows this registration slice.

Refs #149

## Summary by Sourcery

Register Ship across both CLI entry points with lazy user configuration support and compatible runtime, help, and resume behavior.

New Features:
- Register the Ship command in both the standalone `camel-kit` CLI and the `camel kit` subcommand.
- Support repeatable `-p` property overrides and optional `-c` configuration files for Ship start and resume operations.

Bug Fixes:
- Preserve separate-token leading-`@` values for direct Ship text and document context in both CLI entry points while retaining Camel root argument-file expansion for sibling commands.
- Keep status and help operations runtime-free and ensure resume guidance reflects the command entry point used.

Enhancements:
- Load user configuration lazily and quietly for workflow launches, while rejecting configuration that cannot be applied in strict Ship operations.
- Preserve bundled Pi and Node support pins and provide resume reminders for invocation-specific configuration.

Tests:
- Add coverage for Ship registration, help output, argument-file compatibility, configuration cascades, strict validation, and resume behavior.
