### PR TITLE
chore: align drifted guide checklists with canonical sources

### DIFF
--- a/camel-kit-core/src/main/resources/agents/test-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/test-engineer.md
@@ -54,11 +54,14 @@ You are dispatched during the **Execute phase** for test generation tasks. You r
 
 ## Test Design Principles
 
+These are the canonical Test Design Principles for the pipeline; task files reference them instead of restating them.
+
 1. **One test = one behavior** — each test validates a single route behavior
-2. **Realistic test data** — use representative data, not trivial examples
+2. **Realistic test data** — use representative data, not `{"key": "value"}`
 3. **Infrastructure isolation** — Testcontainers for databases, brokers; mock endpoints for external APIs
-4. **Assertion completeness** — verify headers, body, and properties
+4. **Assertion completeness** — verify headers, body, and exchange properties
 5. **Negative testing** — test error paths, not just happy paths
+6. **Idempotent** — tests can run repeatedly with same results
 
 ## Completion Status
 

--- a/camel-kit-core/src/main/resources/agents/test-engineer.md
+++ b/camel-kit-core/src/main/resources/agents/test-engineer.md
@@ -54,14 +54,8 @@ You are dispatched during the **Execute phase** for test generation tasks. You r
 
 ## Test Design Principles
 
-These are the canonical Test Design Principles for the pipeline; task files reference them instead of restating them.
-
-1. **One test = one behavior** — each test validates a single route behavior
-2. **Realistic test data** — use representative data, not `{"key": "value"}`
-3. **Infrastructure isolation** — Testcontainers for databases, brokers; mock endpoints for external APIs
-4. **Assertion completeness** — verify headers, body, and exchange properties
-5. **Negative testing** — test error paths, not just happy paths
-6. **Idempotent** — tests can run repeatedly with same results
+Apply the canonical Test Design Principles from `camel-test/guides/test-generation.md` (already listed under Guides
+You Reference); task files do not restate them.
 
 ## Completion Status
 

--- a/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
@@ -84,14 +84,8 @@ Resolve `TEST_DIR` as the optional `[MODULE_DIR]` prefix plus `src/test/resource
 
 ## Test Design Principles
 
-Include these in every test task:
-
-1. **One test = one behavior** — each test method validates a single route behavior
-2. **Realistic test data** — use representative data, not `{"key": "value"}`
-3. **Infrastructure isolation** — Testcontainers for databases, brokers; mock endpoints for external APIs
-4. **Assertion completeness** — verify headers, body, and exchange properties
-5. **Negative testing** — test error paths, not just happy paths
-6. **Idempotent** — tests can run repeatedly with same results
+Every test task dispatches the `test-engineer` persona, which carries the canonical Test Design Principles
+(`agents/test-engineer.md`). Do not restate them in task files.
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
+++ b/camel-kit-core/src/main/resources/skills/camel-plan/guides/task-template-testing.md
@@ -84,8 +84,8 @@ Resolve `TEST_DIR` as the optional `[MODULE_DIR]` prefix plus `src/test/resource
 
 ## Test Design Principles
 
-Every test task dispatches the `test-engineer` persona, which carries the canonical Test Design Principles
-(`agents/test-engineer.md`). Do not restate them in task files.
+The canonical Test Design Principles live in `camel-test/guides/test-generation.md`, which every test task loads at
+execution time. Do not restate them in task files.
 
 ---
 

--- a/camel-kit-core/src/main/resources/skills/camel-test/guides/test-generation.md
+++ b/camel-kit-core/src/main/resources/skills/camel-test/guides/test-generation.md
@@ -12,6 +12,20 @@
 
 ---
 
+## Test Design Principles
+
+Canonical for the pipeline — the `test-engineer` persona and the plan's test task template point here instead of
+restating these principles.
+
+1. **One test = one behavior** — each test validates a single route behavior
+2. **Realistic test data** — use representative data, not `{"key": "value"}`
+3. **Infrastructure isolation** — Testcontainers for databases, brokers; mock endpoints for external APIs
+4. **Assertion completeness** — verify headers, body, and exchange properties
+5. **Negative testing** — test error paths, not just happy paths
+6. **Idempotent** — tests can run repeatedly with same results
+
+---
+
 ## Step 2: Test Plan Design
 
 ### 2.1 Extract Test Scenarios from the Design Spec

