### PR TITLE
Fix #207: record catalog verification evidence in design specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Design-spec catalog evidence (#207)** — section 5 now records the matched runtime, full platform BOM, returned
+  Camel version, and each selected artifact's verification result and tool provenance. Design-time catalog producers,
+  migration gates, and re-planning share that evidence location; failed verification stays an open design question.
+
 - **Evidence-qualified migration analysis (#78)** — `camel-migrate` now materializes `migration-analysis.md` between
   vendor discovery and design. The register records independently testable behavioral assumptions and evidence gaps as
   Confirmed, Inferred, or Unknown, and carries unresolved risks into Phase 2 instead of assuming API compatibility.

--- a/camel-kit-core/src/main/resources/agents/integration-architect.md
+++ b/camel-kit-core/src/main/resources/agents/integration-architect.md
@@ -55,6 +55,12 @@ Your design output follows the flow design section format:
 - Error handling strategy
 - Configuration properties with `{{PLACEHOLDER}}` syntax
 - DataMapper sections (if XSLT transformation needed)
+- Catalog binding: record the `camel_catalog_components(limit=0)` probe, runtime, full platform BOM, returned
+  `camelVersion`, and `binding=MATCHED` only after validating the match to the resolved project version.
+- Per artifact, use the catalog-researcher labels `Artifact identity:`, `Result:`, and `Verification provenance:`:
+  record the exact type/name, verification result, tool name(s), requested identity, and catalog binding. Supply only
+  validated fields for the `Catalog Verification Evidence` block in `camel-brainstorm/guides/design-assembly.md`.
+  Failed detail calls or missing/mismatched bindings become open design questions, never verified flow choices.
 
 ## What You Do NOT Do
 

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/SKILL.md
@@ -200,6 +200,14 @@ You MUST complete these items in order:
 
 Pass `runtime` and the full `platformBom` GAV (derived from `.camel-kit/config.properties` per `shared/mcp-setup.md` — the file stores bare versions, not the GAV) on every call, and establish the catalog-version binding there (Iron Law 1).
 
+For the orchestrator's own calls, record `Catalog binding:` with the `camel_catalog_components(limit=0)` probe,
+runtime, full platform BOM, returned `camelVersion`, and `binding=MATCHED` after validating the project-version match.
+For each artifact, record `Artifact identity:`, `Result:`, and `Verification provenance:` using the catalog-researcher
+labels: exact type/name, result, tool name(s), requested identity, and catalog binding. Populate section 5's
+`Catalog Verification Evidence` in `guides/design-assembly.md` from these validated fields, including equivalent
+fields returned by the integration architect. A `VERIFIED` result requires a successful matching detail call under
+the matched binding; an inline tag alone is not evidence.
+
 → For MCP setup, version mapping, and fallback policy: see `shared/mcp-setup.md`
 → For graph analysis: use `{COMMAND_PREFIX} graph` CLI commands (see `shared/graph-availability.md`)
 
@@ -217,5 +225,5 @@ Pass `runtime` and the full `platformBom` GAV (derived from `.camel-kit/config.p
 
 - **Missing constitution:** Copy from `templates/constitution.md` and continue.
 - **No config.properties:** Will be created during version selection.
-- **MCP tool failure:** Warn the user, continue with a note that verification is pending.
+- **MCP tool failure:** Warn the user and record an open design question; do not include the unverified artifact in section 3 or create a `VERIFIED` evidence row. Resume that choice only after verification succeeds, per `camel-design/guides/component-selection.md`.
 - **Ambiguous project type:** Ask explicitly — don't guess.

--- a/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/design-assembly.md
+++ b/camel-kit-core/src/main/resources/skills/camel-brainstorm/guides/design-assembly.md
@@ -166,6 +166,25 @@ All flows in this spec are designed to comply with the 8 constitution rules:
 - [ ] Component Support — all components MCP-verified
 - [ ] Infrastructure via Forage — beans follow the Forage configuration ladder
 
+### Catalog Verification Evidence
+
+Catalog binding: camel_catalog_components(limit=0); runtime=[runtime]; platformBom=[groupId:artifactId:version]; returned camelVersion=[camelVersion]; binding=MATCHED
+
+| Artifact identity | Result | Verification provenance |
+|---|---|---|
+| component:[name] | VERIFIED | camel_catalog_component_doc; requested component:[name]; catalog binding=MATCHED |
+| eip:[name] | VERIFIED | camel_catalog_eip_doc; requested eip:[name]; catalog binding=MATCHED |
+| dataformat:[name] | VERIFIED | camel_catalog_dataformat_doc; requested dataformat:[name]; catalog binding=MATCHED |
+| language:[name] | VERIFIED | camel_catalog_language_doc; requested language:[name]; catalog binding=MATCHED |
+
+[Replace the examples with one row per artifact named in section 3, deduplicated across flows by type and exact catalog
+name. Record only VERIFIED rows from successful detail calls whose identities and consumed fields were validated under
+the same runtime/full platform BOM binding. The probe's returned camelVersion must match the resolved project version
+per shared/mcp-setup.md. When component coordinates were consumed, include camel_catalog_component_maven alongside
+camel_catalog_component_doc in that row's provenance. Use the actual recorded calls; do not infer evidence from an
+inline (MCP-verified) tag or invent documentation URLs. If a detail call fails or the binding cannot be established,
+record an open design question and omit the artifact from section 3 until verified.]
+
 ---
 
 ## 6. Project Structure
@@ -268,7 +287,9 @@ absent source features.
 After assembling the spec, check:
 
 1. **Placeholder scan:** Any "TBD", "TODO", empty sections? Fix them.
-2. **MCP verification:** Every component/EIP has "(MCP-verified)" notation? If not, verify now.
+2. **MCP verification:** Every section 3 artifact (component, EIP, dataformat, language) has a `VERIFIED` row in section 5's
+   `Catalog Verification Evidence` under a `binding=MATCHED` line? If not, verify now; unresolved verification stays an
+   open design question and the artifact stays out of section 3. Keep the inline `(MCP-verified)` tags.
 3. **Internal consistency:** Do flow designs match the systems landscape? Are all systems used?
 4. **Constitution compliance:** Would each flow pass all 8 rules as designed?
 5. **Property completeness:** Does every externalized value have a property name?

--- a/camel-kit-core/src/main/resources/skills/camel-design/guides/component-selection.md
+++ b/camel-kit-core/src/main/resources/skills/camel-design/guides/component-selection.md
@@ -29,6 +29,12 @@ Based on the user's description, I suggest: [component-name]
 
 Then retrieve both its documentation and runtime-specific Maven coordinates under the same binding:
 
+Record `Catalog binding:` with the `camel_catalog_components(limit=0)` probe, runtime, full platform BOM, returned
+`camelVersion`, and `binding=MATCHED` only after the project-version match succeeds. Retain this binding and the
+per-artifact `Result:` and `Verification provenance:` fields below for section 5's `Catalog Verification Evidence`
+in `camel-brainstorm/guides/design-assembly.md`, using the catalog-researcher labels. Emit `VERIFIED` only after the
+detail calls succeed and their identities and consumed fields validate under that same binding.
+
 ```
 MCP Tool: camel_catalog_component_doc
 Params: { "component": "[component-name]", "platformBom": "{{PLATFORM_BOM}}", "runtime": "{{RUNTIME}}" }
@@ -37,6 +43,9 @@ MCP Tool: camel_catalog_component_maven
 Params: { "component": "[component-name]", "platformBom": "{{PLATFORM_BOM}}", "runtime": "{{RUNTIME}}" }
 
 Component: [component-name]
+Artifact identity: component:[component-name]
+Result: VERIFIED
+Verification provenance: camel_catalog_component_doc + camel_catalog_component_maven; requested component:[component-name]; catalog binding=MATCHED
 URI syntax:  [exact syntax from catalog]
 Maven:       [groupId]:[artifactId]:[artifact version from component_maven]
 

--- a/camel-kit-core/src/main/resources/skills/camel-design/guides/tdd-assembly.md
+++ b/camel-kit-core/src/main/resources/skills/camel-design/guides/tdd-assembly.md
@@ -60,6 +60,8 @@ flow-level details:
 13. Configuration Properties
 14. Dependencies
 15. Constitution Gate Checks
+    MCP catalog verification is satisfied by the `Catalog Verification Evidence` block in section 5 of the active design
+    spec, as defined in `camel-brainstorm/guides/design-assembly.md`; reference its rows for this flow, do not restate the table.
 16. Testing Strategy (high-level test scenarios)
 17. Implementation Checklist
 

--- a/camel-kit-core/src/main/resources/skills/camel-execute/guides/re-plan-loop.md
+++ b/camel-kit-core/src/main/resources/skills/camel-execute/guides/re-plan-loop.md
@@ -7,7 +7,7 @@ component, pattern, or dependency is structurally wrong and the design must chan
 
 **Always load `shared/context-authority.md` with this guide.**
 
-**Modifies affected flow design sections ONLY — NEVER the business requirements (`docs/camel-kit/<PIPELINE_ID>/business-requirements.md`).**
+**Modifies affected flow design sections and their catalog evidence rows ONLY — NEVER the business requirements (`docs/camel-kit/<PIPELINE_ID>/business-requirements.md`).**
 
 ---
 
@@ -16,7 +16,7 @@ component, pattern, or dependency is structurally wrong and the design must chan
 | Constraint | Value |
 |---|---|
 | Maximum rounds | 3 |
-| Modifiable artifacts | Affected flow sections in `docs/camel-kit/<PIPELINE_ID>/design-spec.md` only |
+| Modifiable artifacts | Affected flow sections and their catalog evidence rows in `docs/camel-kit/<PIPELINE_ID>/design-spec.md` only |
 | business requirements (`docs/camel-kit/<PIPELINE_ID>/business-requirements.md`) | NEVER modified |
 | migration runbook (`docs/camel-kit/<PIPELINE_ID>/migration-runbook.md`) | NEVER modified; marked stale when present |
 | Design scope | ONLY sections affected by the failure |
@@ -137,7 +137,11 @@ Update ONLY the affected sections. Preserve all other sections verbatim.
 1. Replace the failing component/version/pattern with the verified alternative
 2. Update the **Dependencies** table to match the new component's Maven coordinates
 3. Update **Configuration Properties** and endpoint options if the new component requires different properties
-4. Add a **Re-Plan History** appendix entry at the end of the affected flow design:
+4. In section 5's **Catalog Verification Evidence**, update the affected row with the verified replacement's exact
+   identity, result, and tool provenance under the matched catalog binding. Keep one row per artifact; retain the old
+   artifact's row if it is still used by another flow, otherwise remove it. A Step 2 result of `UNKNOWN` never produces
+   a `VERIFIED` row or a replacement choice.
+5. Add a **Re-Plan History** appendix entry at the end of the affected flow design:
 
 ```markdown
 ### Re-Plan [round N] — [YYYY-MM-DD]

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/biztalk-phase2.md
@@ -311,6 +311,8 @@ sequenceDiagram
 Constitution v2.0 — eight enforced rules:
 
 - [ ] **MCP Catalog Verification** — every component, EIP, data format, language, and option was verified with runtime/platform BOM
+  MCP catalog verification is satisfied by the `Catalog Verification Evidence` block in section 5 of the active design
+  spec, as defined in `camel-brainstorm/guides/design-assembly.md`; reference its rows for this flow, do not restate the table.
 - [ ] **Route Structure** — route has a `from:` source and a final `to:` sink
 - [ ] **Single Responsibility** — route has one clear purpose; ≤ 7 processing steps
 - [ ] **Separation of Concerns** — ingestion, processing, and delivery are separate routes where appropriate

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/camel-version-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/camel-version-phase2.md
@@ -321,6 +321,8 @@ datamapper-canonicalize.md, preserving its selected inline Groovy or XSLT engine
 
 ## Section 9: Constitution Gate Checks
 - [ ] MCP Catalog Verification — every component, EIP, data format, language, and option was verified with runtime/platform BOM
+  MCP catalog verification is satisfied by the `Catalog Verification Evidence` block in section 5 of the active design
+  spec, as defined in `camel-brainstorm/guides/design-assembly.md`; reference its rows for this flow, do not restate the table.
 - [ ] Route Structure — route has from: and final to:
 - [ ] Single Responsibility — ≤ 7 processing steps
 - [ ] Separation of Concerns — ingestion/processing/delivery separate

--- a/camel-kit-core/src/main/resources/skills/camel-migrate/guides/mulesoft-phase2.md
+++ b/camel-kit-core/src/main/resources/skills/camel-migrate/guides/mulesoft-phase2.md
@@ -267,6 +267,8 @@ sequenceDiagram
 Constitution v2.0 — eight enforced rules:
 
 - [ ] **MCP Catalog Verification** — every component, EIP, data format, language, and option was verified with runtime/platform BOM
+  MCP catalog verification is satisfied by the `Catalog Verification Evidence` block in section 5 of the active design
+  spec, as defined in `camel-brainstorm/guides/design-assembly.md`; reference its rows for this flow, do not restate the table.
 - [ ] **Route Structure** — route has a `from:` source and a final `to:` sink
 - [ ] **Single Responsibility** — route has one clear purpose; ≤ 7 processing steps
 - [ ] **Separation of Concerns** — ingestion, processing, and delivery are separate routes where appropriate

--- a/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
+++ b/camel-kit-core/src/test/java/io/github/luigidemasi/camelkit/generator/ResourceConsistencyTest.java
@@ -858,6 +858,65 @@ class ResourceConsistencyTest {
     }
 
     @Test
+    void designSpecsRecordCatalogEvidenceInSectionFive() throws Exception {
+        Path resources = repositoryRoot().resolve("camel-kit-core/src/main/resources");
+        String design = Files.readString(resources.resolve("skills/camel-brainstorm/guides/design-assembly.md"));
+        String compliance = section(design, "## 5. Constitution Compliance", "## 6. Project Structure");
+        assertContainsAll(compliance,
+                "### Catalog Verification Evidence",
+                "Catalog binding: camel_catalog_components(limit=0); runtime=[runtime]; "
+                                                     + "platformBom=[groupId:artifactId:version]; returned camelVersion=[camelVersion]; binding=MATCHED",
+                "| Artifact identity | Result | Verification provenance |",
+                "one row per artifact named in section 3, deduplicated",
+                "open design question");
+        for (String type : List.of("component", "eip", "dataformat", "language")) {
+            assertTrue(compliance.contains("| " + type + ":[name] | VERIFIED | camel_catalog_" + type
+                                           + "_doc; requested " + type + ":[name]; catalog binding=MATCHED |"));
+        }
+        assertContainsAll(section(design, "## Self-Review Checklist", "## Save and Present"),
+                "Every section 3 artifact", "`VERIFIED` row", "`binding=MATCHED`", "verify now");
+        assertFalse(design.contains("camel.apache.org/components"));
+
+        for (String agentName : sortedAgentNames()) {
+            InitContext ctx = createContext(agentName, tempDir.resolve(agentName));
+            new DefaultGenerator().generate(ctx);
+            String generated = Files.readString(ctx.skillsDir().resolve("camel-brainstorm/guides/design-assembly.md"));
+            assertEquals(compliance, section(generated, "## 5. Constitution Compliance", "## 6. Project Structure"),
+                    agentName + " must receive the canonical evidence block");
+        }
+    }
+
+    @Test
+    void designEvidenceHasProducersAndOneMigrationLocation() throws IOException {
+        Path resources = repositoryRoot().resolve("camel-kit-core/src/main/resources");
+        for (String producer : List.of(
+                "agents/integration-architect.md",
+                "skills/camel-brainstorm/SKILL.md",
+                "skills/camel-design/guides/component-selection.md")) {
+            assertContainsAll(Files.readString(resources.resolve(producer)),
+                    "Catalog binding:", "Result:", "Verification provenance:", "Catalog Verification Evidence");
+        }
+        String brainstorm = Files.readString(resources.resolve("skills/camel-brainstorm/SKILL.md"));
+        assertFalse(brainstorm.contains("continue with a note that verification is pending"));
+        assertContainsAll(brainstorm, "open design question", "do not include the unverified artifact in section 3");
+        for (String consumer : List.of(
+                "skills/camel-migrate/guides/mulesoft-phase2.md",
+                "skills/camel-migrate/guides/biztalk-phase2.md",
+                "skills/camel-migrate/guides/camel-version-phase2.md",
+                "skills/camel-design/guides/tdd-assembly.md")) {
+            String content = Files.readString(resources.resolve(consumer));
+            assertContainsAll(content,
+                    "MCP catalog verification is satisfied by the `Catalog Verification Evidence` block in section 5",
+                    "camel-brainstorm/guides/design-assembly.md");
+            assertFalse(content.contains("| Artifact identity | Result | Verification provenance |"), consumer);
+        }
+        String replan = Files.readString(resources.resolve("skills/camel-execute/guides/re-plan-loop.md"));
+        assertContainsAll(section(replan, "### Step 3: Modify Design Spec", "### Step 4:"),
+                "Catalog Verification Evidence", "update the affected row", "`UNKNOWN`", "`VERIFIED`",
+                "still used by another flow");
+    }
+
+    @Test
     void catalogAndExecutionIngressRequireValidatedBindingsInsteadOfSummaryTrust() throws IOException {
         Path root = repositoryRoot().resolve("camel-kit-core/src/main/resources");
         String ironLaws = Files.readString(root.resolve("skills/shared/iron-laws.md"));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,20 @@ per independently switchable scope as `Incremental candidate`, `Single cutover r
 scope. Both pipelines converge on the same approved design-spec contract, so `camel-plan` and `camel-execute` work
 identically afterward; the plan does not consume the runbook.
 
+### Design-Time Catalog Evidence
+
+The brainstorm orchestrator and, where dispatched, `integration-architect` record the same binding, result, and
+verification-provenance labels used by `catalog-researcher`. Component-selection calls retain these fields too.
+The shared design assembly writes them into section 5, **Constitution Compliance**, as **Catalog Verification Evidence**:
+one matched runtime/full platform BOM/returned Camel-version binding and one deduplicated `VERIFIED` row per component,
+EIP, dataformat, or language in section 3. Failed verification remains an open design question and cannot become a flow
+choice. Migration flow gates reference this same block, and re-planning updates affected rows when replacing artifacts.
+The evidence records actual catalog tools and exact artifact identities, without constructing documentation URLs.
+
+`catalog-researcher` remains an execute-time research role; it is not newly dispatched during design. Generated Bob
+gates and Gemini traits already load the shared design assembly. Ship workers run without these skills, so this block
+is not a requirement for controller-produced Ship specs.
+
 ### How camel-execute Dispatches Work
 
 1. Read the ready implementation plan derived from the approved design, prefer the `yaml plan-metadata` task graph, and fall back to Markdown task


### PR DESCRIPTION
Design specs marked artifacts `(MCP-verified)` without showing the catalog version or tool evidence behind those claims. Section 5 now includes Catalog Verification Evidence: the matched runtime, full platform BOM and returned Camel version, followed by one deduplicated `VERIFIED` row with provenance for every component, EIP, dataformat and language in the flow designs.

The brainstorm orchestrator, component-selection guide and integration architect supply those fields. Failed verification remains an open design question; migration gates reference the same block, and re-planning updates affected rows while retaining artifacts still used by other flows. The architecture guide and changelog describe the contract. Existing status labels and catalog calls are reused.

Closes #207.

Website impact: required, implemented in https://github.com/luigidemasi/camel-kit-web/pull/37. Merge the website PR after this core change is accepted.

Validation: both new regressions fail on the unchanged resources; all 29 `ResourceConsistencyTest` checks pass after the fix, including the evidence block in generated output for every registered target. The full `./mvnw -B clean install` reactor, source checks, `git diff --check`, and the resource scan for fabricated component documentation URLs pass. Independent review found no required changes.
