### PR TITLE
Drop the Maven Central double-download verification

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/ShipCatalogService.java
@@ -71,7 +71,8 @@ public final class ShipCatalogService {
 
     /**
      * Uses an explicit caller-supplied local repository and the fixed Maven Central release source. The controlling
-     * process remains responsible for creating and protecting that repository from other writers.
+     * process remains responsible for creating and protecting that repository from other writers. Artifacts already
+     * present in the repository are trusted as-is: checksum enforcement applies only when bytes are downloaded.
      */
     public ShipCatalogService(Path localRepository) {
         this(localRepository, ResolutionMode.ONLINE, ShipMavenResolver::resolveArtifacts);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchive.java
@@ -3,10 +3,6 @@ package io.github.luigidemasi.camelkit.ship.evidence;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -47,11 +43,6 @@ public final class JvmPayloadArchive {
 
     public static final String ARCHIVE_NAME = "payload.jar";
     public static final String BOOTSTRAP_CLASS = ShipJvmPayloadBootstrap.class.getName();
-    private static final String CENTRAL = "https://repo.maven.apache.org/maven2/";
-    private static final HttpClient CENTRAL_CLIENT = HttpClient.newBuilder()
-            .connectTimeout(java.time.Duration.ofSeconds(10))
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .build();
     private static final int MAX_ARTIFACTS = 512;
     private static final long MAX_ARTIFACT_BYTES = 128L * 1024 * 1024;
     private static final long MAX_TOTAL_BYTES = 768L * 1024 * 1024;
@@ -233,7 +224,6 @@ public final class JvmPayloadArchive {
             if (size <= 0 || size > MAX_ARTIFACT_BYTES) {
                 throw new IOException("Direct JVM payload artifact has an unsafe size: " + identity);
             }
-            verifyCentralBytes(coordinate, file, size);
             total = Math.addExact(total, size);
             if (total > MAX_TOTAL_BYTES) {
                 throw new IOException("Direct JVM payload dependencies exceed the controller size limit");
@@ -254,63 +244,6 @@ public final class JvmPayloadArchive {
             if (System.getProperty(key) != null && !System.getProperty(key).isBlank()) {
                 throw new IOException("Controller JVM payload refuses repository override property " + key);
             }
-        }
-    }
-
-    private static void verifyCentralBytes(
-            MavenCoordinate artifact, Path local, long expectedSize)
-            throws IOException {
-        requireCoordinatePart(artifact.groupId(), "groupId");
-        requireCoordinatePart(artifact.artifactId(), "artifactId");
-        requireCoordinatePart(artifact.version(), "version");
-        if (!artifact.classifier().isBlank()) {
-            requireCoordinatePart(artifact.classifier(), "classifier");
-        }
-        URI uri = URI.create(CENTRAL
-                             + artifact.groupId().replace('.', '/') + '/'
-                             + artifact.artifactId() + '/' + artifact.version() + '/' + artifact.fileName());
-        HttpRequest request = HttpRequest.newBuilder(uri)
-                .timeout(java.time.Duration.ofSeconds(60))
-                .header("Accept", "application/java-archive")
-                .GET()
-                .build();
-        try {
-            HttpResponse<InputStream> response = centralClient().send(
-                    request, HttpResponse.BodyHandlers.ofInputStream());
-            if (response.statusCode() != 200 || !uri.equals(response.uri())) {
-                response.body().close();
-                throw new IOException("Authenticated Maven Central verification failed for " + artifact);
-            }
-            MessageDigest remoteDigest = sha512();
-            long remoteSize = 0;
-            try (InputStream input = response.body()) {
-                byte[] buffer = new byte[16_384];
-                int count;
-                while ((count = input.read(buffer)) != -1) {
-                    remoteSize = Math.addExact(remoteSize, count);
-                    if (remoteSize > MAX_ARTIFACT_BYTES) {
-                        throw new IOException("Authenticated Maven Central artifact exceeds the size limit");
-                    }
-                    remoteDigest.update(buffer, 0, count);
-                }
-            }
-            if (remoteSize != expectedSize
-                    || !MessageDigest.isEqual(remoteDigest.digest(), digest(local, "SHA-512"))) {
-                throw new IOException("Resolved JVM payload artifact differs from Maven Central: " + artifact);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Interrupted while verifying authenticated Maven Central bytes", e);
-        } catch (IOException e) {
-            throw new IOException(
-                    "Could not verify authenticated Maven Central bytes for " + artifact + ": " + safeMessage(e),
-                    e);
-        }
-    }
-
-    private static void requireCoordinatePart(String value, String label) throws IOException {
-        if (value == null || !value.matches("[A-Za-z0-9_.-]+")) {
-            throw new IOException("Direct JVM payload has an unsafe Maven " + label);
         }
     }
 
@@ -454,23 +387,6 @@ public final class JvmPayloadArchive {
         return "sha256:" + HexFormat.of().formatHex(digest.digest());
     }
 
-    private static byte[] digest(Path file, String algorithm) throws IOException {
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance(algorithm);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException(algorithm + " is unavailable", e);
-        }
-        try (InputStream input = Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS)) {
-            byte[] buffer = new byte[16_384];
-            int count;
-            while ((count = input.read(buffer)) != -1) {
-                digest.update(buffer, 0, count);
-            }
-        }
-        return digest.digest();
-    }
-
     private static String digest(byte[] bytes) {
         return "sha256:" + HexFormat.of().formatHex(sha256().digest(bytes));
     }
@@ -483,23 +399,10 @@ public final class JvmPayloadArchive {
         }
     }
 
-    private static MessageDigest sha512() {
-        try {
-            return MessageDigest.getInstance("SHA-512");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-512 is unavailable", e);
-        }
-    }
-
     private static String safeMessage(Throwable error) {
         return error.getMessage() == null || error.getMessage().isBlank()
                 ? error.getClass().getSimpleName()
                 : error.getMessage();
-    }
-
-    private static HttpClient centralClient() throws IOException {
-        rejectRepositoryOverrides();
-        return CENTRAL_CLIENT;
     }
 
     /** Frozen payload archive and its deterministic content digest. */

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadTestFixture.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadTestFixture.java
@@ -23,7 +23,7 @@ public final class JvmPayloadTestFixture {
             String[] parts = root.split(":", -1);
             Path jar = directory.resolve("root-" + index++ + ".jar");
             try (ZipOutputStream ignored = new ZipOutputStream(Files.newOutputStream(jar))) {
-                // A valid empty JAR is enough: production verification validates real Central bytes.
+                // A valid empty JAR is enough: the archive validates coordinates and sizes, never JAR contents.
             }
             artifacts.add(new JvmPayloadArchive.ArtifactFile(
                     parts[0] + ':' + parts[1] + ":jar:" + parts[2], parts[1], parts[2], jar));

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
@@ -117,7 +117,9 @@ public final class ShipMavenResolver {
     /**
      * Resolves exact artifacts without reading descriptors or traversing dependencies. Requests must contain between
      * one and {@value #MAX_ARTIFACTS} unique immutable coordinates and results retain request order. Results are bound
-     * to the locally resolved bytes. Consumers must compare the returned identity with the bytes they actually read.
+     * to the locally resolved bytes. Consumers must compare the returned identity with the bytes they actually read. In
+     * ONLINE mode an artifact already present in the repository is returned as-is: checksum enforcement applies to
+     * downloads only, so protecting the repository between runs belongs to the caller.
      */
     public static List<ResolvedExactMavenArtifact> resolveArtifacts(
             Path repository, List<MavenCoordinate> artifacts, ResolutionMode mode)
@@ -192,6 +194,9 @@ public final class ShipMavenResolver {
         session.setSystemProperties(Map.of("java.version", Runtime.version().toString()));
         session.setUserProperties(Map.of());
         session.setConfigProperties(Map.of(
+                // REQUEST_TIMEOUT bounds per-read socket inactivity, not the whole transfer: a peer that keeps
+                // trickling bytes can hold a download open beyond it. Ship accepts that availability limit
+                // against the fixed HTTPS Central origin.
                 ConfigurationProperties.CONNECT_TIMEOUT, 10_000,
                 ConfigurationProperties.REQUEST_TIMEOUT, 60_000,
                 ConfigurationProperties.HTTP_FOLLOW_REDIRECTS, false,
@@ -237,6 +242,9 @@ public final class ShipMavenResolver {
         if (!returned.equals(expected)) {
             throw new IOException("Ship resolver returned an artifact outside its exact repository path");
         }
+        // This walk runs after resolution: in ONLINE mode Aether may already have written through a
+        // pre-planted symlink before it fails the run. Planting one requires a same-user writer, which
+        // the Ship product boundary excludes.
         Path current = repository;
         for (Path part : repository.relativize(expected)) {
             current = current.resolve(part);

--- a/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
+++ b/camel-kit-ship-resolver/src/main/java/io/github/luigidemasi/camelkit/ship/resolver/ShipMavenResolver.java
@@ -3,33 +3,17 @@ package io.github.luigidemasi.camelkit.ship.resolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Flow;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.ConfigurationProperties;
@@ -56,10 +40,6 @@ public final class ShipMavenResolver {
     private static final URI CENTRAL = URI.create("https://repo.maven.apache.org/maven2/");
     private static final long MAX_EXACT_JAR_BYTES = 128L * 1024 * 1024;
     private static final long MAX_EXACT_POM_BYTES = 4L * 1024 * 1024;
-    private static final Duration DIRECT_FETCH_TIMEOUT = Duration.ofSeconds(30);
-    private static final String DIRECT_FETCH_TIMEOUT_MESSAGE
-            = "Timed out fetching exact artifact bytes from Maven Central";
-    private static final ScheduledThreadPoolExecutor DIRECT_FETCH_DEADLINES = directFetchDeadlines();
 
     /** Fixed fail-closed ceiling for unique direct roots in one resolution request. */
     public static final int MAX_ROOTS = 64;
@@ -136,51 +116,26 @@ public final class ShipMavenResolver {
 
     /**
      * Resolves exact artifacts without reading descriptors or traversing dependencies. Requests must contain between
-     * one and {@value #MAX_ARTIFACTS} unique immutable coordinates and results retain request order. Online results are
-     * byte-matched against a direct, non-redirecting request to the fixed Maven Central origin; offline results are
-     * bound to the local bytes. The online request relies on the controlling process's TLS, DNS, and security-provider
-     * trust domain. Consumers must compare the returned identity with the bytes they actually read.
+     * one and {@value #MAX_ARTIFACTS} unique immutable coordinates and results retain request order. Results are bound
+     * to the locally resolved bytes. Consumers must compare the returned identity with the bytes they actually read.
      */
     public static List<ResolvedExactMavenArtifact> resolveArtifacts(
             Path repository, List<MavenCoordinate> artifacts, ResolutionMode mode)
             throws IOException {
-        return resolveArtifacts(repository, artifacts, mode, ShipMavenResolver::fetchDirect);
-    }
-
-    static List<ResolvedExactMavenArtifact> resolveArtifacts(
-            Path repository,
-            List<MavenCoordinate> artifacts,
-            ResolutionMode mode,
-            CentralDigestSource centralDigestSource)
-            throws IOException {
         Path local = requireRepository(repository);
         List<MavenCoordinate> requested = copyExactArtifacts(artifacts);
         Objects.requireNonNull(mode, "mode must not be null");
-        Objects.requireNonNull(centralDigestSource, "centralDigestSource must not be null");
         rejectRepositoryOverrides();
         try {
             RepositorySystem system = repositorySystem();
             DefaultRepositorySystemSession session = session(system, local, mode);
             List<ResolvedExactMavenArtifact> result = new ArrayList<>(requested.size());
             for (MavenCoordinate coordinate : requested) {
-                rejectExistingSymlinks(local, coordinate);
-                long limit = exactArtifactLimit(coordinate);
-                ContentIdentity authoritative = null;
-                if (mode == ResolutionMode.ONLINE) {
-                    authoritative = centralDigestSource.identity(centralUri(coordinate), limit);
-                    if (authoritative == null || authoritative.length() > limit) {
-                        throw new IOException("Maven Central returned an invalid exact artifact identity");
-                    }
-                }
                 ArtifactRequest request = new ArtifactRequest(
                         new DefaultArtifact(coordinate.resolverString()), List.of(central()), null);
                 ArtifactResult resolved = system.resolveArtifact(session, request);
                 ResolvedMavenArtifact artifact = requireExactArtifact(local, coordinate, resolved);
-                ContentIdentity localContent = contentIdentity(artifact.path(), limit);
-                if (authoritative != null && !authoritative.equals(localContent)) {
-                    throw new IOException("Cached exact artifact differs from authoritative Maven Central bytes");
-                }
-                ContentIdentity identity = authoritative == null ? localContent : authoritative;
+                ContentIdentity identity = contentIdentity(artifact.path(), exactArtifactLimit(coordinate));
                 result.add(new ResolvedExactMavenArtifact(
                         coordinate, artifact.path(), identity.sha256(), identity.length()));
             }
@@ -295,144 +250,8 @@ public final class ShipMavenResolver {
         return new ResolvedMavenArtifact(actual, expected);
     }
 
-    private static void rejectExistingSymlinks(Path repository, MavenCoordinate coordinate) throws IOException {
-        Path expected = repository.resolve(coordinate.groupId().replace('.', '/'))
-                .resolve(coordinate.artifactId())
-                .resolve(coordinate.version())
-                .resolve(coordinate.fileName())
-                .normalize();
-        Path current = repository;
-        for (Path part : repository.relativize(expected)) {
-            current = current.resolve(part);
-            if (Files.isSymbolicLink(current)) {
-                throw new IOException("Ship resolver repository path contains a symbolic link");
-            }
-            if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
-                break;
-            }
-        }
-    }
-
     private static long exactArtifactLimit(MavenCoordinate coordinate) {
         return "pom".equals(coordinate.extension()) ? MAX_EXACT_POM_BYTES : MAX_EXACT_JAR_BYTES;
-    }
-
-    private static URI centralUri(MavenCoordinate coordinate) throws IOException {
-        String relative = coordinate.groupId().replace('.', '/') + '/' + coordinate.artifactId() + '/'
-                          + coordinate.version() + '/' + coordinate.fileName();
-        URI uri = CENTRAL.resolve(relative);
-        if (!"https".equals(uri.getScheme()) || !CENTRAL.getHost().equals(uri.getHost())
-                || uri.getPort() != -1 || uri.getUserInfo() != null
-                || !uri.getPath().startsWith(CENTRAL.getPath())) {
-            throw new IOException("Exact artifact coordinate escaped the fixed Maven Central origin");
-        }
-        return uri;
-    }
-
-    static ContentIdentity fetchDirect(URI uri, long maxBytes) throws IOException {
-        return fetchDirect(uri, maxBytes, DIRECT_FETCH_TIMEOUT);
-    }
-
-    static ContentIdentity fetchDirect(URI uri, long maxBytes, Duration timeout) throws IOException {
-        Objects.requireNonNull(uri, "uri must not be null");
-        Objects.requireNonNull(timeout, "timeout must not be null");
-        if (maxBytes <= 0 || timeout.isZero() || timeout.isNegative()) {
-            throw new IOException("Direct Maven Central fetch bounds must be positive");
-        }
-        long timeoutNanos;
-        try {
-            timeoutNanos = timeout.toNanos();
-        } catch (ArithmeticException e) {
-            throw new IOException("Direct Maven Central fetch timeout is too large", e);
-        }
-
-        DirectBodyHandler handler = new DirectBodyHandler(maxBytes);
-        CompletableFuture<HttpResponse<ContentIdentity>> exchange
-                = directClient().sendAsync(directRequest(uri, timeout), handler);
-        AtomicBoolean deadlineExpired = new AtomicBoolean();
-        IOException timeoutFailure = new IOException(DIRECT_FETCH_TIMEOUT_MESSAGE);
-        ScheduledFuture<?> watchdog = DIRECT_FETCH_DEADLINES.schedule(() -> {
-            deadlineExpired.set(true);
-            handler.abort(timeoutFailure);
-            exchange.cancel(true);
-        }, timeoutNanos, TimeUnit.NANOSECONDS);
-        try {
-            HttpResponse<ContentIdentity> response = exchange.get(timeoutNanos, TimeUnit.NANOSECONDS);
-            if (!uri.equals(response.uri())) {
-                throw new IOException("Maven Central returned an unexpected HTTP response");
-            }
-            return response.body();
-        } catch (TimeoutException e) {
-            deadlineExpired.set(true);
-            handler.abort(timeoutFailure);
-            exchange.cancel(true);
-            throw timeoutFailure;
-        } catch (InterruptedException e) {
-            handler.abort(new IOException("Interrupted while fetching an exact artifact from Maven Central", e));
-            exchange.cancel(true);
-            Thread.currentThread().interrupt();
-            throw new IOException("Interrupted while fetching an exact artifact from Maven Central", e);
-        } catch (ExecutionException e) {
-            IOException failure = directFetchFailure(e.getCause());
-            if (e.getCause() instanceof HttpTimeoutException) {
-                deadlineExpired.set(true);
-                handler.abort(failure);
-                exchange.cancel(true);
-            }
-            throw failure;
-        } catch (CancellationException e) {
-            if (deadlineExpired.get()) {
-                throw timeoutFailure;
-            }
-            throw new IOException("Maven Central exact artifact fetch was cancelled", e);
-        } finally {
-            watchdog.cancel(false);
-        }
-    }
-
-    static HttpClient directClient() {
-        return DirectClientHolder.INSTANCE;
-    }
-
-    private static HttpClient newDirectClient() {
-        return HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .followRedirects(HttpClient.Redirect.NEVER)
-                .build();
-    }
-
-    static HttpRequest directRequest(URI uri) {
-        return directRequest(uri, DIRECT_FETCH_TIMEOUT);
-    }
-
-    private static HttpRequest directRequest(URI uri, Duration timeout) {
-        return HttpRequest.newBuilder(uri)
-                .timeout(timeout)
-                .header("Accept", "application/octet-stream")
-                .header("Accept-Encoding", "identity")
-                .GET()
-                .build();
-    }
-
-    static IOException directFetchFailure(Throwable failure) {
-        if (failure instanceof HttpTimeoutException) {
-            return new IOException(DIRECT_FETCH_TIMEOUT_MESSAGE, failure);
-        }
-        if (failure instanceof IOException ioFailure) {
-            return ioFailure;
-        }
-        return new IOException("Could not fetch exact artifact bytes from Maven Central", failure);
-    }
-
-    private static ScheduledThreadPoolExecutor directFetchDeadlines() {
-        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, task -> {
-            Thread thread = new Thread(task, "camel-kit-ship-central-fetch-deadline");
-            thread.setDaemon(true);
-            return thread;
-        });
-        executor.setRemoveOnCancelPolicy(true);
-        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-        return executor;
     }
 
     private static ContentIdentity contentIdentity(Path path, long maxBytes) throws IOException {
@@ -505,198 +324,11 @@ public final class ShipMavenResolver {
                 : error.getMessage();
     }
 
-    @FunctionalInterface
-    interface CentralDigestSource {
-        ContentIdentity identity(URI uri, long maxBytes) throws IOException;
-    }
-
     record ContentIdentity(String sha256, long length) {
         ContentIdentity {
             if (sha256 == null || !sha256.matches("sha256:[0-9a-f]{64}") || length <= 0) {
                 throw new IllegalArgumentException("Invalid exact artifact content identity");
             }
-        }
-    }
-
-    static final class DirectBodySubscriber implements HttpResponse.BodySubscriber<ContentIdentity> {
-        private final CompletableFuture<ContentIdentity> body = new CompletableFuture<>();
-        private final MessageDigest digest = sha256();
-        private final long maxBytes;
-        private Flow.Subscription subscription;
-        private long declaredLength = -1;
-        private long length;
-        private boolean terminal;
-
-        DirectBodySubscriber(long maxBytes) {
-            if (maxBytes <= 0) {
-                throw new IllegalArgumentException("Direct body limit must be positive");
-            }
-            this.maxBytes = maxBytes;
-        }
-
-        synchronized void expectLength(long declaredLength) {
-            if (!terminal) {
-                this.declaredLength = declaredLength;
-            }
-        }
-
-        @Override
-        public CompletionStage<ContentIdentity> getBody() {
-            return body;
-        }
-
-        @Override
-        public void onSubscribe(Flow.Subscription nextSubscription) {
-            Objects.requireNonNull(nextSubscription, "subscription must not be null");
-            boolean cancel;
-            synchronized (this) {
-                cancel = terminal || subscription != null;
-                if (!cancel) {
-                    subscription = nextSubscription;
-                }
-            }
-            if (cancel) {
-                nextSubscription.cancel();
-            } else {
-                nextSubscription.request(1);
-            }
-        }
-
-        @Override
-        public void onNext(List<ByteBuffer> buffers) {
-            IOException failure = null;
-            Flow.Subscription next;
-            synchronized (this) {
-                if (terminal) {
-                    return;
-                }
-                next = subscription;
-                if (next == null) {
-                    failure = new IOException("Maven Central body arrived before subscription");
-                } else if (buffers == null) {
-                    failure = new IOException("Maven Central returned an invalid response body");
-                } else {
-                    for (ByteBuffer buffer : buffers) {
-                        if (buffer == null || buffer.remaining() > maxBytes - length) {
-                            failure = new IOException("Exact artifact exceeds its size limit");
-                            break;
-                        }
-                        int bytes = buffer.remaining();
-                        digest.update(buffer);
-                        length += bytes;
-                    }
-                }
-            }
-            if (failure != null) {
-                abort(failure);
-            } else {
-                next.request(1);
-            }
-        }
-
-        @Override
-        public void onError(Throwable error) {
-            abort(error instanceof IOException ioFailure
-                    ? ioFailure
-                    : new IOException("Could not read exact artifact bytes from Maven Central", error));
-        }
-
-        @Override
-        public void onComplete() {
-            ContentIdentity identity = null;
-            IOException failure = null;
-            synchronized (this) {
-                if (terminal) {
-                    return;
-                }
-                if (length == 0) {
-                    failure = new IOException("Exact artifact is empty");
-                } else if (declaredLength >= 0 && declaredLength != length) {
-                    failure = new IOException("Maven Central response length does not match Content-Length");
-                } else {
-                    terminal = true;
-                    identity = new ContentIdentity(
-                            "sha256:" + HexFormat.of().formatHex(digest.digest()), length);
-                }
-            }
-            if (failure != null) {
-                abort(failure);
-            } else {
-                body.complete(identity);
-            }
-        }
-
-        void abort(IOException failure) {
-            Objects.requireNonNull(failure, "failure must not be null");
-            Flow.Subscription toCancel;
-            synchronized (this) {
-                if (terminal) {
-                    return;
-                }
-                terminal = true;
-                toCancel = subscription;
-            }
-            if (toCancel != null) {
-                toCancel.cancel();
-            }
-            body.completeExceptionally(failure);
-        }
-    }
-
-    private static final class DirectBodyHandler implements HttpResponse.BodyHandler<ContentIdentity> {
-        private final long maxBytes;
-        private final DirectBodySubscriber subscriber;
-
-        private DirectBodyHandler(long maxBytes) {
-            this.maxBytes = maxBytes;
-            this.subscriber = new DirectBodySubscriber(maxBytes);
-        }
-
-        @Override
-        public HttpResponse.BodySubscriber<ContentIdentity> apply(HttpResponse.ResponseInfo response) {
-            IOException failure = validate(response);
-            if (failure != null) {
-                subscriber.abort(failure);
-            }
-            return subscriber;
-        }
-
-        private IOException validate(HttpResponse.ResponseInfo response) {
-            if (response.statusCode() != 200) {
-                return new IOException("Maven Central returned an unexpected HTTP response");
-            }
-            List<String> encodings = response.headers().allValues("Content-Encoding");
-            if (encodings.stream().anyMatch(value -> !"identity".equalsIgnoreCase(value.trim()))) {
-                return new IOException("Maven Central returned encoded artifact bytes");
-            }
-            List<String> lengths = response.headers().allValues("Content-Length");
-            if (lengths.size() > 1) {
-                return new IOException("Maven Central returned an invalid Content-Length");
-            }
-            if (!lengths.isEmpty()) {
-                long declared;
-                try {
-                    declared = Long.parseLong(lengths.get(0));
-                } catch (NumberFormatException e) {
-                    return new IOException("Maven Central returned an invalid Content-Length", e);
-                }
-                if (declared <= 0 || declared > maxBytes) {
-                    return new IOException("Maven Central returned an unsafe artifact size");
-                }
-                subscriber.expectLength(declared);
-            }
-            return null;
-        }
-
-        private void abort(IOException failure) {
-            subscriber.abort(failure);
-        }
-    }
-
-    private static final class DirectClientHolder {
-        private static final HttpClient INSTANCE = newDirectClient();
-
-        private DirectClientHolder() {
         }
     }
 }

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
@@ -99,6 +99,21 @@ class ExactArtifactResolutionTest {
     }
 
     @Test
+    void onlineResolutionBindsIdentityToTheLocallyCachedBytes() throws IOException {
+        MavenCoordinate coordinate = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
+        byte[] cached = "cached-bytes".getBytes(StandardCharsets.UTF_8);
+        seed(coordinate, "cached-bytes");
+
+        ResolvedExactMavenArtifact resolved = ShipMavenResolver.resolveArtifacts(
+                repository, List.of(coordinate), ShipMavenResolver.ResolutionMode.ONLINE).get(0);
+
+        // A warm cache is served without touching the network and its bytes are trusted as-is;
+        // the recorded identity must match the cached bytes exactly.
+        assertEquals(cached.length, resolved.contentLength());
+        assertEquals(sha256(cached), resolved.contentSha256());
+    }
+
+    @Test
     void aetherCacheFillDisablesRedirectsAndHonorsJvmTransportProperties() {
         var session = ShipMavenResolver.session(
                 new RepositorySystemSupplier().get(), repository, ShipMavenResolver.ResolutionMode.ONLINE);

--- a/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
+++ b/camel-kit-ship-resolver/src/test/java/io/github/luigidemasi/camelkit/ship/resolver/ExactArtifactResolutionTest.java
@@ -2,32 +2,14 @@ package io.github.luigidemasi.camelkit.ship.resolver;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpTimeoutException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
-import java.time.Duration;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Flow;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import org.eclipse.aether.ConfigurationProperties;
@@ -117,52 +99,6 @@ class ExactArtifactResolutionTest {
     }
 
     @Test
-    void onlineResolutionRejectsAPoisonedCacheAndBindsMatchingCentralBytes() throws IOException {
-        MavenCoordinate coordinate = MavenCoordinate.jar("example.test", "catalog", "1.0.0");
-        seed(coordinate, "poisoned-cache");
-
-        IOException poisoned = assertThrows(IOException.class, () -> ShipMavenResolver.resolveArtifacts(
-                repository,
-                List.of(coordinate),
-                ShipMavenResolver.ResolutionMode.ONLINE,
-                (uri, maxBytes) -> identity("central-bytes")));
-        assertTrue(poisoned.getMessage().contains("differs from authoritative Maven Central bytes"));
-
-        seed(coordinate, "central-bytes");
-        AtomicReference<URI> requested = new AtomicReference<>();
-        ResolvedExactMavenArtifact resolved = ShipMavenResolver.resolveArtifacts(
-                repository,
-                List.of(coordinate),
-                ShipMavenResolver.ResolutionMode.ONLINE,
-                (uri, maxBytes) -> {
-                    requested.set(uri);
-                    assertTrue("central-bytes".getBytes(StandardCharsets.UTF_8).length <= maxBytes);
-                    return identity("central-bytes");
-                }).get(0);
-
-        assertEquals(URI.create(
-                "https://repo.maven.apache.org/maven2/example/test/catalog/1.0.0/catalog-1.0.0.jar"),
-                requested.get());
-        assertEquals("central-bytes".length(), resolved.contentLength());
-        assertEquals(sha256("central-bytes".getBytes(StandardCharsets.UTF_8)), resolved.contentSha256());
-    }
-
-    @Test
-    void directCentralTransportDisablesRedirectsAndContentEncodingAndFollowsJvmProxyDefaults() {
-        URI uri = URI.create("https://repo.maven.apache.org/maven2/example.test");
-        HttpClient client = ShipMavenResolver.directClient();
-        HttpRequest request = ShipMavenResolver.directRequest(uri);
-
-        assertSame(client, ShipMavenResolver.directClient());
-        assertEquals(HttpClient.Redirect.NEVER, client.followRedirects());
-        // No explicit proxy selector: the client follows the JVM default, which
-        // honors the standard proxy system properties.
-        assertTrue(client.proxy().isEmpty());
-        assertEquals("identity", request.headers().firstValue("Accept-Encoding").orElseThrow());
-        assertEquals(uri, request.uri());
-    }
-
-    @Test
     void aetherCacheFillDisablesRedirectsAndHonorsJvmTransportProperties() {
         var session = ShipMavenResolver.session(
                 new RepositorySystemSupplier().get(), repository, ShipMavenResolver.ResolutionMode.ONLINE);
@@ -237,95 +173,6 @@ class ExactArtifactResolutionTest {
                 new ByteArrayInputStream(new byte[exact.length + 1]), exact.length));
     }
 
-    @Test
-    void directFetchTimesOutAndClosesAnExchangeStalledBeforeHeaders() throws Exception {
-        assertStalledExchangeIsBounded(false);
-    }
-
-    @Test
-    void directFetchTimesOutAndClosesAnExchangeStalledMidBody() throws Exception {
-        assertStalledExchangeIsBounded(true);
-    }
-
-    @Test
-    void directFetchNormalizesTheJdkRequestTimeout() {
-        HttpTimeoutException jdkFailure = new HttpTimeoutException("request timed out");
-
-        IOException normalized = ShipMavenResolver.directFetchFailure(jdkFailure);
-
-        assertEquals("Timed out fetching exact artifact bytes from Maven Central", normalized.getMessage());
-        assertSame(jdkFailure, normalized.getCause());
-    }
-
-    @Test
-    void directBodySubscriberCancelsExactlyOnceAndRejectsLateSignals() {
-        ShipMavenResolver.DirectBodySubscriber overflow = new ShipMavenResolver.DirectBodySubscriber(2);
-        RecordingSubscription overflowSubscription = new RecordingSubscription();
-        overflow.onSubscribe(overflowSubscription);
-        overflow.onNext(List.of(ByteBuffer.wrap(new byte[3])));
-
-        CompletionException overflowFailure = assertThrows(
-                CompletionException.class, () -> overflow.getBody().toCompletableFuture().join());
-        assertInstanceOf(IOException.class, overflowFailure.getCause());
-        assertEquals(1, overflowSubscription.cancellations.get());
-        overflow.onComplete();
-        overflow.onNext(List.of(ByteBuffer.wrap(new byte[]{1})));
-        overflow.abort(new IOException("late abort"));
-        assertEquals(1, overflowSubscription.cancellations.get());
-
-        ShipMavenResolver.DirectBodySubscriber aborted = new ShipMavenResolver.DirectBodySubscriber(2);
-        RecordingSubscription abortedSubscription = new RecordingSubscription();
-        aborted.onSubscribe(abortedSubscription);
-        aborted.abort(new IOException("deadline"));
-        aborted.abort(new IOException("duplicate deadline"));
-        aborted.onComplete();
-        assertEquals(1, abortedSubscription.cancellations.get());
-    }
-
-    private static void assertStalledExchangeIsBounded(boolean partialBody) throws Exception {
-        ExecutorService serverExecutor = Executors.newSingleThreadExecutor();
-        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
-            Future<Boolean> clientClosed = serverExecutor.submit(() -> {
-                try (Socket socket = server.accept()) {
-                    socket.setSoTimeout(3_000);
-                    readRequest(socket.getInputStream());
-                    if (partialBody) {
-                        socket.getOutputStream().write(("HTTP/1.1 200 OK\r\n"
-                                                        + "Content-Length: 2\r\n"
-                                                        + "Content-Encoding: identity\r\n"
-                                                        + "Connection: close\r\n\r\n"
-                                                        + "x")
-                                .getBytes(StandardCharsets.US_ASCII));
-                        socket.getOutputStream().flush();
-                    }
-                    return socket.getInputStream().read() == -1;
-                }
-            });
-
-            URI endpoint = URI.create("http://127.0.0.1:" + server.getLocalPort() + "/artifact.jar");
-            IOException failure = assertThrows(IOException.class,
-                    () -> ShipMavenResolver.fetchDirect(endpoint, 2, Duration.ofMillis(300)));
-
-            assertTrue(failure.getMessage().contains("Timed out"), failure.getMessage());
-            assertTrue(clientClosed.get(2, TimeUnit.SECONDS), "cancelled exchange did not close its connection");
-        } finally {
-            serverExecutor.shutdownNow();
-            assertTrue(serverExecutor.awaitTermination(3, TimeUnit.SECONDS));
-        }
-    }
-
-    private static void readRequest(InputStream input) throws IOException {
-        int matched = 0;
-        byte[] terminator = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
-        while (matched < terminator.length) {
-            int next = input.read();
-            if (next < 0) {
-                throw new IOException("client closed before sending an HTTP request");
-            }
-            matched = next == terminator[matched] ? matched + 1 : next == terminator[0] ? 1 : 0;
-        }
-    }
-
     private void seed(MavenCoordinate coordinate, String content) throws IOException {
         Path artifact = path(coordinate);
         Files.createDirectories(artifact.getParent());
@@ -350,25 +197,6 @@ class ExactArtifactResolutionTest {
             return "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
         } catch (java.security.NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
-        }
-    }
-
-    private static ShipMavenResolver.ContentIdentity identity(String value) {
-        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-        return new ShipMavenResolver.ContentIdentity(sha256(bytes), bytes.length);
-    }
-
-    private static final class RecordingSubscription implements Flow.Subscription {
-        private final AtomicInteger cancellations = new AtomicInteger();
-
-        @Override
-        public void request(long count) {
-            // The fixture emits data explicitly.
-        }
-
-        @Override
-        public void cancel() {
-            cancellations.incrementAndGet();
         }
     }
 }


### PR DESCRIPTION
Part of #182 — issue #149 product-boundary alignment, cluster 3 of 6. **Stacked on #184.**

## What

Every ONLINE artifact resolution downloaded the bytes **twice**: once through Aether (already fail-closed: `CHECKSUM_POLICY_FAIL` against the fixed Central repository, `UPDATE_POLICY_NEVER`, strict descriptor policy), then a second time through a bespoke `HttpClient` pipeline (streaming digest `BodySubscriber`, watchdog deadlines, exchange-stall handling) with a byte comparison against the Aether result. `JvmPayloadArchive` repeated the same ritual per payload artifact with SHA-512 — "authoritative Maven Central verification" by its own error strings.

## Why it goes

Supply-chain attestation is an explicit issue #149 non-goal, and the check's only actual coverage was tampering of **Ship's own repositories** between download and use by a same-user writer — the malicious same-user process the product boundary excludes. For the JVM payload that repository is a private, 0700, per-command directory that must start empty (`JvmPayloadArchive` hard-fails otherwise). The catalog repository is persistent across runs (state-root default, `--maven-repository` override), so dropping the check also means a previously cached artifact is trusted as-is on later ONLINE runs: Aether validates checksums on downloads only, never on cache hits. That residual case still requires a same-user writer, who could equally tamper the unsigned evidence living in the same state directory; the accepted contract is documented in the resolver and catalog Javadoc and anchored by a warm-cache identity test. Remote integrity is Aether's checksum enforcement, which stays untouched.

## Change

- `ShipMavenResolver` 702 → 342 lines: ONLINE mode is now plain Aether resolution; the recorded `contentSha256`/`contentLength` are computed once from the resolved bytes (still feeding staleness digests downstream). The whole direct-fetch apparatus (`CentralDigestSource` seam, subscriber, deadlines executor) is gone, along with the pre-resolution symlink walk that duplicated `requireExactArtifact`'s post-resolution walk.
- `JvmPayloadArchive` 566 → 469 lines: `verifyCentralBytes` and its SHA-512/HTTP machinery removed; all coordinate/version-alignment/duplicate/size checks kept.
- **Untouched**: `rejectRepositoryOverrides` (both copies) and its guard tests; proxy/trust-store tolerance (#177) byte-identical; all offline-behavior tests.

Net: **+22/−635 across 5 files.** Full reactor green at `516c5c4d`: 910 core / 187 graph / resolver, 0 failures; the follow-up commit is gated on the GitHub Actions build. Website impact: not required.

## Review follow-up (2026-08-21)

`b03f833c` addresses what the post-review verification surfaced:

- restores ONLINE-mode value coverage of `resolveArtifacts` — a warm-cache test pins that the recorded `contentSha256`/`contentLength` match the cached bytes exactly (the only value-level digest assertion had gone with the deleted poisoned-cache test, and this is also the accepted warm-cache behavior described above);
- documents the cache-trust contract on the `resolveArtifacts` and `ShipCatalogService` Javadoc;
- records two deltas as code comments: `REQUEST_TIMEOUT` bounds per-read socket inactivity, not the whole transfer, and the surviving symlink walk detects after resolution rather than preventing the write;
- fixes a stale `JvmPayloadTestFixture` comment that still described the removed Central verification as current.

The line counts above are also corrected against the actual files (previously stated as 703 → 335; both files are newline-terminated and count 702 → 342).

## Summary by Sourcery

Eliminate redundant Maven Central double-download verification while preserving existing artifact integrity and resolution safeguards.

Enhancements:
- Simplify online Maven artifact resolution by relying on Aether's existing fail-closed repository verification and calculating content identities from the resolved local bytes.
- Remove redundant direct Maven Central downloads, byte-comparison verification, transport timeout machinery, and associated test coverage.
- Retain repository override protections, artifact coordinate and size validation, duplicate checks, and offline resolution behavior.

Tests:
- Remove tests covering the retired direct Maven Central fetch and byte-verification pipeline.
