### PR TITLE
chore: certify Pi 0.84.2 and carry certified Pi versions as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Maintained Pi baseline updated to `0.84.2`** — the bundled `pi.version` pin moved from `0.83.0` to `0.84.2` (Node stays `22.22.2`; Pi `0.84.2` requires Node `>=22.19.0`). Ship reports Pi `0.84.2` as `supported`; other detected versions run only with `--accept-experimental`.
+- **Certified Pi versions: `0.84.2` and `0.83.0`** — the bundled distribution now carries a certified-version list (`pi.supported`); Ship reports every listed version as `supported`, and each entry has completed an authenticated Pi/Linux live-gate run. `pi.version=0.84.2` is the primary install target named in guidance messages (Node stays `22.22.2`; Pi `0.84.2` requires Node `>=22.19.0`). Other detected versions still run only with `--accept-experimental`.
 
 - **Ship harness entry points now delegate to the local controller** — `/camel-ship`, `$camel-ship`, and `/skill:camel-ship` forward their arguments to the configured registered `camel-kit ship` or `camel kit ship` command instead of maintaining a prompt-owned workflow. The local controller is the sole owner of Ship stages, run state, evidence, oversight, and guarded publication.
   - Existing generated workspaces must be regenerated with the same command surface and agent, using `camel-kit init --here --ai <same-agent> --force` or `camel kit init --here --ai <same-agent> --force`; commit or back up workspace customizations first because `--force` rewrites generated configuration, instructions, skills, and templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Maintained Pi baseline updated to `0.84.2`** — the bundled `pi.version` pin moved from `0.83.0` to `0.84.2` (Node stays `22.22.2`; Pi `0.84.2` requires Node `>=22.19.0`). Ship reports Pi `0.84.2` as `supported`; other detected versions run only with `--accept-experimental`.
