### PR TITLE
Add explicit design scope boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Explicit design scope boundaries** — greenfield design specs now record a top-level `Not Doing (and Why)` section
+  with a concrete reason for every excluded capability. Brainstorm captures these boundaries during the interview, and
+  execution passes them to implementers and spec-compliance reviewers so excluded features are treated as scope
+  violations instead of opportunistic improvements.
+
 - **OpenAI Codex CLI AI target (`--ai codex`)** — added a first-class Codex target with native repository assets.
   - Generated workspaces include `AGENTS.md`, `.agents/skills/`, `.codex/config.toml`, and seven `.codex/agents/*.toml` roles without an unused command directory
   - Codex skill references use native `$camel-*` invocation, with `/skills`, `$camel-start`, and `/mcp` guidance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Explicit design scope boundaries** — greenfield design specs now record a top-level `Not Doing (and Why)` section
   with a concrete reason for every excluded capability. Brainstorm captures these boundaries during the interview, and
-  execution passes them to implementers and spec-compliance reviewers so excluded features are treated as scope
-  violations instead of opportunistic improvements.
+  planning omits excluded work while execution passes the boundaries to implementers and spec-compliance reviewers, so
+  excluded features are treated as scope violations instead of opportunistic improvements.
 
 - **OpenAI Codex CLI AI target (`--ai codex`)** — added a first-class Codex target with native repository assets.
   - Generated workspaces include `AGENTS.md`, `.agents/skills/`, `.codex/config.toml`, and seven `.codex/agents/*.toml` roles without an unused command directory

--- a/camel-kit-core/src/main/resources/agents/spec-compliance-reviewer.md
+++ b/camel-kit-core/src/main/resources/agents/spec-compliance-reviewer.md
@@ -54,6 +54,11 @@ If you find nothing wrong after a thorough check, that's a valid PASS. But your 
 - File paths match the plan exactly
 - No unexpected files generated
 
