### PR TITLE
chore: restore keep-going coverage after a failing evidence command

### DIFF
--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidatorTest.java
@@ -243,7 +243,7 @@ class ShipMainValidatorTest {
     void mapsANonzeroCommandExitToItsCheckOutcome() throws Exception {
         Project nonzeroProject = project("orders");
         RecordingExecutor nonzero = new RecordingExecutor();
-        nonzero.nonzeroCommand = "citrus-integration-test-001";
+        nonzero.nonzeroCommand = "route-schema";
 
         ShipMainValidator.Result nonzeroResult = validator(nonzero).validate(
                 RUN_ID,
@@ -258,8 +258,9 @@ class ShipMainValidatorTest {
 
         assertEquals(ShipLocalStamp.Status.FAIL, nonzeroResult.stamp().status());
         assertEquals(Outcome.NONZERO, nonzeroResult.stamp().checks().stream()
-                .filter(check -> "citrus-integration-test-001".equals(check.id()))
+                .filter(check -> "route-schema".equals(check.id()))
                 .findFirst().orElseThrow().outcome());
+        assertEquals(3, nonzero.commands.size(), "later checks still run after a failing command");
     }
 
     @Test


### PR DESCRIPTION
Restores an assertion lost when #183 removed the package-summary scenario: nothing verified anymore that the validator keeps executing later evidence commands after one fails, because the surviving nonzero-exit test targeted the last command in the plan.

- Point `nonzeroCommand` at `route-schema` (the first command) instead of `citrus-integration-test-001` (the last).
- Keep the NONZERO outcome-mapping assertion the test is named for, re-targeted to `route-schema`.
- Assert `commands.size() == 3` so a future regression in the validator loop's keep-going behavior fails the test.

Test-only change. Full reactor green (908 core tests).

Stacked on #186 (`issue-182/04-catalog-toctou`) because the upper stack also modifies `ShipMainValidatorTest`; it should merge after the #183→#186 train.

## Summary by Sourcery

Tests:
- Update validator coverage to verify that later evidence commands continue running after an earlier command fails, while preserving nonzero-exit outcome mapping coverage.