--- a/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/SKILL.md
@@ -61,7 +61,7 @@ Invoked directly by the user: `/camel-validate` or `/camel-validate <PIPELINE_ID
 
 ## Purpose
 
-Provides the domain knowledge guides needed to validate generated Apache Camel routes across multiple quality dimensions. These guides are referenced by the `code-quality-reviewer` and `test-engineer` agent personas.
+Provides the domain knowledge guides needed to validate generated Apache Camel routes across multiple quality dimensions. These guides are referenced by the `code-quality-reviewer` agent persona.
 
 ## Runtime Path Inventory (MANDATORY)
 

--- a/camel-kit-core/src/main/resources/skills/camel-validate/guides/anti-patterns.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/guides/anti-patterns.md
@@ -148,7 +148,7 @@ Too many small messages instead of batches:
 Check: Message granularity
 - Pattern: Individual messages vs batches
 - Volume: [N] messages expected
-  → [N > 1000/min] + Individual messages: ⚠️ WARNING
+  → [N > 100/sec] + Individual messages: ⚠️ WARNING
      Consider batching for better performance
 ```
 

--- a/camel-kit-core/src/main/resources/skills/camel-validate/guides/anti-patterns.md
+++ b/camel-kit-core/src/main/resources/skills/camel-validate/guides/anti-patterns.md
@@ -511,7 +511,7 @@ Use this checklist for manual review:
 - [ ] Idempotent consumer for exactly-once delivery
 
 ### Integration
-- [ ] Batching used for high volume (>1000 msg/min)
+- [ ] Batching used for high volume (>100 msg/sec)
 - [ ] Correlation IDs generated and propagated
 - [ ] Circuit breakers around external calls
 - [ ] Timeouts configured for external calls

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-execute.md
@@ -199,14 +199,21 @@ Do NOT proceed to code quality review until spec review passes.
 Load `.bob/skills/camel-execute/guides/quality-reviewer-criteria.md` (if it exists) or use these criteria:
 
 Check all 8 constitution rules:
-1. No hardcoded URLs
-2. Explicit error handling
-3. Structured logging
-4. Idempotency (for stateful routes)
-5. Circuit breaker (for HTTP calls)
-6. TLS everywhere
+1. Route Structure — every route has a source (`from:`) and a final sink (`to:`); `direct:`/`seda:` sub-routes exempt
+2. Single Responsibility — one route = one purpose; more than 7 processing steps is a WARNING
+3. Separation of Concerns — Ingestion → Processing → Delivery; business logic in beans
+4. Naming Conventions — route IDs `<domain>-<action>[-<qualifier>]`; custom headers `kebab-case`
+5. Observability — every route declares `routeId` and `description`; correlation IDs propagated
+6. External Configuration — no hardcoded connection strings, credentials, or environment values; `{{property}}` syntax
 7. Component verification
 8. Infrastructure via Forage (`forage.*` properties when Forage covers it; ladder: Forage → component properties → hand-rolled bean with stated reason; hand-rolled `camel.beans.*` requires a one-line reason comment)
+
+Check quality and resilience (anti-pattern catalog):
+- Explicit error handling — every route has `onException:` or `doTry:`
+- Structured logging at route entry/exit
+- Idempotency (for stateful routes)
+- Circuit breaker (for HTTP calls)
+- TLS everywhere
 
 Check security:
 - No hardcoded credentials

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-implement.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-implement.md
@@ -144,16 +144,24 @@ Load `guides/route-validation.md` and run cross-route validation:
 
 For EVERY route, verify compliance with all 8 constitution rules:
 
-1. **No Hardcoded URLs** — all endpoints use properties
-2. **Explicit Error Handling** — every route has `onException` or `doTry`
-3. **Structured Logging** — all routes log at entry/exit with correlation ID
-4. **Idempotency** — stateful routes use `idempotentConsumer`
-5. **Circuit Breaker** — HTTP calls have resilience patterns
-6. **TLS Everywhere** — all HTTP endpoints use HTTPS
+1. **Route Structure** — every route has a source (`from:`) and a final sink (`to:`); `direct:`/`seda:` sub-routes exempt
+2. **Single Responsibility** — one route = one purpose; more than 7 processing steps is a WARNING
+3. **Separation of Concerns** — Ingestion → Processing → Delivery; business logic in beans
+4. **Naming Conventions** — route IDs `<domain>-<action>[-<qualifier>]`; custom headers `kebab-case`
+5. **Observability** — every route declares `routeId` and `description`; correlation IDs propagated
+6. **External Configuration** — no hardcoded connection strings, credentials, or environment values; `{{property}}` syntax
 7. **Component Verification** — all components verified via MCP catalog
 8. **Infrastructure via Forage** — infrastructure beans declared with `forage.*` properties when Forage covers them (ladder: Forage → component properties → hand-rolled bean with stated reason); hand-rolled `camel.beans.*` requires a one-line reason comment
 