+### 7. Scope Boundaries
+- Read the complete global `## Not Doing (and Why)` section supplied with the task
+- No generated behavior, component, route, or file implements an explicitly excluded capability
+- Classify every excluded capability that was implemented as **Actionable**; it is never a Trade-off or Noise finding
+
 ## Output Format
 
 ```
@@ -81,6 +86,10 @@ If you find nothing wrong after a thorough check, that's a valid PASS. But your 
 
 ### Files: PASS/FAIL
 [Expected vs actual file list]
+- [Actionable/Trade-off/Noise]: [finding description]
+
+### Scope Boundaries: PASS/FAIL
+[Not Doing entries checked against generated behavior, components, routes, and files]
 - [Actionable/Trade-off/Noise]: [finding description]
 
 ### Overall: PASS/FAIL
@@ -115,6 +124,7 @@ Your focus is singular: **does the output match the spec?** But you approach it 
 |-------|--------------|
 | Missing component | Implementer used wrong component or forgot one |
 | Extra component | Implementer added something not in spec (over-building) |
+| Excluded capability | Implementer crossed an explicit Not Doing boundary |
 | Wrong property name | Implementer used different naming than spec |
 | Missing error handling | Implementer skipped error handling section of spec |
 | Wrong route order | Processing steps in wrong sequence |

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -168,11 +168,12 @@ You MUST complete these items in order:
 2. **Resolve pipeline** — read `shared/pipeline-infrastructure.md` for pipeline resolution logic. If no active pipeline exists, prompt the user to run `{COMMAND_PREFIX} nextId <slug>` to create one. The pipeline ID determines where artifacts are saved.
 3. **Load context** — read `docs/constitution.md` (if it exists), `.camel-kit/config.properties` (if it exists)
 4. **Run greenfield interview** — first read `shared/discovery-completeness.md`, then load
-   `guides/greenfield-interview.md`
+   `guides/greenfield-interview.md`; capture explicit scope boundaries and the reason for every exclusion
 5. **Select Camel version** — load `guides/version-selection.md`
 6. **Design flows** — for each flow, load relevant `camel-design/` guides (component selection, EIPs, data formats, error handling, security, resilience)
 7. **Assemble design spec** — load `guides/design-assembly.md`
-8. **Self-review spec** — scan for placeholders, contradictions, unverified components
+8. **Self-review spec** — scan for placeholders, contradictions, unverified components, and any flow that crosses an
+   explicit `Not Doing (and Why)` boundary
 9. **User reviews spec** — present spec, wait for explicit approval (Iron Law 3)
 10. **Transition** — depends on invocation mode:
     - **Chained mode:** YOU invoke the `camel-plan` skill automatically (do NOT tell the user to run it)

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/design-assembly.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/design-assembly.md
@@ -15,6 +15,7 @@ The design spec is the single source of truth for what gets built. It contains:
 - Technical decisions (version, runtime, error handling)
 - Configuration properties
 - MCP verification evidence
+- Explicit scope boundaries (what will not be built, and why)
 
 **Iron Law 3 reminder:** The user MUST explicitly approve this spec before `camel-plan` is invoked.
 
@@ -31,6 +32,17 @@ The design spec is the single source of truth for what gets built. It contains:
 **Camel Version:** [full Maven version]
 **Runtime:** [Main / Spring Boot / Quarkus]
 **Platform BOM Version:** [resolved platform BOM version]
+
+## Not Doing (and Why)
+
+[The entries below are good examples only. Replace them with the project-specific exclusions captured during discovery
+(greenfield interview Q14). Every entry must name a useful adjacent capability and give a concrete reason for excluding
+it. If the user identified no exclusions, write
+`- **None identified** — No deliberate exclusions remain after the scope interview.`]
+
+- **Dead letter queue** — Adds complexity; start with simple error logging and add a DLQ in iteration 2 if needed
+- **Schema registry integration** — The source topic uses plain JSON, not Avro, so there is no schema evolution concern
+- **Multi-tenant partitioning** — This is a single-tenant deployment, so a partition strategy is out of scope
 
 ---
 
@@ -208,7 +220,9 @@ first approved.
 
 ### For Migration Projects
 
-Use the same structure but add:
+Use the same six numbered sections but add Section 7 below. Include the global `## Not Doing (and Why)` preface only
+when migration discovery explicitly captured project-specific exclusions; do not infer exclusions from omitted or
+absent source features.
 
 ```markdown
 ---
@@ -254,6 +268,10 @@ After assembling the spec, check:
 5. **Property completeness:** Does every externalized value have a property name?
 6. **Flow completeness:** Does each flow from the interview have a design section?
 7. **Decision rationale:** Does every component and EIP selection have Rationale and Constraints filled in? Generic answers like "best fit" are not sufficient — explain the specific technical reasons.
+8. **Scope boundaries:** For every greenfield spec, and for a migration spec only when discovery explicitly captured
+   exclusions, does `## Not Doing (and Why)` contain only project-specific exclusions with a concrete reason for each
+   one? Remove the template examples, and verify that no flow implements an excluded capability. Do not invent a
+   migration exclusion solely to populate this section.
 
 Fix any issues inline.
 

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/greenfield-interview.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/greenfield-interview.md
@@ -294,6 +294,18 @@ Are there any other constraints or requirements we haven't covered?
 
 Record: `project.constraints`
 
+### Question 14: Scope Boundaries
+
+```
+Which useful, adjacent capabilities are we explicitly not building in this iteration, and why?
+
+For each exclusion, name the capability and the concrete reason for leaving it out.
+Or type "none" if no deliberate exclusions remain after the interview.
+```
+
+Record: `project.notDoing` as a list of excluded capabilities and reasons. If the user answers "none", record
+`None identified` rather than inventing exclusions.
+
 ---
 
 ## MCP Component Verification

--- a/camel-kit-core/src/main/resources/skills/camel-design/guides/tdd-assembly.md
+++ b/camel-kit-core/src/main/resources/skills/camel-design/guides/tdd-assembly.md
@@ -13,6 +13,12 @@ Read the active pipeline ID from `.camel-kit/pipeline.json`, then load:
 Do not create standalone per-flow design documents. The active design spec is the single source of truth for planning,
 execution, validation, and verification.
 
+## Scope Boundary
+
+Before expanding a flow design, read the global `## Not Doing (and Why)` section. Do not design or propose a listed
+capability. If a flow requirement conflicts with an explicit exclusion, return the spec to `camel-brainstorm` amend mode
+so the user can resolve the boundary; never silently remove or override it.
+
 ## Constitution Gate Check
 
 Before updating the design spec, verify each flow design against the constitution:

