### PR TITLE
Fix #177: honor JVM proxy and trust-store properties in the Ship resolver

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
@@ -3,8 +3,6 @@ package io.github.luigidemasi.camelkit.ship.evidence;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.ProxySelector;
-import java.net.SocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -56,7 +54,6 @@ public final class JvmPayloadArchive {
     private static final HttpClient CENTRAL_CLIENT = HttpClient.newBuilder()
             .connectTimeout(java.time.Duration.ofSeconds(10))
             .followRedirects(HttpClient.Redirect.NEVER)
-            .proxy(new NoProxySelector())
             .build();
     private static final int MAX_ARTIFACTS = 512;
     private static final long MAX_ARTIFACT_BYTES = 128L * 1024 * 1024;
@@ -279,7 +276,7 @@ public final class JvmPayloadArchive {
         return List.copyOf(result);
     }
 
-    private static void rejectRepositoryOverrides() throws IOException {
+    static void rejectRepositoryOverrides() throws IOException {
         for (String key : List.of(
                 "camel.extra.repos",
                 "camel.default.extra.repos.default.value")) {
@@ -552,19 +549,6 @@ public final class JvmPayloadArchive {
     private static HttpClient centralClient() throws IOException {
         rejectRepositoryOverrides();
         return CENTRAL_CLIENT;
-    }
-
-    private static final class NoProxySelector extends ProxySelector {
-
-        @Override
-        public List<java.net.Proxy> select(URI uri) {
-            return List.of(java.net.Proxy.NO_PROXY);
-        }
-
-        @Override
-        public void connectFailed(URI uri, SocketAddress address, IOException failure) {
-            // There is no proxy endpoint to report.
-        }
     }
 
     public record Identity(Path archive, String aggregateDigest, String archiveDigest, JvmPayloadLock lock) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
@@ -282,15 +282,7 @@ public final class JvmPayloadArchive {
     private static void rejectRepositoryOverrides() throws IOException {
         for (String key : List.of(
                 "camel.extra.repos",
-                "camel.default.extra.repos.default.value",
-                "https.proxyHost",
-                "https.proxyPort",
-                "http.proxyHost",
-                "http.proxyPort",
-                "java.net.useSystemProxies",
-                "javax.net.ssl.trustStore",
-                "javax.net.ssl.trustStoreType",
-                "javax.net.ssl.trustStoreProvider")) {
+                "camel.default.extra.repos.default.value")) {
             if (System.getProperty(key) != null && !System.getProperty(key).isBlank()) {
                 throw new IOException("Controller JVM payload refuses repository override property " + key);
             }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchiveTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchiveTest.java
@@ -142,6 +142,38 @@ class JvmPayloadArchiveTest {
         }
     }
 
+    @Test
+    void overrideGuardToleratesTransportPropertiesButRefusesRepositoryOverrides() throws Exception {
+        withProperty("https.proxyHost", "proxy.corp.example",
+                JvmPayloadArchive::rejectRepositoryOverrides);
+        withProperty("javax.net.ssl.trustStore", "/etc/pki/corp-truststore.p12",
+                JvmPayloadArchive::rejectRepositoryOverrides);
+        withProperty("camel.extra.repos", "https://repo.example/maven", () -> {
+            IOException refused = assertThrows(IOException.class,
+                    JvmPayloadArchive::rejectRepositoryOverrides);
+            assertEquals("Controller JVM payload refuses repository override property camel.extra.repos",
+                    refused.getMessage());
+        });
+    }
+
+    private interface GuardProbe {
+        void run() throws IOException;
+    }
+
+    private static void withProperty(String key, String value, GuardProbe probe) throws IOException {
+        String previous = System.getProperty(key);
+        System.setProperty(key, value);
+        try {
+            probe.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, previous);
+            }
+        }
+    }
+
     private static String classPath(Class<?> type) {
         return type.getName().replace('.', '/') + ".class";
     }

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
@@ -2,9 +2,6 @@ package io.github.luigidemasi.camelkit.ship.resolver;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.Proxy;
-import java.net.ProxySelector;
-import java.net.SocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -246,9 +243,11 @@ public final class ShipMavenResolver {
                 ConfigurationProperties.HTTP_MAX_REDIRECTS, 0,
                 ConfigurationProperties.HTTPS_SECURITY_MODE,
                 ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT,
-                "aether.connector.http.useSystemProperties", false,
+                // Honor the JVM's standard proxy and TLS system properties so Ship
+                // resolves through the developer's configured transport (corporate
+                // proxies, custom trust stores) instead of requiring a direct route.
+                "aether.connector.http.useSystemProperties", true,
                 "aether.checksums.algorithms", "SHA-1"));
-        session.setProxySelector(remote -> null);
         session.setLocalRepositoryManager(
                 system.newLocalRepositoryManager(session, new LocalRepository(repository.toFile())));
         return session;
@@ -399,7 +398,6 @@ public final class ShipMavenResolver {
         return HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .followRedirects(HttpClient.Redirect.NEVER)
-                .proxy(DirectProxySelector.INSTANCE)
                 .build();
     }
 
@@ -494,15 +492,7 @@ public final class ShipMavenResolver {
     private static void rejectRepositoryOverrides() throws IOException {
         for (String key : List.of(
                 "camel.extra.repos",
-                "camel.default.extra.repos.default.value",
-                "https.proxyHost",
-                "https.proxyPort",
-                "http.proxyHost",
-                "http.proxyPort",
-                "java.net.useSystemProxies",
-                "javax.net.ssl.trustStore",
-                "javax.net.ssl.trustStoreType",
-                "javax.net.ssl.trustStoreProvider")) {
+                "camel.default.extra.repos.default.value")) {
             if (System.getProperty(key) != null && !System.getProperty(key).isBlank()) {
                 throw new IOException("Ship resolver refuses repository override property " + key);
             }
@@ -700,21 +690,6 @@ public final class ShipMavenResolver {
 
         private void abort(IOException failure) {
             subscriber.abort(failure);
-        }
-    }
-
-    private static final class DirectProxySelector extends ProxySelector {
-        private static final DirectProxySelector INSTANCE = new DirectProxySelector();
-
-        @Override
-        public List<Proxy> select(URI uri) {
-            Objects.requireNonNull(uri, "uri must not be null");
-            return List.of(Proxy.NO_PROXY);
-        }
-
-        @Override
-        public void connectFailed(URI uri, SocketAddress address, IOException failure) {
-            // A direct connection has no proxy to retry.
         }
     }
 

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
@@ -149,20 +148,22 @@ class ExactArtifactResolutionTest {
     }
 
     @Test
-    void directCentralTransportDisablesRedirectsProxiesAndContentEncoding() {
+    void directCentralTransportDisablesRedirectsAndContentEncodingAndFollowsJvmProxyDefaults() {
         URI uri = URI.create("https://repo.maven.apache.org/maven2/example.test");
         HttpClient client = ShipMavenResolver.directClient();
         HttpRequest request = ShipMavenResolver.directRequest(uri);
 
         assertSame(client, ShipMavenResolver.directClient());
         assertEquals(HttpClient.Redirect.NEVER, client.followRedirects());
-        assertEquals(List.of(Proxy.NO_PROXY), client.proxy().orElseThrow().select(uri));
+        // No explicit proxy selector: the client follows the JVM default, which
+        // honors the standard proxy system properties.
+        assertTrue(client.proxy().isEmpty());
         assertEquals("identity", request.headers().firstValue("Accept-Encoding").orElseThrow());
         assertEquals(uri, request.uri());
     }
 
     @Test
-    void aetherCacheFillAlsoDisablesRedirectsAndAmbientProxyConfiguration() {
+    void aetherCacheFillDisablesRedirectsAndHonorsJvmTransportProperties() {
         var session = ShipMavenResolver.session(
                 new RepositorySystemSupplier().get(), repository, ShipMavenResolver.ResolutionMode.ONLINE);
         Map<String, Object> configuration = session.getConfigProperties();
@@ -173,9 +174,52 @@ class ExactArtifactResolutionTest {
         assertEquals(0, configuration.get(ConfigurationProperties.HTTP_MAX_REDIRECTS));
         assertEquals(ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT,
                 configuration.get(ConfigurationProperties.HTTPS_SECURITY_MODE));
-        assertEquals(false, configuration.get("aether.connector.http.useSystemProperties"));
+        assertEquals(true, configuration.get("aether.connector.http.useSystemProperties"));
         assertEquals("SHA-1", configuration.get("aether.checksums.algorithms"));
+        // No Aether-level proxy override: transport proxying is decided by the
+        // JVM's standard proxy system properties.
         assertNull(session.getProxySelector().getProxy(central));
+    }
+
+    @Test
+    void resolutionToleratesProxyAndTrustStorePropertiesButStillRefusesRepositoryOverrides() throws IOException {
+        MavenCoordinate coordinate = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
+        seed(coordinate, "artifact");
+
+        withProperty("https.proxyHost", "proxy.corp.example", () -> {
+            List<ResolvedExactMavenArtifact> resolved = ShipMavenResolver.resolveArtifacts(
+                    repository, List.of(coordinate), ShipMavenResolver.ResolutionMode.OFFLINE);
+            assertEquals(coordinate, resolved.get(0).coordinate());
+        });
+        withProperty("javax.net.ssl.trustStore", "/etc/pki/corp-truststore.p12", () -> {
+            List<ResolvedExactMavenArtifact> resolved = ShipMavenResolver.resolveArtifacts(
+                    repository, List.of(coordinate), ShipMavenResolver.ResolutionMode.OFFLINE);
+            assertEquals(coordinate, resolved.get(0).coordinate());
+        });
+        withProperty("camel.extra.repos", "https://repo.example/maven", () -> {
+            IOException refused = assertThrows(IOException.class, () -> ShipMavenResolver.resolveArtifacts(
+                    repository, List.of(coordinate), ShipMavenResolver.ResolutionMode.OFFLINE));
+            assertEquals("Ship resolver refuses repository override property camel.extra.repos",
+                    refused.getMessage());
+        });
+    }
+
+    private interface ResolutionProbe {
+        void run() throws IOException;
+    }
+
+    private static void withProperty(String key, String value, ResolutionProbe probe) throws IOException {
+        String previous = System.getProperty(key);
+        System.setProperty(key, value);
+        try {
+            probe.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, previous);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #177.

## What

Ship could not resolve its Camel/Citrus validation payloads on any machine whose JVM transport requires a proxy or a corporate trust store: `ShipMavenResolver.rejectRepositoryOverrides` hard-failed when any standard transport property was set (`https.proxyHost`, `javax.net.ssl.trustStore`, …), the Aether session forced `useSystemProperties=false` plus a null proxy selector, and the direct Maven Central byte fetch pinned `Proxy.NO_PROXY`. `JvmPayloadArchive` carried a duplicate of the same refusal.

## Change

- Enable `aether.connector.http.useSystemProperties` so the Aether transport honors the JVM's standard proxy and TLS system properties; drop the forced null proxy selector.
- Build the direct Maven Central client without an explicit proxy selector, so it follows the JVM default (which honors the same system properties); delete `DirectProxySelector`.
- Reduce both copies of the override refusal (resolver and `JvmPayloadArchive`) to the true resolution-semantics keys: `camel.extra.repos` and `camel.default.extra.repos.default.value`. Those change *what* is resolved and stay refused; transport properties change only *how* bytes travel.
- Checksum (`CHECKSUM_POLICY_FAIL`), offline mode, redirect, and size policies are unchanged.

## Tests

- Updated the two transport-configuration tests to pin the new behavior (system-properties transport enabled; no Aether-level per-repository proxy override; direct client on JVM proxy defaults).
- New regression test: resolution succeeds with `https.proxyHost` / `javax.net.ssl.trustStore` set, and still refuses `camel.extra.repos`.
- Full reactor `./mvnw -B clean install` green: 943 core + 22 resolver tests, 0 failures.

## Summary by Sourcery

Honor JVM transport configuration during Ship artifact resolution while retaining safeguards against repository source overrides.

Bug Fixes:
- Allow Ship payload and Maven resolution to honor JVM-configured proxies and trust stores instead of rejecting or bypassing standard transport properties.

Enhancements:
- Limit repository override protection to properties that alter artifact sources while preserving existing checksum, offline, redirect, and size policies.

Tests:
- Add regression coverage confirming transport properties are accepted and repository overrides remain rejected.