### PR TITLE
Fix JBang launcher versions during releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JBang launcher release synchronization (#145)** — Maven release preparation now keeps both tracked launcher fallbacks aligned with the release version and the following development snapshot.
+
 - **Citrus MCP Doctor validation (#146)** — `doctor` now fails when persisted Citrus metadata or a post-Citrus-only JSON agent proves that the generated `citrus` server is required; legacy-capable agents without that metadata retain the actionable pre-Citrus regeneration warning.
 
 - **Camel plugin command parity and public documentation (#193)** — registered `doc` and `nextId` under `camel kit`, added a direct standalone/plugin parity regression, and aligned stable-versus-snapshot installation, prerequisites, workflow, graph, Knowledge, agent, and Ship documentation.

--- a/camel-kit-main/pom.xml
+++ b/camel-kit-main/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>camel-kit-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/camel-kit-main/src/test/java/io/github/luigidemasi/camelkit/JBangLauncherReleaseTest.java
+++ b/camel-kit-main/src/test/java/io/github/luigidemasi/camelkit/JBangLauncherReleaseTest.java
@@ -1,0 +1,76 @@
+package io.github.luigidemasi.camelkit;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JBangLauncherReleaseTest {
+
+    private static final Pattern PROJECT_VERSION = Pattern.compile(
+            "<artifactId>camel-kit</artifactId>\\s*<version>([^<]+)</version>");
+    private static final Pattern LAUNCHER_VERSION = Pattern.compile("camel[.]kit[.]version:([^}]+)");
+    private static final List<String> LAUNCHERS = List.of(
+            "camel-kit-main/src/main/jbang/main/CamelKit.java",
+            "camel-kit-main/dist/CamelKit.java");
+
+    @Test
+    void trackedLaunchersFollowReleaseAndDevelopmentVersions() throws IOException {
+        Path root = repositoryRoot();
+        String pom = Files.readString(root.resolve("pom.xml"));
+        String projectVersion = matchedValue(PROJECT_VERSION, pom, "root project version");
+
+        for (String launcher : LAUNCHERS) {
+            String launcherVersion = matchedValue(
+                    LAUNCHER_VERSION,
+                    Files.readString(root.resolve(launcher)),
+                    launcher + " fallback version");
+            assertEquals(projectVersion, launcherVersion, launcher);
+            assertTrue(
+                    pom.contains("file=\"${maven.multiModuleProjectDirectory}/" + launcher + "\""),
+                    "The release build must synchronize " + launcher);
+            assertTrue(
+                    pom.contains("<arg value=\"" + launcher + "\" />"),
+                    "The release build must stage " + launcher);
+        }
+
+        assertTrue(pom.contains("<id>sync-jbang-launcher-versions</id>"),
+                "The release build must synchronize both tracked launchers");
+        assertTrue(pom.contains("<id>stage-jbang-launcher-versions</id>"),
+                "The release build must stage both tracked launchers for Maven's scoped SCM commit");
+        assertTrue(pom.contains("<arg value=\"-f\" />"),
+                "The ignored distribution directory requires forced staging");
+        assertTrue(
+                pom.contains(
+                        "<preparationGoals>antrun:run@sync-jbang-launcher-versions clean verify antrun:run@stage-jbang-launcher-versions</preparationGoals>"),
+                "The release-version commit must include synchronized launchers");
+        assertTrue(
+                pom.contains(
+                        "<completionGoals>-N antrun:run@sync-jbang-launcher-versions antrun:run@stage-jbang-launcher-versions</completionGoals>"),
+                "The next-development-version commit must rerun launcher synchronization");
+    }
+
+    private static String matchedValue(Pattern pattern, String content, String description) {
+        Matcher matcher = pattern.matcher(content);
+        assertTrue(matcher.find(), "Could not find " + description);
+        return matcher.group(1);
+    }
+
+    private static Path repositoryRoot() {
+        Path candidate = Path.of("").toAbsolutePath();
+        while (candidate != null) {
+            if (Files.isRegularFile(candidate.resolve("pom.xml"))
+                    && Files.isDirectory(candidate.resolve("camel-kit-main"))) {
+                return candidate;
+            }
+            candidate = candidate.getParent();
+        }
+        throw new AssertionError("Could not locate the project root from " + Path.of("").toAbsolutePath());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -318,12 +318,77 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>sync-jbang-launcher-versions</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replaceregexp
+                                    file="${maven.multiModuleProjectDirectory}/camel-kit-main/src/main/jbang/main/CamelKit.java"
+                                    match="(camel[.]kit[.]version:)[^}]+"
+                                    replace="\1${project.version}"
+                                    byline="true"
+                                    encoding="UTF-8" />
+                                <replaceregexp
+                                    file="${maven.multiModuleProjectDirectory}/camel-kit-main/dist/CamelKit.java"
+                                    match="(camel[.]kit[.]version:)[^}]+"
+                                    replace="\1${project.version}"
+                                    byline="true"
+                                    encoding="UTF-8" />
+                                <chmod
+                                    file="${maven.multiModuleProjectDirectory}/camel-kit-main/dist/CamelKit.java"
+                                    perm="u+x" />
+                                <fail message="JBang launcher fallbacks do not match Maven project version ${project.version}">
+                                    <condition>
+                                        <not>
+                                            <and>
+                                                <resourcecontains
+                                                    resource="${maven.multiModuleProjectDirectory}/camel-kit-main/src/main/jbang/main/CamelKit.java"
+                                                    substring="camel.kit.version:${project.version}}" />
+                                                <resourcecontains
+                                                    resource="${maven.multiModuleProjectDirectory}/camel-kit-main/dist/CamelKit.java"
+                                                    substring="camel.kit.version:${project.version}}" />
+                                            </and>
+                                        </not>
+                                    </condition>
+                                </fail>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- Maven Release commits its POM file set plus files already staged in Git. -->
+                    <execution>
+                        <id>stage-jbang-launcher-versions</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec executable="git" dir="${maven.multiModuleProjectDirectory}" failonerror="true">
+                                    <arg value="add" />
+                                    <arg value="-f" />
+                                    <arg value="--" />
+                                    <arg value="camel-kit-main/src/main/jbang/main/CamelKit.java" />
+                                    <arg value="camel-kit-main/dist/CamelKit.java" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
+                    <preparationGoals>antrun:run@sync-jbang-launcher-versions clean verify antrun:run@stage-jbang-launcher-versions</preparationGoals>
+                    <completionGoals>-N antrun:run@sync-jbang-launcher-versions antrun:run@stage-jbang-launcher-versions</completionGoals>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary

- synchronize both tracked JBang launcher fallbacks with the Maven release and next-development versions
- stage only those launchers before Maven Release Plugin creates each scoped SCM commit, preserving the executable distribution launcher
- verify committed launcher/POM parity and the release wiring with a regression test

## Verification

- mutation probe: changing a committed launcher fallback to `9.9.9-test` made `JBangLauncherReleaseTest` fail against `0.3.2-SNAPSHOT`
- `./mvnw -B -pl camel-kit-main -Dtest=JBangLauncherReleaseTest verify`
- isolated `release:prepare` from `9.8.7` to `9.8.8-SNAPSHOT` with `pushChanges=false`; both signed generated commits contained both launchers with the expected fallback and preserved `100755` mode for `camel-kit-main/dist/CamelKit.java`
- `./mvnw -B clean install`

Website impact: **not required** — this changes release automation only and preserves the existing zero-configuration public JBang alias.

Closes #145

## Summary by Sourcery

Synchronize tracked JBang launchers during Maven release preparation and completion so released and development versions remain consistent.

Bug Fixes:
- Keep both tracked JBang launcher fallbacks synchronized with the Maven release and subsequent development versions.

Enhancements:
- Ensure release commits include the synchronized launchers while preserving the executable distribution launcher.
- Add regression coverage for launcher/POM version parity and release configuration.

Documentation:
- Document the JBang launcher release synchronization fix in the changelog.

Tests:
- Add coverage validating launcher versions and Maven release wiring.