### PR TITLE
Centralize distribution versions and move to Camel 4.22 LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Camel 4.22 LTS default and centralized distribution versions (#209)** — Camel Main, Spring Boot, and the Camel MCP
+  server now default to `4.22.0`. The supported Main and Spring Boot matrix is `4.22.0,4.18.4`; Spring Boot maps those
+  lines to `4.1.0` and `3.5.16`, and Forage maps them to `1.6.0` and `1.4.1`. Quarkus remains on its independent matrix.
+  Runtime defaults, generated MCP configuration, installed skill guidance, Forage tables, and Ship functional rows now
+  derive from `distribution.properties`; a small idempotent helper synchronizes the remaining Maven model-time mirror.
+  Ship records exact 4.22.0 and 4.18.4 validator/catalog evidence. Camel 4.22 adds Jactl to the known-expression
+  classifier, while Ship v1 continues to reject it under the existing Simple-only manifest policy.
+
 - **Shared Camel security checklist (#205)** — the security rules restated across the design guide, the validation
   guides, and the review personas now have one canonical source, `skills/shared/camel-security-checklist.md`. The
   consumers reference it instead of restating the rules, the drifted vault-reference and log-masking snippets are
@@ -74,12 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pre-controller `.camel-kit/ship-state.json` and non-manual `.camel-kit/pipeline.json` state is intentionally not resumable and must be archived outside the project before starting Ship; manual-mode `.camel-kit/pipeline.json` remains supported by standalone pipeline skills and validated `--start-from` imports
   - GitHub Copilot CLI uses native project skills under `.github/skills/` without generating unsupported `.github/commands/`; older command files are inert and may be removed after preserving local edits
   - Pi exposes Ship through `/skill:camel-ship` and removes the older `.pi/prompts/camel-ship.md` alias, whose argument expansion could flatten quoted option values
-
-- **Default Camel version updated to 4.21.0** — Camel Main and Spring Boot runtimes now default to Camel `4.21.0`, with the Spring Boot framework mapped to `4.1.0` (`spring.boot.4.21.0=4.1.0`, matching camel-parent 4.21.0). Supported version lists for Main and Spring Boot move to `4.21.0, 4.18.3, 4.14.7` (LTS fix release 4.18.3 maps to Spring Boot `3.5.16`).
-  - Camel MCP server now pinned to the released `4.21.0` instead of `4.21.0-SNAPSHOT`
-  - Compiled-in fallback defaults in `DistributionConfig` kept in lockstep with `distribution.properties`
-  - `spring.boot.4.20.0` mapping removed — 4.20 is not an LTS line; 4.21.0 is the current latest release alongside LTS `4.18.3` and `4.14.7`
-  - Quarkus runtime stays on Camel `4.18.2` — the latest camel-quarkus release (3.33.1, Quarkus platform 3.33.2.x) still bundles Camel 4.18.2
 
 - **Default AI target changed to IBM Bob 2** — `camel-kit init` and `camel kit init` now default to `--ai bob2` when no `--ai` option is supplied.
   - CLI help and documentation now mark Bob 2 as the default target

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,6 +411,20 @@ We follow [Semantic Versioning](https://semver.org/):
 - MINOR: New features (backward compatible)
 - PATCH: Bug fixes (backward compatible)
 
+### Distribution Version Updates
+
+`distribution.properties` is the source of truth for distribution and compatibility
+versions. Edit the reviewed values there, then synchronize the few literals Maven needs
+while constructing its model:
+
+```bash
+./tools/sync_distribution_mirrors.py
+./tools/sync_distribution_mirrors.py --check
+```
+
+The helper is idempotent, performs no network lookup, and does not certify a version or
+replace the compatibility evidence required for a release.
+
 ### Release Steps
 
 1. Update version in `pom.xml` (parent and all modules)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ camel-kit init my-integration --ai qwen     # Qwen
 camel-kit init my-integration --ai opencode # OpenCode
 
 # 2. Override configuration if needed
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.4"
 
 # 3. Open in your AI assistant
 cd my-integration

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/config/DistributionConfig.java
@@ -25,12 +25,6 @@ import java.util.Properties;
  */
 public class DistributionConfig {
 
-    private static final String DEFAULT_CITRUS_VERSION = "5.0.0-M2";
-    private static final String DEFAULT_CITRUS_MCP_VERSION = "5.0.0-M1";
-    private static final String DEFAULT_PI_VERSION = "0.84.2";
-    private static final String DEFAULT_NODE_VERSION = "22.22.2";
-    private static final String DEFAULT_PI_MCP_ADAPTER_VERSION = "2.11.0";
-
     private static final Path DEFAULT_USER_CONFIG = Path.of(
             System.getProperty("user.home"), ".camel-kit", "config.properties");
 
@@ -56,33 +50,34 @@ public class DistributionConfig {
     private final String piSupported;
     private final String nodeVersion;
     private final String piMcpAdapterVersion;
+    private final String forageCatalogArtifact;
     private final int overrideCount;
 
-    private DistributionConfig(Properties props, int overrideCount) {
+    private DistributionConfig(Properties props, Properties bundled, int overrideCount) {
         this.rawProps = props;
-        this.camelMainVersion = props.getProperty("camel.main.version", "4.21.0");
-        this.camelSpringbootVersion = props.getProperty("camel.springboot.version", "4.21.0");
-        this.camelQuarkusVersion = props.getProperty("camel.quarkus.version", "4.18.2");
-        this.springbootBomVersion = props.getProperty("springboot.bom.version", "4.21.0");
-        this.springBootVersion = props.getProperty("spring.boot.version", "4.1.0");
-        this.quarkusPlatformVersion = props.getProperty("quarkus.platform.version", "3.33.1");
-        this.camelMainSupported = props.getProperty("camel.main.supported", "4.21.0,4.18.3,4.14.7");
-        this.camelSpringbootSupported = props.getProperty("camel.springboot.supported", "4.21.0,4.18.3,4.14.7");
-        this.camelQuarkusSupported = props.getProperty("camel.quarkus.supported", "4.18.2,4.14.7");
-        this.citrusVersion = props.getProperty("citrus.version", DEFAULT_CITRUS_VERSION);
-        this.camelMcpVersion = props.getProperty("camel.mcp.version", "4.21.0");
-        this.knowledgeMcpVersion = props.getProperty("knowledge.mcp.version", "0.0.1-SNAPSHOT");
-        this.citrusMcpVersion = props.getProperty("citrus.mcp.version", DEFAULT_CITRUS_MCP_VERSION);
-        this.camelMcpRepos = props.getProperty("camel.mcp.repos",
-                "central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots");
-        this.knowledgeMcpRepos = props.getProperty("knowledge.mcp.repos", "central=https://repo1.maven.org/maven2/");
-        this.citrusMcpRepos = props.getProperty("citrus.mcp.repos", "central=https://repo1.maven.org/maven2/");
-        this.camelCatalogRepos = props.getProperty("camel.catalog.repos",
-                "https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots");
-        this.piVersion = props.getProperty("pi.version", DEFAULT_PI_VERSION);
+        this.camelMainVersion = configured(props, bundled, "camel.main.version");
+        this.camelSpringbootVersion = configured(props, bundled, "camel.springboot.version");
+        this.camelQuarkusVersion = configured(props, bundled, "camel.quarkus.version");
+        this.springbootBomVersion = configured(props, bundled, "springboot.bom.version");
+        this.springBootVersion = configured(props, bundled, "spring.boot.version");
+        this.quarkusPlatformVersion = configured(props, bundled, "quarkus.platform.version");
+        this.camelMainSupported = configured(props, bundled, "camel.main.supported");
+        this.camelSpringbootSupported = configured(props, bundled, "camel.springboot.supported");
+        this.camelQuarkusSupported = configured(props, bundled, "camel.quarkus.supported");
+        this.citrusVersion = configured(props, bundled, "citrus.version");
+        this.camelMcpVersion = configured(props, bundled, "camel.mcp.version");
+        this.knowledgeMcpVersion = configured(props, bundled, "knowledge.mcp.version");
+        this.citrusMcpVersion = configured(props, bundled, "citrus.mcp.version");
+        this.camelMcpRepos = configured(props, bundled, "camel.mcp.repos");
+        this.knowledgeMcpRepos = configured(props, bundled, "knowledge.mcp.repos");
+        this.citrusMcpRepos = configured(props, bundled, "citrus.mcp.repos");
+        this.camelCatalogRepos = configured(props, bundled, "camel.catalog.repos");
+        this.piVersion = configured(props, bundled, "pi.version");
+        requiredProperty(bundled, "pi.supported");
         this.piSupported = props.getProperty("pi.supported", this.piVersion);
-        this.nodeVersion = props.getProperty("node.version", DEFAULT_NODE_VERSION);
-        this.piMcpAdapterVersion = props.getProperty("pi.mcp.adapter.version", DEFAULT_PI_MCP_ADAPTER_VERSION);
+        this.nodeVersion = configured(props, bundled, "node.version");
+        this.piMcpAdapterVersion = configured(props, bundled, "pi.mcp.adapter.version");
+        this.forageCatalogArtifact = configured(props, bundled, "forage.catalog.artifact");
         this.overrideCount = overrideCount;
     }
 
@@ -110,7 +105,8 @@ public class DistributionConfig {
     private static DistributionConfig loadWithOverrides(
             Path configFile, List<String> cliProperties, Path defaultConfig, boolean strict) {
         // Layer 1: built-in defaults from classpath
-        Properties props = loadClasspathProperties();
+        Properties bundled = loadClasspathProperties();
+        Properties props = copyOf(bundled);
 
         // Layer 2: user config file (-c or default location)
         int overrides = 0;
@@ -158,27 +154,29 @@ public class DistributionConfig {
             }
         }
 
-        return new DistributionConfig(props, overrides);
+        return new DistributionConfig(props, bundled, overrides);
     }
 
     public static DistributionConfig load(InputStream in) {
+        Properties bundled = loadClasspathProperties();
         Properties props = new Properties();
         try {
             if (in != null) {
                 props.load(in);
             }
         } catch (Exception e) {
-            // Fall through with empty properties — defaults will apply
+            // Preserve the packaged baseline when an optional input cannot be applied.
         }
-        return new DistributionConfig(props, 0);
+        return new DistributionConfig(props, bundled, 0);
     }
 
     public static DistributionConfig load(Properties properties) {
+        Properties bundled = loadClasspathProperties();
         Properties props = new Properties();
         if (properties != null) {
             props.putAll(properties);
         }
-        return new DistributionConfig(props, 0);
+        return new DistributionConfig(props, bundled, 0);
     }
 
     public static DistributionConfig loadFromFile(Path path) {
@@ -190,9 +188,10 @@ public class DistributionConfig {
     }
 
     public static DistributionConfig loadFromFileWithClasspathBaseline(Path path) {
-        Properties props = loadClasspathProperties();
+        Properties bundled = loadClasspathProperties();
+        Properties props = copyOf(bundled);
         int overrides = applyFileOverrides(props, path);
-        return new DistributionConfig(props, overrides);
+        return new DistributionConfig(props, bundled, overrides);
     }
 
     public static DistributionConfig loadFromClasspathOrDefaults() {
@@ -201,19 +200,8 @@ public class DistributionConfig {
 
     /** Loads the packaged distribution baseline without user or CLI overrides. */
     public static DistributionConfig loadBundled() {
-        Properties props = new Properties();
-        try (InputStream in = DistributionConfig.class.getClassLoader()
-                .getResourceAsStream("distribution.properties")) {
-            if (in == null) {
-                throw new IllegalStateException(
-                        "Packaged distribution.properties is unavailable");
-            }
-            props.load(in);
-            return new DistributionConfig(props, 0);
-        } catch (java.io.IOException e) {
-            throw new IllegalStateException(
-                    "Packaged distribution.properties could not be loaded", e);
-        }
+        Properties bundled = loadClasspathProperties();
+        return new DistributionConfig(bundled, bundled, 0);
     }
 
     /**
@@ -234,7 +222,12 @@ public class DistributionConfig {
 
     /** Maven {@code groupId:artifactId} of the Forage catalog artifact. */
     public String forageCatalogArtifact() {
-        return rawProps.getProperty("forage.catalog.artifact", "io.kaoto.forage:forage-catalog");
+        return forageCatalogArtifact;
+    }
+
+    /** Returns all exact Camel → Forage stream mappings. */
+    public Map<String, String> forageVersionMappings() {
+        return mappings("forage.version.", null);
     }
 
     /**
@@ -242,15 +235,7 @@ public class DistributionConfig {
      * properties (excluding the default {@code quarkus.platform.version}).
      */
     public Map<String, String> quarkusPlatformMappings() {
-        Map<String, String> mappings = new LinkedHashMap<>();
-        rawProps.stringPropertyNames().stream()
-                .filter(key -> key.startsWith("quarkus.platform.") && !key.equals("quarkus.platform.version"))
-                .sorted(Comparator.comparing(key -> key.substring("quarkus.platform.".length())))
-                .forEach(key -> {
-                    String camelVersion = key.substring("quarkus.platform.".length());
-                    mappings.put(camelVersion, rawProps.getProperty(key));
-                });
-        return mappings;
+        return mappings("quarkus.platform.", "quarkus.platform.version");
     }
 
     /**
@@ -258,12 +243,16 @@ public class DistributionConfig {
      * properties (excluding the default {@code spring.boot.version}).
      */
     public Map<String, String> springBootMappings() {
+        return mappings("spring.boot.", "spring.boot.version");
+    }
+
+    private Map<String, String> mappings(String prefix, String excludedKey) {
         Map<String, String> mappings = new LinkedHashMap<>();
         rawProps.stringPropertyNames().stream()
-                .filter(key -> key.startsWith("spring.boot.") && !key.equals("spring.boot.version"))
-                .sorted(Comparator.comparing(key -> key.substring("spring.boot.".length())))
+                .filter(key -> key.startsWith(prefix) && (excludedKey == null || !key.equals(excludedKey)))
+                .sorted(Comparator.comparing(key -> key.substring(prefix.length())))
                 .forEach(key -> {
-                    String camelVersion = key.substring("spring.boot.".length());
+                    String camelVersion = key.substring(prefix.length());
                     mappings.put(camelVersion, rawProps.getProperty(key));
                 });
         return mappings;
@@ -273,12 +262,34 @@ public class DistributionConfig {
         Properties props = new Properties();
         try (InputStream in = DistributionConfig.class.getClassLoader()
                 .getResourceAsStream("distribution.properties")) {
-            if (in != null) {
-                props.load(in);
+            if (in == null) {
+                throw new IllegalStateException(
+                        "Packaged distribution.properties is unavailable");
             }
-        } catch (Exception ignored) {
+            props.load(in);
+            return props;
+        } catch (java.io.IOException | IllegalArgumentException e) {
+            throw new IllegalStateException(
+                    "Packaged distribution.properties could not be loaded", e);
         }
-        return props;
+    }
+
+    private static String requiredProperty(Properties properties, String key) {
+        String value = properties.getProperty(key);
+        if (value == null) {
+            throw new IllegalStateException("Required distribution property is unavailable: " + key);
+        }
+        return value;
+    }
+
+    private static String configured(Properties properties, Properties bundled, String key) {
+        return properties.getProperty(key, requiredProperty(bundled, key));
+    }
+
+    private static Properties copyOf(Properties source) {
+        Properties copy = new Properties();
+        copy.putAll(source);
+        return copy;
     }
 
     private static int applyFileOverrides(Properties props, Path path) {

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/McpConfigGenerator.java
@@ -45,27 +45,10 @@ class McpConfigGenerator {
 
     private Map<String, Object> templateData(DistributionConfig dist, WorkflowManifest workflow) throws IOException {
         Map<String, Object> data = new java.util.HashMap<>(
-                Map.of(
-                        "CAMEL_MCP_VERSION", dist.camelMcpVersion(),
-                        "KNOWLEDGE_VERSION", dist.knowledgeMcpVersion(),
-                        "CITRUS_MCP_VERSION", dist.citrusMcpVersion(),
-                        "CAMEL_MCP_REPOS", dist.camelMcpRepos(),
-                        "KNOWLEDGE_MCP_REPOS", dist.knowledgeMcpRepos(),
-                        "CITRUS_MCP_REPOS", dist.citrusMcpRepos(),
-                        "CAMEL_CATALOG_REPOS", dist.camelCatalogRepos()));
+                VersionPlaceholderResolver.buildVersionTemplateData(dist));
 
         WorkflowManifest.WorkflowMcpServer camelServer = workflow.mcpServer("camel");
         data.put("CAMEL_TOOLS_JSON", toJsonArray(camelServer.allowedTools()));
-        data.put("CAMEL_VERSION", dist.camelMainVersion());
-        data.put("CAMEL_MAIN_VERSION", dist.camelMainVersion());
-        data.put("CAMEL_SPRINGBOOT_VERSION", dist.camelSpringbootVersion());
-        data.put("CAMEL_QUARKUS_VERSION", dist.camelQuarkusVersion());
-        data.put("SPRINGBOOT_BOM_VERSION", dist.springbootBomVersion());
-        data.put("SPRING_BOOT_VERSION", dist.springBootVersion());
-        data.put("QUARKUS_PLATFORM_VERSION", dist.quarkusPlatformVersion());
-        data.put("CAMEL_MAIN_SUPPORTED", dist.camelMainSupported());
-        data.put("CAMEL_SPRINGBOOT_SUPPORTED", dist.camelSpringbootSupported());
-        data.put("CAMEL_QUARKUS_SUPPORTED", dist.camelQuarkusSupported());
 
         WorkflowManifest.WorkflowMcpServer knowledgeServer = workflow.mcpServer("camel-knowledge");
         data.put("KNOWLEDGE_TOOLS_JSON", toJsonArray(knowledgeServer.allowedTools()));

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/VersionPlaceholderResolver.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/generator/VersionPlaceholderResolver.java
@@ -48,7 +48,7 @@ class VersionPlaceholderResolver {
         Files.writeString(mdFile, rendered.toString());
     }
 
-    private static Map<String, String> buildVersionTemplateData(DistributionConfig dist) {
+    static Map<String, String> buildVersionTemplateData(DistributionConfig dist) {
         Map<String, String> data = new java.util.LinkedHashMap<>();
         data.put("CAMEL_VERSION", dist.camelMainVersion());
         data.put("CAMEL_MAIN_VERSION", dist.camelMainVersion());
@@ -60,22 +60,27 @@ class VersionPlaceholderResolver {
         data.put("CAMEL_MAIN_SUPPORTED", dist.camelMainSupported());
         data.put("CAMEL_SPRINGBOOT_SUPPORTED", dist.camelSpringbootSupported());
         data.put("CAMEL_QUARKUS_SUPPORTED", dist.camelQuarkusSupported());
+        data.put("CAMEL_MCP_VERSION", dist.camelMcpVersion());
+        data.put("KNOWLEDGE_VERSION", dist.knowledgeMcpVersion());
+        data.put("CITRUS_MCP_VERSION", dist.citrusMcpVersion());
+        data.put("CAMEL_MCP_REPOS", dist.camelMcpRepos());
+        data.put("KNOWLEDGE_MCP_REPOS", dist.knowledgeMcpRepos());
+        data.put("CITRUS_MCP_REPOS", dist.citrusMcpRepos());
+        data.put("CAMEL_CATALOG_REPOS", dist.camelCatalogRepos());
 
-        StringBuilder table = new StringBuilder();
-        for (var entry : dist.quarkusPlatformMappings().entrySet()) {
-            table.append("| ").append(entry.getKey())
-                    .append(" | ").append(entry.getValue())
-                    .append(" |\n");
-        }
-        data.put("QUARKUS_PLATFORM_TABLE", table.toString().stripTrailing());
-
-        table = new StringBuilder();
-        for (var entry : dist.springBootMappings().entrySet()) {
-            table.append("| ").append(entry.getKey())
-                    .append(" | ").append(entry.getValue())
-                    .append(" |\n");
-        }
-        data.put("SPRING_BOOT_VERSION_TABLE", table.toString().stripTrailing());
+        data.put("QUARKUS_PLATFORM_TABLE", mappingTable(dist.quarkusPlatformMappings()));
+        data.put("SPRING_BOOT_VERSION_TABLE", mappingTable(dist.springBootMappings()));
+        data.put("FORAGE_VERSION_TABLE", mappingTable(dist.forageVersionMappings()));
         return data;
+    }
+
+    private static String mappingTable(Map<String, String> mappings) {
+        StringBuilder table = new StringBuilder();
+        for (var entry : mappings.entrySet()) {
+            table.append("| ").append(entry.getKey())
+                    .append(" | ").append(entry.getValue())
+                    .append(" |\n");
+        }
+        return table.toString().stripTrailing();
     }
 }

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/service/InitService.java
@@ -369,8 +369,7 @@ public class InitService {
                 config.setProperty("project.platformBomVersion", distribution.camelMainVersion());
             }
         }
-        // forage.version must always track project.camelVersion — recomputed on every write,
-        // including the post-graph runtime rewrite (e.g. main 4.21.0/1.5.0 -> quarkus 4.18.2/1.3).
+        // forage.version must always track project.camelVersion, including after graph-based runtime rewrites.
         String forageVersion = distribution.forageVersionForCamel(config.getProperty("project.camelVersion"));
         if (forageVersion != null) {
             config.setProperty("forage.version", forageVersion);

--- a/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogExpressionInventory.java
+++ b/camel-kit-core/src/main/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogExpressionInventory.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import io.github.luigidemasi.camelkit.ship.expression.ShipExpressionPolicy;
 
-/** Exact Camel YAML selector inventory layered over Ship's bounded Simple expression gate. */
+/** Union of exact, reviewed Camel YAML selectors layered over Ship's bounded Simple expression gate. */
 public final class CatalogExpressionInventory {
 
     public static final String SIMPLE = "simple";
@@ -14,12 +14,12 @@ public final class CatalogExpressionInventory {
 
     private static final Set<String> YAML_ALIASES = Set.of(
             "constant", "csimple", "datasonnet", "exchangeProperty", "groovy", "header",
-            "hl7terser", "java", "joor", "jq", "js", "jsonpath", GENERIC, METHOD, "mvel",
+            "hl7terser", "jactl", "java", "joor", "jq", "js", "jsonpath", GENERIC, METHOD, "mvel",
             "ognl", "python", "ref", SIMPLE, "spel", "tokenize", "variable", "wasm", "xpath",
             "xquery", "xtokenize");
     private static final Set<String> CATALOG_LANGUAGES = Set.of(
             "bean", "constant", "csimple", "datasonnet", "exchangeProperty", "file", "groovy",
-            "header", "hl7terser", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
+            "header", "hl7terser", "jactl", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
             "python", "ref", SIMPLE, "spel", "tokenize", "variable", "wasm", "xpath", "xquery",
             "xtokenize");
 

--- a/camel-kit-core/src/main/resources/skills/camel-design/guides/security.md
+++ b/camel-kit-core/src/main/resources/skills/camel-design/guides/security.md
@@ -107,8 +107,9 @@ renew a renewable lease or obtain a replacement before it expires. PKI engines i
 period, so rotation requires reissuing and deploying a replacement certificate and key before expiry rather than
 renewing a secret lease. Static KV secrets change only when explicitly updated. Camel's HashiCorp refresh hook polls
 KV-v2 version metadata and reloads route/property-placeholder configuration; it does not manage dynamic-secret leases or
-PKI certificate reissuance. The hook is available in supported Camel 4.18.2, 4.18.3, and 4.21.0, but not 4.14.7. For
-Camel Main 4.18.3/4.21.0, a complete KV refresh setup includes the normal Vault connection settings plus:
+PKI certificate reissuance. The hook is available in the bundled Camel Main matrix ({CAMEL_MAIN_SUPPORTED}) and the
+default Camel Quarkus line ({CAMEL_QUARKUS_VERSION}), but not the retained Quarkus 4.14.7 compatibility row. For a
+supported Camel Main version, a complete KV refresh setup includes the normal Vault connection settings plus:
 
 ```properties
 camel.vault.hashicorp.refreshEnabled=true

--- a/camel-kit-core/src/main/resources/skills/shared/forage.md
+++ b/camel-kit-core/src/main/resources/skills/shared/forage.md
@@ -20,9 +20,7 @@ The installed distribution mapping is exact-key only:
 
 | `project.camelVersion` | required `forage.version` |
 |---|---|
-| `4.21.0` | `1.5.0` |
-| `4.18.3` | `1.3` |
-| `4.18.2` | `1.3` |
+{FORAGE_VERSION_TABLE}
 
 An unlisted Camel version has no Forage mapping. Do not infer a compatible stream from version ranges or catalog prose.
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -348,6 +348,16 @@ class DistributionConfigTest {
                 bundled.springBootMappings().get(bundled.camelSpringbootVersion()));
     }
 
+    @Test
+    void snapshotKnowledgeMcpUsesSnapshotRepository() {
+        DistributionConfig config = DistributionConfig.loadBundled();
+        assertTrue(
+                !config.knowledgeMcpVersion().endsWith("-SNAPSHOT")
+                        || config.knowledgeMcpRepos().contains(
+                                "central_snap=https://central.sonatype.com/repository/maven-snapshots/"),
+                "SNAPSHOT Knowledge MCP versions require the Central Portal snapshots repository");
+    }
+
     private static Properties bundledProperties() throws java.io.IOException {
         Properties properties = new Properties();
         try (InputStream input = DistributionConfigTest.class.getClassLoader()

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/config/DistributionConfigTest.java
@@ -25,90 +25,90 @@ import static org.junit.jupiter.api.Assertions.*;
 class DistributionConfigTest {
 
     @Test
-    void loadsPerPlatformVersions() {
-        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
-        DistributionConfig config = DistributionConfig.load(in);
+    void loadsPerPlatformVersions() throws Exception {
+        Properties properties = bundledProperties();
+        DistributionConfig config = DistributionConfig.loadBundled();
 
-        assertEquals("4.21.0", config.camelMainVersion());
-        assertEquals("4.21.0", config.camelSpringbootVersion());
-        assertEquals("4.18.2", config.camelQuarkusVersion());
-        assertEquals("4.21.0", config.springbootBomVersion());
-        assertEquals("4.1.0", config.springBootVersion());
-        assertEquals("3.33.1", config.quarkusPlatformVersion());
+        assertEquals(properties.getProperty("camel.main.version"), config.camelMainVersion());
+        assertEquals(properties.getProperty("camel.springboot.version"), config.camelSpringbootVersion());
+        assertEquals(properties.getProperty("camel.quarkus.version"), config.camelQuarkusVersion());
+        assertEquals(properties.getProperty("springboot.bom.version"), config.springbootBomVersion());
+        assertEquals(properties.getProperty("spring.boot.version"), config.springBootVersion());
+        assertEquals(properties.getProperty("quarkus.platform.version"), config.quarkusPlatformVersion());
     }
 
     @Test
-    void loadsSupportedVersions() {
-        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
-        DistributionConfig config = DistributionConfig.load(in);
+    void loadsSupportedVersions() throws Exception {
+        Properties properties = bundledProperties();
+        DistributionConfig config = DistributionConfig.loadBundled();
 
-        assertEquals("4.21.0,4.18.3,4.14.7", config.camelMainSupported());
-        assertEquals("4.21.0,4.18.3,4.14.7", config.camelSpringbootSupported());
-        assertEquals("4.18.2,4.14.7", config.camelQuarkusSupported());
+        assertEquals(properties.getProperty("camel.main.supported"), config.camelMainSupported());
+        assertEquals(properties.getProperty("camel.springboot.supported"), config.camelSpringbootSupported());
+        assertEquals(properties.getProperty("camel.quarkus.supported"), config.camelQuarkusSupported());
     }
 
     @Test
     void quarkusPlatformForVersionLookup() {
-        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
-        DistributionConfig config = DistributionConfig.load(in);
+        DistributionConfig config = DistributionConfig.loadBundled();
 
-        // Known mapping
-        assertEquals("3.33.1", config.quarkusPlatformForVersion("4.18.2"));
-        assertEquals("3.27.3", config.quarkusPlatformForVersion("4.14.7"));
-
-        // Unknown version falls back to default quarkus.platform.version
-        assertEquals("3.33.1", config.quarkusPlatformForVersion("9.99.99"));
+        config.quarkusPlatformMappings()
+                .forEach((camel, quarkus) -> assertEquals(quarkus, config.quarkusPlatformForVersion(camel)));
+        assertEquals(config.quarkusPlatformVersion(), config.quarkusPlatformForVersion("9.99.99"));
     }
 
     @Test
-    void quarkusPlatformMappingsReturnsExplicitEntries() {
-        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
-        DistributionConfig config = DistributionConfig.load(in);
+    void quarkusPlatformMappingsReturnsExplicitEntries() throws Exception {
+        Properties properties = bundledProperties();
+        DistributionConfig config = DistributionConfig.loadBundled();
 
         var mappings = config.quarkusPlatformMappings();
-        assertEquals("3.33.1", mappings.get("4.18.2"));
-        assertEquals("3.27.3", mappings.get("4.14.7"));
+        long expectedSize = properties.stringPropertyNames().stream()
+                .filter(key -> key.startsWith("quarkus.platform.") && !key.equals("quarkus.platform.version"))
+                .count();
+        assertEquals(expectedSize, mappings.size());
+        mappings.forEach(
+                (camel, quarkus) -> assertEquals(properties.getProperty("quarkus.platform." + camel), quarkus));
         assertFalse(mappings.containsKey("version"), "Default quarkus.platform.version must be excluded");
     }
 
     @Test
-    void springBootMappingsReturnsExplicitEntries() {
-        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
-        DistributionConfig config = DistributionConfig.load(in);
+    void springBootMappingsReturnsExplicitEntries() throws Exception {
+        Properties properties = bundledProperties();
+        DistributionConfig config = DistributionConfig.loadBundled();
 
         var mappings = config.springBootMappings();
-        assertEquals("4.1.0", mappings.get("4.21.0"));
-        assertEquals("3.5.16", mappings.get("4.18.3"));
-        assertEquals("3.5.12", mappings.get("4.14.7"));
+        long expectedSize = properties.stringPropertyNames().stream()
+                .filter(key -> key.startsWith("spring.boot.") && !key.equals("spring.boot.version"))
+                .count();
+        assertEquals(expectedSize, mappings.size());
+        mappings.forEach((camel, spring) -> assertEquals(properties.getProperty("spring.boot." + camel), spring));
         assertFalse(mappings.containsKey("version"), "Default spring.boot.version must be excluded");
     }
 
     @Test
-    void loadsMcpConfig() {
-        InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
-        DistributionConfig config = DistributionConfig.load(in);
+    void loadsMcpAndWorkerConfig() throws Exception {
+        Properties properties = bundledProperties();
+        DistributionConfig config = DistributionConfig.loadBundled();
 
-        assertEquals("4.21.0", config.camelMcpVersion());
-        assertEquals("0.0.1-SNAPSHOT", config.knowledgeMcpVersion());
-        assertEquals("5.0.0-M2", config.citrusVersion());
-        assertEquals("5.0.0-M1", config.citrusMcpVersion());
-        assertEquals("central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots",
-                config.camelMcpRepos());
-        assertEquals("central=https://repo1.maven.org/maven2/", config.knowledgeMcpRepos());
-        assertEquals("central=https://repo1.maven.org/maven2/", config.citrusMcpRepos());
-        assertEquals("https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots",
-                config.camelCatalogRepos());
-        assertEquals("0.84.2", config.piVersion());
-        assertEquals(List.of("0.84.2", "0.83.0"), config.piSupportedVersions());
-        assertEquals("22.22.2", config.nodeVersion());
-        assertEquals("2.11.0", config.piMcpAdapterVersion());
+        assertEquals(properties.getProperty("camel.mcp.version"), config.camelMcpVersion());
+        assertEquals(properties.getProperty("knowledge.mcp.version"), config.knowledgeMcpVersion());
+        assertEquals(properties.getProperty("citrus.version"), config.citrusVersion());
+        assertEquals(properties.getProperty("citrus.mcp.version"), config.citrusMcpVersion());
+        assertEquals(properties.getProperty("camel.mcp.repos"), config.camelMcpRepos());
+        assertEquals(properties.getProperty("knowledge.mcp.repos"), config.knowledgeMcpRepos());
+        assertEquals(properties.getProperty("citrus.mcp.repos"), config.citrusMcpRepos());
+        assertEquals(properties.getProperty("camel.catalog.repos"), config.camelCatalogRepos());
+        assertEquals(properties.getProperty("pi.version"), config.piVersion());
+        assertEquals(List.of(properties.getProperty("pi.supported").split(",")), config.piSupportedVersions());
+        assertEquals(properties.getProperty("node.version"), config.nodeVersion());
+        assertEquals(properties.getProperty("pi.mcp.adapter.version"), config.piMcpAdapterVersion());
     }
 
     @Test
     void camelMcpVersionCanBeOverriddenViaProperties() {
         InputStream in = getClass().getClassLoader().getResourceAsStream("distribution.properties");
         DistributionConfig baselineConfig = DistributionConfig.load(in);
-        assertEquals("4.21.0", baselineConfig.camelMcpVersion());
+        assertEquals(DistributionConfig.loadBundled().camelMcpVersion(), baselineConfig.camelMcpVersion());
 
         Properties properties = new Properties();
         properties.setProperty("camel.mcp.version", "9.9.9-TEST");
@@ -138,10 +138,11 @@ class DistributionConfigTest {
         Files.writeString(overrideFile, "camel.main.version=9.9.9\n");
 
         DistributionConfig config = DistributionConfig.loadFromFileWithClasspathBaseline(overrideFile);
+        DistributionConfig bundled = DistributionConfig.loadBundled();
 
         assertEquals("9.9.9", config.camelMainVersion());
-        assertEquals("4.21.0", config.camelSpringbootVersion());
-        assertEquals("4.21.0", config.camelMcpVersion());
+        assertEquals(bundled.camelSpringbootVersion(), config.camelSpringbootVersion());
+        assertEquals(bundled.camelMcpVersion(), config.camelMcpVersion());
     }
 
     @Test
@@ -152,7 +153,7 @@ class DistributionConfigTest {
         DistributionConfig config = DistributionConfig.load(properties);
 
         assertEquals("4.9.2", config.citrusVersion());
-        assertEquals("5.0.0-M1", config.citrusMcpVersion());
+        assertEquals(DistributionConfig.loadBundled().citrusMcpVersion(), config.citrusMcpVersion());
     }
 
     @Test
@@ -162,14 +163,15 @@ class DistributionConfigTest {
     }
 
     @Test
-    void bundledBaselineLoadsMaintainedWorkerVersionsWithoutOverrides() {
+    void bundledBaselineLoadsMaintainedWorkerVersionsWithoutOverrides() throws Exception {
+        Properties properties = bundledProperties();
         DistributionConfig config = DistributionConfig.loadBundled();
 
-        assertEquals("0.84.2", config.piVersion());
-        assertEquals(List.of("0.84.2", "0.83.0"), config.piSupportedVersions());
+        assertEquals(properties.getProperty("pi.version"), config.piVersion());
+        assertEquals(List.of(properties.getProperty("pi.supported").split(",")), config.piSupportedVersions());
         assertEquals(config.piVersion(), config.piSupportedVersions().get(0),
                 "the bundled primary pi.version must be the first pi.supported entry");
-        assertEquals("22.22.2", config.nodeVersion());
+        assertEquals(properties.getProperty("node.version"), config.nodeVersion());
         assertEquals(0, config.overrideCount());
     }
 
@@ -199,7 +201,7 @@ class DistributionConfigTest {
         assertEquals("", output.toString(StandardCharsets.UTF_8));
         assertEquals("9.9.9", config.camelMainVersion());
         assertEquals("4.9.0", config.citrusVersion());
-        assertEquals("4.21.0", config.camelSpringbootVersion());
+        assertEquals(DistributionConfig.loadBundled().camelSpringbootVersion(), config.camelSpringbootVersion());
         assertEquals("", config.knowledgeMcpVersion());
         assertEquals(5, config.overrideCount());
     }
@@ -232,7 +234,7 @@ class DistributionConfigTest {
     void strictDefaultConfigMayBeAbsentButNotMalformed(@TempDir Path tempDir) throws Exception {
         Path configFile = tempDir.resolve("config.properties");
 
-        assertEquals("4.21.0", DistributionConfig.loadWithOverridesStrict(
+        assertEquals(DistributionConfig.loadBundled().camelMainVersion(), DistributionConfig.loadWithOverridesStrict(
                 null, List.of(), configFile).camelMainVersion());
 
         Files.writeString(configFile, "camel.main.version=9.9.9\n");
@@ -274,7 +276,7 @@ class DistributionConfigTest {
             System.setErr(original);
         }
 
-        assertEquals("4.21.0", config.camelMainVersion());
+        assertEquals(DistributionConfig.loadBundled().camelMainVersion(), config.camelMainVersion());
         assertEquals(0, config.overrideCount());
         assertTrue(error.toString(StandardCharsets.UTF_8)
                 .contains("WARN: Failed to load config from " + malformed + ":"));
@@ -297,22 +299,62 @@ class DistributionConfigTest {
     @Test
     void forageVersionForCamelReturnsMappedStream() {
         Properties props = new Properties();
-        props.setProperty("forage.version.4.21.0", "1.5.0");
-        props.setProperty("forage.version.4.18.3", "1.3");
+        props.setProperty("forage.version.9.9.9", "9.1");
+        props.setProperty("forage.version.8.8.8", "8.1");
         DistributionConfig config = DistributionConfig.load(props);
-        assertEquals("1.5.0", config.forageVersionForCamel("4.21.0"));
-        assertEquals("1.3", config.forageVersionForCamel("4.18.3"));
+        assertEquals("9.1", config.forageVersionForCamel("9.9.9"));
+        assertEquals("8.1", config.forageVersionForCamel("8.8.8"));
+        assertEquals(List.of("8.8.8", "9.9.9"), List.copyOf(config.forageVersionMappings().keySet()));
     }
 
     @Test
     void forageVersionForCamelReturnsNullWhenUnmapped() {
         DistributionConfig config = DistributionConfig.load(new Properties());
-        assertNull(config.forageVersionForCamel("4.14.7"));
+        assertNull(config.forageVersionForCamel("9.9.9"));
     }
 
     @Test
-    void forageCatalogArtifactHasDefault() {
+    void forageCatalogArtifactComesFromBundledBaseline() {
         DistributionConfig config = DistributionConfig.load(new Properties());
-        assertEquals("io.kaoto.forage:forage-catalog", config.forageCatalogArtifact());
+        assertEquals(DistributionConfig.loadBundled().forageCatalogArtifact(), config.forageCatalogArtifact());
+    }
+
+    @Test
+    void partialLoadsUseBundledScalarDefaults() {
+        DistributionConfig bundled = DistributionConfig.loadBundled();
+
+        for (DistributionConfig partial : List.of(
+                DistributionConfig.load(new Properties()),
+                DistributionConfig.load((InputStream) null))) {
+            assertEquals(bundled.camelMainVersion(), partial.camelMainVersion());
+            assertEquals(bundled.camelSpringbootVersion(), partial.camelSpringbootVersion());
+            assertEquals(bundled.springbootBomVersion(), partial.springbootBomVersion());
+            assertEquals(bundled.camelMcpVersion(), partial.camelMcpVersion());
+            assertEquals(bundled.citrusVersion(), partial.citrusVersion());
+            assertEquals(bundled.nodeVersion(), partial.nodeVersion());
+            assertEquals(bundled.forageCatalogArtifact(), partial.forageCatalogArtifact());
+        }
+    }
+
+    @Test
+    void bundledRuntimeDefaultsAreInternallyConsistent() {
+        DistributionConfig bundled = DistributionConfig.loadBundled();
+
+        assertEquals(bundled.camelMainVersion(), bundled.camelMainSupported().split(",")[0]);
+        assertEquals(bundled.camelSpringbootVersion(), bundled.camelSpringbootSupported().split(",")[0]);
+        assertEquals(bundled.camelQuarkusVersion(), bundled.camelQuarkusSupported().split(",")[0]);
+        assertEquals(bundled.camelSpringbootVersion(), bundled.springbootBomVersion());
+        assertEquals(bundled.springBootVersion(),
+                bundled.springBootMappings().get(bundled.camelSpringbootVersion()));
+    }
+
+    private static Properties bundledProperties() throws java.io.IOException {
+        Properties properties = new Properties();
+        try (InputStream input = DistributionConfigTest.class.getClassLoader()
+                .getResourceAsStream("distribution.properties")) {
+            assertNotNull(input, "Missing packaged distribution.properties");
+            properties.load(input);
+        }
+        return properties;
     }
 }

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/DefaultGeneratorTest.java
@@ -253,7 +253,7 @@ class DefaultGeneratorTest {
         assertTrue(Files.exists(versionSelection));
         String content = Files.readString(versionSelection);
 
-        DistributionConfig dist = DistributionConfig.loadFromClasspathOrDefaults();
+        DistributionConfig dist = ctx.distribution();
         var quarkusMappings = dist.quarkusPlatformMappings();
         var springBootMappings = dist.springBootMappings();
         assertFalse(quarkusMappings.isEmpty(), "Expected explicit Quarkus platform mappings");
@@ -278,6 +278,43 @@ class DefaultGeneratorTest {
             assertTrue(content.contains(entry.getValue()),
                     "Spring Boot mapping for " + entry.getKey() + " should appear in table");
         }
+
+        String forage = Files.readString(ctx.skillsDir().resolve("shared/forage.md"));
+        assertFalse(forage.contains("{FORAGE_VERSION_TABLE}"),
+                "Forage table placeholder should be substituted");
+        for (var entry : dist.forageVersionMappings().entrySet()) {
+            assertTrue(forage.contains("| " + entry.getKey() + " | " + entry.getValue() + " |"),
+                    "Forage mapping for " + entry.getKey() + " should appear in table");
+        }
+
+        String mcpSetup = Files.readString(ctx.skillsDir().resolve("shared/mcp-setup.md"));
+        assertTrue(mcpSetup.contains(
+                "org.apache.camel:camel-jbang-mcp:" + dist.camelMcpVersion() + ":runner"));
+        assertTrue(mcpSetup.contains(dist.camelMcpRepos()));
+        assertTrue(mcpSetup.contains(dist.camelCatalogRepos()));
+        assertTrue(mcpSetup.contains(
+                "io.github.luigidemasi:camel-kit-knowledge-mcp:" + dist.knowledgeMcpVersion() + ":runner"));
+        assertTrue(mcpSetup.contains(
+                "org.citrusframework:citrus-mcp-server:" + dist.citrusMcpVersion() + ":runner"));
+        for (String placeholder : List.of(
+                "CAMEL_MCP_VERSION",
+                "CAMEL_MCP_REPOS",
+                "CAMEL_CATALOG_REPOS",
+                "KNOWLEDGE_VERSION",
+                "KNOWLEDGE_MCP_REPOS",
+                "CITRUS_MCP_VERSION",
+                "CITRUS_MCP_REPOS")) {
+            assertFalse(mcpSetup.contains("{" + placeholder + "}"),
+                    placeholder + " should be substituted in installed skills");
+        }
+        assertTrue(mcpSetup.contains("{project.camelVersion}"),
+                "Downstream workspace-property references must be preserved");
+
+        String security = Files.readString(ctx.skillsDir().resolve("camel-design/guides/security.md"));
+        assertTrue(security.contains(dist.camelMainSupported()));
+        assertTrue(security.contains(dist.camelQuarkusVersion()));
+        assertFalse(security.contains("{CAMEL_MAIN_SUPPORTED}"));
+        assertFalse(security.contains("{CAMEL_QUARKUS_VERSION}"));
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -8,7 +8,6 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,6 +17,7 @@ import java.util.stream.Stream;
 import io.github.luigidemasi.camelkit.config.AgentConfig;
 import io.github.luigidemasi.camelkit.config.AgentGeneratorStrategy;
 import io.github.luigidemasi.camelkit.config.AgentRegistry;
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.output.Printer;
 import io.github.luigidemasi.camelkit.workflow.WorkflowManifest;
 import io.github.luigidemasi.camelkit.workflow.WorkflowManifestLoader;
@@ -711,7 +711,9 @@ class ResourceConsistencyTest {
                 "PKI engines issue certificates with a validity period",
                 "polls KV-v2 version metadata",
                 "does not manage dynamic-secret leases",
-                "available in supported Camel 4.18.2, 4.18.3, and 4.21.0, but not 4.14.7",
+                "bundled Camel Main matrix ({CAMEL_MAIN_SUPPORTED})",
+                "default Camel Quarkus line ({CAMEL_QUARKUS_VERSION})",
+                "not the retained Quarkus 4.14.7 compatibility row",
                 "camel.vault.hashicorp.refreshEnabled=true",
                 "camel.main.context-reload-enabled=true",
                 "may be omitted only when every tracked value is referenced through a `hashicorp:` placeholder in the default `secret` mount",
@@ -1363,36 +1365,24 @@ class ResourceConsistencyTest {
     }
 
     @Test
-    void forageVersionTableExactlyMatchesDistributionProperties() throws IOException {
-        Path root = repositoryRoot();
-        Properties distribution = new Properties();
-        try (var reader = Files.newBufferedReader(root.resolve("distribution.properties"))) {
-            distribution.load(reader);
-        }
-
-        Set<String> expected = distribution.stringPropertyNames().stream()
-                .filter(name -> name.startsWith("forage.version."))
-                .map(name -> name + "=" + distribution.getProperty(name))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        String forage = Files.readString(root.resolve(
+    void forageVersionTableRemainsDistributionDriven() throws IOException {
+        String forage = Files.readString(repositoryRoot().resolve(
                 "camel-kit-core/src/main/resources/skills/shared/forage.md"));
-        String mappingTable = section(forage,
-                "The installed distribution mapping is exact-key only:",
-                "An unlisted Camel version has no Forage mapping");
-        Matcher rows = Pattern.compile("(?m)^\\| `([^`]+)` \\| `([^`]+)` \\|$").matcher(mappingTable);
-        Set<String> documented = new LinkedHashSet<>();
-        int documentedRows = 0;
-        while (rows.find()) {
-            if (!"project.camelVersion".equals(rows.group(1))) {
-                documentedRows++;
-                documented.add("forage.version." + rows.group(1) + "=" + rows.group(2));
-            }
-        }
 
-        assertEquals(expected, documented,
-                "The shipped Forage table must match every exact forage.version.* distribution mapping");
-        assertEquals(documented.size(), documentedRows, "The shipped Forage table must not contain duplicate mappings");
+        assertEquals(1, forage.lines().filter("{FORAGE_VERSION_TABLE}"::equals).count(),
+                "The Forage compatibility table must be rendered from distribution.properties");
+    }
+
+    @Test
+    void commandReferenceDefaultsMatchTheDistribution() throws IOException {
+        DistributionConfig distribution = DistributionConfig.loadBundled();
+        String commands = Files.readString(repositoryRoot().resolve("docs/commands.md"));
+
+        assertTrue(commands.contains("| `camel.main.version` | `" + distribution.camelMainVersion() + "` |"));
+        assertTrue(commands.contains(
+                "| `camel.springboot.version` | `" + distribution.camelSpringbootVersion() + "` |"));
+        assertTrue(commands.contains(
+                "| `springboot.bom.version` | `" + distribution.springbootBomVersion() + "` |"));
     }
 
     private static void assertKnowledgeTools(String agentName, String field, JsonNode allowlist) throws IOException {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/VersionPlaceholderResolverTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/VersionPlaceholderResolverTest.java
@@ -24,6 +24,11 @@ class VersionPlaceholderResolverTest {
                 {COMMAND_PREFIX} graph stats
                 Runtime property placeholder: {{CAMEL_VERSION}}
                 Version: {QUARKUS_PLATFORM_VERSION}
+                MCP: {CAMEL_MCP_VERSION}
+                Repositories: {CAMEL_MCP_REPOS}
+                Forage:
+                {FORAGE_VERSION_TABLE}
+                Selected Citrus: {CITRUS_VERSION}
                 """);
         new VersionPlaceholderResolver().substitute(mdFile);
 
@@ -33,8 +38,15 @@ class VersionPlaceholderResolverTest {
         assertTrue(result.contains("${quarkus.platform.version}"), "Maven property must be preserved");
         assertTrue(result.contains("{COMMAND_PREFIX} graph stats"), "Non-version placeholder must be preserved");
         assertTrue(result.contains("{{CAMEL_VERSION}}"), "Camel runtime property placeholder must be preserved");
+        assertTrue(result.contains("{CITRUS_VERSION}"), "Project-selected Citrus version must be preserved");
         assertTrue(result.contains(dist.quarkusPlatformVersion()), "Version placeholder must be resolved");
+        assertTrue(result.contains(dist.camelMcpVersion()), "MCP version placeholder must be resolved");
+        assertTrue(result.contains(dist.camelMcpRepos()), "MCP repository placeholder must be resolved");
+        for (var entry : dist.forageVersionMappings().entrySet()) {
+            assertTrue(result.contains("| " + entry.getKey() + " | " + entry.getValue() + " |"));
+        }
         assertFalse(result.contains("{QUARKUS_PLATFORM_VERSION}"), "Version placeholder must not remain");
+        assertFalse(result.contains("{FORAGE_VERSION_TABLE}"), "Forage table placeholder must not remain");
     }
 
     @Test

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/service/InitServiceTest.java
@@ -345,12 +345,13 @@ class InitServiceTest {
     void forageVersionMappedToDefaultCamelVersionIsWrittenToConfig() throws Exception {
         Path targetDir = tempDir.resolve("orders");
         Properties properties = new Properties();
-        properties.setProperty("forage.version.4.21.0", "1.5.0");
+        properties.setProperty("camel.main.version", "9.9.9");
+        properties.setProperty("forage.version.9.9.9", "9.1");
         DistributionConfig distribution = DistributionConfig.load(properties);
 
         // pre-seeded cache keeps the unit test offline (isCached short-circuits the download);
         // noFetch=false so the caching path actually runs and the offline guard below stays meaningful
-        Path forageCacheDir = targetDir.resolve(".camel-kit/.cache/forage/1.5.0");
+        Path forageCacheDir = targetDir.resolve(".camel-kit/.cache/forage/9.1");
         Files.createDirectories(forageCacheDir);
         Files.writeString(forageCacheDir.resolve("forage-catalog.json"), "{}");
         Files.writeString(forageCacheDir.resolve("forage-configuration-catalog.json"), "{}");
@@ -359,7 +360,7 @@ class InitServiceTest {
                 request(targetDir, "bob2", "default", distribution, false, InitProgress.noop(), InitReporter.noop()));
 
         String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
-        assertTrue(config.contains("forage.version=1.5.0"));
+        assertTrue(config.contains("forage.version=9.1"));
 
         // guard: if the cache short-circuit stopped working, the real download would overwrite
         // these dummy files with actual catalog JSON — asserting content stays "{}" proves no
@@ -372,14 +373,15 @@ class InitServiceTest {
     void noFetchSkipsForageCatalogCaching() throws Exception {
         Path targetDir = tempDir.resolve("orders");
         Properties properties = new Properties();
-        properties.setProperty("forage.version.4.21.0", "1.5.0");
+        properties.setProperty("camel.main.version", "9.9.9");
+        properties.setProperty("forage.version.9.9.9", "9.1");
         DistributionConfig distribution = DistributionConfig.load(properties);
 
         new InitService().initialize(
                 request(targetDir, "bob2", "default", distribution, InitProgress.noop(), InitReporter.noop()));
 
         String config = Files.readString(targetDir.resolve(".camel-kit/config.properties"));
-        assertTrue(config.contains("forage.version=1.5.0"), "version mapping is still written with --no-fetch");
+        assertTrue(config.contains("forage.version=9.1"), "version mapping is still written with --no-fetch");
         assertFalse(Files.exists(targetDir.resolve(".camel-kit/.cache/forage")),
                 "--no-fetch must not attempt any catalog download");
     }
@@ -404,8 +406,10 @@ class InitServiceTest {
                 </project>
                 """);
         Properties properties = new Properties();
-        properties.setProperty("forage.version.4.21.0", "1.5.0");
-        properties.setProperty("forage.version.4.18.2", "1.3");
+        properties.setProperty("camel.main.version", "9.9.9");
+        properties.setProperty("camel.quarkus.version", "8.8.8");
+        properties.setProperty("forage.version.9.9.9", "9.1");
+        properties.setProperty("forage.version.8.8.8", "8.1");
         DistributionConfig distribution = DistributionConfig.load(properties);
 
         new InitService().initialize(
@@ -416,7 +420,7 @@ class InitServiceTest {
             config.load(in);
         }
         assertEquals("quarkus", config.getProperty("project.runtime"));
-        assertEquals("1.3", config.getProperty("forage.version"),
+        assertEquals("8.1", config.getProperty("forage.version"),
                 "forage.version must track the runtime-detected Camel version, not the initial main default");
     }
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipExpressionPolicyConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/ShipExpressionPolicyConsistencyTest.java
@@ -45,12 +45,13 @@ class ShipExpressionPolicyConsistencyTest {
 
         assertEquals(certified, fieldNames(versions),
                 "A certified Camel version needs a reviewed expression inventory before it can ship");
+        Set<String> reviewedAliases = new TreeSet<>();
+        Set<String> reviewedLanguages = new TreeSet<>();
         for (String version : certified) {
             JsonNode inventory = versions.path(version);
             Map<String, String> aliases = textMap(inventory.path("yamlAliases"));
-            assertEquals(CatalogExpressionInventory.yamlAliases(), aliases.keySet(), version);
-            assertEquals(CatalogExpressionInventory.catalogLanguages(), textSet(inventory.path("catalogLanguages")),
-                    version);
+            reviewedAliases.addAll(aliases.keySet());
+            reviewedLanguages.addAll(textSet(inventory.path("catalogLanguages")));
             assertEquals(GENERIC_DEFINITION, aliases.get(CatalogExpressionInventory.GENERIC), version);
             assertEquals(SIMPLE_DEFINITION, aliases.get(CatalogExpressionInventory.SIMPLE), version);
             assertEquals(METHOD_DEFINITION, aliases.get(CatalogExpressionInventory.METHOD), version);
@@ -72,6 +73,10 @@ class ShipExpressionPolicyConsistencyTest {
             assertEquals(inventory.path("catalogLanguagesSha256").asText(),
                     digestLines(textSet(inventory.path("catalogLanguages"))), version);
         }
+        assertEquals(reviewedAliases, CatalogExpressionInventory.yamlAliases(),
+                "The production YAML classifier must equal the union of certified aliases");
+        assertEquals(reviewedLanguages, CatalogExpressionInventory.catalogLanguages(),
+                "The production language classifier must equal the union of certified catalogs");
     }
 
     @Test
@@ -86,6 +91,19 @@ class ShipExpressionPolicyConsistencyTest {
         assertSchemaInventory(JSON.readTree(schemaBytes), inventory);
         assertSchemaInventory(resourceJson("schema/camelYamlDsl-canonical.json"), inventory);
         assertEquals(version, resourceJson("yaml-dsl.json").path("other").path("version").asText());
+    }
+
+    @Test
+    void camel422JactlSelectorStaysVersionSpecific() throws Exception {
+        JsonNode versions = resourceJson(INVENTORY).path("versions");
+        JsonNode former = versions.path("4.18.4");
+        JsonNode current = versions.path("4.22.0");
+
+        assertFalse(former.path("yamlAliases").has("jactl"));
+        assertFalse(textSet(former.path("catalogLanguages")).contains("jactl"));
+        assertEquals("org.apache.camel.model.language.JactlExpression",
+                current.path("yamlAliases").path("jactl").asText());
+        assertTrue(textSet(current.path("catalogLanguages")).contains("jactl"));
     }
 
     private static void assertSchemaInventory(JsonNode schema, JsonNode inventory) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CamelYamlCatalogUsageExtractorTest.java
@@ -124,6 +124,16 @@ class CamelYamlCatalogUsageExtractorTest {
     }
 
     @Test
+    void camel422JactlAliasFailsClosedUnderTheSimpleOnlyPolicy() throws Exception {
+        Path route = expressionRoute("jactl: accepted-order");
+
+        IOException failure = assertThrows(IOException.class,
+                () -> extractor().extract(route, available()));
+
+        assertEquals("Ship v1 permits only the Simple expression language: jactl", failure.getMessage());
+    }
+
+    @Test
     void malformedAmbiguousAndUnsafeGenericExpressionsFailClosed() throws Exception {
         for (String expression : List.of(
                 "language: simple",
@@ -392,7 +402,7 @@ class CamelYamlCatalogUsageExtractorTest {
                 "- pollEnrich:\n    simple: kafka:orders",
                 "- recipientList:\n    simple: kafka:orders",
                 "- routingSlip:\n    simple: kafka:orders",
-                // serviceCall is an endpoint EIP in the certified Camel 4.18.3 schema only.
+                // serviceCall is an endpoint EIP in the certified Camel 4.18.4 schema only.
                 "- serviceCall: orders",
                 "- serviceCall:\n    name: orders\n    component: kafka")) {
             Path route = endpointStepRoute(endpointStep);

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTestVerifier.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/catalog/CatalogTestVerifier.java
@@ -7,10 +7,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.resolver.MavenCoordinate;
 import io.github.luigidemasi.camelkit.ship.resolver.ResolvedExactMavenArtifact;
@@ -19,7 +21,7 @@ import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver.Resolution
 /** Small exact catalog snapshot used by controller tests without a network resolver. */
 public final class CatalogTestVerifier {
 
-    public static final String CAMEL_VERSION = "4.21.0";
+    public static final String CAMEL_VERSION = DistributionConfig.loadBundled().camelMainVersion();
     public static final CatalogTarget TARGET = new CatalogTarget("main", CAMEL_VERSION, null, null);
 
     private CatalogTestVerifier() {
@@ -56,14 +58,14 @@ public final class CatalogTestVerifier {
         entries.put(root + "models.properties", "from\nroute\nto\n");
         entries.put(root + "dataformats.properties", "");
         entries.put(root + "languages.properties", "simple\n");
-        entries.put(root + "components/direct.json", """
+        entries.put(root + "components/direct.json", String.format(Locale.ROOT, """
                 {
                   "component": {
                     "kind": "component",
                     "name": "direct",
                     "groupId": "org.apache.camel",
                     "artifactId": "camel-direct",
-                    "version": "4.21.0",
+                    "version": "%s",
                     "deprecated": false,
                     "syntax": "direct:name",
                     "lenientProperties": false
@@ -80,7 +82,7 @@ public final class CatalogTestVerifier {
                     }
                   }
                 }
-                """);
+                """, CAMEL_VERSION));
         entries.put(root + "models/from.json", """
                 {"model":{"kind":"model","name":"from","deprecated":false}}
                 """);
@@ -90,10 +92,10 @@ public final class CatalogTestVerifier {
         entries.put(root + "models/to.json", """
                 {"model":{"kind":"model","name":"to","deprecated":false}}
                 """);
-        entries.put(root + "languages/simple.json", """
+        entries.put(root + "languages/simple.json", String.format(Locale.ROOT, """
                 {"language":{"kind":"language","name":"simple","groupId":"org.apache.camel",
-                "artifactId":"camel-core-languages","version":"4.21.0","deprecated":false}}
-                """);
+                "artifactId":"camel-core-languages","version":"%s","deprecated":false}}
+                """, CAMEL_VERSION));
 
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (ZipOutputStream zip = new ZipOutputStream(bytes)) {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipCoordinatorTest.java
@@ -791,7 +791,7 @@ class ShipCoordinatorTest {
                 controller,
                 worker,
                 target -> {
-                    assertEquals(CatalogTestVerifier.TARGET, target);
+                    assertEquals(snapshot.target(), target);
                     return snapshot;
                 },
                 new ShipMainValidator(evidence),

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidatorTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/controller/ShipMainValidatorTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.ship.ShipDigest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest;
 import io.github.luigidemasi.camelkit.ship.artifact.ArtifactManifest.DeclaredArtifact;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ShipMainValidatorTest {
 
     private static final String RUN_ID = "ship-" + "a".repeat(32);
+    private static final String CAMEL_VERSION = DistributionConfig.loadBundled().camelMainVersion();
     private static final String CITRUS_VERSION = "5.0.0-M2";
     private static final List<String> CITRUS_DEPENDENCIES
             = CitrusDependencyPolicy.required(CITRUS_VERSION);
@@ -103,7 +105,7 @@ class ShipMainValidatorTest {
                 .allMatch(tool -> tool.support() == Support.UNTESTED
                         && tool.message() != null));
         assertEquals(
-                "4.21.0",
+                CAMEL_VERSION,
                 result.stamp().toolVersions().get(3).version());
         assertEquals(List.of(
                 "artifact-policy",
@@ -214,10 +216,8 @@ class ShipMainValidatorTest {
         Project project = project("orders");
         Path pom = project.root().resolve("pom.xml");
         Files.writeString(pom, Files.readString(pom).replace(
-                """
-                            <dependency><groupId>org.apache.camel</groupId>
-                              <artifactId>camel-direct</artifactId><version>4.21.0</version></dependency>
-                        """, ""));
+                "<artifactId>camel-direct</artifactId>",
+                "<artifactId>camel-missing</artifactId>"));
         writeManifest(project.root(), project.routes(), project.tests());
         RecordingExecutor executor = new RecordingExecutor();
 
@@ -456,30 +456,30 @@ class ShipMainValidatorTest {
             tests.add(new TestArtifact(routeId, testPath, digest(root.resolve(testPath))));
             contracts.add(new RouteContract(routeId, routePath, testPath));
         }
-        write(root, ".camel-kit/config.properties", """
+        write(root, ".camel-kit/config.properties", String.format(Locale.ROOT, """
                 project.runtime=main
-                project.camelVersion=4.21.0
-                project.platformBomVersion=4.21.0
+                project.camelVersion=%s
+                project.platformBomVersion=%s
                 citrus.version=5.0.0-M2
-                """);
-        write(root, "pom.xml", """
+                """, CAMEL_VERSION, CAMEL_VERSION));
+        write(root, "pom.xml", String.format(Locale.ROOT, """
                 <project xmlns="http://maven.apache.org/POM/4.0.0">
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>example</groupId><artifactId>orders</artifactId><version>1.0.0</version>
                   <dependencies>
                     <dependency><groupId>org.apache.camel</groupId>
-                      <artifactId>camel-main</artifactId><version>4.21.0</version></dependency>
+                      <artifactId>camel-main</artifactId><version>%s</version></dependency>
                     <dependency><groupId>org.apache.camel</groupId>
-                      <artifactId>camel-yaml-dsl</artifactId><version>4.21.0</version></dependency>
+                      <artifactId>camel-yaml-dsl</artifactId><version>%s</version></dependency>
                     <dependency><groupId>org.apache.camel</groupId>
-                      <artifactId>camel-direct</artifactId><version>4.21.0</version></dependency>
+                      <artifactId>camel-direct</artifactId><version>%s</version></dependency>
                   </dependencies>
                 </project>
-                """);
+                """, CAMEL_VERSION, CAMEL_VERSION, CAMEL_VERSION));
         writeManifest(root, routes, tests);
         ArtifactPolicy policy = new ArtifactPolicy(
                 "main",
-                "4.21.0",
+                CAMEL_VERSION,
                 null,
                 null,
                 "yaml",
@@ -500,7 +500,7 @@ class ShipMainValidatorTest {
         ArtifactManifest manifest = new ArtifactManifest(
                 ArtifactManifest.SCHEMA_VERSION,
                 "main",
-                "4.21.0",
+                CAMEL_VERSION,
                 null,
                 null,
                 "yaml",

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/EvidenceRunnerTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.ship.security.ProjectEvidenceFiles;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.*;
 
 class EvidenceRunnerTest {
+
+    private static final String CAMEL_VERSION = DistributionConfig.loadBundled().camelMainVersion();
 
     @TempDir
     Path tempDir;
@@ -384,7 +387,7 @@ class EvidenceRunnerTest {
     }
 
     private EvidenceCommand command(Path project, String id, Duration timeout) throws Exception {
-        JvmPayloadRequest payload = JvmPayloadRequest.yamlValidator("4.21.0");
+        JvmPayloadRequest payload = JvmPayloadRequest.yamlValidator(CAMEL_VERSION);
         List<String> arguments = List.of(
                 EvidenceRunner.JAVA_EXECUTABLE, "-cp", JvmPayloadArchive.ARCHIVE_NAME,
                 ShipJvmPayloadBootstrap.class.getName(), "--launcher=" + payload.launcherClass());

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchiveTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadArchiveTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
+import io.github.luigidemasi.camelkit.config.DistributionConfig;
 import io.github.luigidemasi.camelkit.ship.ShipArtifactLimits;
 import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogExpressionInventory;
@@ -20,12 +21,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class JvmPayloadArchiveTest {
 
+    private static final String CAMEL_VERSION = DistributionConfig.loadBundled().camelMainVersion();
+
     @TempDir
     Path directory;
 
     @Test
     void writesAReproducibleArchive() throws Exception {
-        JvmPayloadRequest request = JvmPayloadRequest.camelMain("4.21.0");
+        JvmPayloadRequest request = JvmPayloadRequest.camelMain(CAMEL_VERSION);
         Path first = JvmPayloadTestFixture.create(
                 directory.resolve("first"), request);
         Path second = JvmPayloadTestFixture.create(
@@ -37,10 +40,10 @@ class JvmPayloadArchiveTest {
     @Test
     void isolatedLaunchersContainExactlyTheirApplicationOwnedDependencies() throws Exception {
         for (JvmPayloadRequest request : java.util.List.of(
-                JvmPayloadRequest.yamlValidator("4.21.0"),
-                JvmPayloadRequest.camelMain("4.21.0"),
+                JvmPayloadRequest.yamlValidator(CAMEL_VERSION),
+                JvmPayloadRequest.camelMain(CAMEL_VERSION),
                 JvmPayloadRequest.citrus(
-                        "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2")))) {
+                        CAMEL_VERSION, "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2")))) {
             Path archive = JvmPayloadTestFixture.create(
                     directory.resolve(request.kind().id()), request);
 

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadCompatibilityIT.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 
 import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
@@ -25,6 +26,8 @@ import io.github.luigidemasi.camelkit.ship.resolver.ShipMavenResolver;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,9 +36,6 @@ class JvmPayloadCompatibilityIT {
 
     private static final Duration PROCESS_TIMEOUT = Duration.ofMinutes(2);
     private static final int MAX_RETAINED_OUTPUT_BYTES = 8 * 1024 * 1024;
-    private static final Set<Row> FUNCTIONALLY_TESTED_ROWS = Set.of(
-            new Row("4.21.0", "5.0.0-M2"),
-            new Row("4.18.3", "5.0.0-M2"));
     private static final String RELOCATED_RESOLVER_CLASS
             = "io/github/luigidemasi/camelkit/ship/resolver/internal/org/eclipse/aether/RepositorySystem.class";
 
@@ -64,39 +64,56 @@ class JvmPayloadCompatibilityIT {
     }
 
     @Test
-    void explicitFunctionalRowsCoverTheEntirePackagedPolicy() throws Exception {
+    void validatorAndCitrusEvidenceCoverTheSameCamelVersions() throws Exception {
+        Properties policy = packagedPolicy();
+        Set<String> validatorVersions = csv(
+                policy.getProperty("ship.evidence.camel-yaml-validator.supported"));
+        Set<Row> citrusRows = packagedFunctionalRows(policy);
+
+        assertEquals(
+                citrusRows.stream().map(Row::camelVersion).collect(java.util.stream.Collectors.toSet()),
+                validatorVersions);
+    }
+
+    @ParameterizedTest(name = "Camel {0}")
+    @MethodSource("functionalRows")
+    void packagedPayloadsMaterializeAndRunTheirFunctionalEvidenceInIsolation(Row row) throws Exception {
+        requirePayloads(row.camelVersion(), row.citrusVersion());
+    }
+
+    static Stream<Row> functionalRows() throws Exception {
+        return packagedFunctionalRows(packagedPolicy()).stream()
+                .sorted(java.util.Comparator.comparing(Row::camelVersion).thenComparing(Row::citrusVersion));
+    }
+
+    private static Properties packagedPolicy() throws IOException {
         Properties policy = new Properties();
-        try (InputStream input = getClass().getClassLoader().getResourceAsStream("distribution.properties")) {
+        try (InputStream input = JvmPayloadCompatibilityIT.class.getClassLoader()
+                .getResourceAsStream("distribution.properties")) {
             assertNotNull(input, "Missing packaged distribution.properties");
             policy.load(input);
         }
-        Set<String> validatorVersions = Set.of(
-                policy.getProperty("ship.evidence.camel-yaml-validator.supported").split(","));
-        Set<Row> citrusRows = policy.stringPropertyNames().stream()
+        return policy;
+    }
+
+    private static Set<Row> packagedFunctionalRows(Properties policy) {
+        return policy.stringPropertyNames().stream()
                 .filter(key -> key.startsWith("ship.evidence.citrus."))
                 .filter(key -> key.endsWith(".camel.supported"))
                 .flatMap(key -> {
                     String citrusVersion = key.substring(
                             "ship.evidence.citrus.".length(), key.length() - ".camel.supported".length());
-                    return List.of(policy.getProperty(key).split(",")).stream()
-                            .map(camelVersion -> new Row(camelVersion.trim(), citrusVersion));
+                    return csv(policy.getProperty(key)).stream()
+                            .map(camelVersion -> new Row(camelVersion, citrusVersion));
                 })
                 .collect(java.util.stream.Collectors.toUnmodifiableSet());
-
-        assertEquals(FUNCTIONALLY_TESTED_ROWS, citrusRows);
-        assertEquals(
-                FUNCTIONALLY_TESTED_ROWS.stream().map(Row::camelVersion).collect(java.util.stream.Collectors.toSet()),
-                validatorVersions);
     }
 
-    @Test
-    void camel421PayloadsMaterializeAndRunTheirFunctionalEvidenceInIsolation() throws Exception {
-        requirePayloads("4.21.0", "5.0.0-M2");
-    }
-
-    @Test
-    void camel418PayloadsMaterializeAndRunTheirFunctionalEvidenceInIsolation() throws Exception {
-        requirePayloads("4.18.3", "5.0.0-M2");
+    private static Set<String> csv(String values) {
+        return Stream.of(values.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
     }
 
     private void requirePayloads(String camelVersion, String citrusVersion) throws Exception {

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadRequestTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/ship/evidence/JvmPayloadRequestTest.java
@@ -1,6 +1,9 @@
 package io.github.luigidemasi.camelkit.ship.evidence;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
+import java.util.Properties;
 
 import io.github.luigidemasi.camelkit.ship.artifact.CitrusDependencyPolicy;
 import io.github.luigidemasi.camelkit.ship.catalog.CatalogUsageRecord.RuntimeDependency;
@@ -13,28 +16,47 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class JvmPayloadRequestTest {
 
+    private static final Properties POLICY = packagedPolicy();
+    private static final String CAMEL_VERSION = required("camel.main.version");
+    private static final String SECONDARY_CAMEL_VERSION = List.of(
+            required("ship.evidence.camel-yaml-validator.supported").split(","))
+            .stream()
+            .map(String::trim)
+            .filter(version -> !CAMEL_VERSION.equals(version))
+            .findFirst()
+            .orElseThrow();
+    private static final String CITRUS_VERSION = required("citrus.version");
+
     @Test
     void selectsOnlyControllerOwnedDirectLaunchersAndExactRoots() {
-        JvmPayloadRequest validator = JvmPayloadRequest.yamlValidator("4.21.0");
-        JvmPayloadRequest main = JvmPayloadRequest.camelMain("4.21.0");
+        JvmPayloadRequest validator = JvmPayloadRequest.yamlValidator(CAMEL_VERSION);
+        JvmPayloadRequest main = JvmPayloadRequest.camelMain(CAMEL_VERSION);
         JvmPayloadRequest citrus = JvmPayloadRequest.citrus(
-                "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2"));
+                CAMEL_VERSION, CITRUS_VERSION, CitrusDependencyPolicy.required(CITRUS_VERSION));
 
         assertEquals(JvmPayloadRequest.Kind.CAMEL_YAML_VALIDATE, validator.kind());
         assertEquals(JvmPayloadRequest.Kind.CAMEL_MAIN_START, main.kind());
         assertEquals(JvmPayloadRequest.Kind.CITRUS_YAML, citrus.kind());
-        assertTrue(citrus.roots().contains("org.citrusframework:citrus-junit-jupiter:5.0.0-M2"));
-        assertTrue(citrus.roots().contains("org.citrusframework:citrus-yaml:5.0.0-M2"));
-        assertTrue(citrus.roots().contains("org.citrusframework:citrus-camel:5.0.0-M2"));
-        assertTrue(main.roots().contains("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.2"));
-        assertTrue(main.roots().contains("org.yaml:snakeyaml:2.4"));
-        assertTrue(validator.roots().contains("com.networknt:json-schema-validator:2.0.1"));
-        assertTrue(validator.roots().contains("com.ethlo.time:itu:1.14.0"));
-        assertTrue(validator.roots().contains("org.slf4j:slf4j-api:2.0.17"));
-        assertTrue(JvmPayloadRequest.yamlValidator("4.18.3").roots()
-                .contains("com.networknt:json-schema-validator:1.5.9"));
-        assertTrue(citrus.roots().contains("org.apache.camel:camel-core:4.21.0"));
-        assertTrue(citrus.roots().contains("org.apache.camel:camel-spring:4.21.0"));
+        assertTrue(citrus.roots().contains("org.citrusframework:citrus-junit-jupiter:" + CITRUS_VERSION));
+        assertTrue(citrus.roots().contains("org.citrusframework:citrus-yaml:" + CITRUS_VERSION));
+        assertTrue(citrus.roots().contains("org.citrusframework:citrus-camel:" + CITRUS_VERSION));
+        assertTrue(main.roots().contains("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:"
+                                         + required("ship.evidence.jackson-yaml.version")));
+        assertTrue(main.roots().contains("org.yaml:snakeyaml:" + required("ship.evidence.snakeyaml.version")));
+        assertTrue(validator.roots().contains("com.networknt:json-schema-validator:"
+                                              + required("ship.evidence.camel-yaml-validator." + CAMEL_VERSION
+                                                         + ".json-schema-validator.version")));
+        assertTrue(validator.roots().contains("com.ethlo.time:itu:"
+                                              + required("ship.evidence.camel-yaml-validator.networknt-itu.version")));
+        assertTrue(validator.roots().contains("org.slf4j:slf4j-api:"
+                                              + required(
+                                                      "ship.evidence.camel-yaml-validator.networknt-slf4j.version")));
+        assertTrue(JvmPayloadRequest.yamlValidator(SECONDARY_CAMEL_VERSION).roots()
+                .contains("com.networknt:json-schema-validator:"
+                          + required("ship.evidence.camel-yaml-validator." + SECONDARY_CAMEL_VERSION
+                                     + ".json-schema-validator.version")));
+        assertTrue(citrus.roots().contains("org.apache.camel:camel-core:" + CAMEL_VERSION));
+        assertTrue(citrus.roots().contains("org.apache.camel:camel-spring:" + CAMEL_VERSION));
         assertTrue(citrus.dependencyRoots().stream()
                 .filter(root -> "org.citrusframework".equals(root.groupId()))
                 .allMatch(root -> root.exclusions().equals(List.of(
@@ -48,13 +70,14 @@ class JvmPayloadRequestTest {
     @Test
     void refusesDependencyDriftAliasesSnapshotsAndDuplicateRoots() {
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.citrus(
-                "4.21.0", "5.0.0-M2", List.of(
-                        "org.citrusframework:citrus-camel:5.0.0-M2",
-                        "org.citrusframework:citrus-yaml:5.0.0-M2")));
+                CAMEL_VERSION, CITRUS_VERSION, List.of(
+                        "org.citrusframework:citrus-camel:" + CITRUS_VERSION,
+                        "org.citrusframework:citrus-yaml:" + CITRUS_VERSION)));
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.yamlValidator("LATEST"));
-        assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.yamlValidator("4.21.0-SNAPSHOT"));
+        assertThrows(IllegalArgumentException.class,
+                () -> JvmPayloadRequest.yamlValidator(CAMEL_VERSION + "-SNAPSHOT"));
         assertThrows(IllegalArgumentException.class, () -> new JvmPayloadRequest(
-                JvmPayloadRequest.Kind.CAMEL_MAIN_START, "4.21.0", null, "example.Launcher",
+                JvmPayloadRequest.Kind.CAMEL_MAIN_START, CAMEL_VERSION, null, "example.Launcher",
                 List.of(
                         new DependencyRoot("g", "a", "1", List.of()),
                         new DependencyRoot("g", "a", "1", List.of()))));
@@ -62,18 +85,18 @@ class JvmPayloadRequestTest {
 
     @Test
     void failsClosedBeforeResolutionOutsideThePackagedCompatibilityMatrix() {
-        assertDoesNotThrow(() -> JvmPayloadRequest.yamlValidator("4.21.0"));
-        assertDoesNotThrow(() -> JvmPayloadRequest.yamlValidator("4.18.3"));
+        assertDoesNotThrow(() -> JvmPayloadRequest.yamlValidator(CAMEL_VERSION));
+        assertDoesNotThrow(() -> JvmPayloadRequest.yamlValidator(SECONDARY_CAMEL_VERSION));
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.yamlValidator("4.14.7"));
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.camelMain("4.14.7"));
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.citrus(
-                "4.21.0", "4.9.2", CitrusDependencyPolicy.required("4.9.2")));
+                CAMEL_VERSION, "4.9.2", CitrusDependencyPolicy.required("4.9.2")));
     }
 
     @Test
     void refusesARequestThatChangesTheControllerOwnedExclusionPolicy() {
         JvmPayloadRequest citrus = JvmPayloadRequest.citrus(
-                "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2"));
+                CAMEL_VERSION, CITRUS_VERSION, CitrusDependencyPolicy.required(CITRUS_VERSION));
         List<DependencyRoot> changed = citrus.dependencyRoots().stream()
                 .map(root -> "citrus-camel".equals(root.artifactId())
                         ? new DependencyRoot(root.groupId(), root.artifactId(), root.version(), List.of())
@@ -87,20 +110,20 @@ class JvmPayloadRequestTest {
     @Test
     void authenticatedRuntimeRootsExtendMainAndCitrusPayloadsExactly() {
         List<RuntimeDependency> runtime = List.of(
-                new RuntimeDependency("org.apache.camel", "camel-main", "4.21.0", "compile"),
-                new RuntimeDependency("org.apache.camel", "camel-yaml-dsl", "4.21.0", "compile"),
-                new RuntimeDependency("org.apache.camel", "camel-direct", "4.21.0", "compile"),
-                new RuntimeDependency("org.apache.camel", "camel-csv", "4.21.0", "runtime"));
+                new RuntimeDependency("org.apache.camel", "camel-main", CAMEL_VERSION, "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-yaml-dsl", CAMEL_VERSION, "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-direct", CAMEL_VERSION, "compile"),
+                new RuntimeDependency("org.apache.camel", "camel-csv", CAMEL_VERSION, "runtime"));
 
-        JvmPayloadRequest fixed = JvmPayloadRequest.camelMain("4.21.0");
-        JvmPayloadRequest main = JvmPayloadRequest.camelMain("4.21.0", runtime);
+        JvmPayloadRequest fixed = JvmPayloadRequest.camelMain(CAMEL_VERSION);
+        JvmPayloadRequest main = JvmPayloadRequest.camelMain(CAMEL_VERSION, runtime);
         JvmPayloadRequest citrus = JvmPayloadRequest.citrus(
-                "4.21.0", "5.0.0-M2", CitrusDependencyPolicy.required("5.0.0-M2"), runtime);
+                CAMEL_VERSION, CITRUS_VERSION, CitrusDependencyPolicy.required(CITRUS_VERSION), runtime);
 
-        assertTrue(main.roots().contains("org.apache.camel:camel-csv:4.21.0"));
-        assertTrue(citrus.roots().contains("org.apache.camel:camel-csv:4.21.0"));
+        assertTrue(main.roots().contains("org.apache.camel:camel-csv:" + CAMEL_VERSION));
+        assertTrue(citrus.roots().contains("org.apache.camel:camel-csv:" + CAMEL_VERSION));
         assertEquals(1, main.roots().stream()
-                .filter("org.apache.camel:camel-direct:4.21.0"::equals).count());
+                .filter(("org.apache.camel:camel-direct:" + CAMEL_VERSION)::equals).count());
         assertNotEquals(fixed.digest(), main.digest());
         assertTrue(citrus.dependencyRoots().stream()
                 .filter(root -> "org.citrusframework".equals(root.groupId()))
@@ -111,17 +134,17 @@ class JvmPayloadRequestTest {
     @Test
     void runtimeRootsCannotConflictWithCoreOrIntroduceUnverifiedGroups() {
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.camelMain(
-                "4.21.0", List.of(new RuntimeDependency(
-                        "org.apache.camel", "camel-main", "4.20.0", "compile"))));
+                CAMEL_VERSION, List.of(new RuntimeDependency(
+                        "org.apache.camel", "camel-main", "9.9.8", "compile"))));
         assertThrows(IllegalArgumentException.class, () -> JvmPayloadRequest.camelMain(
-                "4.21.0", List.of(new RuntimeDependency(
+                CAMEL_VERSION, List.of(new RuntimeDependency(
                         "com.example", "unverified", "1.0.0", "compile"))));
     }
 
     @Test
     void springBootAndQuarkusBuildsFailClosedInsteadOfFallingBackToMaven() {
-        JvmPayloadRequest spring = JvmPayloadRequest.runtimeBuild("spring-boot", "4.21.0");
-        JvmPayloadRequest quarkus = JvmPayloadRequest.runtimeBuild("quarkus", "4.18.2");
+        JvmPayloadRequest spring = JvmPayloadRequest.runtimeBuild("spring-boot", CAMEL_VERSION);
+        JvmPayloadRequest quarkus = JvmPayloadRequest.runtimeBuild("quarkus", required("camel.quarkus.version"));
 
         assertFalse(spring.kind().supported());
         assertFalse(quarkus.kind().supported());
@@ -129,5 +152,27 @@ class JvmPayloadRequestTest {
         assertNull(quarkus.launcherClass());
         assertTrue(spring.roots().isEmpty());
         assertTrue(quarkus.roots().isEmpty());
+    }
+
+    private static Properties packagedPolicy() {
+        Properties properties = new Properties();
+        try (InputStream input = JvmPayloadRequestTest.class.getClassLoader()
+                .getResourceAsStream("distribution.properties")) {
+            if (input == null) {
+                throw new IllegalStateException("Missing packaged distribution.properties");
+            }
+            properties.load(input);
+            return properties;
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read packaged distribution.properties", e);
+        }
+    }
+
+    private static String required(String key) {
+        String value = POLICY.getProperty(key);
+        if (value == null) {
+            throw new IllegalStateException("Missing packaged distribution property " + key);
+        }
+        return value;
     }
 }

--- a/camel-kit-core/src/test/resources/ship/expression-policy/catalog-yaml-inventory.json
+++ b/camel-kit-core/src/test/resources/ship/expression-policy/catalog-yaml-inventory.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
   "versions": {
-    "4.18.3": {
-      "yamlSchemaArtifact": "org.apache.camel:camel-yaml-dsl:4.18.3!/schema/camelYamlDsl.json",
+    "4.18.4": {
+      "yamlSchemaArtifact": "org.apache.camel:camel-yaml-dsl:4.18.4!/schema/camelYamlDsl.json",
       "yamlSchemaSha256": "sha256:5d86a18895db53b84e56924e1f39391afa796e11c033de9c3c7a730f702ec627",
-      "catalogLanguagesArtifact": "org.apache.camel:camel-catalog:4.18.3!/org/apache/camel/catalog/languages.properties",
+      "catalogLanguagesArtifact": "org.apache.camel:camel-catalog:4.18.4!/org/apache/camel/catalog/languages.properties",
       "catalogLanguagesSha256": "sha256:b5a2a2ad2234cd73abe350766130fd9f00154f59f7b9adf5062d34eba83a173d",
       "yamlAliases": {
         "constant": "org.apache.camel.model.language.ConstantExpression",
@@ -52,11 +52,11 @@
         "properties": ["beanType", "id", "method", "ref", "resultType", "scope", "trim", "validate"]
       }
     },
-    "4.21.0": {
-      "yamlSchemaArtifact": "org.apache.camel:camel-yaml-dsl:4.21.0!/schema/camelYamlDsl.json",
-      "yamlSchemaSha256": "sha256:76bd2fdd99098009b0c6c23b287c8e89095b79fccebb8b10570cc65db4ebafd0",
-      "catalogLanguagesArtifact": "org.apache.camel:camel-catalog:4.21.0!/org/apache/camel/catalog/languages.properties",
-      "catalogLanguagesSha256": "sha256:b5a2a2ad2234cd73abe350766130fd9f00154f59f7b9adf5062d34eba83a173d",
+    "4.22.0": {
+      "yamlSchemaArtifact": "org.apache.camel:camel-yaml-dsl:4.22.0!/schema/camelYamlDsl.json",
+      "yamlSchemaSha256": "sha256:6d21bc328f53168db47a51b31241da891f2d194849a0c06544f50dc67ea35186",
+      "catalogLanguagesArtifact": "org.apache.camel:camel-catalog:4.22.0!/org/apache/camel/catalog/languages.properties",
+      "catalogLanguagesSha256": "sha256:1ccbc99ba3d86c86b726e64be14aa6294a4643fca78479e12bb1cf7dde5d1da9",
       "yamlAliases": {
         "constant": "org.apache.camel.model.language.ConstantExpression",
         "csimple": "org.apache.camel.model.language.CSimpleExpression",
@@ -65,6 +65,7 @@
         "groovy": "org.apache.camel.model.language.GroovyExpression",
         "header": "org.apache.camel.model.language.HeaderExpression",
         "hl7terser": "org.apache.camel.model.language.Hl7TerserExpression",
+        "jactl": "org.apache.camel.model.language.JactlExpression",
         "java": "org.apache.camel.model.language.JavaExpression",
         "joor": "org.apache.camel.model.language.JoorExpression",
         "jq": "org.apache.camel.model.language.JqExpression",
@@ -87,7 +88,7 @@
       },
       "catalogLanguages": [
         "bean", "constant", "csimple", "datasonnet", "exchangeProperty", "file", "groovy",
-        "header", "hl7terser", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
+        "header", "hl7terser", "jactl", "java", "joor", "jq", "js", "jsonpath", "mvel", "ognl",
         "python", "ref", "simple", "spel", "tokenize", "variable", "wasm", "xpath",
         "xquery", "xtokenize"
       ],

--- a/distribution.properties
+++ b/distribution.properties
@@ -11,11 +11,11 @@
 # differ. Quarkus typically lags behind the main Camel release.
 
 # Main / JBang runtime
-camel.main.version=4.21.0
+camel.main.version=4.22.0
 
 # Spring Boot runtime
-camel.springboot.version=4.21.0
-springboot.bom.version=4.21.0
+camel.springboot.version=4.22.0
+springboot.bom.version=4.22.0
 spring.boot.version=4.1.0
 
 # Quarkus runtime
@@ -26,8 +26,8 @@ quarkus.platform.version=3.33.1
 #
 # Comma-separated list of supported Camel versions per runtime.
 # Shown to the user during /camel-design version selection.
-camel.main.supported=4.21.0,4.18.3,4.14.7
-camel.springboot.supported=4.21.0,4.18.3,4.14.7
+camel.main.supported=4.22.0,4.18.4
+camel.springboot.supported=4.22.0,4.18.4
 camel.quarkus.supported=4.18.2,4.14.7
 
 # ─── Quarkus Platform BOM Mapping ──────────────────────────────────────────
@@ -40,12 +40,11 @@ quarkus.platform.4.14.7=3.27.3
 #
 # Maps each supported Camel Spring Boot version to the Spring Boot framework
 # version used by the Spring Boot Maven plugin.
-spring.boot.4.21.0=4.1.0
-spring.boot.4.18.3=3.5.16
-spring.boot.4.14.7=3.5.12
+spring.boot.4.22.0=4.1.0
+spring.boot.4.18.4=3.5.16
 
 # ─── MCP Server Versions ───────────────────────────────────────────────────
-camel.mcp.version=4.21.0
+camel.mcp.version=4.22.0
 knowledge.mcp.version=0.0.1-SNAPSHOT
 citrus.version=5.0.0-M2
 # Temporary compatibility pin for #147; revisit after the upstream M2 startup incompatibility is fixed.
@@ -63,23 +62,23 @@ slf4j.version=1.7.36
 json.schema.validator.version=2.0.4
 
 # Content-locked JVM payload compatibility. Rows are exact and fail closed;
-# 4.14.x remains excluded until its Simple/runtime edge cases are resolved.
-ship.evidence.camel-yaml-validator.supported=4.21.0,4.18.3
-ship.evidence.camel-yaml-validator.4.21.0.json-schema-validator.version=2.0.1
-ship.evidence.camel-yaml-validator.4.18.3.json-schema-validator.version=1.5.9
+# Main/Spring Boot support is limited to current upstream LTS lines.
+ship.evidence.camel-yaml-validator.supported=4.22.0,4.18.4
+ship.evidence.camel-yaml-validator.4.22.0.json-schema-validator.version=2.0.1
+ship.evidence.camel-yaml-validator.4.18.4.json-schema-validator.version=1.5.9
 ship.evidence.camel-yaml-validator.networknt-itu.version=1.14.0
 ship.evidence.camel-yaml-validator.networknt-slf4j.version=2.0.17
-ship.evidence.citrus.5.0.0-M2.camel.supported=4.21.0,4.18.3
+ship.evidence.citrus.5.0.0-M2.camel.supported=4.22.0,4.18.4
 ship.evidence.jackson-yaml.version=2.19.2
 ship.evidence.snakeyaml.version=2.4
 
 # ─── Forage (KaotoIO) ────────────────────────────────────────────────────────
 #
-# Camel → Forage stream mapping. Forage 1.3 tracks Camel LTS 4.18.x;
-# 1.5.x tracks Camel 4.20+. Camel versions with no mapping (e.g. 4.14.x)
+# Camel → Forage stream mapping. Rows are verified against published
+# Forage runtime metadata. Camel versions with no mapping (e.g. 4.14.x)
 # get no Forage support — skills fall back to component properties / beans.
-forage.version.4.21.0=1.5.0
-forage.version.4.18.3=1.3
+forage.version.4.22.0=1.6.0
+forage.version.4.18.4=1.4.1
 forage.version.4.18.2=1.3
 forage.catalog.artifact=io.kaoto.forage:forage-catalog
 

--- a/distribution.properties
+++ b/distribution.properties
@@ -92,7 +92,7 @@ node.version=22.22.2
 pi.mcp.adapter.version=2.11.0
 
 # ─── MCP Repos ─────────────────────────────────────────────────────────────
-camel.mcp.repos=central=https://repo1.maven.org/maven2/,apache_snap=https://repository.apache.org/snapshots
-knowledge.mcp.repos=central=https://repo1.maven.org/maven2/
+camel.mcp.repos=central=https://repo1.maven.org/maven2/,apache=https://repository.apache.org/content/groups/public/,apache_snap=https://repository.apache.org/content/groups/snapshots/,central_snap=https://central.sonatype.com/repository/maven-snapshots/
+knowledge.mcp.repos=central=https://repo1.maven.org/maven2/,central_snap=https://central.sonatype.com/repository/maven-snapshots/
 citrus.mcp.repos=central=https://repo1.maven.org/maven2/
 camel.catalog.repos=https://repo1.maven.org/maven2/,https://repository.apache.org/snapshots

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,7 +57,7 @@ camel kit init --here [options]
 | `--citrus-version` | `5.0.0-M2` | Citrus Framework version for test schemas and generated test dependencies |
 | `--here` | `false` | Initialize in current directory |
 | `--no-fetch` | `false` | Skip external catalog fetching |
-| `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.main.version=4.18.3"` |
+| `-p`, `--property` | -- | Override a config property (repeatable). Example: `-p "camel.main.version=4.18.4"` |
 | `-c`, `--config` | `~/.camel-kit/config.properties` | Path to a custom config properties file |
 | `--source-platform` | `auto` | Source platform for migration: `mulesoft`, `camel`, `biztalk`, `auto` |
 | `--force` | `false` | Overwrite existing project without prompting (skips overwrite detection) |
@@ -102,7 +102,7 @@ camel-kit init my-integration --ai opencode
 camel-kit init --here
 
 # Override config properties via CLI
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.4"
 
 # Override multiple properties
 camel-kit init my-integration --ai claude -p "camel.quarkus.version=4.18.2" -p "quarkus.platform.version=3.33.1"
@@ -174,9 +174,9 @@ Any property from `distribution.properties` can be overridden at layers 2 or 3. 
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `camel.main.version` | `4.21.0` | Apache Camel version for Camel Main / JBang projects |
-| `camel.springboot.version` | `4.21.0` | Apache Camel version for Spring Boot projects |
-| `springboot.bom.version` | `4.21.0` | Spring Boot BOM version |
+| `camel.main.version` | `4.22.0` | Apache Camel version for Camel Main / JBang projects |
+| `camel.springboot.version` | `4.22.0` | Apache Camel version for Spring Boot projects |
+| `springboot.bom.version` | `4.22.0` | Spring Boot BOM version |
 | `camel.quarkus.version` | `4.18.2` | Apache Camel version for Quarkus projects |
 | `quarkus.platform.version` | `3.33.1` | Quarkus platform BOM version |
 | `camel.mcp.version` | See `distribution.properties` | Camel MCP server version |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -166,13 +166,13 @@ All defaults (Camel version, BOM versions, MCP server versions) are read from a 
 
 **Per-invocation overrides** (highest priority):
 ```bash
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.4"
 ```
 
 **Persistent user config** (applies to all invocations):
 Create `~/.camel-kit/config.properties` with your overrides:
 ```properties
-camel.main.version=4.18.3
+camel.main.version=4.18.4
 camel.quarkus.version=4.18.2
 quarkus.platform.version=3.33.1
 ```

--- a/examples/order-processing/README.md
+++ b/examples/order-processing/README.md
@@ -17,7 +17,7 @@ camel-kit init my-integration --ai opencode   # OpenCode
 You can also override configuration at init time:
 ```bash
 # With custom Camel version
-camel-kit init my-integration --ai claude -p "camel.main.version=4.18.3"
+camel-kit init my-integration --ai claude -p "camel.main.version=4.18.4"
 
 # With custom config file
 camel-kit init my-integration --ai claude -c team-config.properties

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
              distribution.properties is the packaged runtime source of truth.
              These literals must also exist here because Maven builds its model
              and resolves dependency/plugin versions before a lifecycle plugin
-             can read that file. DistributionVersionMirrorTest prevents drift. -->
+             can read that file. Run tools/sync_distribution_mirrors.py after
+             changing the source; DistributionVersionMirrorTest prevents drift. -->
         <camel.main.version>4.21.0</camel.main.version>
-        <camel.mcp.version>4.21.0</camel.mcp.version>
         <ship.evidence.jackson-yaml.version>2.19.2</ship.evidence.jackson-yaml.version>
         <maven.resolver.version>1.9.27</maven.resolver.version>
         <maven.provider.version>3.9.12</maven.provider.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
              and resolves dependency/plugin versions before a lifecycle plugin
              can read that file. Run tools/sync_distribution_mirrors.py after
              changing the source; DistributionVersionMirrorTest prevents drift. -->
-        <camel.main.version>4.21.0</camel.main.version>
+        <camel.main.version>4.22.0</camel.main.version>
         <ship.evidence.jackson-yaml.version>2.19.2</ship.evidence.jackson-yaml.version>
         <maven.resolver.version>1.9.27</maven.resolver.version>
         <maven.provider.version>3.9.12</maven.provider.version>

--- a/tools/sync_distribution_mirrors.py
+++ b/tools/sync_distribution_mirrors.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Synchronize Maven model-time mirrors from distribution.properties."""
+
+import argparse
+import os
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BEGIN_MARKER = "<!-- BEGIN distribution property mirrors"
+END_MARKER = "<!-- END distribution property mirrors -->"
+MIRROR = re.compile(
+    r"(?m)^(?P<indent>[ \t]*)<(?P<key>[A-Za-z][A-Za-z0-9_.-]*)>"
+    r"(?P<value>[^<\r\n]*)</(?P=key)>(?P<trailing>[ \t]*)$"
+)
+
+
+def load_properties(path):
+    values = {}
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", "!")):
+            continue
+        key, separator, value = stripped.partition("=")
+        if not separator or not key:
+            raise ValueError(f"{path}:{line_number}: expected key=value")
+        if key in values:
+            raise ValueError(f"{path}:{line_number}: duplicate property {key}")
+        values[key] = value.strip()
+    return values
+
+
+def synchronized_pom(root):
+    distribution_path = root / "distribution.properties"
+    pom_path = root / "pom.xml"
+    properties = load_properties(distribution_path)
+    pom = pom_path.read_text(encoding="utf-8")
+
+    if pom.count(BEGIN_MARKER) != 1 or pom.count(END_MARKER) != 1:
+        raise ValueError(f"{pom_path}: expected one marked distribution property mirror block")
+    begin = pom.index(BEGIN_MARKER)
+    block_start = pom.index("-->", begin) + 3
+    block_end = pom.index(END_MARKER, block_start)
+    block = pom[block_start:block_end]
+    matches = list(MIRROR.finditer(block))
+    if not matches or MIRROR.sub("", block).strip():
+        raise ValueError(f"{pom_path}: mirror block must contain only literal Maven properties")
+
+    seen = set()
+    changed = []
+    for match in matches:
+        key = match.group("key")
+        if key in seen:
+            raise ValueError(f"{pom_path}: duplicate mirror {key}")
+        seen.add(key)
+        if key not in properties:
+            raise ValueError(f"{distribution_path}: missing mirrored property {key}")
+        if match.group("value") != escape(properties[key]):
+            changed.append(key)
+
+    def replacement(match):
+        key = match.group("key")
+        return (
+            f'{match.group("indent")}<{key}>{escape(properties[key])}</{key}>'
+            f'{match.group("trailing")}'
+        )
+
+    updated_block = MIRROR.sub(replacement, block)
+    return pom_path, pom[:block_start] + updated_block + pom[block_end:], changed
+
+
+def atomic_write(path, content):
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as temporary:
+            temporary.write(content)
+        os.chmod(temporary_name, stat.S_IMODE(path.stat().st_mode))
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def synchronize(root=ROOT, write=True):
+    pom_path, content, changed = synchronized_pom(root)
+    if changed and write:
+        atomic_write(pom_path, content)
+    return changed
+
+
+def main(argv=None, root=ROOT):
+    parser = argparse.ArgumentParser(
+        description="Synchronize marked root-POM properties from distribution.properties."
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="report stale mirrors without changing pom.xml"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        changed = synchronize(root, write=not args.check)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if not changed:
+        print("Maven distribution property mirrors are synchronized.")
+        return 0
+    names = ", ".join(changed)
+    if args.check:
+        print(
+            f"Maven distribution property mirrors are stale: {names}. "
+            "Run ./tools/sync_distribution_mirrors.py.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Synchronized Maven distribution property mirrors: {names}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_sync_distribution_mirrors.py
+++ b/tools/test_sync_distribution_mirrors.py
@@ -1,0 +1,60 @@
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sync_distribution_mirrors as mirrors
+
+
+class SyncDistributionMirrorsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        (self.root / "distribution.properties").write_text(
+            "camel.main.version=4.22.0\nresolver.version=2.0.0\n", encoding="utf-8"
+        )
+        self.original_pom = """<project>
+  <properties>
+    <!-- BEGIN distribution property mirrors
+         distribution.properties is authoritative. -->
+    <camel.main.version>4.21.0</camel.main.version>
+    <resolver.version>2.0.0</resolver.version>
+    <!-- END distribution property mirrors -->
+  </properties>
+</project>
+"""
+        (self.root / "pom.xml").write_text(self.original_pom, encoding="utf-8")
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def test_synchronizes_all_marked_properties_idempotently(self):
+        self.assertEqual(["camel.main.version"], mirrors.synchronize(self.root))
+        updated = (self.root / "pom.xml").read_text(encoding="utf-8")
+        self.assertIn("<camel.main.version>4.22.0</camel.main.version>", updated)
+        self.assertEqual([], mirrors.synchronize(self.root))
+        self.assertEqual(updated, (self.root / "pom.xml").read_text(encoding="utf-8"))
+
+    def test_check_reports_drift_without_writing(self):
+        errors = io.StringIO()
+        with contextlib.redirect_stderr(errors):
+            result = mirrors.main(["--check"], self.root)
+        self.assertEqual(1, result)
+        self.assertIn("camel.main.version", errors.getvalue())
+        self.assertEqual(self.original_pom, (self.root / "pom.xml").read_text(encoding="utf-8"))
+
+    def test_rejects_a_mirror_without_an_authoritative_property(self):
+        (self.root / "distribution.properties").write_text(
+            "camel.main.version=4.22.0\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(ValueError, "missing mirrored property resolver.version"):
+            mirrors.synchronize(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make `distribution.properties` the authoritative source for runtime defaults, supported-version lists, generated MCP configuration, shipped version guidance, Forage tables, and policy-dependent certification rows
- add an idempotent sync/check helper for the one Maven model-time version mirror that cannot be loaded from the properties file
- move Camel Main, Spring Boot, and Camel MCP to `4.22.0`, retain `4.18.4` as the other supported LTS line, and leave the independent Quarkus matrix unchanged
- certify exact Ship evidence for both supported rows and classify Camel 4.22's `jactl` selector so Ship v1 rejects it under the existing Simple-only policy
- update core documentation, examples, generated-output coverage, and the unreleased changelog

Part of #209. This intentionally does not close the issue: the companion website update and Camel 4.22 knowledge index are release/closure gates.

## Verification

- `./mvnw -B clean install`
- `./mvnw -B -V -Plinux-ship-certification -Dformat.skip=true clean install`
  - packaged compatibility integration tests: 3 passed
  - authenticated `ShipCoordinatorLiveIT`: skipped because no live Pi credential was configured
- `./mvnw -B -Psourcecheck validate`
- `./tools/sync_distribution_mirrors.py --check`
- `python3 tools/test_sync_distribution_mirrors.py`
- generated Camel Main and Spring Boot smoke projects both built successfully
  - Main resolved `org.apache.camel:camel-main:4.22.0`
  - Spring Boot resolved `org.apache.camel.springboot:camel-spring-boot-starter:4.22.0` and `org.springframework.boot:spring-boot-starter:4.1.0`
- generated MCP configuration launched `org.apache.camel:camel-jbang-mcp:4.22.0:runner`; `camel_catalog_components` returned `camelVersion=4.22.0`
- direct Camel catalog probe returned `org.apache.camel:camel-timer:4.22.0`

## Website impact

Required. Companion [camel-kit-web PR #36](https://github.com/luigidemasi/camel-kit-web/pull/36) updates the public version tables and examples.

## Summary by Sourcery

Centralize distribution version metadata and adopt Camel 4.22.0 as the default supported LTS release while retaining Camel 4.18.4 compatibility.

New Features:
- Centralize runtime, compatibility, MCP, Forage, documentation, and Ship policy versions in distribution.properties.
- Add an idempotent helper to synchronize and validate Maven model-time version mirrors.
- Support Camel 4.22.0 as the default while retaining Camel 4.18.4 as the supported Main and Spring Boot LTS line.
- Add Camel 4.22 Jactl catalog classification and corresponding Ship policy coverage.

Bug Fixes:
- Ensure partial and overridden distribution configurations consistently fall back to the packaged properties baseline.
- Prevent stale Maven version mirrors through automated synchronization and check support.

Enhancements:
- Generate MCP configuration, version guidance, compatibility tables, and security documentation directly from centralized distribution settings.
- Update Ship compatibility evidence and tests to cover all configured supported Camel rows while preserving the Simple-only expression policy.

Documentation:
- Update contributor guidance, command references, user documentation, examples, skills, and the unreleased changelog for the new supported versions.

Tests:
- Expand generated-resource, configuration, Ship, and compatibility coverage to derive expectations from distribution.properties.