### PR TITLE
Simplify Pi worker recovery and redaction boundaries

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStamp.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStamp.java
@@ -3,6 +3,7 @@ package io.github.luigidemasi.camelkit.ship.evidence;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -480,6 +481,165 @@ public record ShipLocalStamp(
             offset += Character.charCount(codePoint);
         }
         return false;
+    }
+
+    /** Canonicalizes credentials using their original argument positions. */
+    public static List<String> redactSensitiveArguments(
+            List<String> arguments, List<String> redactedArguments) {
+        List<String> original = List.copyOf(
+                Objects.requireNonNull(arguments, "arguments"));
+        List<String> redacted = new ArrayList<>(
+                Objects.requireNonNull(redactedArguments, "redactedArguments"));
+        if (original.size() != redacted.size()
+                || redacted.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException(
+                    "Original and redacted command arguments must align");
+        }
+        redacted.replaceAll(ShipLocalStamp::redactKnownSecrets);
+        for (int index = 0; index < redacted.size(); index++) {
+            String argument = original.get(index);
+            if (compactCredential(argument)) {
+                String prefix = argument.substring(0, 2);
+                String transformed = redacted.get(index);
+                if (!transformed.startsWith(prefix)
+                        || !isRedactedValue(transformed.substring(2))) {
+                    redacted.set(
+                            index,
+                            transformed.startsWith(prefix)
+                                    ? prefix + REDACTED
+                                    : REDACTED);
+                }
+                continue;
+            }
+            int separator = argument.indexOf('=');
+            String name = separator < 0
+                    ? argument
+                    : argument.substring(0, separator);
+            boolean positionalName = separator < 0
+                    && (name.startsWith("-") || authorizationName(name));
+            if (!isSensitiveOption(name)
+                    || (separator < 0 && !positionalName)) {
+                continue;
+            }
+            String supplied = separator < 0
+                    ? index + 1 < original.size() ? original.get(index + 1) : null
+                    : argument.substring(separator + 1).trim();
+            int credentialIndex = separator < 0 ? index + 2 : index + 1;
+            if (authorizationName(name) && authorizationScheme(supplied)) {
+                redactArgument(redacted, credentialIndex);
+                continue;
+            }
+            if (separator < 0) {
+                redactArgument(redacted, index + 1);
+            } else {
+                String prefix = argument.substring(0, separator + 1);
+                String transformed = redacted.get(index);
+                if (!isRedactedValue(transformed)
+                        && (!transformed.startsWith(prefix)
+                                || !isRedactedValue(
+                                        transformed.substring(prefix.length()).trim()))) {
+                    redacted.set(
+                            index,
+                            transformed.startsWith(prefix)
+                                    ? prefix + REDACTED
+                                    : REDACTED);
+                }
+            }
+            if (authorizationName(name)
+                    && credentialIndex < original.size()
+                    && !original.get(credentialIndex).startsWith("-")) {
+                redactArgument(redacted, credentialIndex);
+            }
+        }
+        return List.copyOf(redacted);
+    }
+
+    private static void redactArgument(List<String> arguments, int index) {
+        if (index < arguments.size()
+                && !isRedactedValue(arguments.get(index))) {
+            arguments.set(index, REDACTED);
+        }
+    }
+
+    private static String redactKnownSecrets(String argument) {
+        String redacted = redactAssignments(argument);
+        redacted = redactAuthorizations(redacted);
+        return redactUrls(redacted);
+    }
+
+    private static String redactAssignments(String argument) {
+        Matcher matcher = SENSITIVE_ASSIGNMENT.matcher(argument);
+        StringBuilder result = null;
+        int offset = 0;
+        while (matcher.find()) {
+            String supplied = matcher.group(3).trim();
+            if (isRedactedValue(supplied)
+                    || (authorizationName(matcher.group(1))
+                            && authorizationScheme(supplied))) {
+                continue;
+            }
+            if (result == null) {
+                result = new StringBuilder(argument.length());
+            }
+            result.append(argument, offset, matcher.start());
+            String matched = matcher.group(3);
+            String quote = matched.length() >= 2
+                    && (matched.charAt(0) == '"' || matched.charAt(0) == '\'')
+                    && matched.charAt(matched.length() - 1) == matched.charAt(0)
+                            ? matched.substring(0, 1)
+                            : "";
+            result.append(matcher.group(1))
+                    .append(matcher.group(2))
+                    .append(quote)
+                    .append(REDACTED)
+                    .append(quote);
+            offset = matcher.end();
+        }
+        return finishReplacement(argument, result, offset);
+    }
+
+    private static String redactAuthorizations(String argument) {
+        Matcher matcher = AUTHORIZATION_SCHEME.matcher(argument);
+        StringBuilder result = null;
+        int offset = 0;
+        while (matcher.find()) {
+            if (REDACTED.equals(matcher.group(2))) {
+                continue;
+            }
+            if (result == null) {
+                result = new StringBuilder(argument.length());
+            }
+            result.append(argument, offset, matcher.start())
+                    .append(matcher.group(1))
+                    .append(' ')
+                    .append(REDACTED);
+            offset = matcher.end();
+        }
+        return finishReplacement(argument, result, offset);
+    }
+
+    private static String redactUrls(String argument) {
+        Matcher matcher = URL_USERINFO.matcher(argument);
+        StringBuilder result = null;
+        int offset = 0;
+        while (matcher.find()) {
+            if (REDACTED.equals(matcher.group(1))) {
+                continue;
+            }
+            if (result == null) {
+                result = new StringBuilder(argument.length());
+            }
+            result.append(argument, offset, matcher.start(1)).append(REDACTED);
+            offset = matcher.end(1);
+        }
+        return finishReplacement(argument, result, offset);
+    }
+
+    private static String finishReplacement(
+            String original, StringBuilder result, int offset) {
+        return result == null
+                ? original
+                : result.append(original, offset, original.length()).toString();
     }
 
     public static boolean isSensitiveName(String value) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStamp.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/evidence/ShipLocalStamp.java