--- a/camel-kit-core/src/main/resources/skills/camel-design/guides/tdd-assembly.md
+++ b/camel-kit-core/src/main/resources/skills/camel-design/guides/tdd-assembly.md
@@ -17,7 +17,8 @@ execution, validation, and verification.
 
 Before expanding a flow design, read the global `## Not Doing (and Why)` section. Do not design or propose a listed
 capability. If a flow requirement conflicts with an explicit exclusion, return the spec to `camel-brainstorm` amend mode
-so the user can resolve the boundary; never silently remove or override it.
+so the user can resolve the boundary; never silently remove or override it. If a legacy approved spec has no such
+section, do not invent one; continue with the existing design-derived, no-extras behavior.
 
 ## Constitution Gate Check
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/SKILL.md
@@ -201,6 +201,7 @@ Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces ALL six:
 | "This task is too simple for two-stage review" | Simple tasks get simple reviews. But they still get reviews. |
 | "I'll dispatch multiple implementers in parallel without wave analysis" | Only parallelize within waves from `plan analyze`. Tasks in different waves may conflict. |
 | "The subagent can read the plan file itself" | Provide full task text. Don't make subagents read plan files. |
+| "This extra feature is an obvious improvement" | Read `Not Doing (and Why)` first. An explicit exclusion is an approved scope boundary, not an invitation to improve it. |
 | "I should ask before proceeding to the next task" | The approved design and generated plan authorize every task. Execute ALL tasks without asking. |
 | "Let me check if the user wants to continue" | The design approval already authorizes downstream execution. Keep going. |
 | "The input plan is stale but I'll ignore the warning" | Always warn about staleness. Execution will produce fresh output, but the user should know the plan may be outdated. |
@@ -242,6 +243,12 @@ Extract ALL tasks with:
 - Design spec section reference
 - Review specification
 
+Also read the complete global `## Not Doing (and Why)` section from the approved design spec. Before considering any
+capability beyond a task's explicit requirements, compare it with this list. Never implement a listed exclusion; if a
+task conflicts with one, report `BLOCKED` and name the plan/spec contradiction instead of silently overriding the
+approved design. If a legacy approved spec has no such section, do not invent one during execution; Iron Law 6 still
+prohibits extras.
+
 ### Step 1.5: Pre-Implementation Catalog Research
 
 Before implementing a wave, batch-verify all MCP catalog artifacts referenced in its tasks.
@@ -272,6 +279,7 @@ Use a fresh implementer subagent when supported; otherwise assume the persona an
 perform the task inline. In either case provide:
 - Agent persona (from `agents/[persona].md`)
 - Full task text from the plan
