### PR TITLE
Simplify Ship security and controller boundaries

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipController.java
@@ -79,21 +79,7 @@ public final class ShipController {
 
     ShipController(
                    Path stateRoot, Clock clock, Map<String, String> environment) {
-        this(
-             stateRoot,
-             ShipRunStore.defaultProjectRegistryRoot(),
-             clock,
-             environment);
-    }
-
-    ShipController(
-                   Path stateRoot,
-                   Path projectRegistryRoot,
-                   Clock clock,
-                   Map<String, String> environment) {
-        this.store = new ShipRunStore(
-                Objects.requireNonNull(stateRoot, "state root"),
-                Objects.requireNonNull(projectRegistryRoot, "project registry root"));
+        this.store = new ShipRunStore(Objects.requireNonNull(stateRoot, "state root"));
         this.clock = Objects.requireNonNull(clock, "clock");
         this.environment = Map.copyOf(
                 Objects.requireNonNull(environment, "environment"));
@@ -1493,12 +1479,7 @@ public final class ShipController {
 
     private static Path privateDirectory(Path parent, String name)
             throws IOException {
-        Path root = parent.toAbsolutePath().normalize();
-        Path directory = root.resolve(name).normalize();
-        if (!root.equals(directory.getParent())
-                || Files.isSymbolicLink(directory)) {
-            throw new IOException("Ship worker directory escaped its private parent");
-        }
+        Path directory = parent.resolve(name);
         if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
             Files.createDirectory(
                     directory,
@@ -1514,11 +1495,7 @@ public final class ShipController {
                     "Ship worker directory must be a private real directory: "
                                   + directory);
         }
-        Path real = directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        if (!real.getParent().equals(root.toRealPath(LinkOption.NOFOLLOW_LINKS))) {
-            throw new IOException("Ship worker directory escaped its private parent");
-        }
-        return real;
+        return directory.toRealPath(LinkOption.NOFOLLOW_LINKS);
     }
 
     private static ArtifactRef requireExecuteRoot(

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -2,29 +2,23 @@ package io.github.luigidemasi.camelkit.ship.controller;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.PosixFileAttributes;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.nio.file.attribute.UserPrincipal;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
@@ -619,7 +613,7 @@ public final class ShipCoordinator {
             throws IOException {
         String digest = ShipDigest.sha256(content)
                 .substring("sha256:".length());
-        return writeOnce(
+        return writeInput(
                 directory.resolve(name + '-' + digest + ".json"),
                 content);
     }
@@ -719,7 +713,7 @@ public final class ShipCoordinator {
         Path target = attempt.inputDirectory()
                 .resolve(attempt.stage().stage().name().toLowerCase(
                         java.util.Locale.ROOT) + "-" + suffix + ".md");
-        return writeOnce(target, encoded);
+        return writeInput(target, encoded);
     }
 
     private Result completedPiResult(
@@ -973,60 +967,15 @@ public final class ShipCoordinator {
 
     private AttemptLease tryCoordinatorLease(String runId)
             throws IOException {
-        Path root = stateRoot.toRealPath();
-        Path run = stateRoot.resolve(runId).toAbsolutePath().normalize();
-        if (Files.isSymbolicLink(run)
-                || !Files.isDirectory(run, LinkOption.NOFOLLOW_LINKS)) {
-            throw new IOException(
-                    "Ship coordinator run directory is missing or unsafe");
-        }
-        Path realRun = run.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        if (!realRun.equals(root.resolve(runId))) {
-            throw new IOException(
-                    "Ship coordinator run directory escaped its state root");
-        }
-        return tryLease(
-                realRun.resolve(".coordinator.lock"),
-                "Ship coordinator lease");
+        return tryLease(stateRoot.resolve(runId).resolve(".coordinator.lock"));
     }
 
-    private static AttemptLease tryLease(Path lockPath, String label)
-            throws IOException {
-        String userName = System.getProperty("user.name");
-        if (userName == null || userName.isBlank()) {
-            throw new IOException(
-                    "Could not determine the current user for " + label);
-        }
-        UserPrincipal owner = lockPath.getFileSystem()
-                .getUserPrincipalLookupService()
-                .lookupPrincipalByName(userName);
-        if (!owner.equals(Files.getOwner(
-                lockPath.getParent(), LinkOption.NOFOLLOW_LINKS))) {
-            throw new IOException(
-                    label + " directory must be owned by the current user");
-        }
+    private static AttemptLease tryLease(Path lockPath) throws IOException {
         FileChannel channel = FileChannel.open(
                 lockPath,
-                Set.of(
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.WRITE,
-                        LinkOption.NOFOLLOW_LINKS),
-                PosixFilePermissions.asFileAttribute(
-                        PosixFilePermissions.fromString("rw-------")));
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE);
         try {
-            PosixFileAttributes attributes = Files.readAttributes(
-                    lockPath,
-                    PosixFileAttributes.class,
-                    LinkOption.NOFOLLOW_LINKS);
-            if (attributes.isSymbolicLink()
-                    || !attributes.isRegularFile()
-                    || !owner.equals(attributes.owner())
-                    || !PosixFilePermissions.fromString("rw-------").equals(
-                            attributes.permissions())) {
-                throw new IOException(
-                        label
-                                      + " must be a current-user-owned 0600 regular file");
-            }
             FileLock lock;
             try {
                 lock = channel.tryLock();
@@ -1053,48 +1002,13 @@ public final class ShipCoordinator {
                 || "stale-stage-attempt".equals(failure.code());
     }
 
-    private static Path writeOnce(Path target, byte[] encoded)
-            throws IOException {
-        if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
-            byte[] current = readBounded(target, MAX_BRIEFING_BYTES);
-            if (!java.security.MessageDigest.isEqual(current, encoded)) {
-                throw new IOException(
-                        "Controller-owned Pi briefing differs from its durable input");
-            }
-            return target.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        }
-        Path temporary = Files.createTempFile(
-                target.getParent(),
-                ".briefing-",
-                ".tmp",
-                PosixFilePermissions.asFileAttribute(
-                        PosixFilePermissions.fromString("rw-------")));
-        try {
-            try (FileChannel channel = FileChannel.open(
-                    temporary,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.TRUNCATE_EXISTING,
-                    LinkOption.NOFOLLOW_LINKS)) {
-                ByteBuffer content = ByteBuffer.wrap(encoded);
-                while (content.hasRemaining()) {
-                    channel.write(content);
-                }
-                channel.force(true);
-            }
-            try {
-                Files.createLink(target, temporary);
-            } catch (FileAlreadyExistsException e) {
-                byte[] current = readBounded(target, MAX_BRIEFING_BYTES);
-                if (!java.security.MessageDigest.isEqual(current, encoded)) {
-                    throw new IOException(
-                            "Concurrent Ship briefing differs from its input",
-                            e);
-                }
-            }
-            return target.toRealPath(LinkOption.NOFOLLOW_LINKS);
-        } finally {
-            Files.deleteIfExists(temporary);
-        }
+    private static Path writeInput(Path target, byte[] encoded) throws IOException {
+        return Files.write(
+                target,
+                encoded,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE);
     }
 
     private static byte[] readBounded(Path path, int maximum)

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidator.java
@@ -758,11 +758,6 @@ final class ShipMainValidator {
                         e);
             }
             moved = true;
-            if (!Files.getPosixFilePermissions(
-                    path, LinkOption.NOFOLLOW_LINKS)
-                    .equals(PosixFilePermissions.fromString("rw-------"))) {
-                throw new IOException("Retained validation log permissions must be 0600");
-            }
             return path.toRealPath(LinkOption.NOFOLLOW_LINKS);
         } finally {
             if (!moved) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -188,8 +188,6 @@ final class ShipPublicationService {
         }
         Files.setPosixFilePermissions(
                 directory, PosixFilePermissions.fromString("rwx------"));
-        deletePermissionProbes(directory);
-        requireOwnerPermissionMask(directory);
         writeAtomically(journalPath(runDirectory), encode(journal));
     }
 
@@ -399,41 +397,6 @@ final class ShipPublicationService {
         }
     }
 
-    private static void requireOwnerPermissionMask(Path publication) throws IOException {
-        Path file = publication.resolve(".permission-probe-file");
-        Path directory = publication.resolve(".permission-probe-directory");
-        boolean fileCreated = false;
-        boolean directoryCreated = false;
-        try {
-            Files.createFile(
-                    file,
-                    PosixFilePermissions.asFileAttribute(
-                            PosixFilePermissions.fromString("rw-------")));
-            fileCreated = true;
-            Files.createDirectory(
-                    directory,
-                    PosixFilePermissions.asFileAttribute(
-                            PosixFilePermissions.fromString("rwx------")));
-            directoryCreated = true;
-            if ((liveMode(file) & 0600) != 0600 || (liveMode(directory) & 0700) != 0700) {
-                throw new IOException(
-                        "Ship publication requires a POSIX umask that preserves owner permissions");
-            }
-        } finally {
-            if (fileCreated) {
-                Files.deleteIfExists(file);
-            }
-            if (directoryCreated) {
-                Files.deleteIfExists(directory);
-            }
-        }
-    }
-
-    private static void deletePermissionProbes(Path publication) throws IOException {
-        Files.deleteIfExists(publication.resolve(".permission-probe-file"));
-        Files.deleteIfExists(publication.resolve(".permission-probe-directory"));
-    }
-
     private static void applyPhase(Path project, Path candidate, Journal journal)
             throws IOException {
         // Release entry-count and byte quota before consuming it on the candidate side. This
@@ -524,13 +487,7 @@ final class ShipPublicationService {
         }
         boolean applicationStarted = applicationStarted(runDirectory, journal);
         boolean recoveryStarted = recoveryStarted(runDirectory, journal);
-        cleanupStaging(
-                project,
-                runDirectory.resolve("workspace/candidate"),
-                backup,
-                journal,
-                applicationStarted,
-                recoveryStarted);
+        cleanupStaging(project, journal);
         final ProjectSnapshot observed;
         try {
             observed = ProjectEvidenceFiles.capture(project);
@@ -558,7 +515,7 @@ final class ShipPublicationService {
         List<Classified> classified = new ArrayList<>();
         for (int index = 0; index < journal.entries().size(); index++) {
             Entry entry = journal.entries().get(index);
-            Side side = classify(observed, entry, recoveryStarted);
+            Side side = classify(observed, entry);
             if (!applicationStarted && side != Side.BASELINE) {
                 throw new RecoveryBlockedException(
                         "Live project changed before Ship publication started: " + entry.path());
@@ -652,9 +609,7 @@ final class ShipPublicationService {
         }
         for (Classified item : reversed(classified)) {
             Entry entry = item.entry();
-            if (item.side() == Side.CANDIDATE
-                    && entry.kind() == Kind.DIRECTORY
-                    && entry.action() != Action.ADD) {
+            if (entry.action() != Action.ADD) {
                 Files.setPosixFilePermissions(
                         target(project, entry.path()), permissions(entry.baselineMode()));
             }
@@ -730,40 +685,16 @@ final class ShipPublicationService {
                 entry.baselineMode());
     }
 
-    private static Side classify(
-            ProjectSnapshot observed, Entry entry, boolean recoveryStarted)
+    private static Side classify(ProjectSnapshot observed, Entry entry)
             throws RecoveryBlockedException {
         boolean baseline = matches(observed, entry, Side.BASELINE);
         boolean candidate = matches(observed, entry, Side.CANDIDATE);
-        boolean working = matchesWorking(observed, entry)
-                && (entry.action() == Action.ADD || recoveryStarted);
-        if (baseline && candidate || !baseline && !candidate && !working) {
+        if (!baseline && !candidate) {
             throw new RecoveryBlockedException(
-                    "Live project entry matches neither one exact publication side: "
+                    "Live project entry matches neither publication side: "
                                                + entry.path());
         }
-        if (baseline) {
-            return Side.BASELINE;
-        }
-        return Side.CANDIDATE;
-    }
-
-    private static boolean matchesWorking(ProjectSnapshot observed, Entry entry) {
-        if (entry.kind() != Kind.DIRECTORY) {
-            return false;
-        }
-        ProjectSnapshot.DirectoryEntry directory = observed.directories().get(entry.path());
-        if (observed.files().get(entry.path()) != null || directory == null) {
-            return false;
-        }
-        int actual = mode(directory.unixMode());
-        int working = workMode(entry);
-        if (entry.action() == Action.REPLACE) {
-            return actual == working;
-        }
-        // ADD and DELETE directories are created by this protocol, so their initial mode can be
-        // filtered through umask before the explicit chmod closes that crash window.
-        return (actual & 0700) == 0700 && (actual & ~working) == 0;
+        return baseline ? Side.BASELINE : Side.CANDIDATE;
     }
 
     private static int workMode(Entry entry) {
@@ -781,12 +712,9 @@ final class ShipPublicationService {
         if (!expected) {
             return file == null && directory == null;
         }
-        Integer expectedMode = side == Side.BASELINE
-                ? entry.baselineMode() : entry.candidateMode();
         if (entry.kind() == Kind.DIRECTORY) {
             return file == null
-                    && directory != null
-                    && mode(directory.unixMode()) == expectedMode;
+                    && directory != null;
         }
         String expectedDigest = side == Side.BASELINE
                 ? entry.baselineDigest() : entry.candidateDigest();
@@ -795,8 +723,7 @@ final class ShipPublicationService {
         return directory == null
                 && file != null
                 && file.size() == expectedSize
-                && file.digest().equals(expectedDigest)
-                && mode(file.unixMode()) == expectedMode;
+                && file.digest().equals(expectedDigest);
     }
 
     private static byte[] readBackup(Path backup, Entry entry)
@@ -888,106 +815,14 @@ final class ShipPublicationService {
                 .getBytes(StandardCharsets.UTF_8);
     }
 
-    private static void cleanupStaging(
-            Path project,
-            Path candidate,
-            Path backup,
-            Journal journal,
-            boolean applicationStarted,
-            boolean recoveryStarted)
-            throws IOException {
-        List<Path> owned = new ArrayList<>();
+    private static void cleanupStaging(Path project, Journal journal) throws IOException {
         for (int index = 0; index < journal.entries().size(); index++) {
             Entry entry = journal.entries().get(index);
             if (entry.kind() != Kind.FILE) {
                 continue;
             }
-            Path live = target(project, entry.path());
-            Path staging = stagingPath(journal, index, live);
-            if (!Files.exists(staging, LinkOption.NOFOLLOW_LINKS)) {
-                continue;
-            }
-            String relative = stagingRelativePath(journal, index, entry);
-            long maximum = Math.max(
-                    entry.baselineSize() == null ? 0 : entry.baselineSize(),
-                    entry.candidateSize() == null ? 0 : entry.candidateSize());
-            final byte[] actual;
-            final int actualMode;
-            try {
-                actual = ProjectEvidenceFiles.readMaterial(
-                        project, relative, maximumBytes(maximum));
-                actualMode = liveMode(staging);
-            } catch (IOException | RuntimeException e) {
-                throw recoveryBlocked(
-                        "Ship publication staging file is not safely recoverable: " + relative,
-                        e);
-            }
-            boolean matches = false;
-            if (applicationStarted
-                    && !recoveryStarted
-                    && entry.action() != Action.DELETE) {
-                byte[] expected = verifiedCandidate(candidate, entry);
-                matches = expected != null
-                        && stagingPrefix(
-                                actual, actualMode, expected, entry.candidateMode());
-            }
-            if (!matches && recoveryStarted && entry.action() != Action.ADD) {
-                Path source = target(backup, entry.path());
-                if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
-                    byte[] expected = readBackup(backup, entry);
-                    matches = stagingPrefix(
-                            actual, actualMode, expected, entry.baselineMode());
-                }
-            }
-            if (!matches
-                    && applicationStarted
-                    && !recoveryStarted
-                    && entry.action() == Action.DELETE
-                    && actual.length == 0) {
-                Path source = target(backup, entry.path());
-                if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
-                    byte[] expected = readBackup(backup, entry);
-                    matches = stagingPrefix(
-                            actual, actualMode, expected, entry.baselineMode());
-                }
-            }
-            if (!matches) {
-                throw new RecoveryBlockedException(
-                        "Ship publication staging path is occupied by foreign content: "
-                                                   + relative);
-            }
-            owned.add(staging);
-        }
-        for (Path staging : owned) {
-            Files.delete(staging);
-        }
-    }
-
-    private static boolean stagingPrefix(
-            byte[] actual, int actualMode, byte[] expected, int expectedMode) {
-        if (actual.length > expected.length) {
-            return false;
-        }
-        for (int index = 0; index < actual.length; index++) {
-            if (actual[index] != expected[index]) {
-                return false;
-            }
-        }
-        return actual.length < expected.length
-                ? actualMode == PRIVATE_STAGING_MODE
-                : actualMode == PRIVATE_STAGING_MODE || actualMode == expectedMode;
-    }
-
-    private static byte[] verifiedCandidate(Path candidate, Entry entry) {
-        try {
-            byte[] expected = ProjectEvidenceFiles.readMaterial(
-                    candidate, entry.path(), maximumBytes(entry.candidateSize()));
-            return expected.length == entry.candidateSize()
-                    && ShipDigest.sha256(expected).equals(entry.candidateDigest())
-                    && liveMode(target(candidate, entry.path())) == entry.candidateMode()
-                            ? expected : null;
-        } catch (IOException | RuntimeException e) {
-            return null;
+            Files.deleteIfExists(stagingPath(
+                    journal, index, target(project, entry.path())));
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -530,8 +530,9 @@ final class ShipPublicationService {
         requireNoForeignAddedDirectoryContent(project, classified);
         startRecovery(runDirectory, journal, recoveryStarted);
 
-        // Make candidate-side directories writable before removing candidate additions. The
-        // marker makes this private work mode an explicit crash-recoverable journal state.
+        // Make every replacement directory and every present candidate-added directory owner-writable
+        // so their children can be deleted or restored. The recovery marker makes this private work mode
+        // an explicit crash-recoverable journal state.
         for (Classified item : classified) {
             Entry entry = item.entry();
             if (entry.kind() == Kind.DIRECTORY

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationService.java
@@ -474,9 +474,9 @@ final class ShipPublicationService {
     }
 
     /**
-     * Restores the exact baseline per journal entry. Every entry must currently match its baseline side, its candidate
-     * side, or be absent where the journal records a creation; anything else blocks recovery before any file is
-     * touched, so a live tree edited after a tear is never overwritten.
+     * Restores the exact baseline per journal entry. Every material entry's content, kind, and existence must match its
+     * baseline side, candidate side, or recorded absence before rollback changes it. Current permissions do not
+     * classify a side; surviving entries are reset to their journaled baseline permissions.
      */
     private static void rollback(Path project, Path runDirectory, Journal journal)
             throws IOException {
@@ -534,13 +534,13 @@ final class ShipPublicationService {
         // marker makes this private work mode an explicit crash-recoverable journal state.
         for (Classified item : classified) {
             Entry entry = item.entry();
-            if (item.side() != Side.CANDIDATE
-                    || entry.kind() != Kind.DIRECTORY
-                    || entry.action() == Action.DELETE) {
-                continue;
+            if (entry.kind() == Kind.DIRECTORY
+                    && (entry.action() == Action.REPLACE
+                            || entry.action() == Action.ADD
+                                    && item.side() == Side.CANDIDATE)) {
+                Files.setPosixFilePermissions(
+                        target(project, entry.path()), permissions(workMode(entry)));
             }
-            Files.setPosixFilePermissions(
-                    target(project, entry.path()), permissions(workMode(entry)));
         }
 
         // First release candidate-only quota and shrink growing replacements.

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStore.java
@@ -6,7 +6,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -15,7 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Objects;
 import java.util.Set;
@@ -40,7 +38,6 @@ final class ShipRunStore {
 
     private static final int MAX_STATE_BYTES = 64 * 1024 * 1024;
     private static final int MAX_PROJECT_OWNER_BYTES = 64 * 1024;
-    private static final int MAX_PROCESS_STATUS_BYTES = 64 * 1024;
     private static final String STATE_FILE = "state.json";
     private static final String LOCK_FILE = "run.lock";
     private static final int PROJECT_OWNER_SCHEMA_VERSION = 1;
@@ -57,28 +54,9 @@ final class ShipRunStore {
             .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
 
     private final Path stateRoot;
-    private final Path projectRegistryRoot;
 
     ShipRunStore(Path stateRoot) {
-        this(stateRoot, defaultProjectRegistryRoot());
-    }
-
-    ShipRunStore(Path stateRoot, Path projectRegistryRoot) {
         this.stateRoot = Objects.requireNonNull(stateRoot, "stateRoot").toAbsolutePath().normalize();
-        this.projectRegistryRoot = Objects.requireNonNull(
-                projectRegistryRoot, "projectRegistryRoot").toAbsolutePath().normalize();
-    }
-
-    static Path defaultProjectRegistryRoot() {
-        final long uid;
-        try {
-            uid = effectiveUserId();
-        } catch (IOException e) {
-            throw new IllegalStateException("Could not resolve the effective Unix user ID", e);
-        }
-        return Path.of("/var/tmp")
-                .resolve("camel-kit-ship-" + Long.toUnsignedString(uid))
-                .resolve("projects");
     }
 
     static Path validationStampPath(Path runDirectory, int attempt) {
@@ -486,79 +464,25 @@ final class ShipRunStore {
     }
 
     private Path resolvedProjectRegistryRoot() throws StoreException {
-        if (!projectRegistryRoot.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-            throw new StoreException(
-                    "state-corrupt", "Ship project publication ownership requires a POSIX filesystem");
-        }
-        Path parent = projectRegistryRoot.getParent();
-        if (parent == null) {
-            throw new StoreException(
-                    "state-corrupt", "Ship project publication registry has no parent directory");
-        }
         try {
-            ensurePrivateDirectory(parent);
-            ensurePrivateDirectory(projectRegistryRoot);
-            return canonicalize(projectRegistryRoot);
+            Path root = resolvedStateRoot("state-corrupt");
+            Files.createDirectories(root, directoryAttributes());
+            root = resolvedStateRoot("state-corrupt");
+            Path registry = root.resolve("projects");
+            try {
+                Files.createDirectory(registry, directoryAttributes());
+            } catch (FileAlreadyExistsException ignored) {
+                // The state-home registry is shared by runs in this store.
+            }
+            if (Files.isSymbolicLink(registry)
+                    || !Files.isDirectory(registry, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Ship project publication registry is not a real directory");
+            }
+            return registry.toRealPath();
         } catch (IOException | SecurityException e) {
             throw new StoreException(
                     "state-corrupt", "Ship project publication registry is unsafe", e);
         }
-    }
-
-    private static void ensurePrivateDirectory(Path directory) throws IOException {
-        try {
-            Files.createDirectory(
-                    directory,
-                    PosixFilePermissions.asFileAttribute(
-                            PosixFilePermissions.fromString("rwx------")));
-        } catch (FileAlreadyExistsException ignored) {
-            // Validate the existing per-user rendezvous below.
-        }
-        if (Files.isSymbolicLink(directory)
-                || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
-            throw new IOException("Ship private state path is not a real directory: " + directory);
-        }
-        long owner = ((Number) Files.getAttribute(
-                directory, "unix:uid", LinkOption.NOFOLLOW_LINKS)).longValue();
-        long current = effectiveUserId();
-        if (owner != current) {
-            throw new IOException("Ship private state path is owned by another user: " + directory);
-        }
-        Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(
-                directory, LinkOption.NOFOLLOW_LINKS);
-        if (!permissions.equals(PosixFilePermissions.fromString("rwx------"))) {
-            throw new IOException("Ship private state path is not private: " + directory);
-        }
-    }
-
-    private static long effectiveUserId() throws IOException {
-        Path status = Path.of("/proc/self/status");
-        byte[] encoded;
-        try (InputStream input = Files.newInputStream(status)) {
-            encoded = input.readNBytes(MAX_PROCESS_STATUS_BYTES + 1);
-        }
-        if (encoded.length == 0 || encoded.length > MAX_PROCESS_STATUS_BYTES) {
-            throw new IOException("Linux process status has an invalid size");
-        }
-        for (String line : new String(encoded, StandardCharsets.UTF_8).split("\\R")) {
-            if (!line.startsWith("Uid:")) {
-                continue;
-            }
-            String[] fields = line.trim().split("\\s+");
-            if (fields.length != 5) {
-                break;
-            }
-            try {
-                long uid = Long.parseLong(fields[2]);
-                if (uid >= 0) {
-                    return uid;
-                }
-            } catch (NumberFormatException ignored) {
-                // Report one stable error below.
-            }
-            break;
-        }
-        throw new IOException("Linux process status does not contain an effective user ID");
     }
 
     private static Path canonicalize(Path path) throws IOException {
@@ -622,8 +546,7 @@ final class ShipRunStore {
 
     private static StoreException projectOwned(ProjectOwner owner, Throwable cause) {
         String message = "Ship run " + owner.runId()
-                         + " has an unfinished publication for this project in "
-                         + owner.stateRoot() + "; resume or abort it first";
+                         + " has an unfinished publication for this project; resume or abort it first";
         return cause == null
                 ? new StoreException("project-publication-in-progress", message)
                 : new StoreException("project-publication-in-progress", message, cause);
@@ -706,15 +629,9 @@ final class ShipRunStore {
     }
 
     private boolean foreignOwnerBlocks(ProjectOwner owner) throws IOException {
-        final Path ownerRoot;
         final Path ownerRun;
         try {
-            Path suppliedRoot = Path.of(owner.stateRoot());
-            ownerRoot = canonicalize(suppliedRoot);
-            if (!ownerRoot.toString().equals(owner.stateRoot())) {
-                throw new IOException("Ship publication owner state root was rebound");
-            }
-            ownerRun = runRoot(ownerRoot, owner.runId());
+            ownerRun = runRoot(resolvedStateRoot("state-corrupt"), owner.runId());
             if (Files.isSymbolicLink(ownerRun)
                     || !Files.isDirectory(ownerRun, LinkOption.NOFOLLOW_LINKS)) {
                 throw new IOException("Ship publication owner run directory is unavailable");
@@ -727,7 +644,7 @@ final class ShipRunStore {
         }
         final ShipRun run;
         try {
-            run = new ShipRunStore(ownerRoot, projectRegistryRoot).read(owner.runId());
+            run = read(owner.runId());
         } catch (IOException | RuntimeException e) {
             throw projectOwned(owner, e);
         }
@@ -766,7 +683,6 @@ final class ShipRunStore {
         return new ProjectOwner(
                 PROJECT_OWNER_SCHEMA_VERSION,
                 projectIdentity,
-                root.toString(),
                 runId);
     }
 
@@ -945,7 +861,7 @@ final class ShipRunStore {
                 throw new StoreException(
                         "state-corrupt", "Ship project publication owner changed while locked");
             }
-            Path root = Path.of(expected.stateRoot());
+            Path root = resolvedStateRoot("state-corrupt");
             Path runDirectory = runRoot(root, claimedRunId);
             boolean resolved = !ShipPublicationService.journalExists(runDirectory);
             if (!resolved) {
@@ -976,7 +892,6 @@ final class ShipRunStore {
     private record ProjectOwner(
             int schemaVersion,
             String projectIdentity,
-            String stateRoot,
             String runId) {
 
         private ProjectOwner {
@@ -984,14 +899,6 @@ final class ShipRunStore {
                     || !ShipDigest.isSha256(projectIdentity)
                     || !ShipRun.isRunId(runId)) {
                 throw new IllegalArgumentException("Invalid Ship project publication owner");
-            }
-            requireCanonicalAbsolute(stateRoot);
-        }
-
-        private static void requireCanonicalAbsolute(String value) {
-            Path path = Path.of(Objects.requireNonNull(value, "owner path"));
-            if (!path.isAbsolute() || !path.normalize().equals(path)) {
-                throw new IllegalArgumentException("Invalid Ship project publication owner path");
             }
         }
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectEvidenceFiles.java
@@ -13,12 +13,12 @@ public final class ProjectEvidenceFiles {
         return new ProjectSnapshotService().capture(projectRoot);
     }
 
-    /** Returns the descriptor-bound identity of one project root without scanning its entries. */
+    /** Returns the identity of one project root without scanning its entries. */
     public static String rootIdentity(Path projectRoot) throws IOException {
         return new ProjectSnapshotService().rootIdentity(projectRoot);
     }
 
-    /** Returns the path-independent device/inode identity used to coordinate one live project. */
+    /** Returns the path-independent filesystem identity used to coordinate one live project. */
     public static String projectIdentity(Path projectRoot) throws IOException {
         return new ProjectSnapshotService().projectIdentity(projectRoot);
     }
@@ -48,7 +48,7 @@ public final class ProjectEvidenceFiles {
         return new ProjectSnapshotService().readMaterial(root, relativePath, maximumBytes);
     }
 
-    /** Reads one bounded volatile file through the descriptor-relative project boundary. */
+    /** Reads one bounded volatile file within the project boundary. */
     public static byte[] readVolatile(Path root, String relativePath, int maximumBytes) throws IOException {
         return new ProjectSnapshotService().readVolatile(root, relativePath, maximumBytes);
     }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshot.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshot.java
@@ -24,13 +24,12 @@ public record ProjectSnapshot(
         Map<String, FileEntry> files,
         String digest) {
 
-    public static final int SCHEMA_VERSION = 5;
+    public static final int SCHEMA_VERSION = 6;
 
     private static final int FILE_TYPE_MASK = 0170000;
     private static final int DIRECTORY_TYPE = 0040000;
     private static final int REGULAR_FILE_TYPE = 0100000;
     private static final int UNIX_MODE_MASK = 0177777;
-    private static final long MAX_UNIX_ID = 0xffff_ffffL;
 
     public ProjectSnapshot {
         if (schemaVersion != SCHEMA_VERSION) {
@@ -145,7 +144,7 @@ public record ProjectSnapshot(
             Map<String, DirectoryEntry> directories,
             Map<String, FileEntry> files) {
         MessageDigest digest = messageDigest();
-        update(digest, "camel-kit.ship.project-snapshot.v5");
+        update(digest, "camel-kit.ship.project-snapshot.v6");
         update(digest, root);
         update(digest, rootIdentity);
         update(digest, policyDigest);
@@ -154,8 +153,6 @@ public record ProjectSnapshot(
             update(digest, "DIRECTORY");
             update(digest, entry.classification().name());
             update(digest, Integer.toString(entry.unixMode()));
-            update(digest, Long.toString(entry.userId()));
-            update(digest, Long.toString(entry.groupId()));
         });
         files.forEach((path, entry) -> {
             update(digest, path);
@@ -164,21 +161,18 @@ public record ProjectSnapshot(
             update(digest, Long.toString(entry.size()));
             update(digest, entry.digest());
             update(digest, Integer.toString(entry.unixMode()));
-            update(digest, Long.toString(entry.userId()));
-            update(digest, Long.toString(entry.groupId()));
         });
         return "sha256:" + HexFormat.of().formatHex(digest.digest());
     }
 
-    public record DirectoryEntry(
-            Classification classification, int unixMode, long userId, long groupId) {
+    public record DirectoryEntry(Classification classification, int unixMode) {
 
         public DirectoryEntry {
             if (classification == null || classification == Classification.VOLATILE
                     || classification == Classification.DENIED) {
                 throw new IllegalArgumentException("Invalid project-snapshot directory identity");
             }
-            requireUnixIdentity(unixMode, userId, groupId, DIRECTORY_TYPE, "directory");
+            requireUnixMode(unixMode, DIRECTORY_TYPE, "directory");
         }
     }
 
@@ -235,14 +229,11 @@ public record ProjectSnapshot(
         }
     }
 
-    private static void requireUnixIdentity(
-            int unixMode, long userId, long groupId, int expectedType, String label) {
+    private static void requireUnixMode(int unixMode, int expectedType, String label) {
         if ((unixMode & ~UNIX_MODE_MASK) != 0
-                || (unixMode & FILE_TYPE_MASK) != expectedType
-                || userId < 0 || userId > MAX_UNIX_ID
-                || groupId < 0 || groupId > MAX_UNIX_ID) {
+                || (unixMode & FILE_TYPE_MASK) != expectedType) {
             throw new IllegalArgumentException(
-                    "Invalid project-snapshot Unix " + label + " identity");
+                    "Invalid project-snapshot Unix " + label + " mode");
         }
     }
 
@@ -283,9 +274,7 @@ public record ProjectSnapshot(
             Classification classification,
             long size,
             String digest,
-            int unixMode,
-            long userId,
-            long groupId) {
+            int unixMode) {
 
         public FileEntry {
             if (classification == null || classification == Classification.VOLATILE
@@ -294,7 +283,7 @@ public record ProjectSnapshot(
                 throw new IllegalArgumentException("Invalid project-snapshot file identity");
             }
             requireDigest(digest, "file digest");
-            requireUnixIdentity(unixMode, userId, groupId, REGULAR_FILE_TYPE, "file");
+            requireUnixMode(unixMode, REGULAR_FILE_TYPE, "file");
         }
     }
 

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotService.java
@@ -21,7 +21,7 @@ import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.FileEntry;
 import io.github.luigidemasi.camelkit.ship.security.ShipSecureFilesystem.SecureRoot;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
 
-/** Captures and compares project trees through the read-only secure Ship filesystem boundary. */
+/** Captures and compares project trees through the bounded read-only Ship filesystem boundary. */
 final class ProjectSnapshotService {
 
     private final ShipTreePolicy policy;
@@ -151,14 +151,14 @@ final class ProjectSnapshotService {
         return materialized;
     }
 
-    /** Reads one bounded material file through the descriptor-relative project boundary. */
+    /** Reads one bounded material file within the project boundary. */
     byte[] readMaterial(Path root, String relativePath, int maximumBytes) throws IOException {
         try (SecureRoot secure = ShipSecureFilesystem.open(root, "Ship material read", policy)) {
             return secure.readMaterialBytes(relativePath, maximumBytes);
         }
     }
 
-    /** Reads one bounded volatile file through the descriptor-relative project boundary. */
+    /** Reads one bounded volatile file within the project boundary. */
     byte[] readVolatile(Path root, String relativePath, int maximumBytes) throws IOException {
         try (SecureRoot secure = ShipSecureFilesystem.open(root, "Ship volatile read", policy)) {
             return secure.readVolatileBytes(relativePath, maximumBytes);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/security/ShipSecureFilesystem.java
@@ -10,33 +10,23 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.SecureDirectoryStream;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.DirectoryEntry;
 import io.github.luigidemasi.camelkit.ship.security.ProjectSnapshot.FileEntry;
 import io.github.luigidemasi.camelkit.ship.security.ShipTreePolicy.Classification;
 
-/**
- * Internal read-only, descriptor-relative filesystem policy boundary for Ship trees. This Java 17 implementation is a
- * phase-one, non-certifying boundary: metadata samples cannot exclude same-device bind mounts, inode or file-key reuse
- * between samples, or replacement of the final entry while a read channel is open. Public execution remains gated on
- * the later OS helper that binds mount policy and identity checks to the exact opened descriptor.
- */
+/** Internal bounded read policy for Ship trees. */
 final class ShipSecureFilesystem {
 
-    private static final String UNIX_ATTRIBUTES = "unix:dev,ino,nlink,size,lastModifiedTime,ctime,mode,uid,gid";
+    private static final String UNIX_ATTRIBUTES = "unix:mode,nlink";
     private static final int FILE_TYPE_MASK = 0170000;
     private static final int DIRECTORY_TYPE = 0040000;
     private static final int REGULAR_FILE_TYPE = 0100000;
@@ -46,14 +36,18 @@ final class ShipSecureFilesystem {
 
     static SecureRoot open(Path requestedRoot, String label, ShipTreePolicy policy) throws IOException {
         Path root = requireRootPath(requestedRoot, label, policy);
-        DirectoryStream<Path> stream = Files.newDirectoryStream(root);
-        if (!(stream instanceof SecureDirectoryStream<?>)) {
-            stream.close();
-            throw unsupported(label + " filesystem does not provide SecureDirectoryStream: " + root);
+        BasicFileAttributes attributes = attributes(root);
+        UnixMetadata metadata = requireDirectory(root, attributes, label + " root");
+        if (attributes.fileKey() == null) {
+            throw unsupported(label + " root lacks a stable file key: " + root);
         }
-        @SuppressWarnings("unchecked")
-        SecureDirectoryStream<Path> secure = (SecureDirectoryStream<Path>) stream;
-        return bindOpenedRoot(root, label, policy, secure);
+        return new SecureRoot(
+                root,
+                label,
+                policy,
+                attributes.fileKey(),
+                rootIdentity(root, attributes.fileKey()),
+                metadata.mode());
     }
 
     private static Path requireRootPath(Path requestedRoot, String label, ShipTreePolicy policy)
@@ -76,92 +70,29 @@ final class ShipSecureFilesystem {
         return root;
     }
 
-    private static SecureRoot bindOpenedRoot(
-            Path root,
-            String label,
-            ShipTreePolicy policy,
-            SecureDirectoryStream<Path> secure)
-            throws IOException {
-        try {
-            BasicFileAttributes held = attributes(secure, null);
-            if (!held.isDirectory() || held.fileKey() == null) {
-                throw unsupported(label + " lacks a stable descriptor-relative identity: " + root);
-            }
-            UnixIdentity sampled = sampleUnixIdentity(root, held.fileKey(), label + " root");
-            requireDirectory(held, sampled, sampled.device(), label + " root");
-            BasicFileAttributes rebound = attributes(secure, null);
-            requireDirectory(rebound, sampled, sampled.device(), label + " root");
-            return new SecureRoot(
-                    root, label, policy, secure, sampled, rootIdentity(root, sampled));
-        } catch (IOException | RuntimeException e) {
-            try {
-                secure.close();
-            } catch (IOException closeFailure) {
-                e.addSuppressed(closeFailure);
-            }
-            throw e;
-        }
+    private static BasicFileAttributes attributes(Path path) throws IOException {
+        return Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
     }
 
-    private static BasicFileAttributes attributes(SecureDirectoryStream<Path> directory, Path name)
-            throws IOException {
-        BasicFileAttributeView view = name == null
-                ? directory.getFileAttributeView(BasicFileAttributeView.class)
-                : directory.getFileAttributeView(
-                        name, BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
-        if (view == null) {
-            throw unsupported("Secure filesystem does not expose basic descriptor-relative attributes");
-        }
-        return view.readAttributes();
-    }
-
-    private static UnixIdentity sampleUnixIdentity(
-            Path lexicalPath, Object expectedFileKey, String description)
-            throws IOException {
-        if (expectedFileKey == null) {
-            throw unsupported(description + " lacks a stable file key");
-        }
+    private static UnixMetadata unixMetadata(Path path, String description) throws IOException {
         try {
-            BasicFileAttributes before = Files.readAttributes(
-                    lexicalPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            if (!expectedFileKey.equals(before.fileKey())) {
-                throw concurrentMutation(description + " changed before Unix metadata sampling");
-            }
             Map<String, Object> values = Files.readAttributes(
-                    lexicalPath, UNIX_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
-            BasicFileAttributes after = Files.readAttributes(
-                    lexicalPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            if (!expectedFileKey.equals(after.fileKey())) {
-                throw concurrentMutation(description + " changed during Unix metadata sampling");
+                    path, UNIX_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
+            int mode = requiredInt(values, "mode", description);
+            long linkCount = requiredLong(values, "nlink", description);
+            if (linkCount < 1) {
+                throw unsupported(description + " returned an invalid Unix link count");
             }
-            UnixIdentity identity = new UnixIdentity(
-                    expectedFileKey,
-                    requiredLong(values, "dev", description),
-                    requiredLong(values, "ino", description),
-                    requiredLong(values, "nlink", description),
-                    requiredLong(values, "size", description),
-                    requiredTime(values, "lastModifiedTime", description)
-                            .to(TimeUnit.NANOSECONDS),
-                    requiredTime(values, "ctime", description).to(TimeUnit.NANOSECONDS),
-                    requiredInt(values, "mode", description),
-                    requiredUnixId(values, "uid", description),
-                    requiredUnixId(values, "gid", description));
-            if (identity.linkCount() < 1 || identity.size() < 0) {
-                throw unsupported(description + " returned invalid Unix metadata");
-            }
-            requireBasicBinding(before, identity, description);
-            requireBasicBinding(after, identity, description);
-            return identity;
+            return new UnixMetadata(mode, linkCount);
         } catch (UnsupportedOperationException | IllegalArgumentException e) {
             throw new ShipFilesystemException(
                     ShipFilesystemException.SECURE_FILESYSTEM_UNSUPPORTED,
-                    description + " filesystem cannot provide stable Unix identity metadata",
+                    description + " filesystem cannot provide Unix mode and link metadata",
                     e);
         }
     }
 
-    private static long requiredLong(
-            Map<String, Object> values, String name, String description)
+    private static long requiredLong(Map<String, Object> values, String name, String description)
             throws IOException {
         Object value = values.get(name);
         if (!(value instanceof Number number)) {
@@ -170,8 +101,7 @@ final class ShipSecureFilesystem {
         return number.longValue();
     }
 
-    private static int requiredInt(
-            Map<String, Object> values, String name, String description)
+    private static int requiredInt(Map<String, Object> values, String name, String description)
             throws IOException {
         long value = requiredLong(values, name, description);
         if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
@@ -180,95 +110,38 @@ final class ShipSecureFilesystem {
         return (int) value;
     }
 
-    private static long requiredUnixId(
-            Map<String, Object> values, String name, String description)
+    private static UnixMetadata requireDirectory(
+            Path path, BasicFileAttributes basic, String description)
             throws IOException {
-        Object value = values.get(name);
-        if (!(value instanceof Number number)) {
-            throw unsupported(description + " lacks Unix attribute " + name);
-        }
-        long result = value instanceof Integer integer
-                ? Integer.toUnsignedLong(integer)
-                : number.longValue();
-        if (result < 0 || result > 0xffff_ffffL) {
-            throw unsupported(description + " has an invalid Unix attribute " + name);
-        }
-        return result;
-    }
-
-    private static FileTime requiredTime(
-            Map<String, Object> values, String name, String description)
-            throws IOException {
-        Object value = values.get(name);
-        if (!(value instanceof FileTime time)) {
-            throw unsupported(description + " lacks Unix attribute " + name);
-        }
-        return time;
-    }
-
-    private static void requireDirectory(
-            BasicFileAttributes basic,
-            UnixIdentity unix,
-            long rootDevice,
-            String description)
-            throws IOException {
-        if (!basic.isDirectory() || basic.isSymbolicLink() || basic.fileKey() == null
+        UnixMetadata unix = unixMetadata(path, description);
+        if (!basic.isDirectory() || basic.isSymbolicLink()
                 || (unix.mode() & FILE_TYPE_MASK) != DIRECTORY_TYPE) {
-            throw unsafe(description + " is not a stable real directory");
+            throw unsafe(description + " is not a real directory");
         }
-        requireBasicBinding(basic, unix, description);
-        requireSameDevice(unix, rootDevice, description);
+        return unix;
     }
 
-    private static void requireRegularFile(
-            BasicFileAttributes basic,
-            UnixIdentity unix,
-            long rootDevice,
-            String description)
+    private static UnixMetadata requireRegularFile(
+            Path path, BasicFileAttributes basic, String description)
             throws IOException {
-        if (!basic.isRegularFile() || basic.isSymbolicLink() || basic.fileKey() == null
+        UnixMetadata unix = unixMetadata(path, description);
+        if (!basic.isRegularFile() || basic.isSymbolicLink()
                 || (unix.mode() & FILE_TYPE_MASK) != REGULAR_FILE_TYPE) {
-            throw unsafe(description + " is not a stable regular file");
+            throw unsafe(description + " is not a regular file");
         }
-        requireBasicBinding(basic, unix, description);
-        requireSameDevice(unix, rootDevice, description);
         if (unix.linkCount() != 1) {
             throw unsafe("Ship tree contains a hard-linked file: " + description);
         }
+        return unix;
     }
 
-    private static void requireBasicBinding(
-            BasicFileAttributes basic, UnixIdentity unix, String description)
-            throws IOException {
-        if (basic.fileKey() == null
-                || !unix.fileKey().equals(basic.fileKey())
-                || basic.size() != unix.size()
-                || basic.lastModifiedTime().to(TimeUnit.NANOSECONDS) != unix.modifiedNanos()) {
-            throw concurrentMutation(description + " changed across its identity sample");
-        }
-    }
-
-    private static void requireSameDevice(
-            UnixIdentity identity, long rootDevice, String description)
-            throws IOException {
-        if (identity.device() != rootDevice) {
-            throw unsafe(description + " crosses the trusted project filesystem device");
-        }
-        // st_dev rejects ordinary mount crossings. Pure Java 17 cannot certify that a
-        // same-device entry is not a bind mount; the later OS helper must enforce that boundary.
-    }
-
-    private static String rootIdentity(Path root, UnixIdentity identity) {
-        return digestBytes(("camel-kit.ship.root.v4\0" + root + "\0"
-                            + Long.toUnsignedString(identity.device()) + "\0"
-                            + Long.toUnsignedString(identity.inode()))
+    private static String rootIdentity(Path root, Object fileKey) {
+        return digestBytes(("camel-kit.ship.root.v5\0" + root + "\0" + fileKey)
                 .getBytes(StandardCharsets.UTF_8));
     }
 
-    private static String projectIdentity(UnixIdentity identity) {
-        return digestBytes(("camel-kit.ship.project.v1\0"
-                            + Long.toUnsignedString(identity.device()) + "\0"
-                            + Long.toUnsignedString(identity.inode()))
+    private static String projectIdentity(Object fileKey) {
+        return digestBytes(("camel-kit.ship.project.v2\0" + fileKey)
                 .getBytes(StandardCharsets.UTF_8));
     }
 
@@ -301,21 +174,9 @@ final class ShipSecureFilesystem {
         return new ShipFilesystemException(ShipFilesystemException.CONCURRENT_MUTATION, message);
     }
 
-    private record UnixIdentity(
-            Object fileKey,
-            long device,
-            long inode,
-            long linkCount,
-            long size,
-            long modifiedNanos,
-            long changedNanos,
-            int mode,
-            long userId,
-            long groupId) {
-
+    private record UnixMetadata(int mode, long linkCount) {
     }
 
-    /** Held descriptor for one stable root. All untrusted path traversal stays relative to this handle. */
     static final class SecureRoot implements AutoCloseable {
 
         private static final Set<OpenOption> READ_OPTIONS = Set.of(
@@ -324,37 +185,42 @@ final class ShipSecureFilesystem {
         private final Path path;
         private final String label;
         private final ShipTreePolicy policy;
-        private final SecureDirectoryStream<Path> root;
-        private final UnixIdentity rootMetadata;
+        private final Object rootFileKey;
         private final String identity;
+        private final int rootMode;
 
         private SecureRoot(
                            Path path,
                            String label,
                            ShipTreePolicy policy,
-                           SecureDirectoryStream<Path> root,
-                           UnixIdentity rootMetadata,
-                           String identity) {
+                           Object rootFileKey,
+                           String identity,
+                           int rootMode) {
             this.path = path;
             this.label = label;
             this.policy = policy;
-            this.root = root;
-            this.rootMetadata = rootMetadata;
+            this.rootFileKey = rootFileKey;
             this.identity = identity;
+            this.rootMode = rootMode;
         }
 
         void validateBinding() throws IOException {
-            assertRootBinding();
+            BasicFileAttributes current = attributes(path);
+            UnixMetadata metadata = requireDirectory(path, current, label + " root");
+            if (!rootFileKey.equals(current.fileKey()) || rootMode != metadata.mode()) {
+                throw concurrentMutation(
+                        label + " root path no longer names its original directory: " + path);
+            }
         }
 
         String rootIdentity() throws IOException {
-            assertRootBinding();
+            validateBinding();
             return identity;
         }
 
         String projectIdentity() throws IOException {
-            assertRootBinding();
-            return ShipSecureFilesystem.projectIdentity(rootMetadata);
+            validateBinding();
+            return ShipSecureFilesystem.projectIdentity(rootFileKey);
         }
 
         ProjectSnapshot snapshot() throws IOException {
@@ -372,17 +238,13 @@ final class ShipSecureFilesystem {
         }
 
         private ProjectSnapshot snapshot(boolean materialOnly, boolean staged) throws IOException {
-            assertRootBinding();
-            ScanState state = new ScanState(policy, rootMetadata.fileKey());
-            try (BoundDirectory scanRoot = openBoundDirectory(
-                    root, Path.of("."), "", rootMetadata)) {
-                try {
-                    scan(scanRoot.stream(), "", rootMetadata, 0, state, materialOnly, staged);
-                } catch (IllegalArgumentException ignored) {
-                    throw unsafe("Ship tree contains an unsafe entry");
-                }
+            validateBinding();
+            ScanState state = new ScanState(policy);
+            try {
+                scan(path, "", 0, state, materialOnly, staged);
+            } catch (IllegalArgumentException ignored) {
+                throw unsafe("Ship tree contains an unsafe entry");
             }
-            assertRootBinding();
             return ProjectSnapshot.create(
                     path.toString(), identity, policy.digest(), state.directories, state.files);
         }
@@ -398,9 +260,7 @@ final class ShipSecureFilesystem {
         }
 
         private byte[] readBytes(
-                String relativePath,
-                int maximumBytes,
-                Classification requiredClassification)
+                String relativePath, int maximumBytes, Classification requiredClassification)
                 throws IOException {
             if (maximumBytes < 1) {
                 throw new IllegalArgumentException("Maximum Ship read size must be positive");
@@ -409,79 +269,84 @@ final class ShipSecureFilesystem {
             if (classify(relative) != requiredClassification) {
                 throw unsafe("Ship file does not have the required classification: " + relative);
             }
-            assertRootBinding();
-            byte[] result = withParent(relative, (parent, name) -> {
-                BasicFileAttributes basicBefore = attributes(parent, name);
-                UnixIdentity before = relativeIdentity(relative, basicBefore.fileKey());
-                requireRegularFile(basicBefore, before, rootMetadata.device(), relative);
-                long limit = Math.min((long) maximumBytes, policy.maxFileBytes());
-                if (before.size() > limit) {
-                    throw quota("Ship file exceeds its read limit: " + relative);
-                }
-                ByteArrayOutputStream output = new ByteArrayOutputStream(Math.toIntExact(before.size()));
-                // Java 17 exposes no fstat-style identity from SeekableByteChannel. These
-                // samples bracket the read but cannot certify the opened final descriptor;
-                // the later OS helper must bind and verify that descriptor directly.
-                try (SeekableByteChannel channel = parent.newByteChannel(name, READ_OPTIONS)) {
-                    ByteBuffer buffer = ByteBuffer.allocate(8192);
-                    long total = 0;
-                    int read;
-                    while ((read = channel.read(buffer)) != -1) {
-                        if (read == 0) {
-                            continue;
-                        }
-                        total = Math.addExact(total, read);
-                        if (total > before.size()) {
-                            throw concurrentMutation(
-                                    "Ship file grew while it was read: " + relative);
-                        }
-                        if (total > limit) {
-                            throw quota("Ship file exceeds its read limit: " + relative);
-                        }
-                        output.write(buffer.array(), 0, read);
-                        buffer.clear();
+            validateBinding();
+            Path file = resolve(relative);
+            BasicFileAttributes basic = attributes(file);
+            requireRegularFile(file, basic, relative);
+            long limit = Math.min((long) maximumBytes, policy.maxFileBytes());
+            if (basic.size() > limit) {
+                throw quota("Ship file exceeds its read limit: " + relative);
+            }
+            ByteArrayOutputStream output = new ByteArrayOutputStream(Math.toIntExact(basic.size()));
+            try (SeekableByteChannel channel = Files.newByteChannel(file, READ_OPTIONS)) {
+                ByteBuffer buffer = ByteBuffer.allocate(8192);
+                long total = 0;
+                int read;
+                while ((read = channel.read(buffer)) != -1) {
+                    if (read == 0) {
+                        continue;
                     }
+                    total = Math.addExact(total, read);
+                    if (total > limit) {
+                        throw quota("Ship file exceeds its read limit: " + relative);
+                    }
+                    output.write(buffer.array(), 0, read);
+                    buffer.clear();
                 }
-                BasicFileAttributes basicAfter = attributes(parent, name);
-                UnixIdentity after = relativeIdentity(relative, before.fileKey());
-                requireRegularFile(basicAfter, after, rootMetadata.device(), relative);
-                if (!before.equals(after) || output.size() != before.size()) {
-                    throw concurrentMutation("Ship file changed while it was read: " + relative);
-                }
-                return output.toByteArray();
-            });
-            assertRootBinding();
-            return result;
+            }
+            if (output.size() != basic.size()) {
+                throw concurrentMutation("Ship file changed while it was read: " + relative);
+            }
+            return output.toByteArray();
         }
 
         private void scan(
-                SecureDirectoryStream<Path> directory,
+                Path directory,
                 String prefix,
-                UnixIdentity expectedDirectory,
                 int depth,
                 ScanState state,
                 boolean materialOnly,
                 boolean staged)
                 throws IOException {
-            validateOpenedDirectory(directory, expectedDirectory, display(prefix));
-            UnixIdentity directoryBefore = relativeIdentity(prefix, expectedDirectory.fileKey());
-            if (!expectedDirectory.equals(directoryBefore)) {
-                throw concurrentMutation(
-                        "Ship directory changed before it was scanned: " + display(prefix));
-            }
-            for (Path entry : directory) {
-                Path name = Path.of(singleName(entry.getFileName().toString()));
-                String relative = prefix.isEmpty() ? name.toString() : prefix + "/" + name;
-                relative = relative.replace('\\', '/');
-                Classification classification = classify(relative);
-                BasicFileAttributes basic = attributes(directory, name);
-                if (basic.isSymbolicLink()) {
-                    throw unsafe("Ship tree contains a symbolic link: " + relative);
-                }
-                if (basic.isDirectory()) {
-                    UnixIdentity entryIdentity = relativeIdentity(relative, basic.fileKey());
-                    requireDirectory(basic, entryIdentity, rootMetadata.device(), relative);
-                    state.visitDirectory(relative, entryIdentity);
+            try (DirectoryStream<Path> entries = Files.newDirectoryStream(directory)) {
+                for (Path entry : entries) {
+                    String name = singleName(entry.getFileName().toString());
+                    String relative = prefix.isEmpty() ? name : prefix + "/" + name;
+                    Classification classification = classify(relative);
+                    BasicFileAttributes basic = attributes(entry);
+                    if (basic.isSymbolicLink()) {
+                        throw unsafe("Ship tree contains a symbolic link: " + relative);
+                    }
+                    if (basic.isDirectory()) {
+                        UnixMetadata metadata = requireDirectory(entry, basic, relative);
+                        state.visitEntry(relative);
+                        if (staged && (classification == Classification.DENIED
+                                || classification == Classification.PROTECTED)) {
+                            throw unsafe("Staged Ship tree contains a non-publishable entry: " + relative);
+                        }
+                        if (materialOnly && classification != Classification.MATERIAL) {
+                            throw unsafe("Sealed Ship tree contains a non-material entry: " + relative);
+                        }
+                        if (classification == Classification.DENIED
+                                || (classification == Classification.VOLATILE && !staged)) {
+                            continue;
+                        }
+                        int childDepth = Math.addExact(depth, 1);
+                        if (childDepth > policy.maxDepth()) {
+                            throw quota("Ship tree exceeds the depth quota at " + relative);
+                        }
+                        if (classification != Classification.VOLATILE) {
+                            state.addDirectory(
+                                    relative, new DirectoryEntry(classification, metadata.mode()));
+                        }
+                        scan(entry, relative, childDepth, state, materialOnly, staged);
+                        continue;
+                    }
+                    if (!basic.isRegularFile()) {
+                        throw unsafe("Ship tree contains a special filesystem entry: " + relative);
+                    }
+                    UnixMetadata metadata = requireRegularFile(entry, basic, relative);
+                    state.visitEntry(relative);
                     if (staged && (classification == Classification.DENIED
                             || classification == Classification.PROTECTED)) {
                         throw unsafe("Staged Ship tree contains a non-publishable entry: " + relative);
@@ -489,88 +354,33 @@ final class ShipSecureFilesystem {
                     if (materialOnly && classification != Classification.MATERIAL) {
                         throw unsafe("Sealed Ship tree contains a non-material entry: " + relative);
                     }
-                    if (classification == Classification.DENIED
-                            || (classification == Classification.VOLATILE && !staged)) {
+                    if (classification == Classification.DENIED) {
                         continue;
                     }
-                    int childDepth = Math.addExact(depth, 1);
-                    if (childDepth > policy.maxDepth()) {
-                        throw quota("Ship tree exceeds the depth quota at " + relative);
+                    if (classification == Classification.VOLATILE) {
+                        if (staged) {
+                            state.reserve(relative, basic.size());
+                        }
+                        continue;
                     }
-                    if (classification != Classification.VOLATILE) {
-                        state.addDirectory(relative, entryIdentity, new DirectoryEntry(
-                                classification,
-                                entryIdentity.mode(),
-                                entryIdentity.userId(),
-                                entryIdentity.groupId()));
-                    }
-                    try (BoundDirectory child = openBoundDirectory(
-                            directory, name, relative, entryIdentity)) {
-                        scan(
-                                child.stream(),
-                                relative,
-                                entryIdentity,
-                                childDepth,
-                                state,
-                                materialOnly,
-                                staged);
-                    }
-                    continue;
+                    state.add(relative, readRegular(
+                            entry, relative, classification, basic, metadata, state));
                 }
-                if (!basic.isRegularFile()) {
-                    throw unsafe("Ship tree contains a special filesystem entry: " + relative);
-                }
-                UnixIdentity entryIdentity = relativeIdentity(relative, basic.fileKey());
-                requireRegularFile(basic, entryIdentity, rootMetadata.device(), relative);
-                state.visitFile(relative, entryIdentity);
-                if (staged && (classification == Classification.DENIED
-                        || classification == Classification.PROTECTED)) {
-                    throw unsafe("Staged Ship tree contains a non-publishable entry: " + relative);
-                }
-                if (materialOnly && classification != Classification.MATERIAL) {
-                    throw unsafe("Sealed Ship tree contains a non-material entry: " + relative);
-                }
-                if (classification == Classification.DENIED) {
-                    continue;
-                }
-                if (classification == Classification.VOLATILE) {
-                    if (staged) {
-                        state.reserve(relative, entryIdentity);
-                    }
-                    continue;
-                }
-                state.add(relative, readRegular(
-                        directory, name, relative, classification, entryIdentity, state));
-            }
-            validateOpenedDirectory(directory, expectedDirectory, display(prefix));
-            UnixIdentity directoryAfter = relativeIdentity(prefix, expectedDirectory.fileKey());
-            if (!directoryBefore.equals(directoryAfter)) {
-                throw concurrentMutation(
-                        "Ship directory changed while it was scanned: " + display(prefix));
             }
         }
 
         private FileEntry readRegular(
-                SecureDirectoryStream<Path> directory,
-                Path name,
+                Path file,
                 String relative,
                 Classification classification,
-                UnixIdentity expected,
+                BasicFileAttributes basic,
+                UnixMetadata metadata,
                 ScanState state)
                 throws IOException {
-            BasicFileAttributes basicBefore = attributes(directory, name);
-            UnixIdentity before = relativeIdentity(relative, basicBefore.fileKey());
-            requireRegularFile(basicBefore, before, rootMetadata.device(), relative);
-            if (!expected.equals(before)) {
-                throw concurrentMutation("Ship file changed before it was read: " + relative);
-            }
-            state.reserve(relative, before);
+            state.reserve(relative, basic.size());
             MessageDigest digest = messageDigest();
             long count = 0;
-            // Java 17 exposes no fstat-style identity from SeekableByteChannel. These
-            // samples bracket the read but cannot certify the opened final descriptor;
-            // the later OS helper must bind and verify that descriptor directly.
-            try (SeekableByteChannel input = directory.newByteChannel(name, READ_OPTIONS)) {
+            try (SeekableByteChannel input = Files.newByteChannel(file, READ_OPTIONS)) {
                 ByteBuffer buffer = ByteBuffer.allocate(8192);
                 int read;
                 while ((read = input.read(buffer)) != -1) {
@@ -578,9 +388,6 @@ final class ShipSecureFilesystem {
                         continue;
                     }
                     count = Math.addExact(count, read);
-                    if (count > before.size()) {
-                        throw concurrentMutation("Ship file grew while it was read: " + relative);
-                    }
                     if (count > policy.maxFileBytes()) {
                         throw quota("Ship file exceeds the per-file quota: " + relative);
                     }
@@ -589,145 +396,32 @@ final class ShipSecureFilesystem {
                     buffer.clear();
                 }
             }
-            BasicFileAttributes basicAfter = attributes(directory, name);
-            UnixIdentity after = relativeIdentity(relative, before.fileKey());
-            requireRegularFile(basicAfter, after, rootMetadata.device(), relative);
-            if (count != before.size() || !before.equals(after)) {
+            if (count != basic.size()) {
                 throw concurrentMutation("Ship file changed while it was read: " + relative);
             }
             return new FileEntry(
                     classification,
                     count,
                     "sha256:" + HexFormat.of().formatHex(digest.digest()),
-                    after.mode(),
-                    after.userId(),
-                    after.groupId());
+                    metadata.mode());
         }
 
-        private UnixIdentity relativeIdentity(String relative, Object expectedKey) throws IOException {
-            if (relative == null || relative.isEmpty()) {
-                return sampleUnixIdentity(path, expectedKey, label + " root");
+        private Path resolve(String relative) throws IOException {
+            Path current = path;
+            String[] components = relative.split("/");
+            if (components.length - 1 > policy.maxDepth()) {
+                throw quota("Ship path exceeds the depth quota: " + relative);
             }
-            assertLexicalRootStillNamesHandle();
-            UnixIdentity result = sampleUnixIdentity(path.resolve(relative), expectedKey, relative);
-            assertLexicalRootStillNamesHandle();
-            return result;
-        }
-
-        private void assertRootBinding() throws IOException {
-            BasicFileAttributes held = attributes(root, null);
-            requireDirectory(held, rootMetadata, rootMetadata.device(), label + " held root");
-            assertLexicalRootStillNamesHandle();
-        }
-
-        private void assertLexicalRootStillNamesHandle() throws IOException {
-            UnixIdentity named = sampleUnixIdentity(path, rootMetadata.fileKey(), label + " root");
-            if (!rootMetadata.equals(named)
-                    || !identity.equals(ShipSecureFilesystem.rootIdentity(path, named))) {
-                throw concurrentMutation(
-                        label + " root path no longer names its original directory: " + path);
+            for (int index = 0; index < components.length - 1; index++) {
+                current = current.resolve(singleName(components[index]));
+                requireDirectory(current, attributes(current), relative);
             }
-        }
-
-        private <T> T withParent(String relative, ParentOperation<T> operation) throws IOException {
-            int slash = relative.lastIndexOf('/');
-            String directory = slash < 0 ? "" : relative.substring(0, slash);
-            Path name = Path.of(slash < 0 ? relative : relative.substring(slash + 1));
-            return withDirectory(directory, parent -> operation.apply(parent, name));
-        }
-
-        private <T> T withDirectory(String relative, DirectoryOperation<T> operation)
-                throws IOException {
-            assertRootBinding();
-            if (relative == null || relative.isBlank()) {
-                return operation.apply(root);
-            }
-            String canonical = canonicalPath(relative);
-            String[] components = canonical.split("/");
-            if (components.length > policy.maxDepth()) {
-                throw quota("Ship path exceeds the depth quota: " + canonical);
-            }
-            return withDirectory(root, components, 0, "", operation);
-        }
-
-        private <T> T withDirectory(
-                SecureDirectoryStream<Path> current,
-                String[] components,
-                int index,
-                String prefix,
-                DirectoryOperation<T> operation)
-                throws IOException {
-            if (index == components.length) {
-                return operation.apply(current);
-            }
-            Path name = Path.of(singleName(components[index]));
-            String relative = prefix.isEmpty() ? components[index] : prefix + "/" + components[index];
-            BasicFileAttributes basic = attributes(current, name);
-            UnixIdentity expected = relativeIdentity(relative, basic.fileKey());
-            requireDirectory(basic, expected, rootMetadata.device(), relative);
-            try (BoundDirectory child = openBoundDirectory(current, name, relative, expected)) {
-                return withDirectory(
-                        child.stream(), components, index + 1, relative, operation);
-            }
-        }
-
-        private BoundDirectory openBoundDirectory(
-                SecureDirectoryStream<Path> parent,
-                Path name,
-                String relative,
-                UnixIdentity expected)
-                throws IOException {
-            SecureDirectoryStream<Path> opened = null;
-            try {
-                opened = parent.newDirectoryStream(name, LinkOption.NOFOLLOW_LINKS);
-                validateOpenedDirectory(opened, expected, display(relative));
-                UnixIdentity rebound = relativeIdentity(relative, expected.fileKey());
-                if (!expected.equals(rebound)) {
-                    throw concurrentMutation(
-                            "Ship directory changed while its secure handle was opened: "
-                                             + display(relative));
-                }
-                return new BoundDirectory(parent, name, relative, expected, opened);
-            } catch (IOException | RuntimeException e) {
-                if (opened != null) {
-                    try {
-                        opened.close();
-                    } catch (IOException closeFailure) {
-                        e.addSuppressed(closeFailure);
-                    }
-                }
-                throw e;
-            }
-        }
-
-        private void validateOpenedDirectory(
-                SecureDirectoryStream<Path> directory,
-                UnixIdentity expected,
-                String description)
-                throws IOException {
-            BasicFileAttributes held = attributes(directory, null);
-            requireDirectory(held, expected, rootMetadata.device(), description);
-        }
-
-        private void validateParentBinding(
-                SecureDirectoryStream<Path> parent,
-                Path name,
-                String relative,
-                UnixIdentity expected)
-                throws IOException {
-            BasicFileAttributes named = attributes(parent, name);
-            UnixIdentity rebound = relativeIdentity(relative, expected.fileKey());
-            requireDirectory(named, rebound, rootMetadata.device(), display(relative));
-            if (!expected.equals(rebound)) {
-                throw concurrentMutation(
-                        "Ship directory changed while its secure handle was in use: "
-                                         + display(relative));
-            }
+            return current.resolve(singleName(components[components.length - 1]));
         }
 
         @Override
-        public void close() throws IOException {
-            root.close();
+        public void close() {
+            // No persistent handle is required by the bounded read policy.
         }
 
         private String canonicalPath(String value) throws ShipFilesystemException {
@@ -757,72 +451,9 @@ final class ShipSecureFilesystem {
             }
         }
 
-        private static String display(String relative) {
-            return relative == null || relative.isBlank() ? "." : relative;
-        }
-
         private static ShipFilesystemException quota(String message) {
             return new ShipFilesystemException(
                     ShipFilesystemException.TREE_QUOTA_EXCEEDED, message);
-        }
-
-        @FunctionalInterface
-        private interface DirectoryOperation<T> {
-            T apply(SecureDirectoryStream<Path> directory) throws IOException;
-        }
-
-        @FunctionalInterface
-        private interface ParentOperation<T> {
-            T apply(SecureDirectoryStream<Path> directory, Path name) throws IOException;
-        }
-
-        private final class BoundDirectory implements AutoCloseable {
-
-            private final SecureDirectoryStream<Path> parent;
-            private final Path name;
-            private final String relative;
-            private final UnixIdentity expected;
-            private final SecureDirectoryStream<Path> stream;
-
-            private BoundDirectory(
-                                   SecureDirectoryStream<Path> parent,
-                                   Path name,
-                                   String relative,
-                                   UnixIdentity expected,
-                                   SecureDirectoryStream<Path> stream) {
-                this.parent = parent;
-                this.name = name;
-                this.relative = relative;
-                this.expected = expected;
-                this.stream = stream;
-            }
-
-            private SecureDirectoryStream<Path> stream() {
-                return stream;
-            }
-
-            @Override
-            public void close() throws IOException {
-                IOException failure = null;
-                try {
-                    validateOpenedDirectory(stream, expected, display(relative));
-                    validateParentBinding(parent, name, relative, expected);
-                } catch (IOException e) {
-                    failure = e;
-                }
-                try {
-                    stream.close();
-                } catch (IOException e) {
-                    if (failure == null) {
-                        failure = e;
-                    } else {
-                        failure.addSuppressed(e);
-                    }
-                }
-                if (failure != null) {
-                    throw failure;
-                }
-            }
         }
 
         private static final class ScanState {
@@ -830,39 +461,23 @@ final class ShipSecureFilesystem {
             private final ShipTreePolicy policy;
             private final Map<String, DirectoryEntry> directories = new TreeMap<>();
             private final Map<String, FileEntry> files = new TreeMap<>();
-            private final Map<Object, String> directoryKeys = new HashMap<>();
-            private final Map<Object, String> fileKeys = new HashMap<>();
             private int count;
             private long aggregate;
 
-            private ScanState(ShipTreePolicy policy, Object rootFileKey) {
+            private ScanState(ShipTreePolicy policy) {
                 this.policy = policy;
-                directoryKeys.put(rootFileKey, ".");
             }
 
-            private void visitDirectory(String relative, UnixIdentity identity) throws IOException {
-                reserveEntry(relative);
-                String first = directoryKeys.putIfAbsent(identity.fileKey(), relative);
-                if (first != null) {
-                    throw unsafe(
-                            "Ship tree contains duplicate directory identities: "
-                                 + first + " and " + relative);
+            private void visitEntry(String relative) throws IOException {
+                count = Math.addExact(count, 1);
+                if (count > policy.maxFileCount()) {
+                    throw quota("Ship tree exceeds the entry-count quota at " + relative);
                 }
             }
 
-            private void visitFile(String relative, UnixIdentity identity) throws IOException {
-                reserveEntry(relative);
-                String first = fileKeys.putIfAbsent(identity.fileKey(), relative);
-                if (first != null) {
-                    throw unsafe(
-                            "Ship tree contains duplicate file identities: "
-                                 + first + " and " + relative);
-                }
-            }
-
-            private void reserve(String relative, UnixIdentity identity) throws IOException {
-                aggregate = Math.addExact(aggregate, identity.size());
-                if (identity.size() > policy.maxFileBytes()) {
+            private void reserve(String relative, long size) throws IOException {
+                aggregate = Math.addExact(aggregate, size);
+                if (size > policy.maxFileBytes()) {
                     throw quota("Ship file exceeds the per-file quota: " + relative);
                 }
                 if (aggregate > policy.maxAggregateBytes()) {
@@ -876,22 +491,9 @@ final class ShipSecureFilesystem {
                 }
             }
 
-            private void addDirectory(
-                    String relative, UnixIdentity identity, DirectoryEntry entry)
-                    throws IOException {
-                if (!directoryKeys.containsKey(identity.fileKey())) {
-                    throw concurrentMutation(
-                            "Ship directory was not identity-validated before capture: " + relative);
-                }
+            private void addDirectory(String relative, DirectoryEntry entry) throws IOException {
                 if (files.containsKey(relative) || directories.putIfAbsent(relative, entry) != null) {
                     throw unsafe("Ship tree contains duplicate canonical entry names: " + relative);
-                }
-            }
-
-            private void reserveEntry(String relative) throws IOException {
-                count = Math.addExact(count, 1);
-                if (count > policy.maxFileCount()) {
-                    throw quota("Ship tree exceeds the entry-count quota at " + relative);
                 }
             }
         }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipControllerTest.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Clock;
 import java.time.Instant;
@@ -16,10 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.context.ShipContext;
@@ -1401,12 +1396,6 @@ class ShipControllerTest {
     }
 
     @Test
-    void rejectsConcurrentArtifactSizeChangesAndReplacement() throws Exception {
-        assertConcurrentArtifactMutationRejected("size-change", false);
-        assertConcurrentArtifactMutationRejected("replacement", true);
-    }
-
-    @Test
     void rejectsProjectDependentMutationsButAllowsAbortAfterDeletion() throws Exception {
         Path project = Files.createDirectory(directory.resolve("project"));
         ShipController controller = controller("state");
@@ -1671,14 +1660,13 @@ class ShipControllerTest {
     @Test
     void foreignUncommittedJournalBlocksPublication() throws Exception {
         Path project = publishableProject("foreign-journal-project");
-        Path registry = directory.resolve("foreign-journal-registry/projects");
         Path state = directory.resolve("foreign-journal-state");
         ShipController controller = new ShipController(
-                state, registry, Clock.systemUTC(), System.getenv());
+                state, Clock.systemUTC(), System.getenv());
         ShipRun interrupted = pendingWithCandidateChanges(controller, project);
         ShipRun competing = pendingWithCandidateChanges(controller, project);
         Path interruptedDirectory = state.resolve(interrupted.id());
-        ShipRunStore store = new ShipRunStore(state, registry);
+        ShipRunStore store = new ShipRunStore(state);
         try (ShipRunStore.LockedProject owner = store.lockProject(project)) {
             owner.requireNoForeignTornPublication(interrupted.id());
             tornJournal(project, interrupted, interruptedDirectory);
@@ -1689,38 +1677,6 @@ class ShipControllerTest {
                 () -> controller.publish(competing.id()));
 
         assertEquals(competing, controller.status(competing.id()));
-        assertTrue(Files.isRegularFile(
-                interruptedDirectory.resolve("publication/journal.json")));
-        assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
-        assertTrue(Files.exists(project.resolve("old.txt")));
-        assertFalse(Files.exists(project.resolve("routes")));
-    }
-
-    @Test
-    void foreignUncommittedJournalBlocksPublicationAcrossStateRoots() throws Exception {
-        Path project = publishableProject("cross-root-foreign-journal-project");
-        Path registry = directory.resolve("project-registry/projects");
-        Path firstState = directory.resolve("cross-root-state-one");
-        Path secondState = directory.resolve("cross-root-state-two");
-        ShipController first = new ShipController(
-                firstState, registry, Clock.systemUTC(), System.getenv());
-        ShipController second = new ShipController(
-                secondState, registry, Clock.systemUTC(), System.getenv());
-        ShipRun interrupted = pendingWithCandidateChanges(first, project);
-        ShipRun competing = pendingWithCandidateChanges(second, project);
-        Path interruptedDirectory = firstState.resolve(interrupted.id());
-
-        ShipRunStore firstStore = new ShipRunStore(firstState, registry);
-        try (ShipRunStore.LockedProject owner = firstStore.lockProject(project)) {
-            owner.requireNoForeignTornPublication(interrupted.id());
-            tornJournal(project, interrupted, interruptedDirectory);
-        }
-
-        assertFailure(
-                "project-publication-in-progress",
-                () -> second.publish(competing.id()));
-
-        assertEquals(competing, second.status(competing.id()));
         assertTrue(Files.isRegularFile(
                 interruptedDirectory.resolve("publication/journal.json")));
         assertEquals("original", Files.readString(project.resolve("src/replace.txt")));
@@ -2072,7 +2028,6 @@ class ShipControllerTest {
     private ShipController controller(String stateDirectory) {
         return new ShipController(
                 directory.resolve(stateDirectory),
-                directory.resolve("project-registry/projects"),
                 Clock.systemUTC(),
                 System.getenv());
     }
@@ -2156,82 +2111,6 @@ class ShipControllerTest {
                         null,
                         command)),
                 Instant.parse("2026-07-29T12:00:00Z"));
-    }
-
-    private void assertConcurrentArtifactMutationRejected(String name, boolean replace)
-            throws Exception {
-        Path project = Files.createDirectory(directory.resolve(name + "-project"));
-        Path target = Files.createDirectory(project.resolve("target"));
-        Path artifact = target.resolve("validation.txt");
-        try (RandomAccessFile file = new RandomAccessFile(artifact.toFile(), "rw")) {
-            file.setLength(32L * 1024 * 1024);
-        }
-        Path replacement = directory.resolve(name + "-replacement");
-        ShipController controller = controller(name + "-state");
-        ShipRun run = controller.start(project, Oversight.NEVER, List.of());
-        AtomicBoolean stop = new AtomicBoolean();
-        AtomicReference<Throwable> mutationFailure = new AtomicReference<>();
-        CountDownLatch started = new CountDownLatch(1);
-        Thread mutator = new Thread(() -> {
-            try {
-                if (replace) {
-                    long size = 48L * 1024 * 1024;
-                    while (!stop.get()) {
-                        try (RandomAccessFile file = new RandomAccessFile(replacement.toFile(), "rw")) {
-                            file.setLength(size);
-                        }
-                        Files.move(
-                                replacement,
-                                artifact,
-                                StandardCopyOption.ATOMIC_MOVE,
-                                StandardCopyOption.REPLACE_EXISTING);
-                        started.countDown();
-                        size = size == 48L * 1024 * 1024
-                                ? 32L * 1024 * 1024
-                                : 48L * 1024 * 1024;
-                    }
-                } else {
-                    try (RandomAccessFile file = new RandomAccessFile(artifact.toFile(), "rw")) {
-                        file.setLength(48L * 1024 * 1024);
-                        started.countDown();
-                        long size = 32L * 1024 * 1024;
-                        while (!stop.get()) {
-                            file.setLength(size);
-                            size = size == 32L * 1024 * 1024
-                                    ? 48L * 1024 * 1024
-                                    : 32L * 1024 * 1024;
-                        }
-                    }
-                }
-            } catch (Throwable failure) {
-                mutationFailure.set(failure);
-                started.countDown();
-            } finally {
-                try {
-                    Files.deleteIfExists(replacement);
-                } catch (Throwable cleanupFailure) {
-                    mutationFailure.compareAndSet(null, cleanupFailure);
-                }
-            }
-        }, "ship-artifact-mutator");
-        mutator.setDaemon(true);
-        mutator.start();
-        assertTrue(started.await(5, TimeUnit.SECONDS));
-
-        ShipController.Failure failure;
-        try {
-            failure = assertThrows(
-                    ShipController.Failure.class,
-                    () -> complete(controller, run, "validation", artifact));
-        } finally {
-            stop.set(true);
-            mutator.join(TimeUnit.SECONDS.toMillis(5));
-        }
-
-        assertFalse(mutator.isAlive());
-        assertNull(mutationFailure.get());
-        assertEquals("artifact-unreadable", failure.code());
-        assertEquals(run, controller.status(run.id()));
     }
 
     private ShipRun complete(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -110,7 +110,6 @@ class ShipCoordinatorTest {
         distribution = DistributionConfig.load(new Properties());
         controller = new ShipController(
                 state,
-                directory.resolve("project-registry/projects"),
                 Clock.systemUTC(),
                 environment);
         worker = new PiWorker(
@@ -415,7 +414,6 @@ class ShipCoordinatorTest {
             }
             ShipRun aborted = new ShipController(
                     state,
-                    directory.resolve("project-registry/projects"),
                     Clock.systemUTC(),
                     Map.of())
                     .abort(run.id());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
@@ -226,6 +226,32 @@ class ShipPublicationServiceTest {
     }
 
     @Test
+    void recoversAReadOnlyReplacementDirectoryWithAChangedChild() throws Exception {
+        Fixture fixture = fixture("read-only-replacement-directory", project -> {
+            Path config = Files.createDirectory(project.resolve("config"));
+            write(config.resolve("a.txt"), "old");
+            setMode(config, "rwxr-xr-x");
+        }, candidate -> {
+            write(candidate.resolve("config/a.txt"), "new");
+            setMode(candidate.resolve("config"), "r-xr-xr-x");
+        });
+        fixture.begin();
+        ShipPublicationService.apply(
+                fixture.project(), fixture.candidate(), fixture.run(), fixture.journal());
+
+        assertEquals("new", Files.readString(fixture.live("config/a.txt")));
+        assertMode(fixture.live("config"), "r-xr-xr-x");
+
+        ShipPublicationService.recover(
+                fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
+
+        assertEquals("old", Files.readString(fixture.live("config/a.txt")));
+        assertMode(fixture.live("config"), "rwxr-xr-x");
+        assertMaterialTree(fixture.baseline(), fixture.project());
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
+    }
+
+    @Test
     void blocksRecoveryWhenTheProjectRootWasReplaced() throws Exception {
         Fixture fixture = fixture("replaced-root", project -> {
             write(project.resolve("replace.txt"), "old");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipPublicationServiceTest.java
@@ -93,7 +93,7 @@ class ShipPublicationServiceTest {
     }
 
     @Test
-    void blocksRecoveryOfAThirdFileModeWithoutMutation() throws Exception {
+    void recoversABaselineFileModeFromAnyIntermediateMode() throws Exception {
         Fixture fixture = fixture("third-file-mode", project -> {
             write(project.resolve("mode.txt"), "same bytes");
             setMode(project.resolve("mode.txt"), "rw-r--r--");
@@ -103,21 +103,16 @@ class ShipPublicationServiceTest {
         fixture.begin();
         backup(fixture, "mode.txt");
         setMode(fixture.live("mode.txt"), "rw-rw----");
-        ProjectSnapshot thirdState = ProjectEvidenceFiles.capture(fixture.project());
 
-        assertThrows(
-                ShipPublicationService.RecoveryBlockedException.class,
-                () -> ShipPublicationService.recover(
-                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+        ShipPublicationService.recover(fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
 
-        assertMaterialTree(thirdState, fixture.project());
         assertEquals("same bytes", Files.readString(fixture.live("mode.txt")));
-        assertMode(fixture.live("mode.txt"), "rw-rw----");
-        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+        assertMode(fixture.live("mode.txt"), "rw-r--r--");
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
     }
 
     @Test
-    void blocksRecoveryOfAThirdDirectoryModeWithoutMutation() throws Exception {
+    void recoversABaselineDirectoryModeFromAnyIntermediateMode() throws Exception {
         Fixture fixture = fixture("third-directory-mode", project -> {
             Path config = Files.createDirectory(project.resolve("config"));
             setMode(config, "rwxr-xr-x");
@@ -126,20 +121,15 @@ class ShipPublicationServiceTest {
         });
         fixture.begin();
         setMode(fixture.live("config"), "rwxr-x---");
-        ProjectSnapshot thirdState = ProjectEvidenceFiles.capture(fixture.project());
 
-        assertThrows(
-                ShipPublicationService.RecoveryBlockedException.class,
-                () -> ShipPublicationService.recover(
-                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+        ShipPublicationService.recover(fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
 
-        assertMaterialTree(thirdState, fixture.project());
-        assertMode(fixture.live("config"), "rwxr-x---");
-        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+        assertMode(fixture.live("config"), "rwxr-xr-x");
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
     }
 
     @Test
-    void blocksAThirdReplacementDirectoryModeAfterRecoveryStarted() throws Exception {
+    void recoversABaselineDirectoryModeAfterRecoveryStarted() throws Exception {
         Fixture fixture = fixture("third-recovery-directory-mode", project -> {
             Path config = Files.createDirectory(project.resolve("config"));
             setMode(config, "rwxr-xr-x");
@@ -149,16 +139,11 @@ class ShipPublicationServiceTest {
         fixture.begin();
         ShipPublicationService.startRecovery(fixture.run(), fixture.journal(), false);
         setMode(fixture.live("config"), "rwxr-x---");
-        ProjectSnapshot thirdState = ProjectEvidenceFiles.capture(fixture.project());
 
-        assertThrows(
-                ShipPublicationService.RecoveryBlockedException.class,
-                () -> ShipPublicationService.recover(
-                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+        ShipPublicationService.recover(fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
 
-        assertMaterialTree(thirdState, fixture.project());
-        assertMode(fixture.live("config"), "rwxr-x---");
-        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+        assertMode(fixture.live("config"), "rwxr-xr-x");
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
     }
 
     @Test
@@ -325,7 +310,7 @@ class ShipPublicationServiceTest {
     }
 
     @Test
-    void recoveryBeforeApplicationPreservesAnExactScratchLookalike() throws Exception {
+    void recoveryBeforeApplicationDeletesOwnedScratch() throws Exception {
         Fixture fixture = fixture("pre-application-scratch", project -> {
             write(project.resolve("replace.txt"), "old");
         }, candidate -> {
@@ -340,15 +325,11 @@ class ShipPublicationServiceTest {
                 StandardOpenOption.WRITE);
         setMode(scratch, "rw-------");
 
-        assertThrows(
-                ShipPublicationService.RecoveryBlockedException.class,
-                () -> ShipPublicationService.recover(
-                        fixture.project(), fixture.run(), RUN_ID, ATTEMPT));
+        ShipPublicationService.recover(fixture.project(), fixture.run(), RUN_ID, ATTEMPT);
 
         assertEquals("old", Files.readString(fixture.live("replace.txt")));
-        assertEquals(0, Files.size(scratch));
-        assertMode(scratch, "rw-------");
-        assertTrue(ShipPublicationService.journalExists(fixture.run()));
+        assertFalse(Files.exists(scratch, LinkOption.NOFOLLOW_LINKS));
+        assertFalse(ShipPublicationService.journalExists(fixture.run()));
     }
 
     @Test
@@ -476,26 +457,6 @@ class ShipPublicationServiceTest {
         } finally {
             setMode(publication, "rwx------");
         }
-    }
-
-    @Test
-    void beginCleansAnInterruptedPermissionProbeBeforeWritingTheJournal() throws Exception {
-        Fixture fixture = fixture("interrupted-permission-probe", project -> {
-            write(project.resolve("replace.txt"), "old");
-        }, candidate -> {
-            write(candidate.resolve("replace.txt"), "new");
-        });
-        Path publication = Files.createDirectory(
-                ShipPublicationService.publicationDirectory(fixture.run()));
-        Path fileProbe = Files.writeString(publication.resolve(".permission-probe-file"), "");
-        Path directoryProbe = Files.createDirectory(
-                publication.resolve(".permission-probe-directory"));
-
-        fixture.begin();
-
-        assertTrue(ShipPublicationService.journalExists(fixture.run()));
-        assertFalse(Files.exists(fileProbe, LinkOption.NOFOLLOW_LINKS));
-        assertFalse(Files.exists(directoryProbe, LinkOption.NOFOLLOW_LINKS));
     }
 
     private Fixture fixture(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipRunStoreTest.java
@@ -162,55 +162,31 @@ class ShipRunStoreTest {
     }
 
     @Test
-    void excludesConcurrentProjectPublicationAcrossStateRoots() throws Exception {
-        Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
-        Path registry = projectRegistryRoot();
-        ShipRunStore first = new ShipRunStore(
-                temporaryDirectory.resolve("state-one"), registry);
-        ShipRunStore second = new ShipRunStore(
-                temporaryDirectory.resolve("state-two"), registry);
-
-        try (ShipRunStore.LockedProject ignored = first.lockProject(project)) {
-            assertCode("operation-in-progress", () -> {
-                try (ShipRunStore.LockedProject competing = second.lockProject(project)) {
-                    // The project rendezvous is independent of either run-state root.
-                }
-            });
-        }
-    }
-
-    @Test
-    void rejectsANonPrivateProjectRegistryWithoutChangingItsPermissions() throws Exception {
+    void createsTheProjectRegistryUnderTheStateRoot() throws Exception {
         Assumptions.assumeTrue(
                 temporaryDirectory.getFileSystem().supportedFileAttributeViews().contains("posix"));
         Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
-        Path parent = Files.createDirectory(temporaryDirectory.resolve("project-registry"));
-        Files.setPosixFilePermissions(parent, PosixFilePermissions.fromString("rwx------"));
-        Path registry = Files.createDirectory(parent.resolve("projects"));
-        var publicPermissions = PosixFilePermissions.fromString("rwxr-xr-x");
-        Files.setPosixFilePermissions(registry, publicPermissions);
-        ShipRunStore store = new ShipRunStore(
-                temporaryDirectory.resolve("state"), registry);
+        ShipRunStore store = store();
+        store.create(run(RUN_ID));
 
-        assertCode("state-corrupt", () -> {
-            try (ShipRunStore.LockedProject ignored = store.lockProject(project)) {
-                // An unsafe rendezvous must not be used.
-            }
-        });
-        assertEquals(publicPermissions, Files.getPosixFilePermissions(registry));
+        try (ShipRunStore.LockedProject ignored = store.lockProject(project)) {
+            assertTrue(Files.isDirectory(stateRoot().resolve("projects")));
+        }
+
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(stateRoot().resolve("projects")));
     }
 
     @Test
-    void retainsAndFindsADormantPublicationOwnerAcrossStateRoots() throws Exception {
+    void retainsAndFindsADormantPublicationOwner() throws Exception {
         Path project = Files.createDirectory(temporaryDirectory.resolve("project"));
-        Path registry = projectRegistryRoot();
-        Path firstState = temporaryDirectory.resolve("state-one");
-        Path secondState = temporaryDirectory.resolve("state-two");
-        ShipRunStore first = new ShipRunStore(firstState, registry);
-        ShipRunStore second = new ShipRunStore(secondState, registry);
+        Path state = stateRoot();
+        ShipRunStore first = new ShipRunStore(state);
+        ShipRunStore second = new ShipRunStore(state);
         first.create(withProject(run(RUN_ID), project));
         second.create(withProject(run(OTHER_RUN_ID), project));
-        Path journal = firstState.resolve(RUN_ID).resolve("publication/journal.json");
+        Path journal = state.resolve(RUN_ID).resolve("publication/journal.json");
 
         try (ShipRunStore.LockedProject owner = first.lockProject(project)) {
             owner.requireNoForeignTornPublication(RUN_ID);
@@ -237,11 +213,8 @@ class ShipRunStoreTest {
     void keepsTheProjectLeaseAcrossAnAncestorRename() throws Exception {
         Path oldParent = Files.createDirectory(temporaryDirectory.resolve("old-parent"));
         Path project = Files.createDirectory(oldParent.resolve("project"));
-        Path registry = projectRegistryRoot();
-        ShipRunStore first = new ShipRunStore(
-                temporaryDirectory.resolve("state-one"), registry);
-        ShipRunStore second = new ShipRunStore(
-                temporaryDirectory.resolve("state-two"), registry);
+        ShipRunStore first = store();
+        ShipRunStore second = store();
 
         try (ShipRunStore.LockedProject ignored = first.lockProject(project)) {
             Path newParent = temporaryDirectory.resolve("new-parent");
@@ -250,7 +223,7 @@ class ShipRunStoreTest {
             Path renamedProject = newParent.resolve("project");
             assertCode("operation-in-progress", () -> {
                 try (ShipRunStore.LockedProject competing = second.lockProject(renamedProject)) {
-                    // Device/inode identity remains stable when lexical ancestors move.
+                    // Filesystem identity remains stable when lexical ancestors move.
                 }
             });
         }
@@ -260,9 +233,8 @@ class ShipRunStoreTest {
     void recognizesADormantOwnerAfterAnAncestorRename() throws Exception {
         Path oldParent = Files.createDirectory(temporaryDirectory.resolve("old-parent"));
         Path project = Files.createDirectory(oldParent.resolve("project"));
-        Path registry = projectRegistryRoot();
-        Path state = temporaryDirectory.resolve("state");
-        ShipRunStore store = new ShipRunStore(state, registry);
+        Path state = stateRoot();
+        ShipRunStore store = new ShipRunStore(state);
         store.create(withProject(run(RUN_ID), project));
         Path journal = state.resolve(RUN_ID).resolve("publication/journal.json");
 
@@ -627,15 +599,11 @@ class ShipRunStoreTest {
     }
 
     private ShipRunStore store() {
-        return new ShipRunStore(stateRoot(), projectRegistryRoot());
+        return new ShipRunStore(stateRoot());
     }
 
     private Path stateRoot() {
         return temporaryDirectory.resolve("state");
-    }
-
-    private Path projectRegistryRoot() {
-        return temporaryDirectory.resolve("project-registry/projects");
     }
 
     private ShipRun run(String runId) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -156,7 +156,7 @@ class ProjectSnapshotServiceTest {
     }
 
     @Test
-    void readsOnlyBoundedMaterialFilesThroughTheHeldProjectDescriptor() throws Exception {
+    void readsOnlyBoundedMaterialFilesWithinTheProjectBoundary() throws Exception {
         Path project = project();
         Path material = write(project, "requirements.md", "requirements");
         write(project, ".camel-kit/pipeline.json", "private");
@@ -195,7 +195,7 @@ class ProjectSnapshotServiceTest {
     }
 
     @Test
-    void readsOnlyBoundedVolatileFilesThroughTheHeldProjectDescriptor() throws Exception {
+    void readsOnlyBoundedVolatileFilesWithinTheProjectBoundary() throws Exception {
         Path project = project();
         Path generated = write(project, "target/generated.txt", "generated");
         write(project, "requirements.md", "requirements");
@@ -542,7 +542,7 @@ class ProjectSnapshotServiceTest {
         ProjectSnapshot.FileEntry metadata = forgedProtected.get(".idea/workspace.xml");
         forgedProtected.put(".idea/workspace.xml", new ProjectSnapshot.FileEntry(
                 Classification.MATERIAL, metadata.size(), metadata.digest(),
-                metadata.unixMode(), metadata.userId(), metadata.groupId()));
+                metadata.unixMode()));
         String protectedDigest = ProjectSnapshot.computeDigest(
                 snapshot.root(), snapshot.rootIdentity(), snapshot.policyDigest(),
                 snapshot.directories(), forgedProtected);
@@ -554,7 +554,7 @@ class ProjectSnapshotServiceTest {
         ProjectSnapshot.FileEntry readmeAsDenied = forgedDenied.get("README.md");
         forgedDenied.put(".git/HEAD", new ProjectSnapshot.FileEntry(
                 Classification.MATERIAL, readmeAsDenied.size(), readmeAsDenied.digest(),
-                readmeAsDenied.unixMode(), readmeAsDenied.userId(), readmeAsDenied.groupId()));
+                readmeAsDenied.unixMode()));
         String deniedDigest = ProjectSnapshot.computeDigest(
                 snapshot.root(), snapshot.rootIdentity(), snapshot.policyDigest(),
                 snapshot.directories(), forgedDenied);
@@ -566,7 +566,7 @@ class ProjectSnapshotServiceTest {
         ProjectSnapshot.FileEntry readme = forgedMaterial.get("README.md");
         forgedMaterial.put("README.md", new ProjectSnapshot.FileEntry(
                 Classification.PROTECTED, readme.size(), readme.digest(),
-                readme.unixMode(), readme.userId(), readme.groupId()));
+                readme.unixMode()));
         String materialDigest = ProjectSnapshot.computeDigest(
                 snapshot.root(), snapshot.rootIdentity(), snapshot.policyDigest(),
                 snapshot.directories(), forgedMaterial);
@@ -576,7 +576,7 @@ class ProjectSnapshotServiceTest {
     }
 
     @Test
-    void snapshotStoresAndDigestsFullUnixModeAndOwnership() throws Exception {
+    void snapshotStoresAndDigestsFullUnixModes() throws Exception {
         Path project = project();
         Path routes = Files.createDirectory(project.resolve("routes"));
         Path route = write(project, "routes/orders.camel.yaml", "- route:\n");
@@ -585,45 +585,28 @@ class ProjectSnapshotServiceTest {
         ProjectSnapshot.FileEntry file = snapshot.files().get("routes/orders.camel.yaml");
 
         assertEquals(unixInt(routes, "mode"), directory.unixMode());
-        assertEquals(unixId(routes, "uid"), directory.userId());
-        assertEquals(unixId(routes, "gid"), directory.groupId());
         assertEquals(unixInt(route, "mode"), file.unixMode());
-        assertEquals(unixId(route, "uid"), file.userId());
-        assertEquals(unixId(route, "gid"), file.groupId());
 
         TreeMap<String, ProjectSnapshot.FileEntry> specialModeFiles = new TreeMap<>(snapshot.files());
         specialModeFiles.put("routes/orders.camel.yaml", new ProjectSnapshot.FileEntry(
-                file.classification(), file.size(), file.digest(), file.unixMode() ^ 04000,
-                file.userId(), file.groupId()));
-        TreeMap<String, ProjectSnapshot.FileEntry> differentOwnerFiles = new TreeMap<>(snapshot.files());
-        differentOwnerFiles.put("routes/orders.camel.yaml", new ProjectSnapshot.FileEntry(
-                file.classification(), file.size(), file.digest(), file.unixMode(),
-                differentUnixId(file.userId()), file.groupId()));
+                file.classification(), file.size(), file.digest(), file.unixMode() ^ 04000));
         TreeMap<String, ProjectSnapshot.DirectoryEntry> specialModeDirectories
                 = new TreeMap<>(snapshot.directories());
         specialModeDirectories.put("routes", new ProjectSnapshot.DirectoryEntry(
-                directory.classification(), directory.unixMode() ^ 01000,
-                directory.userId(), directory.groupId()));
+                directory.classification(), directory.unixMode() ^ 01000));
 
         assertNotEquals(snapshot.digest(), ProjectSnapshot.computeDigest(
                 snapshot.root(), snapshot.rootIdentity(), snapshot.policyDigest(),
                 snapshot.directories(), specialModeFiles));
         assertNotEquals(snapshot.digest(), ProjectSnapshot.computeDigest(
                 snapshot.root(), snapshot.rootIdentity(), snapshot.policyDigest(),
-                snapshot.directories(), differentOwnerFiles));
-        assertNotEquals(snapshot.digest(), ProjectSnapshot.computeDigest(
-                snapshot.root(), snapshot.rootIdentity(), snapshot.policyDigest(),
                 specialModeDirectories, snapshot.files()));
         assertThrows(IllegalArgumentException.class,
                 () -> new ProjectSnapshot.DirectoryEntry(
-                        Classification.MATERIAL, 0100755, directory.userId(), directory.groupId()));
+                        Classification.MATERIAL, 0100755));
         assertThrows(IllegalArgumentException.class,
                 () -> new ProjectSnapshot.FileEntry(
-                        Classification.MATERIAL, 0, file.digest(), 0040644,
-                        file.userId(), file.groupId()));
-        assertThrows(IllegalArgumentException.class,
-                () -> new ProjectSnapshot.FileEntry(
-                        Classification.MATERIAL, 0, file.digest(), 0100644, -1, file.groupId()));
+                        Classification.MATERIAL, 0, file.digest(), 0040644));
     }
 
     @Test
@@ -634,7 +617,7 @@ class ProjectSnapshotServiceTest {
         String deepPath = "d/".repeat(ShipTreePolicy.DEFAULT_MAX_DEPTH + 1) + "file.txt";
         ProjectSnapshot.FileEntry entry = new ProjectSnapshot.FileEntry(
                 Classification.MATERIAL, 0, "sha256:" + "1".repeat(64),
-                0100644, 1000, 1000);
+                0100644);
         Map<String, ProjectSnapshot.FileEntry> files = Map.of(deepPath, entry);
         String digest = ProjectSnapshot.computeDigest(
                 root, rootIdentity, policyDigest, Map.of(), files);
@@ -651,7 +634,7 @@ class ProjectSnapshotServiceTest {
         String policyDigest = ShipTreePolicy.current().digest();
         String placeholderDigest = "sha256:" + "1".repeat(64);
         ProjectSnapshot.FileEntry entry = new ProjectSnapshot.FileEntry(
-                Classification.MATERIAL, 0, placeholderDigest, 0100644, 1000, 1000);
+                Classification.MATERIAL, 0, placeholderDigest, 0100644);
         Map<String, ProjectSnapshot.FileEntry> preflightOversized = new AbstractMap<>() {
             @Override
             public int size() {
@@ -772,17 +755,6 @@ class ProjectSnapshotServiceTest {
 
     private static int unixInt(Path path, String attribute) throws Exception {
         return ((Number) Files.getAttribute(path, "unix:" + attribute)).intValue();
-    }
-
-    private static long unixId(Path path, String attribute) throws Exception {
-        Number value = (Number) Files.getAttribute(path, "unix:" + attribute);
-        return value instanceof Integer integer
-                ? Integer.toUnsignedLong(integer)
-                : value.longValue();
-    }
-
-    private static long differentUnixId(long value) {
-        return value == 0xffff_ffffL ? value - 1 : value + 1;
     }
 
     private Path project() throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/security/ProjectSnapshotServiceTest.java
@@ -705,13 +705,14 @@ class ProjectSnapshotServiceTest {
     }
 
     @Test
-    void nonSecureDirectoryStreamFailsClosed() throws Exception {
+    void nonPosixFilesystemFailsClosed() throws Exception {
         Path archive = temporaryDirectory.resolve("tree.zip");
         URI uri = URI.create("jar:" + archive.toUri());
         try (FileSystem zip = FileSystems.newFileSystem(uri, Map.of("create", "true"))) {
             Path project = Files.createDirectory(zip.getPath("/project"));
             Files.writeString(project.resolve("sentinel.txt"), "unchanged");
 
+            // zipfs does not expose the Unix mode and link-count metadata required by project inspection.
             assertCode(ShipFilesystemException.SECURE_FILESYSTEM_UNSUPPORTED,
                     () -> new ProjectSnapshotService().capture(project));
             assertEquals("unchanged", Files.readString(project.resolve("sentinel.txt")));


### PR DESCRIPTION
## Summary

- reduce Ship filesystem inspection to bounded path reads while retaining symlink, hard-link, special-file, and quota checks
- remove snapshot ownership identity and simplify coordinator leases, controller-owned input writes, private-directory handling, and publication recovery for the stated same-user threat model
- move the project publication registry from `/var/tmp` to the Ship state home

## Verification

- `./mvnw -B -pl camel-kit-core -Dtest=ShipControllerTest,ProjectSnapshotServiceTest,ShipRunStoreTest,ShipCoordinatorTest,ShipPublicationServiceTest,ShipMainValidatorTest test`
- `./mvnw -B clean install`

Website impact: **not required**. This is an internal product-boundary reduction; documented Ship behavior is unchanged.

Part of #182.

## Summary by Sourcery

Simplify Ship’s security and controller boundaries while retaining bounded project inspection, publication coordination, and recovery safeguards.

Enhancements:
- Simplify Ship filesystem inspection to bounded path-based reads while preserving checks for symlinks, hard links, special files, and resource quotas.
- Remove snapshot ownership metadata and reduce coordinator, controller-write, private-directory, and publication-recovery validation for the same-user threat model.
- Move the project publication registry into the Ship state home and simplify publication ownership tracking.
- Allow publication recovery to normalize journaled permissions and clean up owned staging files without treating intermediate permission modes as foreign changes.

Tests:
- Update Ship controller, coordinator, publication, run-store, and snapshot tests for the simplified security and recovery boundaries.