### PR TITLE
chore: fix table delimiter column counts in biztalk-phase2 design-spec template

### DIFF
--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
@@ -246,7 +246,7 @@ of the following details:
 ### 3.5 Sub-orchestration / Route References (if applicable)
 
 | BizTalk Sub-orchestration | Camel Route | Direct URI | BizTalk Origin |
-|---|---|---|---|---|
+|---|---|---|---|
 | [sub-orchestration-name] | [camel-route-name] | `direct:[camel-route-name]` | `<Call Orchestration>` shape |
 
 ### DataMapper: kaoto-datamapper-{8hexchars} (if orchestration contains Transform shape)
@@ -303,7 +303,7 @@ sequenceDiagram
 ## Section 8: Dependencies
 
 | Dependency | Maven Coordinates | Notes |
-|---|---|---|---|
+|---|---|---|
 | [component name] | `[groupId:artifactId:version]` | [notes] |
 
 ## Section 9: Constitution Gate Checks

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
@@ -187,7 +187,7 @@ For each BizTalk orchestration, update the relevant `### Flow: {orchestration-na
 Use the same flow-design structure as `camel-brainstorm/guides/design-assembly.md`. The flow section MUST contain all
 of the following details:
 
-```markdown
+````markdown
 # Flow Design: {orchestration-name}
 
 ## Section 1: Overview
@@ -337,8 +337,7 @@ Constitution v2.0 — eight enforced rules:
 - [ ] Ensure `camel-plan` includes an implementation task for this orchestration
 - [ ] Run `camel-execute` to generate Camel YAML and integration tests
 - [ ] Verify against original BizTalk behaviour
-- [ ] Verify against original BizTalk behaviour
-```
+````
 
 **Note:** If the business requirements specify performance/throughput requirements, add a **Section 5e: Throttling & Scaling** covering throttle EIP configuration and messaging component `consumersCount`. If security or compliance requirements exist, add a **Section 5f: Security**. If observability requirements exist, add a **Section 5g: Monitoring**. Renumber sections as needed.
 

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/mulesoft-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/mulesoft-phase2.md
@@ -145,7 +145,7 @@ For each Mule flow, update the relevant `### Flow: {flow-name}` section in
 Use the same flow-design structure as `camel-brainstorm/guides/design-assembly.md`. The flow section MUST contain all
 of the following details:
 
-```markdown
+````markdown
 # Flow Design: {flow-name}
 
 ## Section 1: Overview
@@ -293,8 +293,7 @@ Constitution v2.0 — eight enforced rules:
 - [ ] Ensure `camel-plan` includes an implementation task for this flow
 - [ ] Run `camel-execute` to generate Camel YAML and integration tests
 - [ ] Verify against original Mule behaviour
-- [ ] Verify against original Mule behaviour
-```
+````
 
 **Note:** If the business requirements specify performance/throughput requirements, add a **Section 5e: Throttling & Scaling** covering throttle EIP configuration and Kafka `consumersCount`. If security or compliance requirements exist, add a **Section 5f: Security**. If observability requirements exist, add a **Section 5g: Monitoring**. Renumber sections as needed.
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/MigrationOperationsContractTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/MigrationOperationsContractTest.java
@@ -569,28 +569,7 @@ class MigrationOperationsContractTest {
                                                                                                                                                                                    + "authorizes removal",
                 "The runbook never deletes, disables, or modifies source artifacts");
 
-        long tableColumns = 0;
-        int tableRow = 0;
-        int lineNumber = 0;
-        for (String line : rawRunbook.split("\\R")) {
-            lineNumber++;
-            if (!line.startsWith("|")) {
-                tableRow = 0;
-                continue;
-            }
-            long columns = line.chars().filter(character -> character == '|').count();
-            if (tableRow == 0) {
-                tableColumns = columns;
-            } else {
-                assertEquals(tableColumns, columns,
-                        "Runbook table row " + lineNumber + " must match its header column count");
-            }
-            if (tableRow == 1) {
-                assertTrue(line.matches("\\|(?:-+\\|)+"),
-                        "Runbook table row " + lineNumber + " must be a Markdown delimiter");
-            }
-            tableRow++;
-        }
+        assertMarkdownTableParity("Runbook", rawRunbook);
 
         int runbookBodyStart = rawRunbook.indexOf("\n## Scope and Ownership\n");
         assertTrue(runbookBodyStart >= 0, "Migration runbook must contain its ordered output template");
@@ -696,6 +675,39 @@ class MigrationOperationsContractTest {
         String replanNever = replan.substring(replan.indexOf("## Never"));
         assertContainsAll(replanNever,
                 "Regenerate or clear staleness from `migration-runbook.md` during re-planning");
+    }
+
+    @Test
+    void migrationGuideTemplateTablesKeepHeaderAndDelimiterParity() throws Exception {
+        assertMarkdownTableParity("biztalk-phase2.md",
+                resource("skills/camel-migrate/guides/biztalk-phase2.md"));
+        assertMarkdownTableParity("mulesoft-phase2.md",
+                resource("skills/camel-migrate/guides/mulesoft-phase2.md"));
+    }
+
+    private static void assertMarkdownTableParity(String resourceName, String content) {
+        long tableColumns = 0;
+        int tableRow = 0;
+        int lineNumber = 0;
+        for (String line : content.split("\\R")) {
+            lineNumber++;
+            if (!line.startsWith("|")) {
+                tableRow = 0;
+                continue;
+            }
+            long columns = line.chars().filter(character -> character == '|').count();
+            if (tableRow == 0) {
+                tableColumns = columns;
+            } else {
+                assertEquals(tableColumns, columns,
+                        resourceName + " table row " + lineNumber + " must match its header column count");
+            }
+            if (tableRow == 1) {
+                assertTrue(line.matches("\\|(?:-+\\|)+"),
+                        resourceName + " table row " + lineNumber + " must be a Markdown delimiter");
+            }
+            tableRow++;
+        }
     }
 
     private static String resource(String name) throws Exception {


### PR DESCRIPTION
The design-spec template fenced inside `camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md` contains two Markdown tables whose delimiter rows have one more column than their headers:

- Section 3.5 (Sub-orchestration / Route References): 4-column header, 5-column delimiter
- Section 8 (Dependencies): 3-column header, 4-column delimiter

Because the template is copied verbatim into generated `docs/camel-kit/<PIPELINE_ID>/design-spec.md` documents, the mismatched delimiters propagate into artifacts where GFM then refuses to render the tables. The first commit trims each delimiter row to match its header.

Both mismatches predate #78 and were noted as out-of-scope FYI items in the PR #202 review (https://github.com/luigidemasi/camel-kit/pull/202#issuecomment-5513910706). A sweep of all 252 shipped and docs Markdown files found no other header/delimiter mismatch.

The second commit addresses the review of this PR:

- Extracts the runbook table-parity loop in `MigrationOperationsContractTest` into a shared helper and applies it to `biztalk-phase2.md` and `mulesoft-phase2.md`, so restoring either extra delimiter cell fails CI. The new check fails on parent `e775ad61` (`biztalk-phase2.md table row 249 must match its header column count`) and passes on this head.
- Fixes the nested-fence defect in the same templates: the inner ```` ```mermaid ```` block's bare closer also closed the outer ```` ```markdown ```` fence, pushing Sections 7–11 outside the template. The outer fences now use four backticks. `mulesoft-phase2.md` had the identical structure and gets the same fix, and both files drop a duplicated final checklist line.

Verified with the full-reactor `./mvnw -B clean install` (all six modules, tests included) and `./mvnw -B -Psourcecheck validate`.