### PR TITLE
Fix #146: validate missing Citrus MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Citrus MCP Doctor validation (#146)** — `doctor` now fails when persisted Citrus metadata or a post-Citrus-only JSON agent proves that the generated `citrus` server is required; legacy-capable agents without that metadata retain the actionable pre-Citrus regeneration warning.
+
 - **Camel plugin command parity and public documentation (#193)** — registered `doc` and `nextId` under `camel kit`, added a direct standalone/plugin parity regression, and aligned stable-versus-snapshot installation, prerequisites, workflow, graph, Knowledge, agent, and Ship documentation.
   - Review hardening keeps validator leaves read-only, preserves unrelated OpenCode configuration during regeneration, resolves command prefixes only in Camel-Kit-owned resources, and installs the complete persona library for every current target except the intentionally excluded Bob 1 path
   - `doctor` accepts pre-upgrade Qwen/OpenCode MCP layouts with upgrade warnings while retaining failures for malformed current layouts, and checks registered target assets for drift

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -508,12 +508,12 @@ public class DoctorService {
                 root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), copilotToolsSchema,
                 piDirectToolsSchema, qwenIncludeToolsSchema, openCodeSchema, findings);
         boolean citrusOk;
-        if (servers.has("citrus")) {
+        if (servers.has("citrus") || config.containsKey("citrus.mcp.version")) {
             citrusOk = checkMcpServer(
                     root, mcpFile, servers, "citrus", expectations.citrusMcpTools(), copilotToolsSchema,
                     piDirectToolsSchema, qwenIncludeToolsSchema, openCodeSchema, findings);
         } else {
-            // Workspaces generated before the Citrus MCP server existed stay valid.
+            // Pre-Citrus workspaces have no persisted Citrus MCP version and stay valid.
             findings.add(DoctorFinding.warn("mcp", relativize(root, mcpFile),
                     "MCP server 'citrus' is not configured; camel-test cannot verify Citrus actions",
                     "Regenerate the MCP config with camel-kit init --here --force to add the Citrus MCP server."));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/DoctorService.java
@@ -45,6 +45,13 @@ public class DoctorService {
     private static final String NESTED_RULE = "\n";
     private static final ObjectMapper OPENCODE_MAPPER = OpenCodeProjectConfig.newJsonMapper();
     private static final Duration PREREQUISITE_TIMEOUT = Duration.ofSeconds(3);
+    private static final Set<String> PRE_CITRUS_JSON_AGENTS = Set.of(
+            AgentGeneratorStrategy.BOB.descriptorValue(),
+            AgentGeneratorStrategy.BOB2.descriptorValue(),
+            AgentGeneratorStrategy.CLAUDE.descriptorValue(),
+            AgentGeneratorStrategy.GEMINI.descriptorValue(),
+            AgentGeneratorStrategy.OPENCODE.descriptorValue(),
+            AgentGeneratorStrategy.QWEN.descriptorValue());
     private static final Set<String> OPENCODE_PERMISSION_ACTIONS = Set.of("allow", "ask", "deny");
 
     private static final List<String> REQUIRED_CONFIG_KEYS = List.of(
@@ -507,13 +514,16 @@ public class DoctorService {
         boolean knowledgeOk = checkMcpServer(
                 root, mcpFile, servers, "camel-knowledge", expectations.knowledgeMcpTools(), copilotToolsSchema,
                 piDirectToolsSchema, qwenIncludeToolsSchema, openCodeSchema, findings);
+        boolean citrusOptional = PRE_CITRUS_JSON_AGENTS.contains(normalizedAgentName)
+                && !config.containsKey("citrus.version")
+                && !config.containsKey("citrus.mcp.version");
         boolean citrusOk;
-        if (servers.has("citrus") || config.containsKey("citrus.mcp.version")) {
+        if (servers.has("citrus") || !citrusOptional) {
             citrusOk = checkMcpServer(
                     root, mcpFile, servers, "citrus", expectations.citrusMcpTools(), copilotToolsSchema,
                     piDirectToolsSchema, qwenIncludeToolsSchema, openCodeSchema, findings);
         } else {
-            // Pre-Citrus workspaces have no persisted Citrus MCP version and stay valid.
+            // Only legacy-capable JSON agents without persisted Citrus metadata reach this branch.
             findings.add(DoctorFinding.warn("mcp", relativize(root, mcpFile),
                     "MCP server 'citrus' is not configured; camel-test cannot verify Citrus actions",
                     "Regenerate the MCP config with camel-kit init --here --force to add the Citrus MCP server."));

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentGeneratorStrategy;
@@ -13,6 +14,8 @@ import io.github.luigidemasi.camelkit.generator.AgentGeneratorFactory;
 import io.github.luigidemasi.camelkit.generator.InitContext;
 import io.github.luigidemasi.camelkit.output.Printer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -22,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class DoctorServiceTest {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final DoctorExpectations EXPECTATIONS = DoctorExpectations.loadDefault();
     private static final String CLAUDE = AgentGeneratorStrategy.CLAUDE.descriptorValue();
     private static final String COPILOT = AgentGeneratorStrategy.COPILOT.descriptorValue();
@@ -810,7 +814,7 @@ class DoctorServiceTest {
     }
 
     @Test
-    void missingCitrusServerWarnsWithoutFailing() throws Exception {
+    void preCitrusOpenCodeWorkspaceWarnsWithoutFailing() throws Exception {
         createHealthyWorkspace(tempDir, OPENCODE);
         writeMcpConfig(tempDir, OPENCODE, """
                 {
@@ -833,10 +837,19 @@ class DoctorServiceTest {
         assertFalse(hasFinding(result, DoctorFinding.Status.FAIL, "mcp", "citrus", null));
         assertFalse(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
                 "uses supported server fields", null));
+
+        markCitrusMcpGenerated(tempDir);
+        DoctorResult currentResult = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(currentResult.hasFailures(), currentResult.findings().toString());
+        assertTrue(hasFinding(currentResult, DoctorFinding.Status.FAIL, "mcp",
+                "MCP server 'citrus' is missing", "Regenerate"));
+        assertFalse(hasFinding(currentResult, DoctorFinding.Status.WARN, "mcp",
+                "MCP server 'citrus' is not configured", null));
     }
 
     @Test
-    void preCitrusJsonWorkspaceWarnsWithoutFailing() throws Exception {
+    void missingCitrusServerWarnsOnlyForPreCitrusJsonWorkspace() throws Exception {
         createHealthyWorkspace(tempDir, CLAUDE);
         writeMcpConfig(tempDir, CLAUDE, String.format(Locale.ROOT, """
                 {
@@ -855,6 +868,47 @@ class DoctorServiceTest {
                 "MCP server 'citrus' is not configured", "Regenerate"));
         assertFalse(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
                 "tool allowlists match", null));
+
+        markCitrusMcpGenerated(tempDir);
+        DoctorResult currentResult = new DoctorService().inspect(new DoctorRequest(tempDir));
+
+        assertTrue(currentResult.hasFailures(), currentResult.findings().toString());
+        assertTrue(hasFinding(currentResult, DoctorFinding.Status.FAIL, "mcp",
+                "MCP server 'citrus' is missing", "Regenerate"));
+        assertFalse(hasFinding(currentResult, DoctorFinding.Status.WARN, "mcp",
+                "MCP server 'citrus' is not configured", null));
+    }
+
+    @Test
+    void citrusToolAllowlistMismatchFailsForEachJsonAllowlistSchema() throws Exception {
+        Map<String, List<String>> schemas = Map.of(
+                "bob", List.of("autoApprove", "alwaysAllow"),
+                COPILOT, List.of("tools"),
+                PI, List.of("directTools"),
+                QWEN, List.of("includeTools"));
+
+        for (Map.Entry<String, List<String>> schema : schemas.entrySet()) {
+            String agentName = schema.getKey();
+            Path root = tempDir.resolve(agentName);
+            createHealthyWorkspace(root, agentName);
+            Path mcpFile = root.resolve(AgentRegistry.get(agentName).mcpConfigPath());
+            ObjectNode config = (ObjectNode) MAPPER.readTree(mcpFile.toFile());
+            ObjectNode citrus = (ObjectNode) config.path(AgentRegistry.get(agentName).mcpServerContainerKey())
+                    .path("citrus");
+            schema.getValue().forEach(field -> citrus.putArray(field).add("unexpected_tool"));
+            MAPPER.writeValue(mcpFile.toFile(), config);
+
+            DoctorResult mismatched = new DoctorService().inspect(new DoctorRequest(root));
+
+            assertTrue(mismatched.hasFailures(), agentName + ": " + mismatched.findings());
+            for (String field : schema.getValue()) {
+                assertTrue(hasFinding(mismatched, DoctorFinding.Status.FAIL, "mcp",
+                        "MCP server 'citrus' " + field + " has missing", "update the allowlist"),
+                        agentName + ": " + mismatched.findings());
+            }
+            assertTrue(hasFinding(mismatched, DoctorFinding.Status.FAIL, "mcp",
+                    "extra unexpected_tool", null), agentName + ": " + mismatched.findings());
+        }
     }
 
     @Test
@@ -1440,6 +1494,11 @@ class DoctorServiceTest {
         Path mcpFile = root.resolve(agent.mcpConfigPath());
         Files.createDirectories(mcpFile.getParent());
         Files.writeString(mcpFile, content);
+    }
+
+    private void markCitrusMcpGenerated(Path root) throws Exception {
+        Path configFile = root.resolve(".camel-kit/config.properties");
+        Files.writeString(configFile, Files.readString(configFile) + "citrus.mcp.version=test\n");
     }
 
     private void writePiGuardPolicy(String content) throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/DoctorServiceTest.java
@@ -814,17 +814,21 @@ class DoctorServiceTest {
     }
 
     @Test
-    void preCitrusOpenCodeWorkspaceWarnsWithoutFailing() throws Exception {
+    void missingCitrusServerWarnsWithoutVersionPropertiesInLayeredOpenCodeWorkspace() throws Exception {
         createHealthyWorkspace(tempDir, OPENCODE);
         writeMcpConfig(tempDir, OPENCODE, """
+                {
+                  "mcp": {
+                    "camel": {"type": "local"},
+                    "camel-knowledge": {"type": "local"}
+                  }
+                }
+                """);
+        Files.writeString(tempDir.resolve("opencode.jsonc"), """
                 {
                   "permission": {
                     "camel_*": "ask",
                     "camel-knowledge_*": "ask"
-                  },
-                  "mcp": {
-                    "camel": {"type": "local"},
-                    "camel-knowledge": {"type": "local"}
                   }
                 }
                 """);
@@ -838,7 +842,7 @@ class DoctorServiceTest {
         assertFalse(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
                 "uses supported server fields", null));
 
-        markCitrusMcpGenerated(tempDir);
+        markCitrusGenerated(tempDir, "citrus.mcp.version");
         DoctorResult currentResult = new DoctorService().inspect(new DoctorRequest(tempDir));
 
         assertTrue(currentResult.hasFailures(), currentResult.findings().toString());
@@ -849,34 +853,54 @@ class DoctorServiceTest {
     }
 
     @Test
-    void missingCitrusServerWarnsOnlyForPreCitrusJsonWorkspace() throws Exception {
-        createHealthyWorkspace(tempDir, CLAUDE);
-        writeMcpConfig(tempDir, CLAUDE, String.format(Locale.ROOT, """
-                {
-                  "mcpServers": {
-                    "camel": {"command": "jbang", "autoApprove": [%s], "alwaysAllow": [%s]},
-                    "camel-knowledge": {"command": "jbang", "autoApprove": [%s], "alwaysAllow": [%s]}
-                  }
-                }
-                """, jsonArray(EXPECTATIONS.camelMcpTools()), jsonArray(EXPECTATIONS.camelMcpTools()),
-                jsonArray(EXPECTATIONS.knowledgeMcpTools()), jsonArray(EXPECTATIONS.knowledgeMcpTools())));
+    void missingCitrusServerWarnsWithoutVersionPropertiesForLegacyCapableJsonAgents() throws Exception {
+        for (String agentName : List.of("bob", "bob2", CLAUDE, "gemini", OPENCODE, QWEN)) {
+            Path root = tempDir.resolve(agentName);
+            createHealthyWorkspace(root, agentName);
+            removeCitrusServer(root, agentName);
 
-        DoctorResult result = new DoctorService().inspect(new DoctorRequest(tempDir));
+            DoctorResult result = new DoctorService().inspect(new DoctorRequest(root));
 
-        assertFalse(result.hasFailures(), result.findings().toString());
-        assertTrue(hasFinding(result, DoctorFinding.Status.WARN, "mcp",
-                "MCP server 'citrus' is not configured", "Regenerate"));
-        assertFalse(hasFinding(result, DoctorFinding.Status.PASS, "mcp",
-                "tool allowlists match", null));
+            assertFalse(result.hasFailures(), agentName + ": " + result.findings());
+            assertTrue(hasFinding(result, DoctorFinding.Status.WARN, "mcp",
+                    "MCP server 'citrus' is not configured", "Regenerate"),
+                    agentName + ": " + result.findings());
+            assertFalse(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                    "MCP server 'citrus' is missing", null),
+                    agentName + ": " + result.findings());
+            assertFalse(result.findings().stream().anyMatch(finding -> finding.status() == DoctorFinding.Status.PASS
+                    && "mcp".equals(finding.category())),
+                    agentName + ": " + result.findings());
+        }
 
-        markCitrusMcpGenerated(tempDir);
-        DoctorResult currentResult = new DoctorService().inspect(new DoctorRequest(tempDir));
+        Path currentRoot = tempDir.resolve(CLAUDE);
+        markCitrusGenerated(currentRoot, "citrus.version");
+        DoctorResult currentResult = new DoctorService().inspect(new DoctorRequest(currentRoot));
 
         assertTrue(currentResult.hasFailures(), currentResult.findings().toString());
         assertTrue(hasFinding(currentResult, DoctorFinding.Status.FAIL, "mcp",
                 "MCP server 'citrus' is missing", "Regenerate"));
         assertFalse(hasFinding(currentResult, DoctorFinding.Status.WARN, "mcp",
                 "MCP server 'citrus' is not configured", null));
+    }
+
+    @Test
+    void missingCitrusServerFailsForJsonAgentsIntroducedAfterCitrus() throws Exception {
+        for (String agentName : List.of(COPILOT, PI)) {
+            Path root = tempDir.resolve(agentName);
+            createHealthyWorkspace(root, agentName);
+            removeCitrusServer(root, agentName);
+
+            DoctorResult result = new DoctorService().inspect(new DoctorRequest(root));
+
+            assertTrue(result.hasFailures(), agentName + ": " + result.findings());
+            assertTrue(hasFinding(result, DoctorFinding.Status.FAIL, "mcp",
+                    "MCP server 'citrus' is missing", "Regenerate"),
+                    agentName + ": " + result.findings());
+            assertFalse(hasFinding(result, DoctorFinding.Status.WARN, "mcp",
+                    "MCP server 'citrus' is not configured", null),
+                    agentName + ": " + result.findings());
+        }
     }
 
     @Test
@@ -1496,9 +1520,17 @@ class DoctorServiceTest {
         Files.writeString(mcpFile, content);
     }
 
-    private void markCitrusMcpGenerated(Path root) throws Exception {
+    private void markCitrusGenerated(Path root, String versionProperty) throws Exception {
         Path configFile = root.resolve(".camel-kit/config.properties");
-        Files.writeString(configFile, Files.readString(configFile) + "citrus.mcp.version=test\n");
+        Files.writeString(configFile, Files.readString(configFile) + versionProperty + "=test\n");
+    }
+
+    private void removeCitrusServer(Path root, String agentName) throws Exception {
+        AgentConfig agent = AgentRegistry.get(agentName);
+        Path mcpFile = root.resolve(agent.mcpConfigPath());
+        ObjectNode config = (ObjectNode) MAPPER.readTree(mcpFile.toFile());
+        ((ObjectNode) config.path(agent.mcpServerContainerKey())).remove("citrus");
+        MAPPER.writeValue(mcpFile.toFile(), config);
     }
 
     private void writePiGuardPolicy(String content) throws Exception {


### PR DESCRIPTION
## Summary

- fail Doctor when persisted Citrus metadata or a post-Citrus-only JSON target proves that the generated Citrus MCP server is required
- preserve the actionable missing-server warning only for legacy-capable JSON targets with neither persisted Citrus version property
- cover ordinary JSON and genuinely layered OpenCode configurations, the legacy/current target boundary, and every JSON allowlist schema

## Verification

- focused Citrus Doctor regressions: 5 passed, covering all six legacy-capable JSON targets, Copilot/Pi, both persisted Citrus properties, layered OpenCode, and all JSON allowlist schemas
- test-first mutation checks: the `citrus.version` regression failed before the secondary marker was honored, and the Copilot/Pi regression failed before the historical target boundary was enforced
- `./mvnw -B clean install`: all six reactor modules passed (Ship Resolver 16 + 3 isolation tests, Graph 187, Core 1,021, JBang plugin 5)

## Website impact

Not required. This restores the existing documented three-server Doctor contract while retaining the scoped compatibility warning for legacy-capable JSON workspaces.

Fixes #146