-If any rule is violated, fix immediately before proceeding.
+Also verify these quality checks (anti-pattern catalog):
+
+- **Explicit Error Handling** — every route has `onException` or `doTry`
+- **Structured Logging** — all routes log at entry/exit with correlation ID
+- **Idempotency** — stateful routes use `idempotentConsumer`
+- **Circuit Breaker** — HTTP calls have resilience patterns
+- **TLS Everywhere** — all HTTP endpoints use HTTPS
+
+If any rule or check is violated, fix immediately before proceeding.
 </Step>
 
 <Step>

--- a/camel-kit-core/src/main/resources/templates/bob/gates/camel-validate.md
+++ b/camel-kit-core/src/main/resources/templates/bob/gates/camel-validate.md
@@ -115,34 +115,34 @@ For EACH route file:
 
 Check all 8 constitution rules:
 
-**Rule 1: No Hardcoded URLs**
-- Scan for `http://`, `https://`, `jdbc:`, `amqp://` in URIs
-- All URLs must use `{{property}}` syntax
+**Rule 1: Route Structure**
+- Every route has a source (`from:`) and a final sink (`to:`)
+- `direct:`/`seda:` sub-routes may omit an external sink
+- Report pass-through routes with no processing steps (WARNING)
+
+**Rule 2: Single Responsibility**
+- One route = one purpose, explainable in one sentence
+- Report routes with more than 7 processing steps (WARNING)
+
+**Rule 3: Separation of Concerns**
+- Ingestion → Processing → Delivery decomposition
+- Business logic in beans, integration logic in routes
+- Report routes embedding business logic
+
+**Rule 4: Naming Conventions**
+- Route IDs match `<domain>-<action>[-<qualifier>]`
+- Internal endpoints use `direct:<route-id>` / `seda:<domain>-<purpose>`; custom headers `kebab-case`
+- Report non-conforming names (WARNING)
+
+**Rule 5: Observability**
+- Every route declares `routeId` and `description`
+- Correlation IDs propagated across routes
+- Report routes without `routeId` or `description`
+
+**Rule 6: External Configuration**
+- Scan for hardcoded `http://`, `https://`, `jdbc:`, `amqp://` URIs and credentials
+- All configurable values must use `{{property}}` syntax
 - Report violations with line numbers
-
-**Rule 2: Explicit Error Handling**
-- Every route must have `onException:` or `doTry:`
-- Error handlers must log exceptions
-- Report routes without error handling
-
-**Rule 3: Structured Logging**
-- Routes must log at entry with correlation ID
-- Routes must log at exit
-- Use `log:` EIP with structured format
-- Report routes without logging
-
-**Rule 4: Idempotency**
-- Routes with `file:`, `ftp:`, `sftp:`, `kafka:` consumers must use `idempotentConsumer:`
-- Report stateful routes without idempotency
-
-**Rule 5: Circuit Breaker**
-- Routes with `http:`, `https:` calls must use `circuitBreaker:` or `resilience4j:`
-- Report HTTP calls without resilience
-
-**Rule 6: TLS Everywhere**
-- All HTTP endpoints must use HTTPS (except localhost)
-- All AMQP endpoints must use TLS
-- Report insecure endpoints
 
 **Rule 7: Component Verification**
 - Call `camel_catalog_component_doc` for every component
@@ -153,7 +153,15 @@ Check all 8 constitution rules:
 - Otherwise accept component properties, or a hand-written bean with a one-line reason
 - Report unknown Forage keys and unexplained hand-written beans
 
