### PR TITLE
Clarify Ship plan route path contract

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -51,7 +51,7 @@ public final class ShipCoordinator {
 
     private static final long ABORT_POLL_MILLIS = 50;
     private static final int MAX_BRIEFING_BYTES = 16 * 1024 * 1024;
-    private static final int PLAN_CONTRACT_VERSION = 1;
+    private static final int PLAN_CONTRACT_VERSION = 2;
     private static final String MANIFEST_SCHEMA_RESOURCE
             = "/ship/schema/artifact-manifest.schema.json";
     private static final ObjectMapper JSON = new ObjectMapper();

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -838,7 +838,9 @@ public final class ShipCoordinator {
                     .append(
                             ". Copy every fixed field exactly and replace the empty routes array "
                             + "with one object per planned route using fields routeId, routePath, "
-                            + "and citrusTestPath. For each route, routePath's file name must "
+                            + "and citrusTestPath. Use the exact canonical project-relative routePath "
+                            + "from the plan; use only the file name when the route is at project root. "
+                            + "For each route, routePath's file name must "
                             + "equal <routeId>.camel.yaml and citrusTestPath must equal "
                             + "test/<routeId>.camel.it.yaml. Sort routes canonically by routeId, "
                             + "then routePath, then citrusTestPath.\n");

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/artifact/ArtifactValidatorTest.java
@@ -527,6 +527,18 @@ class ArtifactValidatorTest {
     }
 
     @Test
+    void rejectsRoutePathThatDiffersFromApprovedPolicy() throws Exception {
+        writeSpringProject("${spring.boot.version}");
+
+        ArtifactValidationResult result = ArtifactValidator.validate(
+                project,
+                springManifest(),
+                springPolicy(CITRUS_VERSION, "orders.camel.yaml"));
+
+        assertTrue(hasError(result, "approved-policy-routes", null));
+    }
+
+    @Test
     void rejectsCitrusVersionThatDiffersFromApprovedPolicy() throws Exception {
         writeSpringProject("${spring.boot.version}");
 
@@ -752,12 +764,19 @@ class ArtifactValidatorTest {
     }
 
     private static ArtifactPolicy springPolicy(String citrusVersion) {
+        return springPolicy(
+                citrusVersion,
+                "src/main/resources/routes/orders.camel.yaml");
+    }
+
+    private static ArtifactPolicy springPolicy(
+            String citrusVersion, String routePath) {
         return new ArtifactPolicy(
                 "spring-boot", "4.21.0", "4.21.0", "4.1.0", "yaml", "simple",
                 citrusVersion, CitrusDependencyPolicy.required(citrusVersion),
                 JavaPolicy.FORBIDDEN, List.of(),
                 List.of(new RouteContract(
-                        "orders", "src/main/resources/routes/orders.camel.yaml",
+                        "orders", routePath,
                         "test/orders.camel.it.yaml")),
                 true, true);
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -792,6 +792,8 @@ class ShipCoordinatorTest {
                 inputDirectory, "artifact-policy-");
         assertTrue(Files.readString(fixture.resolve("prompt"))
                 .contains(policyContract.toString()));
+        assertTrue(Files.readString(fixture.resolve("prompt"))
+                .contains("exact canonical project-relative routePath"));
         var fixedPolicy = new ObjectMapper().readTree(
                 Files.readAllBytes(policyContract));
         assertEquals(distribution.camelMainVersion(),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -979,6 +979,73 @@ class ShipCoordinatorTest {
     }
 
     @Test
+    void planContractUpgradeRestartsLegacyDurablePlanResult()
+            throws Exception {
+        Path metadata = Files.createDirectories(project.resolve(".camel-kit"));
+        Files.writeString(
+                metadata.resolve("pipeline.json"),
+                "{\"mode\":\"manual\",\"activePipeline\":\"149-coordinator\"}\n");
+        Path documents = Files.createDirectories(
+                project.resolve("docs/camel-kit/149-coordinator"));
+        Files.writeString(documents.resolve("design-spec.md"), "Imported design");
+        writeWorkerResult("Implementation plan", mainPolicy());
+        ShipRun run = controller.startFrom(
+                project,
+                Stage.PLAN,
+                Oversight.ALWAYS,
+                List.of());
+        ShipRun planned = coordinator.run(run.id());
+        assertEquals(RunStatus.PAUSED, planned.status());
+        assertEquals(Stage.EXECUTE, planned.currentStage());
+
+        Path runDirectory = state.resolve(run.id());
+        Path policyContract = fileWithPrefix(
+                runDirectory.resolve("inputs"), "artifact-policy-");
+        String legacyDigest = ShipDigest.sha256(
+                (planned.stage(Stage.PLAN).inputDigest()
+                 + "\nplan:1:"
+                 + ShipDigest.sha256(Files.readAllBytes(policyContract)))
+                        .getBytes(StandardCharsets.UTF_8));
+        Path markers = runDirectory.resolve("sessions/.camel-kit-results");
+        Path currentMarker = fileWithPrefix(
+                markers, run.id() + "-plan-");
+        String currentDigest = new ObjectMapper()
+                .readTree(currentMarker.toFile())
+                .path("inputDigest")
+                .textValue();
+        assertNotEquals(legacyDigest, currentDigest);
+        Files.writeString(
+                currentMarker,
+                Files.readString(currentMarker)
+                        .replace(currentDigest, legacyDigest));
+        String legacyMarkerName = run.id() + "-plan-"
+                                  + legacyDigest.substring("sha256:".length())
+                                  + "-1.json";
+        Path legacyMarker = currentMarker.resolveSibling(legacyMarkerName);
+        Files.move(currentMarker, legacyMarker);
+        Request legacyRequest = new Request(
+                run.id(),
+                Stage.PLAN,
+                1,
+                project,
+                runDirectory.resolve("sessions"),
+                runDirectory.resolve("evidence/plan-1"),
+                legacyDigest,
+                true,
+                "Recover a legacy PLAN contract result.");
+        assertTrue(worker.recover(legacyRequest).isPresent());
+        Files.writeString(fixture.resolve("mode"), "nonzero\n");
+
+        ShipRun restarted = coordinator.resume(run.id(), List.of());
+
+        assertEquals(RunStatus.FAILED, restarted.status());
+        assertEquals(Stage.PLAN, restarted.currentStage());
+        assertEquals(2, restarted.stage(Stage.PLAN).attempts());
+        assertEquals(StageStatus.PENDING,
+                restarted.stage(Stage.EXECUTE).status());
+    }
+
+    @Test
     void writesOrderedContextToADurableBriefingWithoutPuttingItInArgsOrLogs()
             throws Exception {
         Path document = Files.writeString(


### PR DESCRIPTION
## Summary

- require PLAN routePath values to preserve each route's exact canonical project-relative path
- keep a bare file name valid only for routes planned at the project root
- invalidate durable PLAN results generated under the previous prompt contract
- cover both prompt construction and exact approved-policy route validation

The authenticated live certification exposed the gap: PLAN described a nested route but returned only its file name in the artifact policy, while EXECUTE produced the required nested manifest path. Exact validation then correctly rejected the mismatch.

Refs #182

## Review follow-up

- bump the PLAN contract version so a run resumed after this correction restarts PLAN instead of recovering an old-prompt result
- add a behavioral regression that proves a valid version-1 marker is recoverable under its old identity but rejected by the current coordinator
- add direct `approved-policy-routes` coverage for a basename policy path versus a nested manifest path

The optional request to duplicate the canonical-path grammar in the prompt was not applied: malformed paths already fail closed, and maintaining a second prose copy of the manifest grammar would create drift.

## Testing

- pre-fix: `ShipCoordinatorTest#planContractUpgradeRestartsLegacyDurablePlanResult` failed because the current and version-1 identities were equal
- `./mvnw -B -pl camel-kit-core -Dtest=ShipCoordinatorTest,ArtifactValidatorTest test` (68 tests)
- `./mvnw -B -pl camel-kit-core -Psourcecheck validate`
- `./mvnw -B -pl camel-kit-core -Dtest=ShipCoordinatorTest#generatedPlanExecuteThenValidatorCommitsPassStampFromStubEvidence test`
- authenticated `./mvnw -B -Plinux-ship-certification clean install` at the prompt-correction head
- isolated registered `camel-kit ship` invocation at the prompt-correction head: completed with a PASS validation stamp and publication record

Per maintainer direction, no additional local full-reactor build was run for the review follow-up; the hosted Java matrix is the full-reactor gate for the updated head.

Website impact: **not required** — this is an internal prompt-contract correction that restores already-specified behavior.

## Summary by Sourcery

Preserve canonical project-relative route paths throughout PLAN and EXECUTE artifact policies.

Bug Fixes:
- Require generated PLAN routePath values to preserve each route’s exact canonical project-relative path, while allowing bare file names only for project-root routes.

Enhancements:
- Clarify the coordinator prompt contract for route paths and add a regression assertion to keep the requirement covered.

Tests:
- Extend coordinator regression coverage to verify the canonical routePath contract is included in generated prompts.