@@ -517,8 +517,19 @@ public record ShipLocalStamp(
                     : argument.substring(0, separator);
             boolean positionalName = separator < 0
                     && (name.startsWith("-") || authorizationName(name));
-            if (!isSensitiveOption(name)
-                    || (separator < 0 && !positionalName)) {
+            String transformed = redacted.get(index);
+            int transformedSeparator = transformed.indexOf('=');
+            String transformedName = transformedSeparator < 0
+                    ? transformed
+                    : transformed.substring(0, transformedSeparator);
+            boolean transformedPositionalName = transformedSeparator < 0
+                    && (transformedName.startsWith("-")
+                            || authorizationName(transformedName));
+            if ((!isSensitiveOption(name)
+                    || (separator < 0 && !positionalName))
+                    && (!isSensitiveOption(transformedName)
+                            || (transformedSeparator < 0
+                                    && !transformedPositionalName))) {
                 continue;
             }
             String supplied = separator < 0
@@ -530,10 +541,13 @@ public record ShipLocalStamp(
                 continue;
             }
             if (separator < 0) {
-                redactArgument(redacted, index + 1);
+                if (index + 1 < redacted.size()) {
+                    redactArgument(redacted, index + 1);
+                } else {
+                    redacted.set(index, REDACTED);
+                }
             } else {
                 String prefix = argument.substring(0, separator + 1);
-                String transformed = redacted.get(index);
                 if (!isRedactedValue(transformed)
                         && (!transformed.startsWith(prefix)
                                 || !isRedactedValue(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,7 +55,7 @@ final class LocalCommandRunner {
     private static final Pattern AUTHORIZATION_SCHEME = Pattern.compile(
             "(?i)[\"']?\\b(Bearer|Basic)\\s+[\"']?([^\\s\"',}]+)[\"']?");
     private static final Pattern URL_USERINFO = Pattern.compile(
-            "([A-Za-z][A-Za-z0-9+.-]*://)([^/@\\s]*)@");
+            "(?<=://)[^/@\\s]*@");
     private static final ObjectMapper JSON = new ObjectMapper();
 
     private final Clock clock;
@@ -312,37 +311,69 @@ final class LocalCommandRunner {
     }
 
     private static String redact(String value, List<String> secrets) {
-        String result = value;
+        return redact(value, secrets, Integer.MAX_VALUE);
+    }
+
+    private static String redact(
+            String value, List<String> secrets, int maximumCharacters) {
         List<String> literals = secretRepresentations(secrets);
+        Pattern literalPattern = null;
+        String expression = "(?:" + SENSITIVE_ASSIGNMENT.pattern() + ')'
+                            + "|(?:" + AUTHORIZATION_SCHEME.pattern() + ')'
+                            + "|(?:" + URL_USERINFO.pattern() + ')';
         if (!literals.isEmpty()) {
-            String expression = String.join(
+            String literalExpression = String.join(
                     "|", literals.stream().map(Pattern::quote).toList());
-            result = Pattern.compile(expression).matcher(result)
-                    .replaceAll(Matcher.quoteReplacement(ShipLocalStamp.REDACTED));
+            literalPattern = Pattern.compile(literalExpression);
+            expression += "|(?:" + literalExpression + ')';
         }
-        result = SENSITIVE_ASSIGNMENT.matcher(result)
-                .replaceAll(match -> Matcher.quoteReplacement(redactedAssignment(match)));
-        result = AUTHORIZATION_SCHEME.matcher(result).replaceAll(match -> Matcher.quoteReplacement(
-                match.group(1) + " " + ShipLocalStamp.REDACTED));
-        return URL_USERINFO.matcher(result).replaceAll(match -> Matcher.quoteReplacement(
-                match.group(1) + ShipLocalStamp.REDACTED + "@"));
+        Matcher search = Pattern.compile("(?=(?:" + expression + "))").matcher(value);
+
+        StringBuilder redacted = new StringBuilder(
+                Math.min(value.length(), maximumCharacters));
+        int position = 0;
+        while (search.find(position)) {
+            RedactionMatch match = redactionAt(
+                    value, search.start(), literalPattern);
+            int candidateStart = match.start() + 1;
+            while (search.find(candidateStart)) {
+                RedactionMatch candidate = redactionAt(
+                        value, search.start(), literalPattern);
+                if (candidate.start() >= match.end()) {
+                    break;
+                }
+                match = new RedactionMatch(
+                        match.start(),
+                        Math.max(match.end(), candidate.end()),
+                        match.replacement());
+                candidateStart = candidate.start() + 1;
+            }
+
+            int remaining = maximumCharacters - redacted.length();
+            int unchanged = match.start() - position;
+            if (unchanged > remaining) {
+                appendPrefix(redacted, value, position, remaining);
+                return redacted.toString();
+            }
+            redacted.append(value, position, match.start());
+            if (match.replacement().length()
+                > maximumCharacters - redacted.length()) {
+                return redacted.toString();
+            }
+            redacted.append(match.replacement());
+            position = match.end();
+        }
+        appendPrefix(
+                redacted,
+                value,
+                position,
+                maximumCharacters - redacted.length());
+        return redacted.toString();
     }
 
     private static byte[] redactBounded(
             String value, List<String> secrets, int maximumBytes) {
-        List<String> literals = secretRepresentations(secrets);
-        String expression = "(?<assignment>" + SENSITIVE_ASSIGNMENT.pattern() + ')'
-                            + "|(?<authorization>" + AUTHORIZATION_SCHEME.pattern() + ')'
-                            + "|(?<url>" + URL_USERINFO.pattern() + ')';
-        if (!literals.isEmpty()) {
-            expression += "|(?<literal>" + String.join(
-                    "|", literals.stream().map(Pattern::quote).toList()) + ')';
-        }
-        String result = replaceBounded(
-                value,
-                Pattern.compile(expression),
-                LocalCommandRunner::boundedReplacement,
-                maximumBytes);
+        String result = redact(value, secrets, maximumBytes);
         byte[] encoded = result.getBytes(StandardCharsets.UTF_8);
         if (encoded.length <= maximumBytes) {
             return encoded;
@@ -361,67 +392,56 @@ final class LocalCommandRunner {
         return prefix.getBytes(StandardCharsets.UTF_8);
     }
 
-    private static String replaceBounded(
-            String value,
-            Pattern pattern,
-            Function<Matcher, String> replacement,
-            int maximumCharacters) {
-        Matcher matcher = pattern.matcher(value);
-        StringBuilder bounded = new StringBuilder(
-                Math.min(value.length(), maximumCharacters));
-        int position = 0;
-        while (matcher.find()) {
-            int remaining = maximumCharacters - bounded.length();
-            int unmatched = matcher.start() - position;
-            if (unmatched > remaining) {
-                appendPrefix(bounded, value, position, remaining);
-                return bounded.toString();
-            }
-            bounded.append(value, position, matcher.start());
-            String replacementValue = replacement.apply(matcher);
-            if (replacementValue.length()
-                > maximumCharacters - bounded.length()) {
-                return bounded.toString();
-            }
-            bounded.append(replacementValue);
-            position = matcher.end();
+    private static RedactionMatch redactionAt(
+            String value, int start, Pattern literalPattern) {
+        int end = start;
+        String replacement = null;
+
+        Matcher assignment = at(SENSITIVE_ASSIGNMENT, value, start);
+        if (assignment.lookingAt()) {
+            end = assignment.end();
+            replacement = redactedAssignment(assignment);
         }
-        appendPrefix(
-                bounded,
-                value,
-                position,
-                maximumCharacters - bounded.length());
-        return bounded.toString();
+        Matcher authorization = at(AUTHORIZATION_SCHEME, value, start);
+        if (authorization.lookingAt()) {
+            end = Math.max(end, authorization.end());
+            if (replacement == null) {
+                replacement = authorization.group(1) + " " + ShipLocalStamp.REDACTED;
+            }
+        }
+        Matcher url = at(URL_USERINFO, value, start);
+        if (url.lookingAt()) {
+            end = Math.max(end, url.end());
+            if (replacement == null) {
+                replacement = ShipLocalStamp.REDACTED + "@";
+            }
+        }
+        if (literalPattern != null) {
+            Matcher literal = at(literalPattern, value, start);
+            if (literal.lookingAt()) {
+                end = Math.max(end, literal.end());
+                if (replacement == null) {
+                    replacement = ShipLocalStamp.REDACTED;
+                }
+            }
+        }
+        if (literalPattern != null
+                && !ShipLocalStamp.REDACTED.equals(replacement)
+                && literalPattern.matcher(replacement).find()) {
+            replacement = ShipLocalStamp.REDACTED;
+        }
+        return new RedactionMatch(start, end, replacement);
     }
 
-    private static String boundedReplacement(Matcher match) {
-        String assignmentValue = match.group("assignment");
-        if (assignmentValue != null) {
-            Matcher assignment = SENSITIVE_ASSIGNMENT.matcher(assignmentValue);
-            if (assignment.matches()) {
-                return redactedAssignment(assignment);
-            }
-        }
-        String authorizationValue = match.group("authorization");
-        if (authorizationValue != null) {
-            Matcher authorization = AUTHORIZATION_SCHEME.matcher(authorizationValue);
-            if (authorization.matches()) {
-                return authorization.group(1) + " " + ShipLocalStamp.REDACTED;
-            }
-        }
-        String urlValue = match.group("url");
-        if (urlValue != null) {
-            Matcher url = URL_USERINFO.matcher(urlValue);
-            if (url.matches()) {
-                return url.group(1) + ShipLocalStamp.REDACTED + "@";
-            }
-        }
-        return ShipLocalStamp.REDACTED;
+    private static Matcher at(Pattern pattern, String value, int start) {
+        return pattern.matcher(value)
+                .region(start, value.length())
+                .useTransparentBounds(true);
     }
 
     private static void appendPrefix(
             StringBuilder target, String value, int start, int maximumCharacters) {
-        int end = Math.min(value.length(), start + maximumCharacters);
+        int end = start + Math.min(maximumCharacters, value.length() - start);
         if (end > start
                 && end < value.length()
                 && Character.isHighSurrogate(value.charAt(end - 1))
@@ -883,6 +903,9 @@ final class LocalCommandRunner {
     }
 
     record RetainedLog(Path path, String digest, long size) {
+    }
+
+    private record RedactionMatch(int start, int end, String replacement) {
     }
 
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -955,8 +955,15 @@ final class LocalCommandRunner {
             while (assignment.find()) {
                 int valueStart = assignment.end();
                 int end = assignmentEnd(valueStart);
+                String separator = assignment.group(2);
                 if (end <= valueStart) {
-                    continue;
+                    if (valueStart == 0
+                            || !isInlineWhitespace(value.charAt(valueStart - 1))) {
+                        continue;
+                    }
+                    valueStart--;
+                    end = valueStart + 1;
+                    separator = separator.substring(0, separator.length() - 1);
                 }
                 String quote = isQuote(value.charAt(valueStart))
                         ? value.substring(valueStart, valueStart + 1)
@@ -964,7 +971,7 @@ final class LocalCommandRunner {
                 assignmentMatch = new RedactionMatch(
                         assignment.start(),
                         end,
-                        assignment.group(1) + assignment.group(2)
+                        assignment.group(1) + separator
                              + quote + ShipLocalStamp.REDACTED + quote);
                 return;
             }
@@ -1069,6 +1076,13 @@ final class LocalCommandRunner {
                     || value == '\n'
                     || value == ','
                     || value == '}';
+        }
+
+        private static boolean isInlineWhitespace(char value) {
+            return value == ' '
+                    || value == '\t'
+                    || value == '\u000b'
+                    || value == '\f';
         }
 
         private static boolean isAuthorizationDelimiter(char value) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.PriorityQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,7 +27,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,16 +44,23 @@ final class LocalCommandRunner {
     private static final Path KILL = Path.of("/bin/kill");
     private static final byte[] OUTPUT_LIMIT_LOG
             = "<output-limit-exceeded>\n".getBytes(StandardCharsets.UTF_8);
+    private static final String SENSITIVE_NAME_EXPRESSION
+            = "docker[-_]?auth[-_]?config|npm[-_]?config[-_]*auth"
+              + "|password|passwd|pass|passphrase|pwd"
+              + "|secret|token|credentials?|auth(?:orization)?"
+              + "|api[-_]?key"
+              + "|access[-_]?key(?:[-_]?id)?|private[-_]?key|jwt|pat";
     private static final Pattern SENSITIVE_ASSIGNMENT = Pattern.compile(
-            "(?i)(docker[-_]?auth[-_]?config|npm[-_]?config[-_]*auth"
-                                                                        + "|password|passwd|pass|passphrase|pwd"
-                                                                        + "|secret|token|credentials?|auth(?:orization)?"
-                                                                        + "|api[-_]?key"
-                                                                        + "|access[-_]?key(?:[-_]?id)?|private[-_]?key|jwt|pat)"
+            "(?i)(" + SENSITIVE_NAME_EXPRESSION + ")"
                                                                         + "([\"']?\\s*[:=]\\s*)"
                                                                         + "(\"[^\"\\r\\n]*\"|'[^'\\r\\n]*'|[^\"'\\r\\n,}]+)");
+    private static final Pattern SENSITIVE_ASSIGNMENT_PREFIX = Pattern.compile(
+            "(?i)(" + SENSITIVE_NAME_EXPRESSION + ")"
+                                                                               + "([\"']?\\s*[:=]\\s*)(?=[^\\r\\n,}])");
     private static final Pattern AUTHORIZATION_SCHEME = Pattern.compile(
             "(?i)[\"']?\\b(Bearer|Basic)\\s+[\"']?([^\\s\"',}]+)[\"']?");
+    private static final Pattern AUTHORIZATION_PREFIX = Pattern.compile(
+            "(?i)[\"']?\\b(Bearer|Basic)\\s+[\"']?");
     private static final Pattern URL_USERINFO = Pattern.compile(
             "(?<=://)([^/@\\s]*)@");
     private static final ObjectMapper JSON = new ObjectMapper();
@@ -307,156 +314,45 @@ final class LocalCommandRunner {
 
     static List<String> redactArguments(
             List<String> arguments, List<String> secrets) {
-        return arguments.stream().map(argument -> redact(argument, secrets)).toList();
+        List<String> redacted = arguments.stream()
+                .map(argument -> redact(argument, secrets))
+                .toList();
+        return ShipLocalStamp.redactSensitiveArguments(arguments, redacted);
     }
 
     private static String redact(String value, List<String> secrets) {
-        return redact(value, secrets, Integer.MAX_VALUE);
-    }
-
-    private static String redact(
-            String value, List<String> secrets, int maximumCharacters) {
-        List<String> literals = secretRepresentations(secrets);
-        Pattern literalPattern = null;
-        String expression = "(?:" + SENSITIVE_ASSIGNMENT.pattern() + ')'
-                            + "|(?:" + AUTHORIZATION_SCHEME.pattern() + ')'
-                            + "|(?:" + URL_USERINFO.pattern() + ')';
-        if (!literals.isEmpty()) {
-            String literalExpression = String.join(
-                    "|", literals.stream().map(Pattern::quote).toList());
-            literalPattern = Pattern.compile(literalExpression);
-            expression += "|(?:" + literalExpression + ')';
-        }
-        Matcher search = Pattern.compile("(?=(?:" + expression + "))").matcher(value);
-
-        StringBuilder redacted = new StringBuilder(
-                Math.min(value.length(), maximumCharacters));
-        int position = 0;
-        while (search.find(position)) {
-            RedactionMatch match = redactionAt(
-                    value, search.start(), literalPattern);
-            int candidateStart = match.start() + 1;
-            while (search.find(candidateStart)) {
-                RedactionMatch candidate = redactionAt(
-                        value, search.start(), literalPattern);
-                if (candidate.start() >= match.end()) {
-                    break;
-                }
-                match = new RedactionMatch(
-                        match.start(),
-                        Math.max(match.end(), candidate.end()),
-                        match.replacement());
-                candidateStart = candidate.start() + 1;
-            }
-
-            int remaining = maximumCharacters - redacted.length();
-            int unchanged = match.start() - position;
-            if (unchanged > remaining) {
-                appendPrefix(redacted, value, position, remaining);
-                return redacted.toString();
-            }
-            redacted.append(value, position, match.start());
-            if (match.replacement().length()
-                > maximumCharacters - redacted.length()) {
-                return redacted.toString();
-            }
-            redacted.append(match.replacement());
-            position = match.end();
-        }
-        appendPrefix(
-                redacted,
-                value,
-                position,
-                maximumCharacters - redacted.length());
-        return redacted.toString();
+        StringBuilder result = new StringBuilder(value.length());
+        redact(value, secrets, (part, start, end, atomic) -> {
+            result.append(part, start, end);
+            return true;
+        });
+        return result.toString();
     }
 
     private static byte[] redactBounded(
             String value, List<String> secrets, int maximumBytes) {
-        String result = redact(value, secrets, maximumBytes);
-        byte[] encoded = result.getBytes(StandardCharsets.UTF_8);
-        if (encoded.length <= maximumBytes) {
-            return encoded;
-        }
-        int end = maximumBytes;
-        while (end > 0 && (encoded[end] & 0xc0) == 0x80) {
-            end--;
-        }
-        String prefix = new String(encoded, 0, end, StandardCharsets.UTF_8);
-        for (int length = 1; length < ShipLocalStamp.REDACTED.length(); length++) {
-            if (prefix.endsWith(ShipLocalStamp.REDACTED.substring(0, length))) {
-                prefix = prefix.substring(0, prefix.length() - length);
-                break;
-            }
-        }
-        return prefix.getBytes(StandardCharsets.UTF_8);
+        BoundedUtf8Output result = new BoundedUtf8Output(maximumBytes);
+        redact(value, secrets, result::append);
+        return result.toByteArray();
     }
 
-    private static RedactionMatch redactionAt(
-            String value, int start, Pattern literalPattern) {
-        int end = start;
-        String replacement = null;
-
-        Matcher assignment = at(SENSITIVE_ASSIGNMENT, value, start);
-        if (assignment.lookingAt()) {
-            end = assignment.end();
-            replacement = redactedAssignment(assignment);
-        }
-        Matcher authorization = at(AUTHORIZATION_SCHEME, value, start);
-        if (authorization.lookingAt()) {
-            end = Math.max(end, authorization.end());
-            if (replacement == null) {
-                replacement = authorization.group(1) + " " + ShipLocalStamp.REDACTED;
+    private static void redact(
+            String value, List<String> secrets, RedactionSink output) {
+        RedactionCursor cursor = new RedactionCursor(
+                value, secretRepresentations(secrets));
+        int offset = 0;
+        while (offset < value.length()) {
+            RedactionMatch match = cursor.next(offset);
+            int unchangedEnd = match == null ? value.length() : match.start();
+            if (!output.append(value, offset, unchangedEnd, false) || match == null) {
+                return;
             }
-        }
-        Matcher url = at(URL_USERINFO, value, start);
-        if (url.lookingAt()) {
-            end = Math.max(end, url.end());
-            if (replacement == null) {
-                replacement = ShipLocalStamp.REDACTED + "@";
+            String replacement = match.replacement();
+            if (!output.append(replacement, 0, replacement.length(), true)) {
+                return;
             }
+            offset = match.end();
         }
-        if (literalPattern != null) {
-            Matcher literal = at(literalPattern, value, start);
-            if (literal.lookingAt()) {
-                end = Math.max(end, literal.end());
-                if (replacement == null) {
-                    replacement = ShipLocalStamp.REDACTED;
-                }
-            }
-        }
-        if (literalPattern != null
-                && !ShipLocalStamp.REDACTED.equals(replacement)
-                && literalPattern.matcher(replacement).find()) {
-            replacement = ShipLocalStamp.REDACTED;
-        }
-        return new RedactionMatch(start, end, replacement);
-    }
-
-    private static Matcher at(Pattern pattern, String value, int start) {
-        return pattern.matcher(value)
-                .region(start, value.length())
-                .useTransparentBounds(true);
-    }
-
-    private static void appendPrefix(
-            StringBuilder target, String value, int start, int maximumCharacters) {
-        int end = start + Math.min(maximumCharacters, value.length() - start);
-        if (end > start
-                && end < value.length()
-                && Character.isHighSurrogate(value.charAt(end - 1))
-                && Character.isLowSurrogate(value.charAt(end))) {
-            end--;
-        }
-        target.append(value, start, end);
-    }
-
-    private static String redactedAssignment(MatchResult match) {
-        String supplied = match.group(3);
-        String value = unquote(supplied);
-        String quote = value.equals(supplied) ? "" : supplied.substring(0, 1);
-        return match.group(1) + match.group(2)
-               + quote + ShipLocalStamp.REDACTED + quote;
     }
 
     private static List<String> secretRepresentations(List<String> secrets) {
@@ -906,6 +802,420 @@ final class LocalCommandRunner {
     }
 
     private record RedactionMatch(int start, int end, String replacement) {
+    }
+
+    private record CursorMatch(int source, RedactionMatch match) {
+    }
+
+    private static final class RedactionCursor {
+
+        private static final int ASSIGNMENT_SOURCE = 0;
+        private static final int AUTHORIZATION_SOURCE = 1;
+        private static final int URL_SOURCE = 2;
+        private static final int LITERAL_SOURCE = 3;
+
+        private final String value;
+        private final List<String> literals;
+        private final PriorityQueue<LiteralCursor> literalMatches;
+        private final Matcher assignment;
+        private final Matcher authorization;
+        private final Matcher url;
+        private RedactionMatch assignmentMatch;
+        private RedactionMatch authorizationMatch;
+        private RedactionMatch urlMatch;
+        private int assignmentBoundary = -1;
+        private int authorizationBoundary = -1;
+
+        private RedactionCursor(String value, List<String> literals) {
+            this.value = value;
+            this.literals = literals;
+            literalMatches = new PriorityQueue<>(
+                    Comparator.comparingInt(LiteralCursor::start)
+                            .thenComparingInt(LiteralCursor::priority));
+            for (int index = 0; index < literals.size(); index++) {
+                LiteralCursor literal = new LiteralCursor(
+                        value, literals.get(index), index);
+                literal.advance();
+                if (literal.start() >= 0) {
+                    literalMatches.add(literal);
+                }
+            }
+            assignment = SENSITIVE_ASSIGNMENT_PREFIX.matcher(value);
+            authorization = AUTHORIZATION_PREFIX.matcher(value);
+            url = URL_USERINFO.matcher(value);
+            advanceAssignment();
+            advanceAuthorization();
+            advanceUrl();
+        }
+
+        private RedactionMatch next(int offset) {
+            advanceTo(offset);
+            CursorMatch selected = earliest();
+            if (selected == null) {
+                return null;
+            }
+            RedactionMatch result = selected.match();
+            advance(selected.source());
+            while (result.end() < value.length()) {
+                selected = earliest();
+                if (selected == null || selected.match().start() >= result.end()) {
+                    break;
+                }
+                RedactionMatch candidate = selected.match();
+                result = new RedactionMatch(
+                        result.start(),
+                        Math.max(result.end(), candidate.end()),
+                        result.replacement());
+                advance(selected.source());
+            }
+            if (!ShipLocalStamp.REDACTED.equals(result.replacement())
+                    && literals.stream().anyMatch(result.replacement()::contains)) {
+                result = new RedactionMatch(
+                        result.start(), result.end(), ShipLocalStamp.REDACTED);
+            }
+            return result;
+        }
+
+        private void advanceTo(int offset) {
+            while (assignmentMatch != null && assignmentMatch.start() < offset) {
+                advanceAssignment();
+            }
+            while (authorizationMatch != null
+                    && authorizationMatch.start() < offset) {
+                advanceAuthorization();
+            }
+            while (urlMatch != null && urlMatch.start() < offset) {
+                advanceUrl();
+            }
+            while (!literalMatches.isEmpty()
+                    && literalMatches.peek().start() < offset) {
+                LiteralCursor literal = literalMatches.remove();
+                do {
+                    literal.advance();
+                } while (literal.start() >= 0 && literal.start() < offset);
+                if (literal.start() >= 0) {
+                    literalMatches.add(literal);
+                }
+            }
+        }
+
+        private CursorMatch earliest() {
+            CursorMatch result = candidate(ASSIGNMENT_SOURCE, assignmentMatch);
+            result = earlier(
+                    result,
+                    candidate(AUTHORIZATION_SOURCE, authorizationMatch));
+            result = earlier(result, candidate(URL_SOURCE, urlMatch));
+            LiteralCursor literal = literalMatches.peek();
+            if (literal != null) {
+                result = earlier(
+                        result,
+                        candidate(
+                                LITERAL_SOURCE + literal.priority(),
+                                new RedactionMatch(
+                                        literal.start(),
+                                        literal.start() + literal.length(),
+                                        ShipLocalStamp.REDACTED)));
+            }
+            return result;
+        }
+
+        private static CursorMatch candidate(
+                int source, RedactionMatch match) {
+            return match == null ? null : new CursorMatch(source, match);
+        }
+
+        private static CursorMatch earlier(
+                CursorMatch current, CursorMatch candidate) {
+            if (current == null) {
+                return candidate;
+            }
+            if (candidate == null) {
+                return current;
+            }
+            int currentStart = current.match().start();
+            int candidateStart = candidate.match().start();
+            return candidateStart < currentStart
+                    || (candidateStart == currentStart
+                            && candidate.source() < current.source())
+                                    ? candidate
+                                    : current;
+        }
+
+        private void advance(int source) {
+            switch (source) {
+                case ASSIGNMENT_SOURCE -> advanceAssignment();
+                case AUTHORIZATION_SOURCE -> advanceAuthorization();
+                case URL_SOURCE -> advanceUrl();
+                default -> advanceLiteral(source - LITERAL_SOURCE);
+            }
+        }
+
+        private void advanceAssignment() {
+            assignmentMatch = null;
+            while (assignment.find()) {
+                int valueStart = assignment.end();
+                int end = assignmentEnd(valueStart);
+                if (end <= valueStart) {
+                    continue;
+                }
+                String quote = isQuote(value.charAt(valueStart))
+                        ? value.substring(valueStart, valueStart + 1)
+                        : "";
+                assignmentMatch = new RedactionMatch(
+                        assignment.start(),
+                        end,
+                        assignment.group(1) + assignment.group(2)
+                             + quote + ShipLocalStamp.REDACTED + quote);
+                return;
+            }
+        }
+
+        private int assignmentEnd(int start) {
+            if (start >= value.length()) {
+                return -1;
+            }
+            char first = value.charAt(start);
+            if (isQuote(first)) {
+                for (int index = start + 1; index < value.length(); index++) {
+                    char current = value.charAt(index);
+                    if (current == '\r' || current == '\n') {
+                        return -1;
+                    }
+                    if (current == first) {
+                        return index + 1;
+                    }
+                }
+                return -1;
+            }
+            if (start < assignmentBoundary) {
+                return assignmentBoundary;
+            }
+            int end = start;
+            while (end < value.length()
+                    && !isAssignmentDelimiter(value.charAt(end))) {
+                end++;
+            }
+            assignmentBoundary = end;
+            return end;
+        }
+
+        private void advanceAuthorization() {
+            authorizationMatch = null;
+            while (authorization.find()) {
+                int credentialStart = authorization.end();
+                int end = authorizationEnd(credentialStart);
+                if (end <= credentialStart) {
+                    continue;
+                }
+                authorizationMatch = new RedactionMatch(
+                        authorization.start(),
+                        end,
+                        authorization.group(1) + " " + ShipLocalStamp.REDACTED);
+                return;
+            }
+        }
+
+        private int authorizationEnd(int start) {
+            if (start >= value.length()) {
+                return -1;
+            }
+            int end;
+            if (start < authorizationBoundary) {
+                end = authorizationBoundary;
+            } else {
+                end = start;
+                while (end < value.length()
+                        && !isAuthorizationDelimiter(value.charAt(end))) {
+                    end++;
+                }
+                authorizationBoundary = end;
+            }
+            if (end == start) {
+                return -1;
+            }
+            return end < value.length() && isQuote(value.charAt(end))
+                    ? end + 1
+                    : end;
+        }
+
+        private void advanceUrl() {
+            urlMatch = url.find()
+                    ? new RedactionMatch(
+                            url.start(),
+                            url.end(),
+                            ShipLocalStamp.REDACTED + "@")
+                    : null;
+        }
+
+        private void advanceLiteral(int priority) {
+            LiteralCursor literal = literalMatches.poll();
+            if (literal == null || literal.priority() != priority) {
+                throw new IllegalStateException(
+                        "Literal redaction cursor is inconsistent");
+            }
+            literal.advance();
+            if (literal.start() >= 0) {
+                literalMatches.add(literal);
+            }
+        }
+
+        private static boolean isQuote(char value) {
+            return value == '\'' || value == '"';
+        }
+
+        private static boolean isAssignmentDelimiter(char value) {
+            return isQuote(value)
+                    || value == '\r'
+                    || value == '\n'
+                    || value == ','
+                    || value == '}';
+        }
+
+        private static boolean isAuthorizationDelimiter(char value) {
+            return value == ' '
+                    || value == '\t'
+                    || value == '\n'
+                    || value == '\u000b'
+                    || value == '\f'
+                    || value == '\r'
+                    || isQuote(value)
+                    || value == ','
+                    || value == '}';
+        }
+
+        private static final class LiteralCursor {
+
+            private final String value;
+            private final String literal;
+            private final int priority;
+            private final int[] failure;
+            private int offset;
+            private int matched;
+            private int start = -1;
+
+            private LiteralCursor(
+                                  String value, String literal, int priority) {
+                this.value = value;
+                this.literal = literal;
+                this.priority = priority;
+                failure = failureTable(literal);
+            }
+
+            private void advance() {
+                start = -1;
+                while (offset < value.length()) {
+                    char current = value.charAt(offset++);
+                    while (matched > 0
+                            && literal.charAt(matched) != current) {
+                        matched = failure[matched - 1];
+                    }
+                    if (literal.charAt(matched) == current) {
+                        matched++;
+                    }
+                    if (matched == literal.length()) {
+                        start = offset - literal.length();
+                        matched = failure[matched - 1];
+                        return;
+                    }
+                }
+            }
+
+            private int start() {
+                return start;
+            }
+
+            private int priority() {
+                return priority;
+            }
+
+            private int length() {
+                return literal.length();
+            }
+
+            private static int[] failureTable(String literal) {
+                int[] result = new int[literal.length()];
+                int matched = 0;
+                for (int index = 1; index < literal.length(); index++) {
+                    char current = literal.charAt(index);
+                    while (matched > 0
+                            && literal.charAt(matched) != current) {
+                        matched = result[matched - 1];
+                    }
+                    if (literal.charAt(matched) == current) {
+                        matched++;
+                    }
+                    result[index] = matched;
+                }
+                return result;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface RedactionSink {
+
+        boolean append(String value, int start, int end, boolean atomic);
+    }
+
+    private static final class BoundedUtf8Output {
+
+        private final ByteArrayOutputStream output;
+        private final int maximumBytes;
+
+        private BoundedUtf8Output(int maximumBytes) {
+            this.maximumBytes = maximumBytes;
+            output = new ByteArrayOutputStream(Math.min(maximumBytes, 8192));
+        }
+
+        private boolean append(
+                String value, int start, int end, boolean atomic) {
+            if (atomic && encodedLength(value, start, end)
+                          > maximumBytes - output.size()) {
+                return false;
+            }
+            for (int index = start; index < end;) {
+                int codePoint = value.codePointAt(index);
+                int encodedBytes = codePoint <= 0x7f
+                        ? 1
+                        : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+                if (output.size() + encodedBytes > maximumBytes) {
+                    return false;
+                }
+                if (encodedBytes == 1) {
+                    output.write(codePoint);
+                } else if (encodedBytes == 2) {
+                    output.write(0xc0 | codePoint >> 6);
+                    output.write(0x80 | codePoint & 0x3f);
+                } else if (encodedBytes == 3) {
+                    output.write(0xe0 | codePoint >> 12);
+                    output.write(0x80 | codePoint >> 6 & 0x3f);
+                    output.write(0x80 | codePoint & 0x3f);
+                } else {
+                    output.write(0xf0 | codePoint >> 18);
+                    output.write(0x80 | codePoint >> 12 & 0x3f);
+                    output.write(0x80 | codePoint >> 6 & 0x3f);
+                    output.write(0x80 | codePoint & 0x3f);
+                }
+                index += Character.charCount(codePoint);
+            }
+            return true;
+        }
+
+        private static int encodedLength(String value, int start, int end) {
+            int length = 0;
+            for (int index = start; index < end;) {
+                int codePoint = value.codePointAt(index);
+                length += codePoint <= 0x7f
+                        ? 1
+                        : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+                index += Character.charCount(codePoint);
+            }
+            return length;
+        }
+
+        private byte[] toByteArray() {
+            return output.toByteArray();
+        }
     }
 
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -310,62 +310,48 @@ final class LocalCommandRunner {
     }
 
     private static String redact(String value, List<String> secrets) {
-        StringBuilder result = new StringBuilder(value.length());
-        redact(value, secrets, (part, start, end, atomic) -> {
-            result.append(part, start, end);
-            return true;
-        });
-        return result.toString();
+        String result = value;
+        List<String> literals = secretRepresentations(secrets);
+        if (!literals.isEmpty()) {
+            String expression = String.join(
+                    "|", literals.stream().map(Pattern::quote).toList());
+            result = Pattern.compile(expression).matcher(result)
+                    .replaceAll(Matcher.quoteReplacement(ShipLocalStamp.REDACTED));
+        }
+        result = SENSITIVE_ASSIGNMENT.matcher(result)
+                .replaceAll(match -> Matcher.quoteReplacement(redactedAssignment(match)));
+        result = AUTHORIZATION_SCHEME.matcher(result).replaceAll(match -> Matcher.quoteReplacement(
+                match.group(1) + " " + ShipLocalStamp.REDACTED));
+        return URL_USERINFO.matcher(result).replaceAll(match -> Matcher.quoteReplacement(
+                match.group(1) + ShipLocalStamp.REDACTED + "@"));
     }
 
     private static byte[] redactBounded(
             String value, List<String> secrets, int maximumBytes) {
-        BoundedUtf8Output result = new BoundedUtf8Output(maximumBytes);
-        redact(value, secrets, result::append);
-        return result.toByteArray();
+        byte[] encoded = redact(value, secrets).getBytes(StandardCharsets.UTF_8);
+        if (encoded.length <= maximumBytes) {
+            return encoded;
+        }
+        int end = maximumBytes;
+        while (end > 0 && (encoded[end] & 0xc0) == 0x80) {
+            end--;
+        }
+        String prefix = new String(encoded, 0, end, StandardCharsets.UTF_8);
+        for (int length = 1; length < ShipLocalStamp.REDACTED.length(); length++) {
+            if (prefix.endsWith(ShipLocalStamp.REDACTED.substring(0, length))) {
+                prefix = prefix.substring(0, prefix.length() - length);
+                break;
+            }
+        }
+        return prefix.getBytes(StandardCharsets.UTF_8);
     }
 
-    private static void redact(
-            String value, List<String> secrets, RedactionSink output) {
-        RedactionCursor cursor = new RedactionCursor(
-                value, secretRepresentations(secrets));
-        int offset = 0;
-        while (offset < value.length()) {
-            RedactionMatch match = cursor.next(offset);
-            int unchangedEnd = match == null ? value.length() : match.start();
-            if (!output.append(value, offset, unchangedEnd, false) || match == null) {
-                return;
-            }
-            String replacement = match.replacement();
-            if (!output.append(replacement, 0, replacement.length(), true)) {
-                return;
-            }
-            offset = match.end();
-        }
-    }
-
-    private static RedactionMatch combine(
-            RedactionMatch current, RedactionMatch candidate) {
-        if (current == null) {
-            return candidate;
-        }
-        if (candidate == null) {
-            return current;
-        }
-        if (candidate.start() < current.start()) {
-            return candidate.end() > current.start()
-                    ? new RedactionMatch(
-                            candidate.start(),
-                            Math.max(candidate.end(), current.end()),
-                            candidate.replacement())
-                    : candidate;
-        }
-        return candidate.start() < current.end()
-                ? new RedactionMatch(
-                        current.start(),
-                        Math.max(current.end(), candidate.end()),
-                        current.replacement())
-                : current;
+    private static String redactedAssignment(java.util.regex.MatchResult match) {
+        String supplied = match.group(3);
+        String value = unquote(supplied);
+        String quote = value.equals(supplied) ? "" : supplied.substring(0, 1);
+        return match.group(1) + match.group(2)
+               + quote + ShipLocalStamp.REDACTED + quote;
     }
 
     private static List<String> secretRepresentations(List<String> secrets) {
@@ -814,155 +800,4 @@ final class LocalCommandRunner {
     record RetainedLog(Path path, String digest) {
     }
 
-    private record RedactionMatch(int start, int end, String replacement) {
-    }
-
-    private static final class RedactionCursor {
-
-        private final String value;
-        private final List<String> literals;
-        private final int[] literalStarts;
-        private final Matcher assignment;
-        private final Matcher authorization;
-        private final Matcher url;
-        private boolean assignmentAvailable;
-        private boolean authorizationAvailable;
-        private boolean urlAvailable;
-
-        private RedactionCursor(String value, List<String> literals) {
-            this.value = value;
-            this.literals = literals;
-            literalStarts = new int[literals.size()];
-            for (int index = 0; index < literals.size(); index++) {
-                literalStarts[index] = value.indexOf(literals.get(index));
-            }
-            assignment = SENSITIVE_ASSIGNMENT.matcher(value);
-            authorization = AUTHORIZATION_SCHEME.matcher(value);
-            url = URL_USERINFO.matcher(value);
-            assignmentAvailable = assignment.find();
-            authorizationAvailable = authorization.find();
-            urlAvailable = url.find();
-        }
-
-        private RedactionMatch next(int offset) {
-            while (assignmentAvailable && assignment.start() < offset) {
-                assignmentAvailable = assignment.find();
-            }
-            while (authorizationAvailable && authorization.start() < offset) {
-                authorizationAvailable = authorization.find();
-            }
-            while (urlAvailable && url.start() < offset) {
-                urlAvailable = url.find();
-            }
-            RedactionMatch result = assignmentAvailable
-                    ? new RedactionMatch(
-                            assignment.start(),
-                            assignment.end(),
-                            redactedAssignment(assignment))
-                    : null;
-            result = combine(result, authorizationAvailable
-                    ? new RedactionMatch(
-                            authorization.start(),
-                            authorization.end(),
-                            authorization.group(1) + " " + ShipLocalStamp.REDACTED)
-                    : null);
-            result = combine(result, urlAvailable
-                    ? new RedactionMatch(
-                            url.start(),
-                            url.end(),
-                            url.group(1) + ShipLocalStamp.REDACTED + "@")
-                    : null);
-            for (int index = 0; index < literals.size(); index++) {
-                String literal = literals.get(index);
-                if (literalStarts[index] >= 0 && literalStarts[index] < offset) {
-                    literalStarts[index] = value.indexOf(literal, offset);
-                }
-                int start = literalStarts[index];
-                if (start >= 0) {
-                    result = combine(
-                            result,
-                            new RedactionMatch(
-                                    start,
-                                    start + literal.length(),
-                                    ShipLocalStamp.REDACTED));
-                }
-            }
-            return result;
-        }
-
-        private static String redactedAssignment(Matcher matcher) {
-            String supplied = matcher.group(3);
-            String value = unquote(supplied);
-            String quote = value.equals(supplied) ? "" : supplied.substring(0, 1);
-            return matcher.group(1) + matcher.group(2)
-                   + quote + ShipLocalStamp.REDACTED + quote;
-        }
-    }
-
-    @FunctionalInterface
-    private interface RedactionSink {
-
-        boolean append(String value, int start, int end, boolean atomic);
-    }
-
-    private static final class BoundedUtf8Output {
-
-        private final ByteArrayOutputStream output;
-        private final int maximumBytes;
-
-        private BoundedUtf8Output(int maximumBytes) {
-            this.maximumBytes = maximumBytes;
-            output = new ByteArrayOutputStream(Math.min(maximumBytes, 8192));
-        }
-
-        private boolean append(
-                String value, int start, int end, boolean atomic) {
-            if (atomic && encodedLength(value, start, end)
-                          > maximumBytes - output.size()) {
-                return false;
-            }
-            for (int index = start; index < end;) {
-                int codePoint = value.codePointAt(index);
-                int encodedBytes = codePoint <= 0x7f
-                        ? 1
-                        : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
-                if (output.size() + encodedBytes > maximumBytes) {
-                    return false;
-                }
-                if (encodedBytes == 1) {
-                    output.write(codePoint);
-                } else if (encodedBytes == 2) {
-                    output.write(0xc0 | codePoint >> 6);
-                    output.write(0x80 | codePoint & 0x3f);
-                } else if (encodedBytes == 3) {
-                    output.write(0xe0 | codePoint >> 12);
-                    output.write(0x80 | codePoint >> 6 & 0x3f);
-                    output.write(0x80 | codePoint & 0x3f);
-                } else {
-                    output.write(0xf0 | codePoint >> 18);
-                    output.write(0x80 | codePoint >> 12 & 0x3f);
-                    output.write(0x80 | codePoint >> 6 & 0x3f);
-                    output.write(0x80 | codePoint & 0x3f);
-                }
-                index += Character.charCount(codePoint);
-            }
-            return true;
-        }
-
-        private static int encodedLength(String value, int start, int end) {
-            int length = 0;
-            for (int index = start; index < end;) {
-                int codePoint = value.codePointAt(index);
-                length += codePoint <= 0x7f
-                        ? 1
-                        : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
-                index += Character.charCount(codePoint);
-            }
-            return length;
-        }
-
-        private byte[] toByteArray() {
-            return output.toByteArray();
-        }
-    }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -261,7 +263,7 @@ final class LocalCommandRunner {
                     StandardOpenOption.TRUNCATE_EXISTING,
                     StandardOpenOption.WRITE,
                     LinkOption.NOFOLLOW_LINKS);
-            return new RetainedLog(log, ShipDigest.sha256(retained));
+            return new RetainedLog(log, ShipDigest.sha256(retained), retained.length);
         } catch (IOException | RuntimeException e) {
             Files.deleteIfExists(log);
             throw e;
@@ -328,7 +330,33 @@ final class LocalCommandRunner {
 
     private static byte[] redactBounded(
             String value, List<String> secrets, int maximumBytes) {
-        byte[] encoded = redact(value, secrets).getBytes(StandardCharsets.UTF_8);
+        String result = value;
+        List<String> literals = secretRepresentations(secrets);
+        if (!literals.isEmpty()) {
+            String expression = String.join(
+                    "|", literals.stream().map(Pattern::quote).toList());
+            result = replaceBounded(
+                    result,
+                    Pattern.compile(expression),
+                    match -> ShipLocalStamp.REDACTED,
+                    maximumBytes);
+        }
+        result = replaceBounded(
+                result,
+                SENSITIVE_ASSIGNMENT,
+                LocalCommandRunner::redactedAssignment,
+                maximumBytes);
+        result = replaceBounded(
+                result,
+                AUTHORIZATION_SCHEME,
+                match -> match.group(1) + " " + ShipLocalStamp.REDACTED,
+                maximumBytes);
+        result = replaceBounded(
+                result,
+                URL_USERINFO,
+                match -> match.group(1) + ShipLocalStamp.REDACTED + "@",
+                maximumBytes);
+        byte[] encoded = result.getBytes(StandardCharsets.UTF_8);
         if (encoded.length <= maximumBytes) {
             return encoded;
         }
@@ -346,7 +374,52 @@ final class LocalCommandRunner {
         return prefix.getBytes(StandardCharsets.UTF_8);
     }
 
-    private static String redactedAssignment(java.util.regex.MatchResult match) {
+    private static String replaceBounded(
+            String value,
+            Pattern pattern,
+            Function<MatchResult, String> replacement,
+            int maximumCharacters) {
+        Matcher matcher = pattern.matcher(value);
+        StringBuilder bounded = new StringBuilder(
+                Math.min(value.length(), maximumCharacters));
+        int position = 0;
+        while (matcher.find()) {
+            int remaining = maximumCharacters - bounded.length();
+            int unmatched = matcher.start() - position;
+            if (unmatched > remaining) {
+                appendPrefix(bounded, value, position, remaining);
+                return bounded.toString();
+            }
+            bounded.append(value, position, matcher.start());
+            String replacementValue = replacement.apply(matcher);
+            if (replacementValue.length()
+                > maximumCharacters - bounded.length()) {
+                return bounded.toString();
+            }
+            bounded.append(replacementValue);
+            position = matcher.end();
+        }
+        appendPrefix(
+                bounded,
+                value,
+                position,
+                maximumCharacters - bounded.length());
+        return bounded.toString();
+    }
+
+    private static void appendPrefix(
+            StringBuilder target, String value, int start, int maximumCharacters) {
+        int end = Math.min(value.length(), start + maximumCharacters);
+        if (end > start
+                && end < value.length()
+                && Character.isHighSurrogate(value.charAt(end - 1))
+                && Character.isLowSurrogate(value.charAt(end))) {
+            end--;
+        }
+        target.append(value, start, end);
+    }
+
+    private static String redactedAssignment(MatchResult match) {
         String supplied = match.group(3);
         String value = unquote(supplied);
         String quote = value.equals(supplied) ? "" : supplied.substring(0, 1);
@@ -797,7 +870,7 @@ final class LocalCommandRunner {
         }
     }
 
-    record RetainedLog(Path path, String digest) {
+    record RetainedLog(Path path, String digest, long size) {
     }
 
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -55,7 +55,7 @@ final class LocalCommandRunner {
     private static final Pattern AUTHORIZATION_SCHEME = Pattern.compile(
             "(?i)[\"']?\\b(Bearer|Basic)\\s+[\"']?([^\\s\"',}]+)[\"']?");
     private static final Pattern URL_USERINFO = Pattern.compile(
-            "(?<=://)[^/@\\s]*@");
+            "(?<=://)([^/@\\s]*)@");
     private static final ObjectMapper JSON = new ObjectMapper();
 
     private final Clock clock;
@@ -526,7 +526,7 @@ final class LocalCommandRunner {
 
     private static void addUrlMatches(List<String> values, Matcher matcher) {
         while (matcher.find()) {
-            String userInfo = matcher.group(2);
+            String userInfo = matcher.group(1);
             addSecretValue(values, userInfo, false);
             int colon = userInfo.indexOf(':');
             if (colon >= 0) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunner.java
@@ -330,31 +330,18 @@ final class LocalCommandRunner {
 
     private static byte[] redactBounded(
             String value, List<String> secrets, int maximumBytes) {
-        String result = value;
         List<String> literals = secretRepresentations(secrets);
+        String expression = "(?<assignment>" + SENSITIVE_ASSIGNMENT.pattern() + ')'
+                            + "|(?<authorization>" + AUTHORIZATION_SCHEME.pattern() + ')'
+                            + "|(?<url>" + URL_USERINFO.pattern() + ')';
         if (!literals.isEmpty()) {
-            String expression = String.join(
-                    "|", literals.stream().map(Pattern::quote).toList());
-            result = replaceBounded(
-                    result,
-                    Pattern.compile(expression),
-                    match -> ShipLocalStamp.REDACTED,
-                    maximumBytes);
+            expression += "|(?<literal>" + String.join(
+                    "|", literals.stream().map(Pattern::quote).toList()) + ')';
         }
-        result = replaceBounded(
-                result,
-                SENSITIVE_ASSIGNMENT,
-                LocalCommandRunner::redactedAssignment,
-                maximumBytes);
-        result = replaceBounded(
-                result,
-                AUTHORIZATION_SCHEME,
-                match -> match.group(1) + " " + ShipLocalStamp.REDACTED,
-                maximumBytes);
-        result = replaceBounded(
-                result,
-                URL_USERINFO,
-                match -> match.group(1) + ShipLocalStamp.REDACTED + "@",
+        String result = replaceBounded(
+                value,
+                Pattern.compile(expression),
+                LocalCommandRunner::boundedReplacement,
                 maximumBytes);
         byte[] encoded = result.getBytes(StandardCharsets.UTF_8);
         if (encoded.length <= maximumBytes) {
@@ -377,7 +364,7 @@ final class LocalCommandRunner {
     private static String replaceBounded(
             String value,
             Pattern pattern,
-            Function<MatchResult, String> replacement,
+            Function<Matcher, String> replacement,
             int maximumCharacters) {
         Matcher matcher = pattern.matcher(value);
         StringBuilder bounded = new StringBuilder(
@@ -405,6 +392,31 @@ final class LocalCommandRunner {
                 position,
                 maximumCharacters - bounded.length());
         return bounded.toString();
+    }
+
+    private static String boundedReplacement(Matcher match) {
+        String assignmentValue = match.group("assignment");
+        if (assignmentValue != null) {
+            Matcher assignment = SENSITIVE_ASSIGNMENT.matcher(assignmentValue);
+            if (assignment.matches()) {
+                return redactedAssignment(assignment);
+            }
+        }
+        String authorizationValue = match.group("authorization");
+        if (authorizationValue != null) {
+            Matcher authorization = AUTHORIZATION_SCHEME.matcher(authorizationValue);
+            if (authorization.matches()) {
+                return authorization.group(1) + " " + ShipLocalStamp.REDACTED;
+            }
+        }
+        String urlValue = match.group("url");
+        if (urlValue != null) {
+            Matcher url = URL_USERINFO.matcher(urlValue);
+            if (url.matches()) {
+                return url.group(1) + ShipLocalStamp.REDACTED + "@";
+            }
+        }
+        return ShipLocalStamp.REDACTED;
     }
 
     private static void appendPrefix(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -374,7 +374,11 @@ public final class PiWorker {
             versionRun.deleteLogs();
             versionLogsDeleted = true;
             if (turn.validatedSession() != null) {
-                PiWorkerResultStore.write(request, result);
+                PiWorkerResultStore.write(
+                        request,
+                        result,
+                        turn.stdoutSize(),
+                        turn.stderrSize());
                 try {
                     publishSession(
                             turn.validatedSession(),
@@ -769,8 +773,10 @@ public final class PiWorker {
                     exitCode,
                     retainedStdout.path(),
                     retainedStdout.digest(),
+                    retainedStdout.size(),
                     retainedStderr.path(),
                     retainedStderr.digest(),
+                    retainedStderr.size(),
                     naturalCompletion
                             ? completedTurn.terminal().text()
                             : null,
@@ -2407,7 +2413,7 @@ public final class PiWorker {
 
         private final int limit;
         private final BlockingQueue<Frame> frames = new LinkedBlockingQueue<>(
-                QUEUE_CAPACITY);
+                QUEUE_CAPACITY + 1);
         private final ByteArrayOutputStream safe = new ByteArrayOutputStream(8192);
         private final AtomicBoolean limited = new AtomicBoolean();
         private final AtomicBoolean protocolUnverifiable = new AtomicBoolean();
@@ -2441,7 +2447,7 @@ public final class PiWorker {
             if (line.size() > 0 || lineLimited) {
                 emit(line.toByteArray(), lineLimited, false);
             }
-            offer(Frame.end());
+            frames.add(Frame.end());
         }
 
         private void emit(byte[] bytes, boolean truncated, boolean terminated)
@@ -2481,7 +2487,7 @@ public final class PiWorker {
             }
             appendRetained(retained);
             appendRetained(new byte[]{'\n'});
-            offer(Frame.event(event, rawBytes));
+            offer(Frame.event(event));
             settled |= "agent_settled".equals(type);
         }
 
@@ -2506,7 +2512,8 @@ public final class PiWorker {
         }
 
         private void offer(Frame frame) {
-            if (!frames.offer(frame)) {
+            if (frames.size() >= QUEUE_CAPACITY
+                    || !frames.offer(frame)) {
                 markUnverifiableLimit();
             }
         }
@@ -2619,18 +2626,18 @@ public final class PiWorker {
     }
 
     private record Frame(
-            JsonNode event, String failure, boolean endOfStream, long rawBytes) {
+            JsonNode event, String failure, boolean endOfStream) {
 
-        private static Frame event(JsonNode event, long rawBytes) {
-            return new Frame(event, null, false, rawBytes);
+        private static Frame event(JsonNode event) {
+            return new Frame(event, null, false);
         }
 
         private static Frame failed(String failure) {
-            return new Frame(null, failure, false, 0);
+            return new Frame(null, failure, false);
         }
 
         private static Frame end() {
-            return new Frame(null, null, true, 0);
+            return new Frame(null, null, true);
         }
     }
 
@@ -2692,8 +2699,10 @@ public final class PiWorker {
             Integer exitCode,
             Path stdoutLog,
             String stdoutDigest,
+            long stdoutSize,
             Path stderrLog,
             String stderrDigest,
+            long stderrSize,
             String assistantText,
             String stopReason,
             String protocolFailure,

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorker.java
@@ -12,7 +12,6 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
@@ -22,16 +21,11 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.nio.file.attribute.UserPrincipal;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -76,14 +70,12 @@ public final class PiWorker {
 
     private static final int MAX_PROMPT_BYTES = 1024 * 1024;
     static final int MAX_LOG_BYTES = 16 * 1024 * 1024;
-    private static final int MAX_SESSION_HEADER_BYTES = 64 * 1024;
     private static final long MAX_SESSION_BYTES = 64L * 1024 * 1024;
     private static final int MAX_VERSION_LENGTH = 1024;
     // Short values cannot be distinguished reliably from ordinary transcript text.
     private static final int MIN_SENSITIVE_TRANSCRIPT_MATCH_LENGTH = 8;
     private static final Duration VERSION_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration ABORT_TIMEOUT = Duration.ofSeconds(5);
-    private static final Duration ABORT_DRAIN_RESERVE = Duration.ofSeconds(1);
     private static final Duration EXIT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration IO_TIMEOUT = Duration.ofSeconds(5);
     private static final String PROMPT_ID = "prompt-1";
@@ -172,9 +164,9 @@ public final class PiWorker {
      * Executes one Pi stage. The prompt is sent as an RPC command and never appears in argv.
      *
      * <p>
-     * A validated session turn is published atomically, but that publication is not atomic with the controller's
-     * durable {@link ShipRun}. The controller must recover the result for the same run, stage, input, and attempt
-     * before starting a later attempt.
+     * A completed session is published atomically, but that publication is not atomic with the controller's durable
+     * {@link ShipRun}. The controller must recover the result for the same run, stage, input, and attempt before
+     * starting a later attempt.
      */
     public Result run(Request request) throws IOException, InterruptedException {
         Objects.requireNonNull(request, "request");
@@ -185,7 +177,7 @@ public final class PiWorker {
         requireDisjoint(workingDirectory, sessionDirectory, "working and session directories");
         requireDisjoint(workingDirectory, evidenceDirectory, "working and evidence directories");
         requireDisjoint(sessionDirectory, evidenceDirectory, "session and evidence directories");
-        UserPrincipal sessionOwner = requirePrivateSessionDirectory(sessionDirectory);
+        requirePrivateSessionDirectory(sessionDirectory);
         String prompt = requirePrompt(request.prompt());
         Set<String> sensitive = sensitiveEnvironmentValues(environment);
         List<String> sensitiveValues = List.copyOf(sensitive);
@@ -201,8 +193,7 @@ public final class PiWorker {
         boolean restoreInterrupt = false;
         try {
             String sessionId = sessionId(request);
-            sessionLock = lockSession(
-                    sessionDirectory, sessionId, sessionOwner);
+            sessionLock = lockSession(sessionDirectory, sessionId);
             nodeVersionRun = commands.run(new Command(
                     nodeExecutable,
                     List.of("--version"),
@@ -305,10 +296,9 @@ public final class PiWorker {
                                       + "; explicitly accept experimental Pi or Node before starting the stage");
             }
 
-            cleanupAbandonedScratch(sessionDirectory, sessionId, sessionOwner);
+            cleanupAbandonedScratch(sessionDirectory, sessionId);
             SessionState previousSession = snapshotExistingSession(
-                    sessionDirectory, sessionId, workingDirectory, sessionOwner);
-            refuseCompletedTurnReplay(previousSession.transcript(), prompt);
+                    sessionDirectory, sessionId);
             ScratchSession scratch = createScratch(
                     sessionDirectory, sessionId, previousSession);
             scratchDirectory = scratch.directory();
@@ -320,7 +310,6 @@ public final class PiWorker {
                     sessionDirectory,
                     evidenceDirectory,
                     sessionId,
-                    sessionOwner,
                     scratch.previous(),
                     previousSession,
                     prompt,
@@ -499,9 +488,9 @@ public final class PiWorker {
         Request requested = Objects.requireNonNull(request, "request");
         Path sessionDirectory = realDirectory(
                 requested.sessionDirectory(), "Pi session directory");
-        UserPrincipal owner = requirePrivateSessionDirectory(sessionDirectory);
+        requirePrivateSessionDirectory(sessionDirectory);
         SessionLock lock = lockSession(
-                sessionDirectory, sessionId(requested), owner);
+                sessionDirectory, sessionId(requested));
         try {
             return new Recovery(
                     PiWorkerResultStore.read(requested),
@@ -523,7 +512,6 @@ public final class PiWorker {
             Path canonicalSessionDirectory,
             Path evidenceDirectory,
             String sessionId,
-            UserPrincipal sessionOwner,
             SessionState previousSession,
             SessionState canonicalPreviousSession,
             String prompt,
@@ -707,10 +695,7 @@ public final class PiWorker {
                 validatedSession = validatePersistedSession(
                         sessionDirectory,
                         sessionId,
-                        workingDirectory,
-                        sessionOwner,
                         previousSession,
-                        prompt,
                         completedTurn);
             } else {
                 if (!awaitExit(process, EXIT_TIMEOUT)
@@ -844,60 +829,8 @@ public final class PiWorker {
                     validatedSession = validatePersistedSession(
                             sessionDirectory,
                             sessionId,
-                            workingDirectory,
-                            sessionOwner,
                             previousSession,
-                            prompt,
                             reconciliation.turn());
-                    if (process.exitValue() == 0
-                            && reconciliation.naturalCompletion()
-                            && !outputLimited
-                            && !stdout.protocolUnverifiable()
-                            && protocolFailure == null) {
-                        List<String> stdoutSecrets = new ArrayList<>(
-                                sensitiveValues.size() + 1);
-                        stdoutSecrets.add(prompt);
-                        stdoutSecrets.addAll(sensitiveValues);
-                        RetainedLog retainedStdout = LocalCommandRunner.retain(
-                                stdout.safeBytes(),
-                                evidenceDirectory,
-                                ".stdout.log",
-                                MAX_LOG_BYTES,
-                                stdoutSecrets);
-                        RetainedLog retainedStderr;
-                        try {
-                            retainedStderr = LocalCommandRunner.retain(
-                                    stderr.metadata(),
-                                    evidenceDirectory,
-                                    ".stderr.log",
-                                    MAX_LOG_BYTES,
-                                    sensitiveValues);
-                        } catch (IOException | RuntimeException retentionFailure) {
-                            Files.deleteIfExists(retainedStdout.path());
-                            throw retentionFailure;
-                        }
-                        Instant endedAt = clock.instant();
-                        if (endedAt.isBefore(startedAt)) {
-                            endedAt = startedAt;
-                        }
-                        interrupted = false;
-                        completedNormally = true;
-                        return new RpcRun(
-                                startedAt,
-                                endedAt,
-                                false,
-                                false,
-                                0,
-                                retainedStdout.path(),
-                                retainedStdout.digest(),
-                                retainedStderr.path(),
-                                retainedStderr.digest(),
-                                reconciliation.turn().terminal().text(),
-                                reconciliation.turn().terminal().stopReason(),
-                                null,
-                                validatedSession,
-                                true);
-                    }
                     if (process.exitValue() == 0
                             && !reconciliation.naturalCompletion()
                             && !stdout.protocolUnverifiable()
@@ -992,27 +925,7 @@ public final class PiWorker {
                     close(process.getOutputStream());
                     inputClosed = true;
                 }
-                if (!inputClosed
-                        && lifecycle.shouldDisposeTerminal()
-                        && abortRemaining
-                           <= ABORT_DRAIN_RESERVE.toNanos()) {
-                    if (promptWriter.isDone()
-                            && (abortWriter == null
-                                    || abortWriter.isDone())) {
-                        if (abortWriter != null
-                                && completedFailureUninterruptibly(
-                                        abortWriter,
-                                        "Could not send the Pi abort")
-                                   != null) {
-                            return null;
-                        }
-                        close(process.getOutputStream());
-                        inputClosed = true;
-                    }
-                }
                 if (abortWriter == null
-                        && abortRemaining
-                           > ABORT_DRAIN_RESERVE.toNanos()
                         && lifecycle.shouldIssueAbort()
                         && promptWriter.isDone()
                         && process.isAlive()) {
@@ -1502,27 +1415,16 @@ public final class PiWorker {
         }
     }
 
-    private static UserPrincipal requirePrivateSessionDirectory(Path directory)
+    private static void requirePrivateSessionDirectory(Path directory)
             throws IOException {
-        String userName = System.getProperty("user.name");
-        if (userName == null || userName.isBlank()) {
-            throw new IOException("Could not determine the current user for the Pi session directory");
-        }
-        UserPrincipal currentUser = FileSystems.getDefault()
-                .getUserPrincipalLookupService()
-                .lookupPrincipalByName(userName);
-        if (!currentUser.equals(Files.getOwner(directory, LinkOption.NOFOLLOW_LINKS))) {
-            throw new IOException("Pi session directory must be owned by the current user");
-        }
         if (!PRIVATE_DIRECTORY.equals(
                 Files.getPosixFilePermissions(directory, LinkOption.NOFOLLOW_LINKS))) {
             throw new IOException("Pi session directory permissions must be 0700");
         }
-        return currentUser;
     }
 
     private static SessionLock lockSession(
-            Path directory, String sessionId, UserPrincipal owner)
+            Path directory, String sessionId)
             throws IOException {
         Path path = directory.resolve("." + sessionId + ".lock");
         if (Files.isSymbolicLink(path)) {
@@ -1536,10 +1438,9 @@ public final class PiWorker {
                         LinkOption.NOFOLLOW_LINKS),
                 PosixFilePermissions.asFileAttribute(PRIVATE_FILE));
         try {
-            if (!owner.equals(Files.getOwner(path, LinkOption.NOFOLLOW_LINKS))
-                    || !PRIVATE_FILE.equals(
-                            Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS))) {
-                throw new IOException("Pi stage session lock must be owned by the current user and 0600");
+            if (!PRIVATE_FILE.equals(
+                    Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS))) {
+                throw new IOException("Pi stage session lock permissions must be 0600");
             }
             FileLock lock;
             try {
@@ -1558,21 +1459,13 @@ public final class PiWorker {
     }
 
     private static void cleanupAbandonedScratch(
-            Path directory, String sessionId, UserPrincipal owner)
+            Path directory, String sessionId)
             throws IOException {
         String prefix = SCRATCH_PREFIX + sessionId + "-";
         try (DirectoryStream<Path> entries = Files.newDirectoryStream(directory)) {
             for (Path entry : entries) {
                 if (!entry.getFileName().toString().startsWith(prefix)) {
                     continue;
-                }
-                if (Files.isSymbolicLink(entry)
-                        || !Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS)
-                        || !owner.equals(Files.getOwner(entry, LinkOption.NOFOLLOW_LINKS))
-                        || !PRIVATE_DIRECTORY.equals(
-                                Files.getPosixFilePermissions(
-                                        entry, LinkOption.NOFOLLOW_LINKS))) {
-                    throw new IOException("Pi stage scratch directory is unsafe");
                 }
                 deleteTree(entry);
             }
@@ -1592,8 +1485,7 @@ public final class PiWorker {
             if (previous.file() == null) {
                 return new ScratchSession(
                         scratch,
-                        new SessionState(
-                                null, 0, null, previous.transcript()));
+                        new SessionState(null, 0));
             }
             Path copy = scratch.resolve(previous.file().getFileName());
             Files.copy(
@@ -1605,9 +1497,7 @@ public final class PiWorker {
                     scratch,
                     new SessionState(
                             copy,
-                            previous.size(),
-                            previous.digest(),
-                            previous.transcript()));
+                            previous.size()));
         } catch (IOException | RuntimeException e) {
             try {
                 deleteTree(scratch);
@@ -1670,9 +1560,6 @@ public final class PiWorker {
         if (attributes == null) {
             return;
         }
-        if (attributes.isSymbolicLink()) {
-            throw new IOException("Pi scratch cleanup refused a symbolic link");
-        }
         if (attributes.isDirectory()) {
             try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
                 for (Path entry : entries) {
@@ -1685,40 +1572,27 @@ public final class PiWorker {
 
     private static SessionState snapshotExistingSession(
             Path directory,
-            String sessionId,
-            Path workingDirectory,
-            UserPrincipal owner)
+            String sessionId)
             throws IOException {
-        List<Path> matches = sessionFiles(directory, sessionId, owner, true);
+        List<Path> matches = sessionFiles(directory, sessionId, true);
         if (matches.size() > 1) {
             throw new IOException("Pi stage session ID is ambiguous");
         }
         if (matches.isEmpty()) {
-            return new SessionState(
-                    null,
-                    0,
-                    null,
-                    new SessionTranscript(null, List.of()));
+            return new SessionState(null, 0);
         }
         Path file = matches.get(0);
-        long size = boundedSessionSize(file);
-        SessionTranscript transcript = parseSession(
-                file, size, sessionId, workingDirectory);
-        return new SessionState(
-                file, size, fileDigest(file, size), transcript);
+        return new SessionState(file, boundedSessionSize(file));
     }
 
     private Path validatePersistedSession(
             Path directory,
             String sessionId,
-            Path workingDirectory,
-            UserPrincipal owner,
             SessionState previous,
-            String prompt,
             CompletedTurn turn)
             throws IOException {
         Objects.requireNonNull(turn, "turn");
-        List<Path> matches = sessionFiles(directory, sessionId, owner, false);
+        List<Path> matches = sessionFiles(directory, sessionId, false);
         if (matches.size() != 1) {
             throw new IOException("Pi did not persist exactly one stage session");
         }
@@ -1727,120 +1601,59 @@ public final class PiWorker {
             throw new IOException("Pi replaced the existing stage session");
         }
         long size = boundedSessionSize(file);
+        if (size == 0) {
+            throw new IOException("Pi stage session has an invalid size");
+        }
         if (previous.file() != null) {
             if (size <= previous.size()) {
                 throw new IOException("Pi did not append the current stage turn");
             }
-            if (!previous.digest().equals(fileDigest(file, previous.size()))) {
-                throw new IOException("Pi rewrote the existing stage session");
-            }
         }
-        SessionTranscript transcript = parseSession(
-                file, size, sessionId, workingDirectory);
-        validatePersistedTurn(previous, transcript, prompt, turn);
-        rejectSensitiveEnvironmentValues(transcript, turn);
+        rejectSensitiveEnvironmentValues(turn);
         return file;
     }
 
-    private static void validatePersistedTurn(
-            SessionState previous,
-            SessionTranscript transcript,
-            String prompt,
-            CompletedTurn turn)
+    private static List<Path> sessionFiles(
+            Path directory,
+            String sessionId,
+            boolean canonical)
             throws IOException {
-        List<JsonNode> entries = transcript.entries();
-        int prefix = previous.transcript().entries().size();
-        if (previous.file() == null) {
-            if (transcript.header() == null
-                    || entries.size() < 2
-                    || !"model_change".equals(entries.get(0).path("type").textValue())
-                    || !"thinking_level_change".equals(
-                            entries.get(1).path("type").textValue())) {
-                throw new IOException(
-                        "Pi new stage session has an invalid model/thinking bootstrap");
-            }
-            prefix = 2;
-        } else if (!previous.transcript().header().equals(transcript.header())
-                || entries.size() < prefix
-                || !previous.transcript().entries().equals(
-                        entries.subList(0, prefix))) {
-            throw new IOException("Pi rewrote the existing stage session records");
-        }
-
-        List<ExpectedRecord> expected = turn.records();
-        if (previous.file() == null
-                && (expected.isEmpty()
-                        || !"message".equals(expected.get(0).type())
-                        || !"user".equals(
-                                expected.get(0).value().path("role").textValue()))) {
-            throw new IOException(
-                    "Pi new stage session persisted a record before its prompt");
-        }
-        if (entries.size() - prefix != expected.size()) {
-            throw new IOException(
-                    "Pi persisted records that do not match the ordered RPC results");
-        }
-        for (int index = 0; index < expected.size(); index++) {
-            JsonNode entry = entries.get(prefix + index);
-            ExpectedRecord record = expected.get(index);
-            if (!record.type().equals(entry.path("type").textValue())
-                    || !matchesExpectedRecord(entry, record)) {
-                throw new IOException(
-                        "Pi persisted records that do not match the ordered RPC results");
-            }
-        }
-
-        boolean userSeen = false;
-        for (ExpectedRecord record : expected) {
-            if (!"message".equals(record.type())) {
-                continue;
-            }
-            String role = record.value().path("role").textValue();
-            if ("user".equals(role)) {
-                if (userSeen
-                        || !matchesPrompt(
-                                record.value().path("content"), prompt)) {
-                    throw new IOException(
-                            "Pi persisted an unrelated current stage prompt");
+        List<Path> matches = new ArrayList<>(2);
+        String suffix = "_" + sessionId + ".jsonl";
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(directory)) {
+            for (Path file : files) {
+                String name = file.getFileName().toString();
+                if (!name.endsWith(suffix)) {
+                    continue;
                 }
-                userSeen = true;
-            } else if (!userSeen) {
-                throw new IOException(
-                        "Pi persisted a message before the current stage prompt");
+                if (Files.isSymbolicLink(file)) {
+                    throw new IOException("Pi stage session must not be a symbolic link");
+                }
+                if (!Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException(
+                            "Pi stage session must be a regular file");
+                }
+                if (canonical
+                        && !PRIVATE_FILE.equals(
+                                Files.getPosixFilePermissions(
+                                        file,
+                                        LinkOption.NOFOLLOW_LINKS))) {
+                    throw new IOException(
+                            "Pi stage session permissions must be 0600");
+                }
+                matches.add(file.toAbsolutePath().normalize());
+                if (matches.size() > 1) {
+                    break;
+                }
             }
         }
-        if (!userSeen) {
-            throw new IOException("Pi did not persist the current stage prompt");
-        }
-        Terminal terminal = turn.terminal();
-        JsonNode lastMessage = null;
-        for (ExpectedRecord record : expected) {
-            if ("message".equals(record.type())) {
-                lastMessage = record.value();
-            }
-        }
-        if (lastMessage == null || !terminal.assistant().equals(lastMessage)) {
-            throw new IOException(
-                    "Pi persisted terminal content that does not match the RPC result");
-        }
+        return matches;
     }
 
-    private static boolean matchesExpectedRecord(
-            JsonNode entry, ExpectedRecord expected) {
-        if ("message".equals(expected.type())) {
-            return expected.value().equals(entry.path("message"));
-        }
-        if (!"compaction".equals(expected.type())) {
-            return false;
-        }
-        JsonNode value = expected.value();
-        return value.path("summary").equals(entry.path("summary"))
-                && value.path("firstKeptEntryId").equals(
-                        entry.path("firstKeptEntryId"))
-                && value.path("tokensBefore").equals(entry.path("tokensBefore"))
-                && value.path("details").equals(entry.path("details"))
-                && entry.path("fromHook").isBoolean()
-                && !entry.path("fromHook").booleanValue();
+    private static boolean isNonBlankText(JsonNode value) {
+        return value != null
+                && value.isTextual()
+                && !value.textValue().isBlank();
     }
 
     private static boolean matchesPrompt(JsonNode content, String prompt) {
@@ -1862,283 +1675,15 @@ public final class PiWorker {
         return prompt.contentEquals(text);
     }
 
-    private static List<Path> sessionFiles(
-            Path directory,
-            String sessionId,
-            UserPrincipal owner,
-            boolean canonical)
-            throws IOException {
-        List<Path> matches = new ArrayList<>(2);
-        String suffix = "_" + sessionId + ".jsonl";
-        try (DirectoryStream<Path> files = Files.newDirectoryStream(directory)) {
-            for (Path file : files) {
-                String name = file.getFileName().toString();
-                if (!name.endsWith(suffix)) {
-                    continue;
-                }
-                if (Files.isSymbolicLink(file)) {
-                    throw new IOException("Pi stage session must not be a symbolic link");
-                }
-                if (!Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
-                        || !owner.equals(
-                                Files.getOwner(file, LinkOption.NOFOLLOW_LINKS))) {
-                    throw new IOException(
-                            "Pi stage session must be a regular file owned by the current user");
-                }
-                if (canonical
-                        && !PRIVATE_FILE.equals(
-                                Files.getPosixFilePermissions(
-                                        file,
-                                        LinkOption.NOFOLLOW_LINKS))) {
-                    throw new IOException(
-                            "Pi stage session permissions must be 0600");
-                }
-                matches.add(file.toAbsolutePath().normalize());
-                if (matches.size() > 1) {
-                    break;
-                }
-            }
-        }
-        return matches;
-    }
-
-    private static SessionTranscript parseSession(
-            Path file,
-            long expectedSize,
-            String sessionId,
-            Path workingDirectory)
-            throws IOException {
-        if (Files.isSymbolicLink(file)
-                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
-            throw new IOException("Pi stage session must be a real JSONL file");
-        }
-        byte[] bytes = new byte[Math.toIntExact(expectedSize)];
-        try (InputStream input = Files.newInputStream(
-                file, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
-            if (input.readNBytes(bytes, 0, bytes.length) != bytes.length
-                    || input.read() != -1) {
-                throw new IOException(
-                        "Pi stage session changed while it was inspected");
-            }
-        }
-        int headerEnd = 0;
-        while (headerEnd < bytes.length && bytes[headerEnd] != '\n') {
-            headerEnd++;
-        }
-        int headerBytes = headerEnd;
-        if (headerBytes > 0 && bytes[headerBytes - 1] == '\r') {
-            headerBytes--;
-        }
-        if (headerBytes > MAX_SESSION_HEADER_BYTES) {
-            throw new IOException(
-                    "Pi stage session header exceeds its size limit");
-        }
-        String jsonl = decodeStrict(bytes);
-        String[] lines = jsonl.split("\n", -1);
-        List<JsonNode> records = new ArrayList<>(lines.length);
-        for (int index = 0; index < lines.length; index++) {
-            String line = lines[index];
-            if (line.endsWith("\r")) {
-                line = line.substring(0, line.length() - 1);
-            }
-            if (line.isEmpty() && index == lines.length - 1) {
-                continue;
-            }
-            if (line.isBlank()) {
-                throw new IOException("Pi stage session contains a blank JSONL record");
-            }
-            JsonNode record;
-            try {
-                record = JSON.readTree(line);
-            } catch (IOException e) {
-                throw new IOException(
-                        "Pi stage session contains a malformed JSONL record");
-            }
-            if (record == null || !record.isObject()) {
-                throw new IOException(
-                        "Pi stage session contains a malformed JSONL record");
-            }
-            records.add(record);
-        }
-        if (records.isEmpty()) {
-            throw new IOException("Pi stage session has no JSONL header");
-        }
-        JsonNode header = records.remove(0);
-        if (header == null
-                || !header.isObject()
-                || header.size() != 5
-                || !"session".equals(header.path("type").textValue())
-                || !header.path("version").isIntegralNumber()
-                || header.path("version").longValue() != 3
-                || !sessionId.equals(header.path("id").textValue())
-                || !isNonBlankText(header.path("timestamp"))
-                || !workingDirectory.toString().equals(header.path("cwd").textValue())) {
-            throw new IOException("Pi stage session header does not match this stage");
-        }
-        if (records.isEmpty()) {
-            throw new IOException("Pi stage session has no persisted turn records");
-        }
-        validateLinearEntries(records);
-        List<JsonNode> entries = new ArrayList<>(records.size());
-        for (JsonNode record : records) {
-            entries.add(record.deepCopy());
-        }
-        return new SessionTranscript(
-                header.deepCopy(),
-                List.copyOf(entries));
-    }
-
-    private static void validateLinearEntries(List<JsonNode> entries)
-            throws IOException {
-        Set<String> ids = new HashSet<>();
-        String parent = null;
-        for (int index = 0; index < entries.size(); index++) {
-            JsonNode entry = entries.get(index);
-            if (entry == null
-                    || !entry.isObject()
-                    || !isNonBlankText(entry.path("id"))
-                    || !isNonBlankText(entry.path("timestamp"))) {
-                throw new IOException("Pi stage session has an invalid entry");
-            }
-            String id = entry.path("id").textValue();
-            if (ids.contains(id)) {
-                throw new IOException("Pi stage session has a duplicate entry ID");
-            }
-            JsonNode parentId = entry.get("parentId");
-            if ((index == 0 && (parentId == null || !parentId.isNull()))
-                    || (index > 0
-                            && (parentId == null
-                                    || !parentId.isTextual()
-                                    || !parent.equals(parentId.textValue())))) {
-                throw new IOException(
-                        "Pi stage session entries do not form one linear chain");
-            }
-
-            String type = entry.path("type").textValue();
-            switch (type == null ? "" : type) {
-                case "model_change" -> {
-                    if (index != 0
-                            || entry.size() != 6
-                            || !isNonBlankText(entry.path("provider"))
-                            || !isNonBlankText(entry.path("modelId"))) {
-                        throw new IOException(
-                                "Pi stage session has an invalid model bootstrap");
-                    }
-                }
-                case "thinking_level_change" -> {
-                    if (index != 1
-                            || entry.size() != 5
-                            || !"model_change".equals(
-                                    entries.get(0).path("type").textValue())
-                            || !isNonBlankText(entry.path("thinkingLevel"))) {
-                        throw new IOException(
-                                "Pi stage session has an invalid thinking bootstrap");
-                    }
-                }
-                case "message" -> validateMessageEntry(entry, index);
-                case "compaction" -> validateCompactionEntry(entry, ids);
-                default -> throw new IOException(
-                        "Pi stage session contains an unsupported entry type");
-            }
-            ids.add(id);
-            parent = id;
-        }
-        if (entries.size() < 2
-                || !"model_change".equals(entries.get(0).path("type").textValue())
-                || !"thinking_level_change".equals(
-                        entries.get(1).path("type").textValue())) {
-            throw new IOException(
-                    "Pi stage session has an invalid model/thinking bootstrap");
-        }
-    }
-
-    private static void validateMessageEntry(JsonNode entry, int index)
-            throws IOException {
-        JsonNode message = entry.get("message");
-        String role = message == null ? null : message.path("role").textValue();
-        if (index < 2
-                || entry.size() != 5
-                || message == null
-                || !message.isObject()
-                || (!"user".equals(role)
-                        && !"assistant".equals(role)
-                        && !"toolResult".equals(role))
-                || message.get("content") == null) {
-            throw new IOException("Pi stage session has an invalid message entry");
-        }
-        if ("assistant".equals(role)
-                && !isNonBlankText(message.path("stopReason"))) {
-            throw new IOException(
-                    "Pi stage session has an assistant without a stop reason");
-        }
-    }
-
-    private static void validateCompactionEntry(
-            JsonNode entry, Set<String> priorIds)
-            throws IOException {
-        String firstKept = entry.path("firstKeptEntryId").textValue();
-        if (entry.size() != 9
-                || !isNonBlankText(entry.path("summary"))
-                || firstKept == null
-                || !priorIds.contains(firstKept)
-                || !entry.path("tokensBefore").isIntegralNumber()
-                || entry.path("tokensBefore").longValue() < 0
-                || entry.get("details") == null
-                || !entry.path("fromHook").isBoolean()
-                || entry.path("fromHook").booleanValue()) {
-            throw new IOException("Pi stage session has an invalid compaction entry");
-        }
-    }
-
-    private static boolean isNonBlankText(JsonNode value) {
-        return value != null
-                && value.isTextual()
-                && !value.textValue().isBlank();
-    }
-
-    private static void refuseCompletedTurnReplay(
-            SessionTranscript transcript, String prompt)
-            throws IOException {
-        if (transcript == null || transcript.entries().isEmpty()) {
-            return;
-        }
-        JsonNode lastUser = null;
-        JsonNode lastAssistant = null;
-        for (JsonNode entry : transcript.entries()) {
-            if (!"message".equals(entry.path("type").textValue())) {
-                continue;
-            }
-            JsonNode message = entry.path("message");
-            String role = message.path("role").textValue();
-            if ("user".equals(role)) {
-                lastUser = message;
-                lastAssistant = null;
-            } else if (lastUser != null && "assistant".equals(role)) {
-                lastAssistant = message;
-            }
-        }
-        if (lastUser != null
-                && lastAssistant != null
-                && matchesPrompt(lastUser.path("content"), prompt)
-                && "stop".equals(
-                        lastAssistant.path("stopReason").textValue())) {
-            throw new IOException(
-                    "Pi completed turn requires controller recovery before another attempt");
-        }
-    }
-
     private void rejectSensitiveEnvironmentValues(
-            SessionTranscript transcript, CompletedTurn turn)
+            CompletedTurn turn)
             throws IOException {
         Set<String> sensitive = sensitiveEnvironmentValues(environment);
         if (sensitive.isEmpty()) {
             return;
         }
-        if (containsSensitiveValue(transcript.header(), sensitive)) {
-            throw sensitiveOutput();
-        }
-        for (JsonNode entry : transcript.entries()) {
-            if (containsSensitiveValue(entry, sensitive)) {
+        for (ExpectedRecord record : turn.records()) {
+            if (containsSensitiveValue(record.value(), sensitive)) {
                 throw sensitiveOutput();
             }
         }
@@ -2213,30 +1758,6 @@ public final class PiWorker {
             throw new IOException("Pi stage session exceeds its size limit");
         }
         return size;
-    }
-
-    private static String fileDigest(Path file, long length) throws IOException {
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 is unavailable", e);
-        }
-        try (InputStream input = new DigestInputStream(
-                Files.newInputStream(
-                        file, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS),
-                digest)) {
-            byte[] buffer = new byte[8192];
-            long remaining = length;
-            while (remaining > 0) {
-                int read = input.read(buffer, 0, (int) Math.min(buffer.length, remaining));
-                if (read < 0) {
-                    throw new IOException("Pi stage session changed while it was inspected");
-                }
-                remaining -= read;
-            }
-        }
-        return "sha256:" + HexFormat.of().formatHex(digest.digest());
     }
 
     private static void requireLinux() {
@@ -2570,10 +2091,6 @@ public final class PiWorker {
                             || !terminalMatchesLastMessage());
         }
 
-        boolean shouldDisposeTerminal() {
-            return !settled && authoritativeTerminal();
-        }
-
         void markAbortIssued() {
             abortIssued = true;
         }
@@ -2889,14 +2406,12 @@ public final class PiWorker {
                 "message_update", "tool_execution_update");
 
         private final int limit;
-        private final BlockingQueue<Frame> frames = new LinkedBlockingQueue<>();
+        private final BlockingQueue<Frame> frames = new LinkedBlockingQueue<>(
+                QUEUE_CAPACITY);
         private final ByteArrayOutputStream safe = new ByteArrayOutputStream(8192);
         private final AtomicBoolean limited = new AtomicBoolean();
         private final AtomicBoolean protocolUnverifiable = new AtomicBoolean();
-        private long primaryMaterialBytes;
-        private long recoveryMaterialBytes;
-        private long queuedBytes;
-        private int queuedFrames;
+        private long materialBytes;
         private boolean settled;
 
         private RpcOutput(int limit) {
@@ -2926,7 +2441,7 @@ public final class PiWorker {
             if (line.size() > 0 || lineLimited) {
                 emit(line.toByteArray(), lineLimited, false);
             }
-            frames.offer(Frame.end());
+            offer(Frame.end());
         }
 
         private void emit(byte[] bytes, boolean truncated, boolean terminated)
@@ -2971,14 +2486,12 @@ public final class PiWorker {
         }
 
         private boolean admitMaterial(long rawBytes) {
-            if (!limited.get()
-                    && primaryMaterialBytes <= limit - rawBytes) {
-                primaryMaterialBytes += rawBytes;
-                return true;
-            }
-            limited.set(true);
-            if (recoveryMaterialBytes <= limit - rawBytes) {
-                recoveryMaterialBytes += rawBytes;
+            long budget = 2L * limit;
+            if (rawBytes <= budget - materialBytes) {
+                materialBytes += rawBytes;
+                if (materialBytes > limit) {
+                    limited.set(true);
+                }
                 return true;
             }
             markUnverifiableLimit();
@@ -2992,22 +2505,9 @@ public final class PiWorker {
             }
         }
 
-        private synchronized void offer(Frame frame) {
-            long rawBytes = frame.rawBytes();
-            if (queuedFrames >= QUEUE_CAPACITY
-                    || queuedBytes > limit - rawBytes) {
+        private void offer(Frame frame) {
+            if (!frames.offer(frame)) {
                 markUnverifiableLimit();
-                return;
-            }
-            queuedFrames++;
-            queuedBytes += rawBytes;
-            frames.offer(frame);
-        }
-
-        private synchronized void release(Frame frame) {
-            if (!frame.endOfStream()) {
-                queuedFrames--;
-                queuedBytes -= frame.rawBytes();
             }
         }
 
@@ -3028,19 +2528,11 @@ public final class PiWorker {
         }
 
         Frame poll(long nanos) throws InterruptedException {
-            Frame frame = frames.poll(nanos, TimeUnit.NANOSECONDS);
-            if (frame != null) {
-                release(frame);
-            }
-            return frame;
+            return frames.poll(nanos, TimeUnit.NANOSECONDS);
         }
 
         Frame pollNow() {
-            Frame frame = frames.poll();
-            if (frame != null) {
-                release(frame);
-            }
-            return frame;
+            return frames.poll();
         }
 
         boolean limited() {
@@ -3142,14 +2634,10 @@ public final class PiWorker {
         }
     }
 
-    private record SessionState(
-            Path file, long size, String digest, SessionTranscript transcript) {
+    private record SessionState(Path file, long size) {
     }
 
     private record ScratchSession(Path directory, SessionState previous) {
-    }
-
-    private record SessionTranscript(JsonNode header, List<JsonNode> entries) {
     }
 
     private record ExpectedRecord(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -232,18 +232,14 @@ final class PiWorkerResultStore {
                     "Pi stage result evidence does not match its request");
         }
 
-        Path stdout = resolveLog(
+        resolveLog(
                 evidenceDirectory,
                 evidence.stdoutLog(),
                 marker.stdoutSize());
-        Path stderr = resolveLog(
+        resolveLog(
                 evidenceDirectory,
                 evidence.stderrLog(),
                 marker.stderrSize());
-        if (stdout.equals(stderr)) {
-            throw new UntrustedResultException(
-                    "Pi stage result stdout and stderr must be distinct files");
-        }
     }
 
     private static Path normalizedAbsolute(String supplied, String label)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -99,7 +99,12 @@ final class PiWorkerResultStore {
         return Optional.of(marker.result());
     }
 
-    static void write(Request request, Result result) throws IOException {
+    static void write(
+            Request request,
+            Result result,
+            long stdoutSize,
+            long stderrSize)
+            throws IOException {
         Path path = resultPath(request, true);
         byte[] encoded;
         try {
@@ -110,8 +115,8 @@ final class PiWorkerResultStore {
                             request.stage(),
                             request.attempt(),
                             request.inputDigest(),
-                            Files.size(Path.of(result.evidence().stdoutLog())),
-                            Files.size(Path.of(result.evidence().stderrLog())),
+                            stdoutSize,
+                            stderrSize,
                             result));
         } catch (JsonProcessingException e) {
             throw new IOException("Pi stage result marker cannot be encoded", e);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStore.java
@@ -18,7 +18,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.controller.ShipRun.Stage;
 import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
@@ -35,7 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /** Atomic recovery marker for a completed Pi stage attempt. */
 final class PiWorkerResultStore {
 
-    private static final int SCHEMA_VERSION = 2;
+    private static final int SCHEMA_VERSION = 3;
     private static final int MAX_RESULT_BYTES = 20 * 1024 * 1024;
     private static final String DIRECTORY = ".camel-kit-results";
     private static final ObjectMapper JSON = new ObjectMapper(
@@ -96,7 +95,7 @@ final class PiWorkerResultStore {
             throw new UntrustedResultException(
                     "Pi stage result marker does not match its attempt");
         }
-        verifyEvidence(request, marker.result());
+        verifyEvidence(request, marker);
         return Optional.of(marker.result());
     }
 
@@ -111,6 +110,8 @@ final class PiWorkerResultStore {
                             request.stage(),
                             request.attempt(),
                             request.inputDigest(),
+                            Files.size(Path.of(result.evidence().stdoutLog())),
+                            Files.size(Path.of(result.evidence().stderrLog())),
                             result));
         } catch (JsonProcessingException e) {
             throw new IOException("Pi stage result marker cannot be encoded", e);
@@ -208,8 +209,9 @@ final class PiWorkerResultStore {
     }
 
     private static void verifyEvidence(
-            Request request, Result result)
+            Request request, Marker marker)
             throws IOException {
+        Result result = marker.result();
         CommandRun evidence = result.evidence();
         Path workingDirectory = realDirectory(
                 request.workingDirectory(), "Pi working directory");
@@ -225,28 +227,18 @@ final class PiWorkerResultStore {
                     "Pi stage result evidence does not match its request");
         }
 
-        VerifiedLog stdout = resolveLog(
+        Path stdout = resolveLog(
                 evidenceDirectory,
                 evidence.stdoutLog(),
-                evidence.stdoutDigest());
-        VerifiedLog stderr = resolveLog(
+                marker.stdoutSize());
+        Path stderr = resolveLog(
                 evidenceDirectory,
                 evidence.stderrLog(),
-                evidence.stderrDigest());
-        final boolean sameFile;
-        try {
-            sameFile = Files.isSameFile(stdout.path(), stderr.path());
-        } catch (NoSuchFileException e) {
-            throw new UntrustedResultException(
-                    "Pi stage result log is missing",
-                    e);
-        }
-        if (stdout.identity().equals(stderr.identity()) || sameFile) {
+                marker.stderrSize());
+        if (stdout.equals(stderr)) {
             throw new UntrustedResultException(
                     "Pi stage result stdout and stderr must be distinct files");
         }
-        verifyLog(stdout);
-        verifyLog(stderr);
     }
 
     private static Path normalizedAbsolute(String supplied, String label)
@@ -283,78 +275,34 @@ final class PiWorkerResultStore {
         }
     }
 
-    private static VerifiedLog resolveLog(
-            Path evidenceDirectory, String supplied, String digest)
+    private static Path resolveLog(
+            Path evidenceDirectory, String supplied, long expectedSize)
             throws IOException {
-        Path log = Path.of(supplied).toAbsolutePath().normalize();
-        BasicFileAttributes attributes = attributesIfPresent(log);
-        if (attributes == null
-                || attributes.isSymbolicLink()
-                || !attributes.isRegularFile()) {
+        Path log = normalizedAbsolute(supplied, "Pi stage result log");
+        if (!log.toString().equals(supplied)
+                || !log.startsWith(evidenceDirectory)) {
+            throw new UntrustedResultException(
+                    "Pi stage result log escaped its evidence directory: " + log);
+        }
+        if (expectedSize < 0
+                || expectedSize > PiWorker.MAX_LOG_BYTES
+                || !Files.isRegularFile(log)) {
             throw new UntrustedResultException(
                     "Pi stage result log is missing or invalid: " + log);
         }
-        Path real;
+        final long actualSize;
         try {
-            real = log.toRealPath();
+            actualSize = Files.size(log);
         } catch (NoSuchFileException e) {
             throw new UntrustedResultException(
                     "Pi stage result log is missing or invalid: " + log,
                     e);
         }
-        if (!real.startsWith(evidenceDirectory)) {
+        if (actualSize != expectedSize) {
             throw new UntrustedResultException(
-                    "Pi stage result log escaped its evidence directory: " + log);
+                    "Pi stage result log does not match its recorded size: " + log);
         }
-        if (attributes.size() > PiWorker.MAX_LOG_BYTES) {
-            throw new UntrustedResultException(
-                    "Pi stage result log exceeds its size limit: " + log);
-        }
-        Object identity = attributes.fileKey() == null
-                ? real
-                : attributes.fileKey();
-        return new VerifiedLog(identity, real, attributes.size(), digest);
-    }
-
-    private static void verifyLog(VerifiedLog log) throws IOException {
-        byte[] content;
-        try (InputStream input = Files.newInputStream(
-                log.path(), StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
-            content = input.readNBytes(PiWorker.MAX_LOG_BYTES + 1);
-        } catch (NoSuchFileException e) {
-            throw new UntrustedResultException(
-                    "Pi stage result log is missing: " + log.path(),
-                    e);
-        }
-        BasicFileAttributes after;
-        try {
-            after = Files.readAttributes(
-                    log.path(),
-                    BasicFileAttributes.class,
-                    LinkOption.NOFOLLOW_LINKS);
-        } catch (NoSuchFileException e) {
-            throw new UntrustedResultException(
-                    "Pi stage result log is missing: " + log.path(),
-                    e);
-        }
-        Object identity = after.fileKey() == null
-                ? log.path()
-                : after.fileKey();
-        if (!after.isRegularFile()
-                || after.isSymbolicLink()
-                || !identity.equals(log.identity())
-                || content.length > PiWorker.MAX_LOG_BYTES
-                || content.length != log.size()
-                || after.size() != log.size()
-                || !ShipDigest.sha256(content).equals(log.digest())) {
-            throw new UntrustedResultException(
-                    "Pi stage result log does not match its recorded digest: "
-                                               + log.path());
-        }
-    }
-
-    private record VerifiedLog(
-            Object identity, Path path, long size, String digest) {
+        return log;
     }
 
     private record Marker(
@@ -363,6 +311,8 @@ final class PiWorkerResultStore {
             Stage stage,
             int attempt,
             String inputDigest,
+            long stdoutSize,
+            long stderrSize,
             Result result) {
 
         private boolean matches(Request request) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -263,7 +263,7 @@ class LocalCommandRunnerTest {
     void boundsShortSecretRedactionWithoutRescanningTheMarker() throws Exception {
         int maximumBytes = 1024;
         LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
-                "a".repeat(4096).getBytes(StandardCharsets.UTF_8),
+                "a".repeat(16 * 1024 * 1024).getBytes(StandardCharsets.UTF_8),
                 evidenceDirectory,
                 ".stdout.log",
                 maximumBytes,
@@ -271,6 +271,7 @@ class LocalCommandRunnerTest {
 
         String content = Files.readString(retained.path());
         assertTrue(Files.size(retained.path()) <= maximumBytes);
+        assertEquals(Files.size(retained.path()), retained.size());
         assertEquals(
                 ShipLocalStamp.REDACTED.repeat(
                         maximumBytes / ShipLocalStamp.REDACTED.length()),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -199,6 +199,25 @@ class LocalCommandRunnerTest {
     }
 
     @Test
+    void redactsCredentialedUrlSuppliedAsAKnownSecret() throws Exception {
+        String secret = "https://user:hunter2@host/path";
+        Command command = new Command(
+                executable,
+                List.of("known-secret", secret),
+                workingDirectory,
+                evidenceDirectory,
+                Duration.ofSeconds(5),
+                4096,
+                List.of(secret));
+
+        LocalCommandRunner.Result result = new LocalCommandRunner().run(command);
+
+        assertEquals(List.of("known-secret", "<redacted>"), result.redactedArguments());
+        assertFalse(Files.readString(result.stdoutLog()).contains("user:hunter2"));
+        assertFalse(Files.readString(result.stderrLog()).contains("user:hunter2"));
+    }
+
+    @Test
     void filtersOnlyBooleanFeatureToggleEnvironmentValues() {
         assertFalse(LocalCommandRunner.isSensitiveEnvironmentValue(
                 "AUTH_ENABLED", "true"));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -351,6 +351,18 @@ class LocalCommandRunnerTest {
     }
 
     @Test
+    void redactsWhitespaceBeforeUnterminatedAssignmentQuote() throws Exception {
+        LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
+                "token=   \"".getBytes(StandardCharsets.UTF_8),
+                evidenceDirectory,
+                ".stdout.log",
+                4096,
+                List.of());
+
+        assertEquals("token=  <redacted>\"", Files.readString(retained.path()));
+    }
+
+    @Test
     void mergesOverlappingCredentialRedactions() throws Exception {
         List<String> output = List.of(
                 "prefix https://user:hunter2@host",
@@ -451,6 +463,22 @@ class LocalCommandRunnerTest {
                         List.of("token=abc}tail"),
                         List.of("abc}ta"),
                         List.of("token=<redacted>")),
+                new Case(
+                        List.of("passx="),
+                        List.of("token", "x"),
+                        List.of("<redacted>")),
+                new Case(
+                        List.of("jwtaba=credentials"),
+                        List.of("aba"),
+                        List.of("<redacted>")),
+                new Case(
+                        List.of("--token"),
+                        List.of(),
+                        List.of("<redacted>")),
+                new Case(
+                        List.of("-api-key:aba"),
+                        List.of("aba"),
+                        List.of("<redacted>")),
                 new Case(
                         List.of("--token=actual-secret"),
                         List.of(),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -307,10 +307,42 @@ class LocalCommandRunnerTest {
             String content = Files.readString(retained.path());
 
             assertTrue(Files.size(retained.path()) <= maximumBytes);
-            assertTrue(content.contains("https://<redacted>@"));
+            assertTrue(content.contains("<redacted>@"));
+            if (secrets.isEmpty()) {
+                assertTrue(content.contains("https://<redacted>@"));
+            } else {
+                assertFalse(content.contains("https"));
+            }
             assertFalse(content.contains("user"));
             assertFalse(content.contains("hunter2pass"));
         }
+    }
+
+    @Test
+    void mergesOverlappingCredentialRedactions() throws Exception {
+        List<String> output = List.of(
+                "prefix https://user:hunter2@host",
+                "token=https://user,hunter2@host",
+                "Bearer https://user,hunter2@host",
+                "https://user:hunter2@host",
+                "token=hunter2");
+        List<String> secrets = List.of("prefix https", "https", "oken");
+        List<String> expected = List.of(
+                "<redacted>://<redacted>@host",
+                "<redacted>host",
+                "Bearer <redacted>host",
+                "<redacted>://<redacted>@host",
+                "<redacted>");
+
+        assertEquals(expected, LocalCommandRunner.redactArguments(output, secrets));
+
+        LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
+                String.join("\n", output).getBytes(StandardCharsets.UTF_8),
+                evidenceDirectory,
+                ".stdout.log",
+                4096,
+                secrets);
+        assertEquals(String.join("\n", expected), Files.readString(retained.path()));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -279,6 +279,41 @@ class LocalCommandRunnerTest {
     }
 
     @Test
+    void redactsUrlUserInfo() throws Exception {
+        LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
+                "proxy https://user:hunter2@host/path".getBytes(StandardCharsets.UTF_8),
+                evidenceDirectory,
+                ".stdout.log",
+                4096,
+                List.of());
+
+        assertEquals(
+                "proxy https://<redacted>@host/path",
+                Files.readString(retained.path()));
+    }
+
+    @Test
+    void redactsUrlUserInfoAcrossTheTruncationBoundary() throws Exception {
+        int maximumBytes = 1024;
+        String output = "x".repeat(1000) + "https://user:hunter2pass@h.io/p";
+
+        for (List<String> secrets : List.of(List.<String>of(), List.of("https"))) {
+            LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
+                    output.getBytes(StandardCharsets.UTF_8),
+                    evidenceDirectory,
+                    ".stdout.log",
+                    maximumBytes,
+                    secrets);
+            String content = Files.readString(retained.path());
+
+            assertTrue(Files.size(retained.path()) <= maximumBytes);
+            assertTrue(content.contains("https://<redacted>@"));
+            assertFalse(content.contains("user"));
+            assertFalse(content.contains("hunter2pass"));
+        }
+    }
+
+    @Test
     void rejectsPreInterruptedInvocationWithoutLaunching() {
         Thread.currentThread().interrupt();
         try {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/LocalCommandRunnerTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledOnOs(OS.LINUX)
@@ -338,22 +339,57 @@ class LocalCommandRunnerTest {
     }
 
     @Test
+    void redactsWhitespaceAssignmentValue() throws Exception {
+        LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
+                "token=   ".getBytes(StandardCharsets.UTF_8),
+                evidenceDirectory,
+                ".stdout.log",
+                4096,
+                List.of());
+
+        assertEquals("token=  <redacted>", Files.readString(retained.path()));
+    }
+
+    @Test
     void mergesOverlappingCredentialRedactions() throws Exception {
         List<String> output = List.of(
                 "prefix https://user:hunter2@host",
                 "token=https://user,hunter2@host",
                 "Bearer https://user,hunter2@host",
                 "https://user:hunter2@host",
-                "token=hunter2");
-        List<String> secrets = List.of("prefix https", "https", "oken");
-        List<String> expected = List.of(
+                "token=hunter2",
+                "token=\"x password\"=hunter2",
+                "Bearer /Basic hunter2",
+                "Bearer abc\u2003def",
+                "ababa",
+                "abababa");
+        List<String> secrets = List.of("prefix https", "https", "oken", "aba");
+        List<String> argumentExpected = List.of(
+                "<redacted>://<redacted>@host",
+                "<redacted>",
+                "Bearer <redacted>",
+                "<redacted>://<redacted>@host",
+                "<redacted>",
+                "<redacted>",
+                "Bearer <redacted>",
+                "Bearer <redacted>",
+                "<redacted>",
+                "<redacted>");
+        List<String> logExpected = List.of(
                 "<redacted>://<redacted>@host",
                 "<redacted>host",
                 "Bearer <redacted>host",
                 "<redacted>://<redacted>@host",
+                "<redacted>",
+                "<redacted>",
+                "Bearer <redacted>",
+                "Bearer <redacted>",
+                "<redacted>",
                 "<redacted>");
 
-        assertEquals(expected, LocalCommandRunner.redactArguments(output, secrets));
+        assertEquals(
+                argumentExpected,
+                LocalCommandRunner.redactArguments(output, secrets));
 
         LocalCommandRunner.RetainedLog retained = LocalCommandRunner.retain(
                 String.join("\n", output).getBytes(StandardCharsets.UTF_8),
@@ -361,7 +397,114 @@ class LocalCommandRunnerTest {
                 ".stdout.log",
                 4096,
                 secrets);
-        assertEquals(String.join("\n", expected), Files.readString(retained.path()));
+        assertEquals(
+                String.join("\n", logExpected),
+                Files.readString(retained.path()));
+    }
+
+    @Test
+    void redactsLongOverlappingAssignmentsWithinLinearTime() {
+        String argument = "--api-key=x".repeat(20_000);
+
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(1),
+                () -> assertEquals(
+                        List.of("--api-key=" + ShipLocalStamp.REDACTED),
+                        LocalCommandRunner.redactArguments(
+                                List.of(argument), List.of())));
+    }
+
+    @Test
+    void redactsLongSelfOverlappingLiteralsWithinLinearTime() {
+        String secret = "a".repeat(50_000);
+        String argument = secret + "a".repeat(50_000);
+
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(1),
+                () -> assertEquals(
+                        List.of(ShipLocalStamp.REDACTED),
+                        LocalCommandRunner.redactArguments(
+                                List.of(argument), List.of(secret))));
+    }
+
+    @Test
+    void redactsArgumentsIntoCommandRunValidForms() {
+        record Case(
+                List<String> input,
+                List<String> secrets,
+                List<String> expected) {
+        }
+        List<Case> cases = List.of(
+                new Case(
+                        List.of("Bearer https://user,hunter2@host"),
+                        List.of("prefix https", "https", "oken"),
+                        List.of("Bearer <redacted>")),
+                new Case(
+                        List.of("token=abc,XYZmore"),
+                        List.of("abc,XYZ"),
+                        List.of("token=<redacted>")),
+                new Case(
+                        List.of("token=\"abc\"tail"),
+                        List.of("abc\"ta"),
+                        List.of("token=<redacted>")),
+                new Case(
+                        List.of("token=abc}tail"),
+                        List.of("abc}ta"),
+                        List.of("token=<redacted>")),
+                new Case(
+                        List.of("--token=actual-secret"),
+                        List.of(),
+                        List.of("--token=<redacted>")),
+                new Case(
+                        List.of("--token", "actual-secret"),
+                        List.of(),
+                        List.of("--token", "<redacted>")),
+                new Case(
+                        List.of("--token", "hunter2"),
+                        List.of("token"),
+                        List.of("--<redacted>", "<redacted>")),
+                new Case(
+                        List.of("--token", "<redacted>"),
+                        List.of("redacted"),
+                        List.of("--token", "<redacted>")),
+                new Case(
+                        List.of("--token=<redacted>"),
+                        List.of("redacted"),
+                        List.of("<redacted>")),
+                new Case(
+                        List.of("-uuser:actual-secret"),
+                        List.of(),
+                        List.of("-u<redacted>")),
+                new Case(
+                        List.of("-u<redacted>"),
+                        List.of("redacted"),
+                        List.of("-u<redacted>")),
+                new Case(
+                        List.of("-bSID=actual-secret"),
+                        List.of(),
+                        List.of("-b<redacted>")),
+                new Case(
+                        List.of("--authorization=Bearer", "actual-secret"),
+                        List.of(),
+                        List.of("--authorization=<redacted>", "<redacted>")),
+                new Case(
+                        List.of("--authorization", "Basic", "actual-secret"),
+                        List.of(),
+                        List.of("--authorization", "Basic", "<redacted>")),
+                new Case(
+                        List.of("Authorization", "Bearer", "actual-secret"),
+                        List.of(),
+                        List.of("Authorization", "Bearer", "<redacted>")));
+
+        for (Case testCase : cases) {
+            List<String> redacted = LocalCommandRunner.redactArguments(
+                    testCase.input(), testCase.secrets());
+
+            assertEquals(
+                    testCase.expected(),
+                    stampArguments(redacted).redactedArguments(),
+                    testCase.input().toString());
+        }
     }
 
     @Test
@@ -518,6 +661,26 @@ class LocalCommandRunnerTest {
                 result.stdoutDigest(),
                 result.stderrLog().toString(),
                 result.stderrDigest());
+    }
+
+    private ShipLocalStamp.CommandRun stampArguments(List<String> arguments) {
+        String digest = ShipDigest.sha256(new byte[0]);
+        return new ShipLocalStamp.CommandRun(
+                executable.toString(),
+                "1.0",
+                arguments,
+                workingDirectory.toString(),
+                List.of(digest),
+                true,
+                false,
+                false,
+                0,
+                "2026-08-25T00:00:00Z",
+                "2026-08-25T00:00:01Z",
+                evidenceDirectory.resolve("stdout.log").toString(),
+                digest,
+                evidenceDirectory.resolve("stderr.log").toString(),
+                digest);
     }
 
     private void assertProcessesGone() throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -33,8 +33,8 @@ class PiWorkerResultStoreTest {
         PiWorker.Request first = request(RUN_A, sessions);
         PiWorker.Request second = request(RUN_B, sessions);
 
-        PiWorkerResultStore.write(first, result("first"));
-        PiWorkerResultStore.write(second, result("second"));
+        write(first, result("first"));
+        write(second, result("second"));
 
         assertEquals(
                 "first",
@@ -93,7 +93,7 @@ class PiWorkerResultStoreTest {
     void rejectsMismatchedAndUnsupportedMarkers() throws Exception {
         Path sessions = Files.createDirectory(directory.resolve("sessions"));
         PiWorker.Request request = request(RUN_A, sessions);
-        PiWorkerResultStore.write(request, result("done"));
+        write(request, result("done"));
         Path marker = marker(sessions);
         String encoded = Files.readString(marker);
 
@@ -124,7 +124,7 @@ class PiWorkerResultStoreTest {
     void rejectsEmptyMalformedAndOversizedMarkers() throws Exception {
         Path sessions = Files.createDirectory(directory.resolve("sessions"));
         PiWorker.Request request = request(RUN_A, sessions);
-        PiWorkerResultStore.write(request, result("done"));
+        write(request, result("done"));
         Path marker = marker(sessions);
 
         Files.write(marker, new byte[0]);
@@ -151,7 +151,7 @@ class PiWorkerResultStoreTest {
         PiWorker.Request request = request(RUN_A, sessions);
 
         PiWorker.Result deleted = result("deleted");
-        PiWorkerResultStore.write(request, deleted);
+        write(request, deleted);
         Files.delete(Path.of(deleted.evidence().stdoutLog()));
         assertTrue(assertThrows(
                 IOException.class,
@@ -159,7 +159,7 @@ class PiWorkerResultStoreTest {
                 .getMessage().contains("missing or invalid"));
 
         PiWorker.Result truncated = result("truncated");
-        PiWorkerResultStore.write(request, truncated);
+        write(request, truncated);
         Files.writeString(
                 Path.of(truncated.evidence().stderrLog()),
                 "x");
@@ -188,7 +188,7 @@ class PiWorkerResultStoreTest {
                 original.evidence().stderrDigest(),
                 original.evidence().version());
 
-        PiWorkerResultStore.write(request, escaped);
+        write(request, escaped);
 
         assertTrue(assertThrows(
                 IOException.class,
@@ -206,7 +206,7 @@ class PiWorkerResultStoreTest {
 
         Path otherWorking = Files.createDirectory(
                 directory.resolve("other-working"));
-        PiWorkerResultStore.write(
+        write(
                 request,
                 withEvidence(
                         original,
@@ -226,7 +226,7 @@ class PiWorkerResultStoreTest {
         String otherDigest = ShipDigest.sha256(
                 "other input".getBytes(
                         java.nio.charset.StandardCharsets.UTF_8));
-        PiWorkerResultStore.write(
+        write(
                 request,
                 withEvidence(
                         original,
@@ -247,7 +247,7 @@ class PiWorkerResultStoreTest {
                 .toAbsolutePath()
                 .normalize()
                 .toString();
-        PiWorkerResultStore.write(
+        write(
                 request,
                 withEvidence(
                         original,
@@ -266,7 +266,7 @@ class PiWorkerResultStoreTest {
                         .evidence()
                         .executable());
 
-        PiWorkerResultStore.write(request, original);
+        write(request, original);
         Path marker = marker(sessions);
         String encoded = Files.readString(marker);
         String version = "\"version\" : \"0.83.0\"";
@@ -282,6 +282,16 @@ class PiWorkerResultStoreTest {
                 IOException.class,
                 () -> PiWorkerResultStore.read(request))
                 .getMessage().contains("malformed"));
+    }
+
+    private static void write(
+            PiWorker.Request request, PiWorker.Result result)
+            throws IOException {
+        PiWorkerResultStore.write(
+                request,
+                result,
+                Files.size(Path.of(result.evidence().stdoutLog())),
+                Files.size(Path.of(result.evidence().stderrLog())));
     }
 
     private PiWorker.Request request(String runId, Path sessions)

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -188,7 +188,8 @@ class PiWorkerResultStoreTest {
     }
 
     @Test
-    void rejectsSharedStdoutAndStderrEvidence() throws Exception {
+    void rejectsMarkerWithSharedCommandEvidencePathsDuringDeserialization()
+            throws Exception {
         Path sessions = Files.createDirectory(directory.resolve("sessions"));
         PiWorker.Request request = request(RUN_A, sessions);
         PiWorker.Result original = result("shared");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -114,7 +114,7 @@ class PiWorkerResultStoreTest {
                 () -> PiWorkerResultStore.read(request))
                 .getMessage().contains("does not match"));
 
-        Files.writeString(marker, encoded.replace("\"schemaVersion\" : 2", "\"schemaVersion\" : 3"));
+        Files.writeString(marker, encoded.replace("\"schemaVersion\" : 3", "\"schemaVersion\" : 4"));
         assertTrue(assertThrows(IOException.class,
                 () -> PiWorkerResultStore.read(request))
                 .getMessage().contains("schema version"));
@@ -146,7 +146,7 @@ class PiWorkerResultStoreTest {
     }
 
     @Test
-    void rejectsDeletedTamperedAndOversizedEvidenceLogs() throws Exception {
+    void rejectsDeletedAndTruncatedEvidenceLogs() throws Exception {
         Path sessions = Files.createDirectory(directory.resolve("sessions"));
         PiWorker.Request request = request(RUN_A, sessions);
 
@@ -158,27 +158,15 @@ class PiWorkerResultStoreTest {
                 () -> PiWorkerResultStore.read(request))
                 .getMessage().contains("missing or invalid"));
 
-        PiWorker.Result tampered = result("tampered");
-        PiWorkerResultStore.write(request, tampered);
+        PiWorker.Result truncated = result("truncated");
+        PiWorkerResultStore.write(request, truncated);
         Files.writeString(
-                Path.of(tampered.evidence().stderrLog()),
-                "changed");
+                Path.of(truncated.evidence().stderrLog()),
+                "x");
         assertTrue(assertThrows(
                 IOException.class,
                 () -> PiWorkerResultStore.read(request))
-                .getMessage().contains("recorded digest"));
-
-        PiWorker.Result oversized = result("oversized");
-        PiWorkerResultStore.write(request, oversized);
-        try (RandomAccessFile file = new RandomAccessFile(
-                Path.of(oversized.evidence().stdoutLog()).toFile(),
-                "rw")) {
-            file.setLength((long) PiWorker.MAX_LOG_BYTES + 1);
-        }
-        assertTrue(assertThrows(
-                IOException.class,
-                () -> PiWorkerResultStore.read(request))
-                .getMessage().contains("size limit"));
+                .getMessage().contains("recorded size"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -11,6 +11,7 @@ import io.github.luigidemasi.camelkit.ship.controller.ShipRun;
 import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp;
 import io.github.luigidemasi.camelkit.ship.evidence.ShipLocalStamp.CommandRun;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -167,6 +168,41 @@ class PiWorkerResultStoreTest {
                 IOException.class,
                 () -> PiWorkerResultStore.read(request))
                 .getMessage().contains("recorded size"));
+    }
+
+    @Test
+    void rejectsEvidenceLogsWithAnOversizedRecordedSize() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorker.Result result = result("oversized");
+        PiWorkerResultStore.write(
+                request,
+                result,
+                PiWorker.MAX_LOG_BYTES + 1L,
+                Files.size(Path.of(result.evidence().stderrLog())));
+
+        assertTrue(assertThrows(
+                IOException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("missing or invalid"));
+    }
+
+    @Test
+    void rejectsSharedStdoutAndStderrEvidence() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorker.Result original = result("shared");
+        write(request, original);
+        Path marker = marker(sessions);
+        ObjectMapper json = new ObjectMapper();
+        Files.writeString(marker, Files.readString(marker).replace(
+                json.writeValueAsString(original.evidence().stderrLog()),
+                json.writeValueAsString(original.evidence().stdoutLog())));
+
+        assertTrue(assertThrows(
+                PiWorker.UntrustedResultException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("malformed"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -521,7 +521,7 @@ class PiWorkerTest {
     }
 
     @Test
-    void allowsResumeCompactionBeforeTheNewUserButRejectsUnrelatedAssistants()
+    void allowsCompactionBeforeTheNewUserButRejectsUnrelatedAssistants()
             throws Exception {
         PiWorker worker = worker(Duration.ofSeconds(5));
         worker.run(request(ShipRun.Stage.DESIGN, "baseline"));
@@ -544,15 +544,6 @@ class PiWorkerTest {
         assertEquals(8, persisted.size());
         assertTrue(persisted.get(5).contains("\"type\":\"compaction\""));
         assertTrue(persisted.get(6).contains("\"role\":\"user\""));
-
-        Files.writeString(fixture.resolve("mode"), "pre-user-compaction\n");
-        IOException newSessionCompaction = assertThrows(
-                IOException.class,
-                () -> worker.run(request(
-                        ShipRun.Stage.DISCOVERY, "new")));
-        assertTrue(newSessionCompaction.getMessage().contains(
-                "before its prompt"));
-        assertFalse(hasSession(sessionId(ShipRun.Stage.DISCOVERY)));
 
         Files.writeString(fixture.resolve("mode"), "unrelated-intermediate\n");
         IOException unrelated = assertThrows(
@@ -832,30 +823,6 @@ class PiWorkerTest {
             assertTrue(Files.size(Path.of(result.evidence().stdoutLog()))
                        < 1024 * 1024);
         }
-    }
-
-    @Test
-    void malformedSessionErrorsDoNotRetainSensitiveJson() throws Exception {
-        String secret = "malformed-secret-credential";
-        Files.writeString(fixture.resolve("secret"), secret);
-        Files.writeString(
-                fixture.resolve("mode"), "session-malformed-secret\n");
-
-        IOException failure = assertThrows(
-                IOException.class,
-                () -> worker(
-                        Duration.ofSeconds(5),
-                        Map.of("API_TOKEN", secret))
-                        .run(request(ShipRun.Stage.PLAN, "prompt")));
-
-        for (Throwable cause = failure;
-             cause != null;
-             cause = cause.getCause()) {
-            assertFalse(cause.toString().contains(secret));
-        }
-        assertFalse(hasSession(sessionId(ShipRun.Stage.PLAN)));
-        assertNoScratchDirectories();
-        assertEvidenceDoesNotContain(secret);
     }
 
     @Test
@@ -1149,40 +1116,27 @@ class PiWorkerTest {
     }
 
     @Test
-    void rejectsMismatchedOrAmbiguousPersistedStageSessions() throws Exception {
-        String[] modes = {"session-mismatch", "session-cwd", "session-duplicate"};
-        ShipRun.Stage[] stages = {
-                ShipRun.Stage.DISCOVERY,
-                ShipRun.Stage.DESIGN,
-                ShipRun.Stage.PLAN
-        };
+    void rejectsAmbiguousPersistedStageSessions() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "session-duplicate\n");
 
-        for (int index = 0; index < modes.length; index++) {
-            int caseIndex = index;
-            Files.writeString(fixture.resolve("mode"), modes[index] + "\n");
+        IOException failure = assertThrows(
+                IOException.class,
+                () -> worker(Duration.ofSeconds(5))
+                        .run(request(ShipRun.Stage.PLAN, "prompt")));
 
-            IOException failure = assertThrows(
-                    IOException.class,
-                    () -> worker(Duration.ofSeconds(5))
-                            .run(request(stages[caseIndex], "prompt")),
-                    modes[index]);
-
-            assertTrue(
-                    failure.getMessage().contains("session"),
-                    modes[index] + ": " + failure.getMessage());
-        }
+        assertTrue(failure.getMessage().contains("session"));
     }
 
     @Test
-    void requiresPersistedTurnRecordsAndAppendOnlyResume() throws Exception {
-        Files.writeString(fixture.resolve("mode"), "header-only\n");
+    void requiresANonemptySessionAndAppendOnlyResume() throws Exception {
+        Files.writeString(fixture.resolve("mode"), "empty-session\n");
 
-        IOException headerOnly = assertThrows(
+        IOException empty = assertThrows(
                 IOException.class,
                 () -> worker(Duration.ofSeconds(5))
                         .run(request(ShipRun.Stage.DISCOVERY, "prompt")));
 
-        assertTrue(headerOnly.getMessage().contains("no persisted turn records"));
+        assertTrue(empty.getMessage().contains("invalid size"));
 
         Files.writeString(fixture.resolve("mode"), "success\n");
         PiWorker worker = worker(Duration.ofSeconds(5));
@@ -1198,66 +1152,6 @@ class PiWorkerTest {
         assertTrue(java.util.Arrays.equals(
                 before, Files.readAllBytes(sessionFile(sessionId(ShipRun.Stage.DESIGN)))));
 
-        Files.writeString(fixture.resolve("mode"), "rewrite-session\n");
-        IOException rewritten = assertThrows(
-                IOException.class,
-                () -> worker.run(request(ShipRun.Stage.DESIGN, "third")));
-
-        assertTrue(rewritten.getMessage().contains("Pi"));
-        assertArrayEquals(
-                before,
-                Files.readAllBytes(
-                        sessionFile(sessionId(ShipRun.Stage.DESIGN))));
-    }
-
-    @Test
-    void refusesToReplayACompletedPromptBeforeLaunchingRpc() throws Exception {
-        PiWorker worker = worker(Duration.ofSeconds(5));
-        PiWorker.Request first = request(
-                ShipRun.Stage.DESIGN, "same prompt", true);
-        worker.run(first);
-        Path canonical = sessionFile(sessionId(ShipRun.Stage.DESIGN));
-        byte[] before = Files.readAllBytes(canonical);
-        Files.delete(fixture.resolve("args"));
-        Files.delete(fixture.resolve("prompt"));
-
-        IOException failure = assertThrows(
-                IOException.class,
-                () -> worker.run(new PiWorker.Request(
-                        RUN_ID,
-                        ShipRun.Stage.DESIGN,
-                        2,
-                        workingDirectory,
-                        sessions,
-                        evidence,
-                        inputDigest(),
-                        true,
-                        "same prompt")));
-
-        assertTrue(failure.getMessage().contains("controller recovery"));
-        assertFalse(Files.exists(fixture.resolve("args")));
-        assertFalse(Files.exists(fixture.resolve("prompt")));
-        assertArrayEquals(before, Files.readAllBytes(canonical));
-    }
-
-    @Test
-    void rejectsBrokenLinearSessionChainsWithoutPublishingThem() throws Exception {
-        PiWorker worker = worker(Duration.ofSeconds(5));
-        for (ShipRun.Stage stage : List.of(
-                ShipRun.Stage.DISCOVERY, ShipRun.Stage.DESIGN)) {
-            String mode = stage == ShipRun.Stage.DISCOVERY
-                    ? "session-wrong-parent"
-                    : "session-duplicate-id";
-            Files.writeString(fixture.resolve("mode"), mode + "\n");
-
-            IOException failure = assertThrows(
-                    IOException.class,
-                    () -> worker.run(request(stage, "prompt")));
-
-            assertTrue(failure.getMessage().contains("session"));
-            assertFalse(hasSession(sessionId(stage)));
-            assertNoScratchDirectories();
-        }
     }
 
     @Test
@@ -1292,85 +1186,6 @@ class PiWorkerTest {
             assertTrue(locked.getMessage().contains("already running"));
             assertFalse(hasSession(lockedSession));
         }
-    }
-
-    @Test
-    void rejectsInvalidAppendedSessionTurns() throws Exception {
-        String[] modes = {
-                "session-whitespace",
-                "session-malformed-turn",
-                "session-unrelated-prompt",
-                "session-wrong-stop",
-                "session-missing-stop"
-        };
-        ShipRun.Stage[] stages = ShipRun.Stage.values();
-        PiWorker worker = worker(Duration.ofSeconds(5));
-
-        for (int index = 0; index < modes.length; index++) {
-            ShipRun.Stage stage = stages[index];
-            Files.writeString(fixture.resolve("mode"), "success\n");
-            worker.run(request(stage, "baseline"));
-            Path canonical = sessionFile(sessionId(stage));
-            byte[] before = Files.readAllBytes(canonical);
-            Files.writeString(fixture.resolve("mode"), modes[index] + "\n");
-
-            IOException failure = assertThrows(
-                    IOException.class,
-                    () -> worker.run(request(stage, "current")),
-                    modes[index]);
-
-            assertTrue(failure.getMessage().contains("Pi"), modes[index]);
-            assertArrayEquals(
-                    before, Files.readAllBytes(canonical), modes[index]);
-        }
-    }
-
-    @Test
-    void retriesFromTheCleanCanonicalPrefixAfterDiscardingPoisonedScratch()
-            throws Exception {
-        PiWorker worker = worker(Duration.ofSeconds(5));
-        ShipRun.Stage stage = ShipRun.Stage.DESIGN;
-        worker.run(request(stage, "baseline"));
-        Path canonical = sessionFile(sessionId(stage));
-        byte[] baseline = Files.readAllBytes(canonical);
-
-        Files.writeString(
-                fixture.resolve("mode"), "session-unrelated-prompt\n");
-        assertThrows(
-                IOException.class,
-                () -> worker.run(new PiWorker.Request(
-                        RUN_ID,
-                        stage,
-                        2,
-                        workingDirectory,
-                        sessions,
-                        evidence,
-                        inputDigest(),
-                        true,
-                        "current")));
-        assertArrayEquals(baseline, Files.readAllBytes(canonical));
-
-        Files.writeString(fixture.resolve("mode"), "success\n");
-        PiWorker.Result retry = worker.run(new PiWorker.Request(
-                RUN_ID,
-                stage,
-                3,
-                workingDirectory,
-                sessions,
-                evidence,
-                inputDigest(),
-                true,
-                "current"));
-
-        assertEquals(PiWorker.Outcome.SUCCEEDED, retry.outcome());
-        List<String> persisted = Files.readAllLines(canonical);
-        assertEquals(7, persisted.size());
-        assertEquals(
-                1,
-                persisted.stream()
-                        .filter(line -> line.contains(
-                                "\"content\":\"current\""))
-                        .count());
     }
 
     @Test
@@ -1466,39 +1281,6 @@ class PiWorkerTest {
         assertEquals(6, persisted.size());
         assertTrue(persisted.get(4).contains("\"stopReason\":\"stop\""));
         assertTrue(persisted.get(5).contains("\"type\":\"compaction\""));
-    }
-
-    @Test
-    void interruptionRecoversANaturalStopThatWinsAfterAbort() throws Exception {
-        Files.writeString(fixture.resolve("mode"), "natural-stop-after-abort\n");
-        PiWorker worker = worker(Duration.ofSeconds(30));
-        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
-        AtomicReference<Throwable> failure = new AtomicReference<>();
-        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
-        AtomicBoolean interrupted = new AtomicBoolean();
-        Thread invocation = new Thread(() -> {
-            try {
-                result.set(worker.run(request));
-                interrupted.set(Thread.currentThread().isInterrupted());
-            } catch (Throwable unexpected) {
-                failure.set(unexpected);
-            }
-        });
-
-        invocation.start();
-        awaitFile(fixture.resolve("ready"));
-        invocation.interrupt();
-        invocation.join(Duration.ofSeconds(10).toMillis());
-
-        assertFalse(invocation.isAlive());
-        assertNull(failure.get());
-        assertTrue(interrupted.get());
-        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
-        assertEquals("done", result.get().assistantText());
-        assertEquals(result.get(), worker.recover(request).orElseThrow());
-        assertEquals(
-                List.of("{\"id\":\"abort-1\",\"type\":\"abort\"}"),
-                Files.readAllLines(fixture.resolve("abort")));
     }
 
     @Test
@@ -1660,79 +1442,6 @@ class PiWorkerTest {
         assertInterruptedInvalidNaturalStopIsRetryable(
                 "duplicate-response-natural-stop-after-eof",
                 ShipRun.Stage.PLAN);
-    }
-
-    @Test
-    void interruptionDrainsAQueuedNaturalTurnAsPiExits()
-            throws Exception {
-        Files.writeString(fixture.resolve("mode"), "queued-natural-exit\n");
-        PiWorker worker = worker(Duration.ofSeconds(30));
-        AtomicReference<Throwable> failure = new AtomicReference<>();
-        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
-        AtomicBoolean interrupted = new AtomicBoolean();
-        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
-        Thread invocation = new Thread(() -> {
-            try {
-                result.set(worker.run(request));
-                interrupted.set(Thread.currentThread().isInterrupted());
-            } catch (Throwable unexpected) {
-                failure.set(unexpected);
-            }
-        });
-
-        invocation.start();
-        awaitFile(fixture.resolve("ready"));
-        invocation.interrupt();
-        Thread.sleep(250);
-        Files.writeString(fixture.resolve("release"), "release\n");
-        invocation.join(Duration.ofSeconds(10).toMillis());
-
-        assertFalse(invocation.isAlive());
-        assertNull(failure.get());
-        assertTrue(interrupted.get());
-        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
-        assertEquals(result.get(), worker.recover(request).orElseThrow());
-        assertFalse(Files.exists(fixture.resolve("abort")));
-        List<String> persisted = Files.readAllLines(
-                sessionFile(sessionId(ShipRun.Stage.DESIGN)));
-        assertEquals(5, persisted.size());
-        assertTrue(persisted.get(4).contains("\"stopReason\":\"stop\""));
-    }
-
-    @Test
-    void interruptionDisposesAndPublishesAPostAgentTerminalWithoutSettled()
-            throws Exception {
-        Files.writeString(
-                fixture.resolve("mode"), "terminal-no-settled\n");
-        PiWorker worker = worker(Duration.ofSeconds(30));
-        AtomicReference<Throwable> failure = new AtomicReference<>();
-        AtomicReference<PiWorker.Result> result = new AtomicReference<>();
-        AtomicBoolean interrupted = new AtomicBoolean();
-        PiWorker.Request request = request(ShipRun.Stage.DESIGN, "prompt");
-        Thread invocation = new Thread(() -> {
-            try {
-                result.set(worker.run(request));
-                interrupted.set(Thread.currentThread().isInterrupted());
-            } catch (Throwable unexpected) {
-                failure.set(unexpected);
-            }
-        });
-
-        invocation.start();
-        awaitFile(fixture.resolve("ready"));
-        invocation.interrupt();
-        invocation.join(Duration.ofSeconds(10).toMillis());
-
-        assertFalse(invocation.isAlive());
-        assertNull(failure.get());
-        assertTrue(interrupted.get());
-        assertEquals(PiWorker.Outcome.SUCCEEDED, result.get().outcome());
-        assertEquals(result.get(), worker.recover(request).orElseThrow());
-        assertFalse(Files.exists(fixture.resolve("unexpected-input")));
-        List<String> persisted = Files.readAllLines(
-                sessionFile(sessionId(ShipRun.Stage.DESIGN)));
-        assertEquals(5, persisted.size());
-        assertTrue(persisted.get(4).contains("\"stopReason\":\"stop\""));
     }
 
     @Test
@@ -2072,7 +1781,7 @@ class PiWorkerTest {
     }
 
     @Test
-    void recoveryPreservesHistoricalExecutableAndRejectsDeletedOrTamperedEvidence()
+    void recoveryPreservesHistoricalExecutableAndRejectsDeletedOrTruncatedEvidence()
             throws Exception {
         PiWorker worker = worker(Duration.ofSeconds(5));
         PiWorker.Request request = request(
@@ -2097,11 +1806,11 @@ class PiWorkerTest {
                         .orElseThrow());
         assertEquals(result, worker.recover(request).orElseThrow());
 
-        Files.writeString(stdout, "tampered");
-        PiWorker.UntrustedResultException tampered = assertThrows(
+        Files.writeString(stdout, "x");
+        PiWorker.UntrustedResultException truncated = assertThrows(
                 PiWorker.UntrustedResultException.class,
                 () -> worker.recover(request));
-        assertTrue(tampered.getMessage().contains("recorded digest"));
+        assertTrue(truncated.getMessage().contains("recorded size"));
 
         Files.write(stdout, stdoutBytes);
         Files.delete(stderr);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerTest.java
@@ -800,6 +800,18 @@ class PiWorkerTest {
     }
 
     @Test
+    void acceptsCredentialedUrlInSensitiveEnvironment() throws Exception {
+        String secret = "https://user:hunter2@host/path";
+
+        PiWorker.Result result = worker(
+                Duration.ofSeconds(5), Map.of("API_TOKEN", secret))
+                .run(request(ShipRun.Stage.DISCOVERY, "prompt"));
+
+        assertEquals(PiWorker.Outcome.SUCCEEDED, result.outcome());
+        assertFalse(result.evidence().toString().contains("user:hunter2"));
+    }
+
+    @Test
     void ignoresCumulativeStreamingSnapshotsWithoutLosingTheTerminal()
             throws Exception {
         String[] modes = {

--- a/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-rpc.sh
+++ b/camel-kit-core/src/test/resources/io/github/luigidemasi/camelkit/ship/worker/fake-pi-rpc.sh
@@ -64,7 +64,6 @@ user_emitted=0
 entry_count=0
 last_id=""
 current_user_id=""
-append_count=0
 
 initialize_state() {
   if [ -f "$session_file" ]; then
@@ -76,24 +75,12 @@ initialize_state() {
 ensure_session() {
   if [ -f "$session_file" ]; then
     initialize_state
-    if [ "$mode" = "rewrite-session" ]; then
-      printf '{"type":"session","version":3,"id":"%s","timestamp":"2026-07-24T00:00:01.000Z","cwd":"%s"}\n' \
-        "$session" "$PWD" > "$session_file"
-      printf '%s\n' '{"type":"rewrite-padding","padding":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}' >> "$session_file"
-      initialize_state
-    fi
     return
   fi
-  header_id="$session"
-  header_cwd="$PWD"
-  if [ "$mode" = "session-mismatch" ]; then
-    header_id="ship-ffffffffffffffffffffffffffffffff-discovery"
-  elif [ "$mode" = "session-cwd" ]; then
-    header_cwd="/wrong/project"
-  fi
   printf '{"type":"session","version":3,"id":"%s","timestamp":"2026-07-24T00:00:00.000Z","cwd":"%s"}\n' \
-    "$header_id" "$header_cwd" > "$session_file"
-  if [ "$mode" = "header-only" ]; then
+    "$session" "$PWD" > "$session_file"
+  if [ "$mode" = "empty-session" ]; then
+    : > "$session_file"
     return
   fi
   printf '%s\n' '{"type":"model_change","id":"e1","parentId":null,"timestamp":"2026-07-24T00:00:00.001Z","provider":"fixture","modelId":"fixture-model"}' >> "$session_file"
@@ -106,45 +93,13 @@ append_message() {
   message="$1"
   role="$2"
   ensure_session
-  if [ "$mode" = "header-only" ] || [ "$mode" = "unchanged-session" ]; then
+  if [ "$mode" = "empty-session" ] || [ "$mode" = "unchanged-session" ]; then
     return
   fi
-  if [ "$append_count" -eq 0 ]; then
-    if [ "$mode" = "session-whitespace" ]; then
-      printf ' \t\n' >> "$session_file"
-    elif [ "$mode" = "session-malformed-turn" ]; then
-      printf '%s\n' 'not-json' >> "$session_file"
-    elif [ "$mode" = "session-malformed-secret" ]; then
-      printf '{"type":"message","credential":%s\n' \
-        "$(cat "$fixture/secret")" >> "$session_file"
-    elif [ "$mode" = "session-assistant-first" ]; then
-      entry_count=$((entry_count + 1))
-      printf '{"type":"message","id":"e%s","parentId":"%s","timestamp":"2026-07-24T00:00:00.010Z","message":{"role":"assistant","content":[],"stopReason":"stop","timestamp":0}}\n' \
-        "$entry_count" "$last_id" >> "$session_file"
-      last_id="e$entry_count"
-    fi
-  fi
-  append_count=$((append_count + 1))
   entry_count=$((entry_count + 1))
   id="e$entry_count"
   parent="$last_id"
-  if [ "$mode" = "session-wrong-parent" ] && [ "$append_count" -eq 1 ]; then
-    parent="not-the-parent"
-  elif [ "$mode" = "session-duplicate-id" ] && [ "$append_count" -eq 1 ]; then
-    id="$last_id"
-  fi
   persisted="$message"
-  if [ "$role" = "user" ] && [ "$mode" = "session-unrelated-prompt" ]; then
-    persisted='{"role":"user","content":"unrelated","timestamp":1}'
-  elif [ "$role" = "assistant" ] && [ "$mode" = "session-missing-stop" ]; then
-    persisted='{"role":"assistant","content":[],"timestamp":2}'
-  elif [ "$role" = "assistant" ] && [ "$mode" = "session-wrong-stop" ]; then
-    persisted='{"role":"assistant","content":[],"stopReason":"error","timestamp":2}'
-  elif [ "$role" = "assistant" ] \
-      && { [ "$mode" = "session-content-mismatch" ] \
-           || [ "$mode" = "terminal-content-mismatch" ]; }; then
-    persisted='{"role":"assistant","content":[{"type":"text","text":"different"}],"stopReason":"stop","timestamp":2}'
-  fi
   printf '{"type":"message","id":"%s","parentId":"%s","timestamp":"2026-07-24T00:00:00.010Z","message":%s}\n' \
     "$id" "$parent" "$persisted" >> "$session_file"
   last_id="$id"
@@ -368,18 +323,6 @@ if [ "$mode" = "preflight-compaction-block" ]; then
   exit 0
 fi
 
-if [ "$mode" = "queued-natural-exit" ]; then
-  touch "$fixture/ready"
-  while [ ! -e "$fixture/release" ]; do sleep 0.01; done
-  printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
-  begin_turn
-  natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
-  emit_message "$natural" assistant
-  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"
-  printf '%s\n' '{"type":"agent_settled"}'
-  exit 0
-fi
-
 if [ "$mode" = "malformed-natural-stop-after-eof" ] \
     || [ "$mode" = "duplicate-response-natural-stop-after-eof" ]; then
   printf '%s\n' '{"id":"prompt-1","type":"response","command":"prompt","success":true}'
@@ -454,17 +397,6 @@ if [ "$mode" = "abort-hang" ]; then
   IFS= read -r abort || exit 6
   printf '%s\n' "$abort" > "$fixture/abort"
   sleep 300
-  exit 0
-fi
-
-if [ "$mode" = "terminal-no-settled" ]; then
-  natural='{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop","timestamp":2}'
-  emit_message "$natural" assistant
-  printf '{"type":"agent_end","messages":[%s],"willRetry":false}\n' "$natural"
-  touch "$fixture/ready"
-  while IFS= read -r unexpected; do
-    printf '%s\n' "$unexpected" >> "$fixture/unexpected-input"
-  done
   exit 0
 fi
 


### PR DESCRIPTION
Part of #182 — issue #149 product-boundary alignment, cluster 5 of 6.

## What

- Stop parsing and field-certifying Pi's private JSONL session format. The worker now keeps the contract it owns: one bounded session file for the derived stage-session ID, append progress on resume, a private canonical file, scratch copy, fsync, and atomic publication.
- Replace the quadratic overlap lookahead with lazy assignment, authorization, URL, and KMP literal cursors over the original input. Strictly intersecting spans are merged before bounded UTF-8 emission without collecting every match. Command arguments are then canonicalized from their original argv positions against the Local Stamp grammar, including inline, compact, positional, split authorization, transformed-name, and dangling sensitive-option cases. Retained-log assignment redaction preserves the whitespace fallback before an unmatched value quote.
- Reduce result recovery to attempt/input binding plus ordinary retained-log path and exact retained-byte-count checks. Missing or truncated logs still fail recovery, and serialized stdout/stderr paths remain distinct.
- Remove the interrupt completion-race success path and abort drain microstate. Acknowledged partial turns remain resumable; an interrupted invocation no longer becomes a successful result.
- Bound RPC output to 256 material frames while reserving a dedicated queue slot for the end-of-stream sentinel.
- Remove same-user ownership and scratch-tree forensics while retaining 0700 session-directory and 0600 canonical-session/lock boundaries.

The timeout/abort resume core, sanitized retained logs, secret scanning, scratch publication, and atomic recovery marker remain covered.

## Recovery compatibility

- The completed-turn replay guard was removed with the private-session parser. If a completed turn has no usable recovery marker, retry now safely re-runs the prompt and may append a duplicate turn instead of failing permanently; retaining the old guard would wedge that retry path.
- The recovery marker schema moves from v2 to v3 to require retained-log sizes. An in-flight v2 marker is rejected after upgrade, records an optimistic recovery failure, and re-runs the stage; there is no v2 migration path.

Net: **−145 lines across 8 files.** Website impact: not required (internal boundary simplification; documented behavior is unchanged).

## Verification

- `./mvnw -B -pl camel-kit-core -Dtest=LocalCommandRunnerTest,ShipLocalStampTest test` — 40 tests, 0 failures, including real `CommandRun` validation for inline, compact, positional, split-authorization, transformed-name, dangling-option, and sentinel-idempotence cases.
- `LocalCommandRunnerTest#boundsShortSecretRedactionWithoutRescanningTheMarker` — green in a 192 MiB test JVM with the existing 16 MiB dense-match input.
- `./mvnw -B clean install` — full reactor green: 914 core / 187 graph / resolver, isolation, and JBang suites, 0 failures; formatting and forbidden-API checks green.
- Hosted Java 17, 21, and 25 builds plus Sourcery are green on the current head.

## Summary by Sourcery

Simplify Pi worker recovery around owned session and evidence boundaries while making redaction and interrupted-process handling safer.

Bug Fixes:
- Prevent interrupted invocations from being reported as successful results and keep incomplete turns resumable.
- Improve sensitive-data redaction for overlapping secrets, credential carriers, authorization values, URLs, and bounded output.
- Strengthen recovery handling by detecting missing or truncated retained logs through exact byte counts.

Enhancements:
- Simplify Pi session recovery to validate stage and attempt binding plus bounded append-only session files without parsing the private JSONL format.
- Remove same-user ownership checks, scratch-tree forensics, completed-turn replay blocking, and abort-drain recovery paths while retaining private filesystem permissions.
- Bound RPC material frames while reserving capacity for the end-of-stream marker.

Tests:
- Expand coverage for overlapping and credentialed redaction, truncation boundaries, linear-time behavior, session recovery, and interruption handling.

Chores:
- Advance the recovery marker schema to version 3 with retained stdout and stderr sizes and reject older markers without migration.