-Report constitution violations per route.
+Check quality and resilience (anti-pattern catalog):
+
+- **Explicit Error Handling** — every route must have `onException:` or `doTry:`; error handlers must log exceptions
+- **Structured Logging** — routes log at entry and exit with correlation ID (`log:` EIP, structured format)
+- **Idempotency** — routes with `file:`, `ftp:`, `sftp:`, `kafka:` consumers must use `idempotentConsumer:`
+- **Circuit Breaker** — routes with `http:`/`https:` calls must use `circuitBreaker:` or `resilience4j:`
+- **TLS Everywhere** — all HTTP endpoints use HTTPS (except localhost); AMQP endpoints use TLS
+
+Report constitution and quality violations per route.
 </Step>
 
 <Step>

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/BobGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/BobGeneratorTest.java
@@ -346,6 +346,28 @@ class BobGeneratorTest {
         }
     }
 
+    @Test
+    void installsCanonicalTestDesignPrinciplesForBobTestTasks() throws Exception {
+        InitContext ctx = createContext();
+        new BobGenerator().generate(ctx);
+
+        Path guide = tempDir.resolve(".bob/skills/camel-test/guides/test-generation.md");
+        assertTrue(Files.isRegularFile(guide));
+        String guideContent = Files.readString(guide);
+        assertTrue(guideContent.contains("## Test Design Principles"));
+        for (String principle : List.of("One test = one behavior", "Realistic test data", "Infrastructure isolation",
+                "Assertion completeness", "Negative testing", "Idempotent")) {
+            assertTrue(guideContent.contains(principle), principle);
+        }
+
+        // Bob installs no persona resources, so the test task template must not point at agents/
+        Path template = tempDir.resolve(".bob/skills/camel-plan/guides/task-template-testing.md");
+        assertTrue(Files.isRegularFile(template));
+        String templateContent = Files.readString(template);
+        assertTrue(templateContent.contains("camel-test/guides/test-generation.md"));
+        assertFalse(templateContent.contains("agents/"));
+    }
+
     private void assertEditRejects(String mode, String... paths) {
         Pattern pattern = editPattern(mode);
         for (String path : paths) {


### PR DESCRIPTION
Fixes four consistency drifts in shipped skill/template content, found while re-checking issue #73 against `main` (`8d4206b0`):

1. **Batching threshold** — `skills/camel-validate/guides/anti-patterns.md` said batching applies at `>1000 msg/min` while `skills/camel-design/guides/performance.md` (twice) and the adjacent async line in the same checklist use `>100 msg/sec`. Aligned to `>100 msg/sec`.

2. **Bob gate constitution lists** — all three bob gates (`templates/bob/gates/camel-execute.md`, `camel-implement.md`, `camel-validate.md`) claimed to check "all 8 constitution rules" but listed a different set (No hardcoded URLs / Explicit error handling / Structured logging / Idempotency / Circuit breaker / TLS everywhere) than the canonical `templates/constitution.md` and `skills/shared/iron-laws.md` (Route Structure / Single Responsibility / Separation of Concerns / Naming Conventions / Observability / External Configuration). `skills/camel-brainstorm/guides/design-assembly.md` already uses the canonical list. The gate lists now match the constitution; the previously listed non-constitution checks are retained under an explicit "quality and resilience (anti-pattern catalog)" block, so no check is weakened.

3. **Test Design Principles dedupe** — the block existed in two drifted copies: `skills/camel-plan/guides/task-template-testing.md` (6 items) vs `agents/test-engineer.md` (5 items, missing "Idempotent", differing wording). Every test task dispatches the `test-engineer` persona, so the persona now carries the canonical 6-item list and the plan template points to it instead of restating it.

4. **Stale cross-reference** — `skills/camel-validate/SKILL.md` said its guides are referenced by the `code-quality-reviewer` and `test-engineer` personas; `test-engineer` references only `camel-test` guides. Dropped the stale mention.

Full-reactor `./mvnw -B clean install` passes locally (all six modules, 1,250 tests, 0 failures).

Website impact: not required (internal consistency fixes restoring already-documented behavior).

## Summary by Sourcery

Restore consistency across shipped skill, template, and persona guidance by aligning canonical checklists, thresholds, and cross-references.

Bug Fixes:
- Align inconsistent batching thresholds with the canonical performance guidance.
- Correct Bob gate constitution checks and preserve the displaced quality and resilience checks in a separate catalog.
- Remove stale validation guide references to the test-engineer persona.

Enhancements:
- Centralize the canonical six-item Test Design Principles in the test-generation guide and have test task resources reference it instead of duplicating the list.

Tests:
- Add generator coverage ensuring Bob installs the canonical test design principles and references them correctly from test task templates.