### PR TITLE
Fix #169: harden tampered Pi marker recovery

### DIFF
--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinator.java
@@ -1040,9 +1040,12 @@ public final class ShipCoordinator {
     }
 
     private String truncate(String value) {
-        String message = value == null || value.isBlank()
-                ? "Ship stage failed"
+        String message = value == null
+                ? ""
                 : value.replace('\0', ' ').strip();
+        if (message.isBlank()) {
+            message = "Ship stage failed";
+        }
         if (ChangedWorkspaceSecretScanner.containsSensitiveValue(
                 message.getBytes(StandardCharsets.UTF_8), environment)) {
             return "Failed";

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -50,6 +50,7 @@ import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Outcome;
 import io.github.luigidemasi.camelkit.ship.worker.PiWorker.Request;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -203,6 +204,31 @@ class ShipCoordinatorTest {
                 List.of(sessionId(run)),
                 Files.readAllLines(fixture.resolve("session-ids")));
         assertFalse(Files.exists(fixture.resolve("resumed-sessions")));
+    }
+
+    @Test
+    void recoveredDurableNulFailureUsesFallbackWithoutWedging()
+            throws Exception {
+        ShipRun run = designRun(List.of(
+                new ShipContext.TextInput("recover failed result")));
+        Files.writeString(fixture.resolve("mode"), "stop-error\n");
+        Path marker = seedDurableResult(run, Outcome.FAILED);
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode document = (ObjectNode) mapper.readTree(marker.toFile());
+        ((ObjectNode) document.path("result"))
+                .put("failure", String.valueOf('\0'));
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(marker.toFile(), document);
+
+        ShipRun failed = coordinator.run(run.id());
+
+        assertEquals(RunStatus.FAILED, failed.status());
+        assertEquals(StageStatus.FAILED,
+                failed.stage(Stage.DESIGN).status());
+        assertEquals(1, failed.stage(Stage.DESIGN).attempts());
+        assertEquals("Ship stage failed", failed.message());
+        assertEquals(failed, controller.status(run.id()));
+        assertEquals(failed, coordinator.run(run.id()));
     }
 
     @Test
@@ -1427,7 +1453,12 @@ class ShipCoordinatorTest {
         Files.writeString(file, content);
     }
 
-    private void seedDurableResult(ShipRun run) throws Exception {
+    private Path seedDurableResult(ShipRun run) throws Exception {
+        return seedDurableResult(run, Outcome.SUCCEEDED);
+    }
+
+    private Path seedDurableResult(ShipRun run, Outcome expected)
+            throws Exception {
         StageAttempt attempt = controller.prepareAttempt(run.id());
         Request request = new Request(
                 run.id(),
@@ -1439,8 +1470,11 @@ class ShipCoordinatorTest {
                 run.stage(Stage.DESIGN).inputDigest(),
                 true,
                 "Seed the exact durable controller attempt.");
-        assertEquals(Outcome.SUCCEEDED, worker.run(request).outcome());
-        assertTrue(worker.recover(request).isPresent());
+        assertEquals(expected, worker.run(request).outcome());
+        assertEquals(expected, worker.recover(request).orElseThrow().outcome());
+        return fileWithPrefix(
+                request.sessionDirectory().resolve(".camel-kit-results"),
+                sessionId(run));
     }
 
     private String retainedEvidence(ShipRun run) throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/worker/PiWorkerResultStoreTest.java
@@ -207,6 +207,34 @@ class PiWorkerResultStoreTest {
     }
 
     @Test
+    void rejectsOversizedWarningAsUntrustedMarker() throws Exception {
+        Path sessions = Files.createDirectory(directory.resolve("sessions"));
+        PiWorker.Request request = request(RUN_A, sessions);
+        PiWorker.Result original = result("warning");
+        PiWorker.Result experimental = new PiWorker.Result(
+                original.outcome(),
+                ShipLocalStamp.Support.EXPERIMENTAL,
+                original.version(),
+                "experimental",
+                original.node(),
+                original.assistantText(),
+                original.failure(),
+                original.evidence());
+        write(request, experimental);
+        Path marker = marker(sessions);
+        Files.writeString(
+                marker,
+                Files.readString(marker).replace(
+                        "\"warning\" : \"experimental\"",
+                        "\"warning\" : \"" + "x".repeat(4097) + "\""));
+
+        assertTrue(assertThrows(
+                PiWorker.UntrustedResultException.class,
+                () -> PiWorkerResultStore.read(request))
+                .getMessage().contains("malformed"));
+    }
+
+    @Test
     void rejectsEvidenceLogsOutsideTheirDirectory() throws Exception {
         Path sessions = Files.createDirectory(directory.resolve("sessions"));
         PiWorker.Request request = request(RUN_A, sessions);


### PR DESCRIPTION
## Summary

- add regression coverage for oversized warnings in recovered Pi stage markers
- normalize recovered failure text before applying the fallback so an escaped-NUL-only value cannot leave a run wedged in `RUNNING`
- keep the controller boundary strict while covering both tampered-marker recovery paths

## Verification

- `./mvnw -B -pl camel-kit-core -Dtest=ShipCoordinatorTest#recoveredDurableNulFailureUsesFallbackWithoutWedging test`
- `./mvnw -B -pl camel-kit-core -Dtest=ShipCoordinatorTest,PiWorkerResultStoreTest test` (36 tests)
- mutation check: restoring the old normalization order makes the new test fail with `stage-result-invalid`
- `./mvnw -B clean install` (all six modules; Core 1,019 tests, Graph 187, Ship Resolver 16 plus 3 isolation tests, JBang plugin 5)

## Website impact

**Not required.** This hardens internal durable-marker recovery for directly edited state; it does not change commands, options, defaults, workflows, or documented behavior.

Fixes #169