+
 - **Ship harness entry points now delegate to the local controller** — `/camel-ship`, `$camel-ship`, and `/skill:camel-ship` forward their arguments to the configured registered `camel-kit ship` or `camel kit ship` command instead of maintaining a prompt-owned workflow. The local controller is the sole owner of Ship stages, run state, evidence, oversight, and guarded publication.
   - Existing generated workspaces must be regenerated with the same command surface and agent, using `camel-kit init --here --ai <same-agent> --force` or `camel kit init --here --ai <same-agent> --force`; commit or back up workspace customizations first because `--force` rewrites generated configuration, instructions, skills, and templates
   - Initialization aborts up front — before writing any project files — when a managed agent path (for example a symlinked `.claude` or `.bob` from a dotfiles setup) is a symbolic link; the error names the link. Replace the link with a real directory before running the upgrade command

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,6 +53,7 @@ public class DistributionConfig {
     private final String citrusMcpRepos;
     private final String camelCatalogRepos;
     private final String piVersion;
+    private final String piSupported;
     private final String nodeVersion;
     private final String piMcpAdapterVersion;
     private final int overrideCount;
@@ -78,6 +80,7 @@ public class DistributionConfig {
         this.camelCatalogRepos = props.getProperty("camel.catalog.repos",
                 "https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots");
         this.piVersion = props.getProperty("pi.version", DEFAULT_PI_VERSION);
+        this.piSupported = props.getProperty("pi.supported", this.piVersion);
         this.nodeVersion = props.getProperty("node.version", DEFAULT_NODE_VERSION);
         this.piMcpAdapterVersion = props.getProperty("pi.mcp.adapter.version", DEFAULT_PI_MCP_ADAPTER_VERSION);
         this.overrideCount = overrideCount;
@@ -364,6 +367,14 @@ public class DistributionConfig {
 
     public String piVersion() {
         return piVersion;
+    }
+
+    /** Certified Pi versions; the first entry is the primary install target. */
+    public List<String> piSupportedVersions() {
+        return Arrays.stream(piSupported.split(","))
+                .map(String::trim)
+                .filter(version -> !version.isEmpty())
+                .toList();
     }
 
     public String nodeVersion() {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -369,7 +369,12 @@ public class DistributionConfig {
         return piVersion;
     }
 
-    /** Certified Pi versions; the first entry is the primary install target. */
+    /**
+     * Certified Pi versions; the first entry is the primary install target and must match {@link #piVersion()} — the
+     * bundled ordering invariant is pinned by DistributionConfigTest, and overrides of the two properties must stay
+     * consistent. Unlike the sibling raw-string supported accessors, this returns a parsed list because the Ship worker
+     * needs list membership and positional access rather than template interpolation.
+     */
     public List<String> piSupportedVersions() {
         return Arrays.stream(piSupported.split(","))
                 .map(String::trim)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -26,7 +26,7 @@ public class DistributionConfig {
 
     private static final String DEFAULT_CITRUS_VERSION = "5.0.0-M2";
     private static final String DEFAULT_CITRUS_MCP_VERSION = "5.0.0-M1";
-    private static final String DEFAULT_PI_VERSION = "0.83.0";
+    private static final String DEFAULT_PI_VERSION = "0.84.2";
     private static final String DEFAULT_NODE_VERSION = "22.22.2";
     private static final String DEFAULT_PI_MCP_ADAPTER_VERSION = "2.11.0";
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -90,7 +90,7 @@ public final class ShipCoordinator {
         DistributionConfig maintained = DistributionConfig.loadBundled();
         this.worker = new PiWorker(
                 piExecutable,
-                maintained.piVersion(),
+                maintained.piSupportedVersions(),
                 nodeExecutable,
                 maintained.nodeVersion(),
                 timeout,

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -103,7 +103,7 @@ public final class PiWorker {
             .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
     private final Path executable;
-    private final String supportedVersion;
+    private final List<String> supportedVersions;
     private final Path nodeExecutable;
     private final String supportedNodeVersion;
     private final Duration timeout;
@@ -113,13 +113,13 @@ public final class PiWorker {
 
     public PiWorker(
                     Path executable,
-                    String supportedVersion,
+                    List<String> supportedVersions,
                     Path nodeExecutable,
                     String supportedNodeVersion,
                     Duration timeout) {
         this(
              executable,
-             supportedVersion,
+             supportedVersions,
              nodeExecutable,
              supportedNodeVersion,
              timeout,
@@ -128,14 +128,14 @@ public final class PiWorker {
 
     public PiWorker(
                     Path executable,
-                    String supportedVersion,
+                    List<String> supportedVersions,
                     Path nodeExecutable,
                     String supportedNodeVersion,
                     Duration timeout,
                     Map<String, String> environment) {
         this(
              executable,
-             supportedVersion,
+             supportedVersions,
              nodeExecutable,
              supportedNodeVersion,
              timeout,
@@ -145,14 +145,20 @@ public final class PiWorker {
 
     PiWorker(
              Path executable,
-             String supportedVersion,
+             List<String> supportedVersions,
              Path nodeExecutable,
              String supportedNodeVersion,
              Duration timeout,
              Clock clock,
              Map<String, String> environment) {
         this.executable = requireExecutable(executable, "Pi");
-        this.supportedVersion = requireVersion(supportedVersion, "supported Pi version");
+        Objects.requireNonNull(supportedVersions, "supported Pi versions");
+        if (supportedVersions.isEmpty()) {
+            throw new IllegalArgumentException("supported Pi versions must not be empty");
+        }
+        this.supportedVersions = supportedVersions.stream()
+                .map(version -> requireVersion(version, "supported Pi version"))
+                .toList();
         this.nodeExecutable = requireExecutable(nodeExecutable, "Node");
         this.supportedNodeVersion = requireVersion(
                 supportedNodeVersion, "supported Node version");
@@ -273,17 +279,17 @@ public final class PiWorker {
             if ("0.80.3".equals(detectedVersion)) {
                 throw new IOException(
                         "Pi 0.80.3 lacks the required settled RPC event; install the maintained Pi "
-                                      + supportedVersion);
+                                      + supportedVersions.get(0));
             }
             ShipLocalStamp.Support support
-                    = detectedVersion.equals(supportedVersion)
+                    = supportedVersions.contains(detectedVersion)
                             ? ShipLocalStamp.Support.SUPPORTED
                             : ShipLocalStamp.Support.EXPERIMENTAL;
             String warning = support == ShipLocalStamp.Support.SUPPORTED
                     ? null
                     : "Pi " + detectedVersion
                       + " is unverified; install maintained Pi "
-                      + supportedVersion;
+                      + supportedVersions.get(0);
             String experimentalWarning = warning == null
                     ? nodeWarning
                     : nodeWarning == null

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/command/ship/ShipCommandTest.java
@@ -799,7 +799,7 @@ class ShipCommandTest {
         assertEquals(1, result.exitCode(), result.error());
         String id = runId(result.output());
         String message = "Pi stage could not run: Pi 0.81.1 is unverified; "
-                         + "install maintained Pi 0.83.0; explicitly accept experimental Pi "
+                         + "install maintained Pi 0.84.2; explicitly accept experimental Pi "
                          + "or Node before starting the stage";
         assertEquals(summary(
                 id,

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -98,7 +98,7 @@ class DistributionConfigTest {
         assertEquals("central=https://repo1.maven.org/maven2/", config.citrusMcpRepos());
         assertEquals("https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots",
                 config.camelCatalogRepos());
-        assertEquals("0.83.0", config.piVersion());
+        assertEquals("0.84.2", config.piVersion());
         assertEquals("22.22.2", config.nodeVersion());
         assertEquals("2.11.0", config.piMcpAdapterVersion());
     }
@@ -163,7 +163,7 @@ class DistributionConfigTest {
     void bundledBaselineLoadsMaintainedWorkerVersionsWithoutOverrides() {
         DistributionConfig config = DistributionConfig.loadBundled();
 
-        assertEquals("0.83.0", config.piVersion());
+        assertEquals("0.84.2", config.piVersion());
         assertEquals("22.22.2", config.nodeVersion());
         assertEquals(0, config.overrideCount());
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -99,6 +99,7 @@ class DistributionConfigTest {
         assertEquals("https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots",
                 config.camelCatalogRepos());
         assertEquals("0.84.2", config.piVersion());
+        assertEquals(List.of("0.84.2", "0.83.0"), config.piSupportedVersions());
         assertEquals("22.22.2", config.nodeVersion());
         assertEquals("2.11.0", config.piMcpAdapterVersion());
     }
@@ -126,6 +127,7 @@ class DistributionConfigTest {
         DistributionConfig config = DistributionConfig.load(properties);
 
         assertEquals("9.9.9-test", config.piVersion());
+        assertEquals(List.of("9.9.9-test"), config.piSupportedVersions());
         assertEquals("7.7.7-test", config.nodeVersion());
         assertEquals("8.8.8-test", config.piMcpAdapterVersion());
     }
@@ -164,6 +166,7 @@ class DistributionConfigTest {
         DistributionConfig config = DistributionConfig.loadBundled();
 
         assertEquals("0.84.2", config.piVersion());
+        assertEquals(List.of("0.84.2", "0.83.0"), config.piSupportedVersions());
         assertEquals("22.22.2", config.nodeVersion());
         assertEquals(0, config.overrideCount());
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -167,6 +167,8 @@ class DistributionConfigTest {
 
         assertEquals("0.84.2", config.piVersion());
         assertEquals(List.of("0.84.2", "0.83.0"), config.piSupportedVersions());
+        assertEquals(config.piVersion(), config.piSupportedVersions().get(0),
+                "the bundled primary pi.version must be the first pi.supported entry");
         assertEquals("22.22.2", config.nodeVersion());
         assertEquals(0, config.overrideCount());
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorLiveIT.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorLiveIT.java
@@ -156,8 +156,8 @@ class ShipCoordinatorLiveIT {
                 stamp.toolVersions().stream()
                         .map(ShipLocalStamp.ToolVersion::tool)
                         .toList());
-        assertEquals(distribution.piVersion(),
-                stamp.toolVersions().get(0).version());
+        assertTrue(distribution.piSupportedVersions()
+                .contains(stamp.toolVersions().get(0).version()));
         assertEquals(
                 pi.toRealPath().toString(),
                 stamp.toolVersions().get(0).executable());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -123,7 +123,7 @@ class ShipCoordinatorTest {
                 environment);
         worker = new PiWorker(
                 fixture.resolve("pi-rpc"),
-                distribution.piVersion(),
+                List.of(distribution.piVersion()),
                 nodeExecutable,
                 distribution.nodeVersion(),
                 Duration.ofSeconds(30),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -108,7 +108,7 @@ class ShipCoordinatorTest {
                         fi
                         """);
         Files.writeString(fixture.resolve("node-version"), "v22.22.2\n");
-        Files.writeString(fixture.resolve("version"), "0.83.0\n");
+        Files.writeString(fixture.resolve("version"), "0.84.2\n");
         Files.writeString(fixture.resolve("mode"), "success\n");
         writeDesignResult();
 
@@ -163,10 +163,10 @@ class ShipCoordinatorTest {
 
         assertEquals(RunStatus.FAILED, piFailed.status());
         assertTrue(piFailed.message().contains(
-                "Pi 0.81.1 is unverified; install maintained Pi 0.83.0"));
+                "Pi 0.81.1 is unverified; install maintained Pi 0.84.2"));
         assertFalse(Files.exists(fixture.resolve("args")));
 
-        Files.writeString(fixture.resolve("version"), "0.83.0\n");
+        Files.writeString(fixture.resolve("version"), "0.84.2\n");
         Files.writeString(fixture.resolve("node-version"), "v23.0.0\n");
         ShipRun unmaintainedNode = controller.start(
                 project,

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -439,11 +439,16 @@ class PiWorkerTest {
     void rejectsSensitiveVersionDiagnosticsBeforePublication()
             throws Exception {
         Files.writeString(fixture.resolve("version"), "0.81.1\n");
-        String secret = "Pi 0.81.1 is unverified; install maintained Pi 0.83.0";
+        String secret = "Pi 0.81.1 is unverified; install maintained Pi 0.84.2";
         PiWorker.Request request = request(
                 ShipRun.Stage.DISCOVERY, "prompt");
-        PiWorker worker = worker(
-                Duration.ofSeconds(5), Map.of("API_TOKEN", secret));
+        PiWorker worker = new PiWorker(
+                executable,
+                List.of("0.84.2", "0.83.0"),
+                nodeExecutable,
+                "22.22.2",
+                Duration.ofSeconds(5),
+                Map.of("API_TOKEN", secret));
 
         IOException failure = assertThrows(
                 IOException.class,
@@ -914,7 +919,34 @@ class PiWorkerTest {
 
     @Test
     void supportsEveryCertifiedPiVersion() throws Exception {
-        PiWorker.Result result = new PiWorker(
+        List<String> certified = List.of("0.84.2", "0.83.0");
+        List<ShipRun.Stage> stages = List.of(ShipRun.Stage.DISCOVERY, ShipRun.Stage.DESIGN);
+        for (int i = 0; i < certified.size(); i++) {
+            String version = certified.get(i);
+            Files.writeString(fixture.resolve("version"), version + "\n");
+            Files.deleteIfExists(fixture.resolve("args"));
+            Files.deleteIfExists(fixture.resolve("prompt"));
+
+            PiWorker.Result result = new PiWorker(
+                    executable,
+                    certified,
+                    nodeExecutable,
+                    "22.22.2",
+                    Duration.ofSeconds(5))
+                    .run(request(stages.get(i), "prompt"));
+
+            assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome(), version);
+            assertEquals(ShipLocalStamp.Support.SUPPORTED, result.support(), version);
+            assertEquals(version, result.version());
+            assertNull(result.warning(), version);
+        }
+    }
+
+    @Test
+    void experimentalWarningNamesThePrimaryCertifiedVersion() throws Exception {
+        Files.writeString(fixture.resolve("version"), "0.81.1\n");
+
+        PiWorker.Result experimental = new PiWorker(
                 executable,
                 List.of("0.84.2", "0.83.0"),
                 nodeExecutable,
@@ -922,10 +954,8 @@ class PiWorkerTest {
                 Duration.ofSeconds(5))
                 .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
 
-        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
-        assertEquals(ShipLocalStamp.Support.SUPPORTED, result.support());
-        assertEquals("0.83.0", result.version());
-        assertNull(result.warning());
+        assertEquals(ShipLocalStamp.Support.EXPERIMENTAL, experimental.support());
+        assertTrue(experimental.warning().contains("install maintained Pi 0.84.2"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -225,7 +225,7 @@ class PiWorkerTest {
                         """);
         PiWorker blocked = new PiWorker(
                 executable,
-                "0.83.0",
+                List.of("0.83.0"),
                 blockingNode,
                 "22.22.2",
                 Duration.ofSeconds(30));
@@ -725,7 +725,7 @@ class PiWorkerTest {
 
         PiWorker.Result result = new PiWorker(
                 wrapper,
-                "0.83.0",
+                List.of("0.83.0"),
                 nodeExecutable,
                 "22.22.2",
                 Duration.ofSeconds(5),
@@ -913,6 +913,22 @@ class PiWorkerTest {
     }
 
     @Test
+    void supportsEveryCertifiedPiVersion() throws Exception {
+        PiWorker.Result result = new PiWorker(
+                executable,
+                List.of("0.84.2", "0.83.0"),
+                nodeExecutable,
+                "22.22.2",
+                Duration.ofSeconds(5))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertEquals(ShipLocalStamp.Support.SUPPORTED, result.support());
+        assertEquals("0.83.0", result.version());
+        assertNull(result.warning());
+    }
+
+    @Test
     void reportsVersionCompatibilityAndExecutableGuidance() throws Exception {
         Files.writeString(fixture.resolve("version"), "0.81.1\n");
 
@@ -954,7 +970,7 @@ class PiWorkerTest {
                 IllegalArgumentException.class,
                 () -> new PiWorker(
                         temporaryDirectory.resolve("missing-pi"),
-                        "0.83.0",
+                        List.of("0.83.0"),
                         nodeExecutable,
                         "22.22.2",
                         Duration.ofSeconds(5)));
@@ -970,7 +986,7 @@ class PiWorkerTest {
 
         PiWorker.Result result = new PiWorker(
                 symlink,
-                "0.83.0",
+                List.of("0.83.0"),
                 nodeExecutable,
                 "22.22.2",
                 Duration.ofSeconds(5))
@@ -2044,7 +2060,7 @@ class PiWorkerTest {
                 result,
                 new PiWorker(
                         otherExecutable,
-                        "0.83.0",
+                        List.of("0.83.0"),
                         nodeExecutable,
                         "22.22.2",
                         Duration.ofSeconds(5))
@@ -2242,7 +2258,7 @@ class PiWorkerTest {
     private PiWorker worker(Duration timeout) {
         return new PiWorker(
                 executable,
-                "0.83.0",
+                List.of("0.83.0"),
                 nodeExecutable,
                 "22.22.2",
                 timeout);
@@ -2252,7 +2268,7 @@ class PiWorkerTest {
             Duration timeout, Map<String, String> environment) {
         return new PiWorker(
                 executable,
-                "0.83.0",
+                List.of("0.83.0"),
                 nodeExecutable,
                 "22.22.2",
                 timeout,

--- a/distribution.properties
+++ b/distribution.properties
@@ -84,7 +84,7 @@ forage.version.4.18.2=1.3
 forage.catalog.artifact=io.kaoto.forage:forage-catalog
 
 # ─── Pi Agent Versions ─────────────────────────────────────────────────────
-pi.version=0.83.0
+pi.version=0.84.2
 node.version=22.22.2
 pi.mcp.adapter.version=2.11.0
 

--- a/distribution.properties
+++ b/distribution.properties
@@ -85,6 +85,10 @@ forage.catalog.artifact=io.kaoto.forage:forage-catalog
 
 # ─── Pi Agent Versions ─────────────────────────────────────────────────────
 pi.version=0.84.2
+# Comma-separated certified Pi versions. Every entry has completed an
+# authenticated Pi/Linux live-gate run; pi.version is the primary install
+# target named in guidance messages and must be the first entry.
+pi.supported=0.84.2,0.83.0
 node.version=22.22.2
 pi.mcp.adapter.version=2.11.0
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -903,7 +903,7 @@ Implementation changes stay in a staged workspace until the configured oversight
 
 Ordinary process interruption is recoverable with the run ID, but Ship is not a daemon or a guarantee against OS or power loss. It assumes the invoking OS account is trusted: it is not a hostile same-user sandbox, credential broker, or long-lived service. Provider credentials remain under Pi and provider tooling.
 
-Maintainers can opt into the authenticated Pi/Linux live test on a merged-/usr host with Bubblewrap installed. Set `CAMEL_KIT_SHIP_LIVE_PI` and `CAMEL_KIT_SHIP_LIVE_NODE` to absolute executable paths for the bundled supported versions (currently Pi `0.84.2` and Node `22.22.2`), then run:
+Maintainers can opt into the authenticated Pi/Linux live test on a merged-/usr host with Bubblewrap installed. Set `CAMEL_KIT_SHIP_LIVE_PI` and `CAMEL_KIT_SHIP_LIVE_NODE` to absolute executable paths for a bundled certified configuration (currently Pi `0.84.2` or `0.83.0`, with Node `22.22.2`), then run:
 
 ```bash
 ./mvnw -B -Plinux-ship-certification clean install

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -903,7 +903,7 @@ Implementation changes stay in a staged workspace until the configured oversight
 
 Ordinary process interruption is recoverable with the run ID, but Ship is not a daemon or a guarantee against OS or power loss. It assumes the invoking OS account is trusted: it is not a hostile same-user sandbox, credential broker, or long-lived service. Provider credentials remain under Pi and provider tooling.
 
-Maintainers can opt into the authenticated Pi/Linux live test on a merged-/usr host with Bubblewrap installed. Set `CAMEL_KIT_SHIP_LIVE_PI` and `CAMEL_KIT_SHIP_LIVE_NODE` to absolute executable paths for the bundled supported versions (currently Pi `0.83.0` and Node `22.22.2`), then run:
+Maintainers can opt into the authenticated Pi/Linux live test on a merged-/usr host with Bubblewrap installed. Set `CAMEL_KIT_SHIP_LIVE_PI` and `CAMEL_KIT_SHIP_LIVE_NODE` to absolute executable paths for the bundled supported versions (currently Pi `0.84.2` and Node `22.22.2`), then run:
 
 ```bash
 ./mvnw -B -Plinux-ship-certification clean install


### PR DESCRIPTION
Introduces a certified Pi version list and certifies Pi 0.84.2 on top of the already-certified 0.83.0. Pi self-updates aggressively (0.83.0 → 0.84.2 within days), so a single pin was labeling every fresh install experimental the moment upstream released.

## Model

`supported` keeps its meaning — a configuration covered by a live end-to-end test — but is now carried as an enumerable list instead of a single value. Every list entry has a passing authenticated live-gate Stamp; versions enter the list only with one. This is deliberately a certified *list*, not a version *range*: an open range would claim untested and unreleased versions, and Pi has previously changed the required RPC surface within a patch series (0.80.3, which stays denylisted as incompatible).

## Changes

- `distribution.properties`: new `pi.supported=0.84.2,0.83.0` following the existing `camel.main.supported` comma-list convention; `pi.version=0.84.2` remains the primary install target named in guidance messages (Node stays `22.22.2`; Pi 0.84.2 requires Node `>=22.19.0`)
- `DistributionConfig`: `piSupportedVersions()` parses the list and defaults to the single primary when the property is absent
- `PiWorker`: takes the certified list; support is list membership; the `0.80.3` denylist, the experimental warning, and the `--accept-experimental` gate are unchanged. Guidance messages keep naming the primary
- `ShipCoordinator`: passes the bundled certified list — support still comes exclusively from bundled pins, so user configuration cannot promote a version to supported
- Tests: new `supportsEveryCertifiedPiVersion` (a secondary certified version is `SUPPORTED` with no warning); list assertions for the bundled values and for the absent-property fallback; pin-coupled expectations updated in `DistributionConfigTest`, `ShipCommandTest`, and `ShipCoordinatorTest`; the live IT accepts any certified version
- `docs/commands.md` maintainer live-gate line and CHANGELOG updated

## Verification

- Full reactor `./mvnw -B clean install`: green (camel-kit-core 942 tests, +1 new)
- Authenticated Pi/Linux live-gate runs through the registered `camel-kit ship` entry point, both on 2026-08-19, both document-driven with oversight `never`, both with Stamp `pass` and all six mandatory checks passing (including an executed Citrus test):
  - Pi `0.83.0` + Node `22.22.2` — all five stages completed
  - Pi `0.84.2` + Node `22.22.2` — all five stages completed on single attempts, with this change built and installed
- A version not in the list still fails closed before the stage starts, with the warning and both remedies in the error; `--accept-experimental` remains the explicit override and the Stamp then records `experimental`

The paired website update rides on the open camel-kit-web#29.

## Summary by Sourcery

Carry certified Pi versions as an explicit list and promote Pi 0.84.2 as the primary supported release.

New Features:
- Certify Pi 0.84.2 alongside 0.83.0 through a bundled enumerable list of supported versions.

Bug Fixes:
- Prevent newly released Pi versions from being incorrectly treated as experimental when they have passed certification.

Enhancements:
- Update Ship support checks and guidance to recognize all certified Pi versions while retaining the primary install target and experimental-version safeguards.

Documentation:
- Update Ship live-gate documentation and the changelog for the certified Pi version list.

Tests:
- Add coverage for multiple certified Pi versions, fallback configuration behavior, and live validation against any certified version.