+- Complete global `## Not Doing (and Why)` section
 - Relevant design spec section (read and include — don't make the subagent find it)
 - Guide file paths to load
 - MCP tool parameters (runtime, platformBom)
@@ -326,6 +334,7 @@ isolated when supported and inline otherwise.
 
 Provide:
 - The generated files (or paths to them)
+- The complete global `## Not Doing (and Why)` section
 - The design spec section this task implements
 - The task's review specification
 
@@ -452,6 +461,7 @@ Save the completion summary as `docs/camel-kit/<PIPELINE_ID>/execution-report.md
 - Make an isolated role read the plan file without receiving full task context
 - Ignore subagent questions
 - Accept "close enough" on spec compliance
+- Add or retain a capability explicitly excluded by `## Not Doing (and Why)`
 - Skip re-review after fixes
 - Move to next task with open issues
 - Stop or pause between tasks to ask the user

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/implementer-context.md
@@ -27,13 +27,26 @@ Include the FULL task text from the plan. Do not summarize. Do not paraphrase.
 
 #### 3. Design Spec Context
 
-Read the relevant design spec section and include it directly:
+Read the global `## Not Doing (and Why)` section and the relevant flow section. Include both directly, even when the
+global section says that no exclusions were identified:
 
 ```
+## Design Spec — Not Doing (and Why)
+
+[full text of the global scope-boundary section from docs/camel-kit/<PIPELINE_ID>/design-spec.md]
+
 ## Design Spec — Flow: [flow-name]
 
 [full text of the flow design from docs/camel-kit/<PIPELINE_ID>/design-spec.md Section 3]
 ```
+
+If a legacy approved spec has no `## Not Doing (and Why)` section, include `Not present in approved design spec` in its
+place and continue to enforce the task text and Iron Law 6. Do not invent exclusions or amend the approved spec during
+execution.
+
+Before adding any capability beyond the task text, consult the global scope boundaries. Never implement a listed
+exclusion. If the task conflicts with one, report `BLOCKED` and name the plan/spec contradiction instead of overriding
+the approved design.
 
 #### 4. Project Configuration
 
@@ -100,6 +113,7 @@ If no pre-verification was run (e.g., single-task wave with few components), inc
    (If a pre-verified catalog summary is provided above, trust it — do not re-verify.)
 2. EVERY route MUST pass all 8 constitution rules
 3. Generate ONLY what the task specifies — no extras
+4. Do NOT implement anything listed in the design spec's Not Doing section
 
 Read `shared/iron-laws.md` for full details and rationalization defense.
 ```

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/spec-reviewer-criteria.md
@@ -12,6 +12,8 @@
    - The persona text (full — do not summarize)
    - The generated files (or paths to them)
    - The design spec section this task implements
+   - The complete global `## Not Doing (and Why)` section from the design spec, or an explicit note that the approved
+     legacy spec does not contain one
    - The task's review specification
    - Any trade-offs documented by the ACR Moderator (from `guides/adversarial-code-review.md`), if ACR ran for this task
 3. Use a fresh subagent when supported; otherwise review sequentially inline and record the missing isolation. Produce the same structured review report.
@@ -19,6 +21,9 @@
 ## Handling Review Results
 
 The spec reviewer classifies each finding as **Actionable**, **Trade-off**, or **Noise**.
+
+Implementing any capability explicitly listed in `## Not Doing (and Why)` is an **Actionable** scope violation. It is
+not a quality improvement or a trade-off; the implementation must remove it or the approved design must be amended.
 
 | Finding classification | Orchestrator action |
 |---|---|

--- a/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/SKILL.md
@@ -122,6 +122,11 @@ Read `shared/iron-laws.md` for the full Iron Laws. This phase enforces:
 
 If the design spec covers multiple independent subsystems or has more than ~10 flows, suggest breaking into separate plans — one per subsystem or logical group. Each plan should produce working, testable software on its own.
 
+Before decomposing the approved design, read its global `## Not Doing (and Why)` section when present. Do not create a
+task or acceptance criterion for any listed exclusion. If another part of the approved design requires an excluded
+capability, stop and require the design contradiction to be resolved and re-approved before planning. A legacy approved
+spec without this section keeps the existing design-derived, no-extras behavior.
+
 ---
 
 ## Plan Content Rules
@@ -140,6 +145,7 @@ If the design spec covers multiple independent subsystems or has more than ~10 f
 - Generated Java code
 - Generated POM dependencies
 - Any artifact that the execution phase produces
+- Any capability listed in the approved design's `## Not Doing (and Why)` section
 
 The plan is a RECIPE, not the MEAL.
 

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
@@ -139,7 +139,8 @@ Confirm all findings with the user.
 **Persist findings to disk:** After confirming, create the `docs/` directory if it does not exist, then write a structured summary to `docs/interview-notes.md`:
 - Systems identified and their roles
 - Data flow requirements and key decisions
-- Explicit scope boundaries and the reason for each excluded capability
+- Explicit scope boundaries and the reason for each excluded capability (greenfield, or migration only when explicitly
+  captured during discovery)
 - Components discussed and their MCP verification status
 - Migration concerns (if migration)
 
@@ -189,7 +190,8 @@ Assemble the complete design spec including:
 - Component selections (all MCP-verified)
 - Route designs
 - Non-functional requirements
-- `## Not Doing (and Why)` scope boundaries
+- `## Not Doing (and Why)` scope boundaries for greenfield, or for migration only when discovery explicitly captured
+  project-specific exclusions; never infer migration exclusions from absent source features
 
 Save to `docs/camel-kit/<PIPELINE_ID>/design-spec.md`.
 Run `{COMMAND_PREFIX} doc init --by camel-brainstorm docs/camel-kit/<PIPELINE_ID>/design-spec.md`.
@@ -203,7 +205,8 @@ Scan the design spec for:
 - Unverified components (did you call MCP for every one?)
 - Contradictions between requirements and design
 - Missing error handling or security considerations
-- Template examples left in `## Not Doing (and Why)`, missing reasons, or a flow that implements an exclusion
+- For greenfield, or migration with explicitly captured exclusions: template examples left in `## Not Doing (and Why)`,
+  missing reasons, or a flow that implements an exclusion
 
 Fix any issues inline.
 </Step>

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-brainstorm.md
@@ -139,6 +139,7 @@ Confirm all findings with the user.
 **Persist findings to disk:** After confirming, create the `docs/` directory if it does not exist, then write a structured summary to `docs/interview-notes.md`:
 - Systems identified and their roles
 - Data flow requirements and key decisions
+- Explicit scope boundaries and the reason for each excluded capability
 - Components discussed and their MCP verification status
 - Migration concerns (if migration)
 
@@ -188,6 +189,7 @@ Assemble the complete design spec including:
 - Component selections (all MCP-verified)
 - Route designs
 - Non-functional requirements
+- `## Not Doing (and Why)` scope boundaries
 
 Save to `docs/camel-kit/<PIPELINE_ID>/design-spec.md`.
 Run `{COMMAND_PREFIX} doc init --by camel-brainstorm docs/camel-kit/<PIPELINE_ID>/design-spec.md`.
@@ -201,6 +203,7 @@ Scan the design spec for:
 - Unverified components (did you call MCP for every one?)
 - Contradictions between requirements and design
 - Missing error handling or security considerations
+- Template examples left in `## Not Doing (and Why)`, missing reasons, or a flow that implements an exclusion
 
 Fix any issues inline.
 </Step>

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
@@ -77,6 +77,11 @@ Parse the plan and extract:
 - Design spec section reference per task
 - Review specification per task
 
+Read the complete global `## Not Doing (and Why)` section from the approved design spec. It applies to every task in
+the queue. If a legacy approved spec has no such section, do not invent one during execution; the no-extras rule still
+applies. If a plan task requires a listed exclusion, stop and escalate the plan/spec contradiction; do not silently skip
+the task or implement the exclusion.
+
 Create a task execution queue with all tasks in order.
 </Step>
 
@@ -91,6 +96,7 @@ For EACH task in the queue:
 
 **Step 1: Read Task Context**
 - Read the full task text from the plan
+- Read `## Not Doing (and Why)` before considering any capability beyond the task
 - Read the relevant design spec section (if specified)
 - Load project context (config.properties, constitution.md)
 
@@ -111,6 +117,7 @@ Follow the task's step-by-step instructions. For implementation tasks:
    - For EVERY language: `camel_catalog_language_doc`
 
 2. **Generate artifacts:**
+   - Do not generate any behavior, component, route, or file that implements a listed `Not Doing` exclusion
    - YAML routes: follow `.bob/skills/camel-implement/guides/yaml-structure.md` and `.bob/skills/camel-implement/guides/yaml-catalog-rules.md`
    - Properties: follow `.bob/skills/camel-implement/guides/properties-generation.md`
    - POM: follow `.bob/skills/camel-implement/guides/maven-dependencies.md`
@@ -151,6 +158,7 @@ Check:
 - Is the data flow correct (source → transformations → sink)?
 - Are all properties defined?
 - Are all error handlers specified in the design spec present?
+- Does the implementation avoid every capability listed in `## Not Doing (and Why)`? Any violation is Actionable.
 
 If spec review FAILS:
 1. Identify the gap

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-plan.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-plan.md
@@ -55,6 +55,10 @@ If the design spec covers multiple independent subsystems or has more than ~10 f
 
 Each plan should produce working, testable software on its own. Record the
 decomposition in the plan and continue without adding another approval gate.
+
+Read the global `## Not Doing (and Why)` section when present. Do not create a task or acceptance criterion for a listed
+exclusion. If another part of the approved design requires one, stop and require the design contradiction to be resolved
+and re-approved before planning. For a legacy approved spec without the section, retain the existing no-extras behavior.
 </Step>
 
 <Step>

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -284,6 +284,48 @@ class ResourceConsistencyTest {
     }
 
     @Test
+    void explicitScopeBoundariesSurviveDesignAndExecutionHandoff() throws IOException {
+        Path root = repositoryRoot().resolve("camel-kit-core/src/main/resources");
+        String interview = Files.readString(root.resolve(
+                "skills/camel-brainstorm/guides/greenfield-interview.md"));
+        String designAssembly = Files.readString(root.resolve(
+                "skills/camel-brainstorm/guides/design-assembly.md"));
+        String flowAssembly = Files.readString(root.resolve(
+                "skills/camel-design/guides/tdd-assembly.md"));
+        String execute = Files.readString(root.resolve("skills/camel-execute/SKILL.md"));
+        String implementerContext = Files.readString(root.resolve(
+                "skills/camel-execute/guides/implementer-context.md"));
+        String specCriteria = Files.readString(root.resolve(
+                "skills/camel-execute/guides/spec-reviewer-criteria.md"));
+        String specPersona = Files.readString(root.resolve("agents/spec-compliance-reviewer.md"));
+        String bobBrainstorm = Files.readString(root.resolve("templates/bob/gates/camel-brainstorm.md"));
+        String bobExecute = Files.readString(root.resolve("templates/bob/gates/camel-execute.md"));
+        int scopeStart = designAssembly.indexOf("\n## Not Doing (and Why)\n");
+        int scopeEnd = designAssembly.indexOf("\n## 1. Executive Summary\n");
+
+        assertTrue(interview.contains("Which useful, adjacent capabilities are we explicitly not building"));
+        assertTrue(interview.contains("project.notDoing"));
+        assertTrue(scopeStart >= 0);
+        assertTrue(scopeEnd > scopeStart);
+        String scopeTemplate = designAssembly.substring(scopeStart, scopeEnd);
+        assertTrue(scopeTemplate.contains("- **Dead letter queue**"));
+        assertTrue(scopeTemplate.contains("- **Schema registry integration**"));
+        assertTrue(scopeTemplate.contains("- **Multi-tenant partitioning**"));
+        assertTrue(designAssembly.contains("for a migration spec only when discovery explicitly captured"));
+        assertTrue(flowAssembly.contains("read the global `## Not Doing (and Why)` section"));
+        assertTrue(implementerContext.contains("## Design Spec — Not Doing (and Why)"));
+        assertTrue(implementerContext.contains("report `BLOCKED` and name the plan/spec contradiction"));
+        assertTrue(execute.contains("Never implement a listed exclusion"));
+        assertTrue(execute.contains("report `BLOCKED` and name the plan/spec contradiction"));
+        assertTrue(specCriteria.contains("is an **Actionable** scope violation"));
+        assertTrue(specPersona.contains("Classify every excluded capability that was implemented as **Actionable**"));
+        assertTrue(bobBrainstorm.contains("Explicit scope boundaries and the reason for each excluded capability"));
+        assertTrue(bobBrainstorm.contains("`## Not Doing (and Why)` scope boundaries"));
+        assertTrue(bobExecute.contains("Read `## Not Doing (and Why)` before considering any capability"));
+        assertTrue(bobExecute.contains("Any violation is Actionable"));
+    }
+
+    @Test
     void dockerComposeGenerationIsConditionalForEveryRuntime() throws IOException {
         Path root = repositoryRoot().resolve("camel-kit-core/src/main/resources");
         String composeGuide = Files.readString(root.resolve(

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -292,6 +292,7 @@ class ResourceConsistencyTest {
                 "skills/camel-brainstorm/guides/design-assembly.md"));
         String flowAssembly = Files.readString(root.resolve(
                 "skills/camel-design/guides/tdd-assembly.md"));
+        String plan = Files.readString(root.resolve("skills/camel-plan/SKILL.md"));
         String execute = Files.readString(root.resolve("skills/camel-execute/SKILL.md"));
         String implementerContext = Files.readString(root.resolve(
                 "skills/camel-execute/guides/implementer-context.md"));
@@ -299,9 +300,11 @@ class ResourceConsistencyTest {
                 "skills/camel-execute/guides/spec-reviewer-criteria.md"));
         String specPersona = Files.readString(root.resolve("agents/spec-compliance-reviewer.md"));
         String bobBrainstorm = Files.readString(root.resolve("templates/bob/gates/camel-brainstorm.md"));
+        String bobPlan = Files.readString(root.resolve("templates/bob/gates/camel-plan.md"));
         String bobExecute = Files.readString(root.resolve("templates/bob/gates/camel-execute.md"));
         int scopeStart = designAssembly.indexOf("\n## Not Doing (and Why)\n");
         int scopeEnd = designAssembly.indexOf("\n## 1. Executive Summary\n");
+        String normalizedPlan = plan.replaceAll("\\s+", " ");
 
         assertTrue(interview.contains("Which useful, adjacent capabilities are we explicitly not building"));
         assertTrue(interview.contains("project.notDoing"));
@@ -313,6 +316,7 @@ class ResourceConsistencyTest {
         assertTrue(scopeTemplate.contains("- **Multi-tenant partitioning**"));
         assertTrue(designAssembly.contains("for a migration spec only when discovery explicitly captured"));
         assertTrue(flowAssembly.contains("read the global `## Not Doing (and Why)` section"));
+        assertTrue(normalizedPlan.contains("Do not create a task or acceptance criterion for any listed exclusion"));
         assertTrue(implementerContext.contains("## Design Spec — Not Doing (and Why)"));
         assertTrue(implementerContext.contains("report `BLOCKED` and name the plan/spec contradiction"));
         assertTrue(execute.contains("Never implement a listed exclusion"));
@@ -321,6 +325,7 @@ class ResourceConsistencyTest {
         assertTrue(specPersona.contains("Classify every excluded capability that was implemented as **Actionable**"));
         assertTrue(bobBrainstorm.contains("Explicit scope boundaries and the reason for each excluded capability"));
         assertTrue(bobBrainstorm.contains("`## Not Doing (and Why)` scope boundaries"));
+        assertTrue(bobPlan.contains("Do not create a task or acceptance criterion for a listed"));
         assertTrue(bobExecute.contains("Read `## Not Doing (and Why)` before considering any capability"));
         assertTrue(bobExecute.contains("Any violation is Actionable"));
     }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -305,6 +305,7 @@ class ResourceConsistencyTest {
         int scopeStart = designAssembly.indexOf("\n## Not Doing (and Why)\n");
         int scopeEnd = designAssembly.indexOf("\n## 1. Executive Summary\n");
         String normalizedPlan = plan.replaceAll("\\s+", " ");
+        String normalizedBobBrainstorm = bobBrainstorm.replaceAll("\\s+", " ");
 
         assertTrue(interview.contains("Which useful, adjacent capabilities are we explicitly not building"));
         assertTrue(interview.contains("project.notDoing"));
@@ -316,6 +317,8 @@ class ResourceConsistencyTest {
         assertTrue(scopeTemplate.contains("- **Multi-tenant partitioning**"));
         assertTrue(designAssembly.contains("for a migration spec only when discovery explicitly captured"));
         assertTrue(flowAssembly.contains("read the global `## Not Doing (and Why)` section"));
+        assertTrue(flowAssembly.contains("legacy approved spec has no such"));
+        assertTrue(flowAssembly.contains("design-derived, no-extras behavior"));
         assertTrue(normalizedPlan.contains("Do not create a task or acceptance criterion for any listed exclusion"));
         assertTrue(implementerContext.contains("## Design Spec — Not Doing (and Why)"));
         assertTrue(implementerContext.contains("report `BLOCKED` and name the plan/spec contradiction"));
@@ -325,6 +328,10 @@ class ResourceConsistencyTest {
         assertTrue(specPersona.contains("Classify every excluded capability that was implemented as **Actionable**"));
         assertTrue(bobBrainstorm.contains("Explicit scope boundaries and the reason for each excluded capability"));
         assertTrue(bobBrainstorm.contains("`## Not Doing (and Why)` scope boundaries"));
+        assertTrue(normalizedBobBrainstorm.contains("migration only when explicitly captured during discovery"));
+        assertTrue(normalizedBobBrainstorm.contains("never infer migration exclusions from absent source features"));
+        assertTrue(
+                normalizedBobBrainstorm.contains("For greenfield, or migration with explicitly captured exclusions"));
         assertTrue(bobPlan.contains("Do not create a task or acceptance criterion for a listed"));
         assertTrue(bobExecute.contains("Read `## Not Doing (and Why)` before considering any capability"));
         assertTrue(bobExecute.contains("Any violation is Actionable"));


### PR DESCRIPTION
## Summary

- add a top-level Not Doing (and Why) section to greenfield design specs with three concrete examples
- capture explicit exclusions and their rationale during the brainstorm interview
- keep excluded capabilities out of implementation plans, then pass global boundaries to implementers and spec-compliance review, including Bob 1 parity
- treat implemented exclusions as Actionable scope violations and block plan/spec contradictions
- keep migration exclusions conditional on explicit discovery and retain no-extras behavior for legacy approved specs without the new section

## Website impact

Required and addressed by https://github.com/luigidemasi/camel-kit-web/pull/32.

## Validation

- ./mvnw -B -pl camel-kit-core -Dtest=ResourceConsistencyTest,ShippedAssetStructureTest test
- ./mvnw -B -Psourcecheck validate
- ./mvnw -B clean install
- independent review: PASS

Fixes #77
